### PR TITLE
firefox: Add note for non-nixos support with `MOZ_LEGACY_PROFILES`

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -233,7 +233,12 @@ in
         The ${appName} package to use. If state version ≥ 19.09 then
         this should be a wrapped ${appName} package. For earlier state
         versions it should be an unwrapped ${appName} package.
-        Set to `null` to disable installing ${appName}.
+        Set to `null` to disable installing ${appName}. Note that most versions
+        of ${appName} will attempt to update the `profiles.ini` configuration file
+        on startup which will fail if home-manager is managing it. If you wish to
+        use an unwrapped ${appName} (e.g. from outside Nix), consider setting the
+        environment variable `MOZ_LEGACY_PROFILES=1` to disable attempts to write
+        to the file.
       '';
     };
 


### PR DESCRIPTION
### Description

Closes: #6170. Firefox, by default, will attempt to migrate the `profiles.ini` file to also include install information. If the user wishes to not have home-manager install Firefox but have it manage their profiles, this causes an error when it tries to write that file.

This can be mitigated by setting `MOZ_LEGACY_PROFILES` (as the wrapped nix packages do), which disables this migration, so call that out in the documentation.

---

I considered having `MOZ_LEGACY_PROFILES` be set automatically when `package == null`, but updating the environment like that seems kind of rude and makes assumptions as to what the user is likely doing.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef). (Not required)

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
