### PR TITLE
programs.rclone: use 'config update' to preserve tokens

### DIFF
--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -304,9 +304,12 @@ in
                   fi
                 '') (lib.attrValues (remoteData.secrets or { }))}
 
-                ${lib.getExe cfg.package} config update "${remoteName}" \
+                if ! ${lib.getExe cfg.package} config update "${remoteName}" \
                   ${lib.concatStringsSep " " allArgs} \
-                  --non-interactive
+                  --non-interactive; then
+                  echo "Failed to update remote: ${remoteName}"
+                  exit 1
+                fi
               ''
             ) cfg.remotes
           );
@@ -336,7 +339,26 @@ in
 
                   text = ''
                     configPath="${rcloneConfigPath}"
+                    configName="$(basename "$configPath")"
+                    savedConfigPath="$(dirname "$configPath")/.$configName.orig"
+
+                    cleanup() {
+                      echo "Failed to render config."
+                      if [ -f "$savedConfigPath" ]; then
+                        echo "Restoring original config from backup"
+                        cp -v "$savedConfigPath" "$configPath"
+                      fi
+                      exit 1
+                    }
+
+                    trap cleanup SIGINT SIGTERM ERR
+
                     mkdir -p "$(dirname "$configPath")"
+
+                    # Create backup of existing config if it exists
+                    if [ -f "$configPath" ]; then
+                      cp -v "$configPath" "$savedConfigPath"
+                    fi
 
                     # Ensure the file exists so rclone can update it.
                     # 'config update' creates it if missing, but we ensure permissions here.
@@ -346,6 +368,11 @@ in
                     fi
 
                     ${rcloneConfigScript}
+
+                    # Clean up backup on success
+                    if [ -f "$savedConfigPath" ]; then
+                      rm -f "$savedConfigPath"
+                    fi
                   '';
                 }
               );

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -273,6 +273,12 @@ in
           # Helper to convert nix bools to strings expected by rclone CLI
           toRcloneVal = v: if builtins.isBool v then (if v then "true" else "false") else toString v;
 
+          # Custom escaping that allows variable expansion but escapes special chars
+          escapePathForShell =
+            path:
+            # Escape only double quotes and backslashes to allow variable expansion
+            builtins.replaceStrings [ "\"" "\\" ] [ "\\\"" "\\\\" ] path;
+
           # Generate a script that runs 'rclone config update' for each remote
           rcloneConfigScript = lib.concatStringsSep "\n" (
             lib.mapAttrsToList (
@@ -298,7 +304,7 @@ in
                 echo "Updating remote: ${remoteName}"
                 # Ensure all secret files exist before running the command
                 ${lib.concatMapStrings (path: ''
-                  if [ ! -r ${lib.escapeShellArg path} ]; then
+                  if [ ! -r "${escapePathForShell path}" ]; then
                     echo "Error: Secret file not found: ${path}"
                     exit 1
                   fi


### PR DESCRIPTION
### Description

This fixes an issue where the `programs.rclone` activation script unconditionally overwrote `rclone.conf` using `install`. This behavior caused minor data loss for remotes that rely on dynamic state, specifically OAuth tokens (e.g., Google Drive, OneDrive), forcing users to re-authenticate after every configuration change or system reboot.

**Changes:**

  - Replaced the destructive `install` command with `rclone config update`.
  - This creates a "smart merge" behavior: declarative settings from Nix are enforced, but existing dynamic keys in the file (like `token`) are preserved.
  - Unified the static configuration and secret injection into a single loop, removing the need for `pkgs.formats.ini`.

**Note on Drift:**
This change introduces a minor trade-off: removing a setting from `home.nix` will no longer automatically remove it from `rclone.conf` (it must be manually deleted). This is necessary to preserve the authentication tokens that Nix cannot manage.

Closes [\#8334](https://github.com/nix-community/home-manager/issues/8334)

### Checklist

  - [x] Change is backwards compatible.

  - [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

  - [x] Code tested through `nix run .#tests -- test-all` or
    `nix-shell --pure tests -A run.all`.
    *(Note: Existing build tests pass. The fix addresses a runtime behavior (file overwrite) that cannot be reproduced in the sandboxed test suite, but was verified manually via VM reproduction.)*

  - [ ] Test cases updated/added. See [[example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef)](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef). -- Probably not desirable, it's not easy to construct a test for this as it requires a VM.

  - [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [[CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style)](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [[recent commit messages](https://github.com/nix-community/home-manager/commits/master)](https://github.com/nix-community/home-manager/commits/master) for examples.

  - If this PR adds a new module (N/A)

  - If this PR adds an exciting new feature or contains a breaking change. (N/A)