### PR TITLE
home-manager: expose all attributes returned by evalModules

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -57,9 +57,8 @@ let
     let
       module = moduleChecks rawModule;
     in
-    {
-      inherit (module) options config;
-
+    module
+    // {
       activationPackage = module.config.home.activationPackage;
 
       # For backwards compatibility. Please use activationPackage instead.


### PR DESCRIPTION
### Description

This change brings the homeConfigurations output inline with how the
nixosConfiguration output presents its attributes.

The primary purpose is for exposing the graph attribute however there is
no downside to exposing the rest along with it to prevent needing to add
each desired attribute individually in the future if more are added.

My personal use-case is I'm currently developing a script that is used by my CI to determine which machines & hm profiles to evaluate and rebuild based on which files are modified in the commit & which hosts / profile use those files.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
