### PR TITLE
home-manager-auto-upgrade

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -523,6 +523,12 @@
     github = "silmarp";
     githubId = 67292496;
   };
+  soracat = {
+    name = "soracat";
+    email = "125882337+s0racat@users.noreply.github.com";
+    github = "s0racat";
+    githubId = 125882337;
+  };
   yarn = {
     name = "yarncat";
     email = "30006414+yaaaarn@users.noreply.github.com";

--- a/modules/misc/news/2026/01/2026-01-13_10-11-50.nix
+++ b/modules/misc/news/2026/01/2026-01-13_10-11-50.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+{
+  time = "2026-01-13T01:11:50+00:00";
+  condition = config.services.home-manager.autoUpgrade.enable;
+  message = ''
+
+    Multiple new options are available:
+
+    - services.home-manager.autoUpgrade.flags
+    - services.home-manager.autoUpgrade.preSwitchCommands
+  '';
+}

--- a/modules/services/home-manager-auto-upgrade.nix
+++ b/modules/services/home-manager-auto-upgrade.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -10,26 +11,25 @@ let
 
   homeManagerPackage = config.programs.home-manager.package;
 
+  preSwitchCommandsStateVersion = lib.hm.deprecations.mkStateVersionOptionDefault {
+    inherit (config.home) stateVersion;
+    inherit config options;
+    since = "26.05";
+    optionPath = [
+      "services"
+      "home-manager"
+      "autoUpgrade"
+      "preSwitchCommands"
+    ];
+    legacy.value = [ "nix flake update" ];
+    current.value = [ ];
+    deferWarningToConfig = true;
+    shouldWarn = { optionUsesDefaultPriority, ... }: cfg.useFlake && optionUsesDefaultPriority;
+  };
+
   hmExtraArgs = lib.escapeShellArgs cfg.flags;
 
-  legacyPreSwitchCommands = lib.warn ''
-    services.home-manager.autoUpgrade:
-    Implicit `nix flake update` before `home-manager switch` is deprecated.
-    Please set `services.home-manager.autoUpgrade.preSwitchCommands`
-    explicitly.
-  '' [ "nix flake update" ];
-
-  # null = legacy behavior
-  # []   = run nothing
-  preSwitchCommands =
-    if cfg.useFlake && cfg.preSwitchCommands == null then
-      legacyPreSwitchCommands
-    else if cfg.preSwitchCommands == null then
-      [ ]
-    else
-      cfg.preSwitchCommands;
-
-  hasPreSwitchCommands = preSwitchCommands != [ ];
+  hasPreSwitchCommands = cfg.preSwitchCommands != [ ];
 
   preSwitchScript = lib.optionalString hasPreSwitchCommands (
     lib.concatStringsSep "\n" (
@@ -37,7 +37,7 @@ let
         ''echo "Running pre-switch commands"''
         "set -o xtrace"
       ]
-      ++ preSwitchCommands
+      ++ cfg.preSwitchCommands
     )
   );
 
@@ -139,8 +139,16 @@ in
       };
 
       preSwitchCommands = lib.mkOption {
-        type = lib.types.nullOr (lib.types.listOf lib.types.str);
-        default = null;
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        defaultText = lib.literalExpression ''
+          if lib.versionAtLeast config.home.stateVersion "26.05"
+             || !config.services.home-manager.autoUpgrade.useFlake
+          then
+            [ ]
+          else
+            [ "nix flake update" ]
+        '';
         example = lib.literalExpression ''
           [
             "''${pkgs.gitMinimal}/bin/git pull"
@@ -149,18 +157,21 @@ in
         '';
         description = ''
           Shell commands executed before `home-manager switch`.
-
-          - null: use legacy behavior (deprecated)
-          - []: run no pre-switch commands
         '';
       };
     };
   };
 
   config = lib.mkIf cfg.enable {
+    warnings = lib.optional preSwitchCommandsStateVersion.shouldWarn preSwitchCommandsStateVersion.warning;
+
     assertions = [
       (lib.hm.assertions.assertPlatform "services.home-manager.autoUpgrade" pkgs lib.platforms.linux)
     ];
+
+    services.home-manager.autoUpgrade.preSwitchCommands = lib.mkIf cfg.useFlake (
+      lib.mkOptionDefault preSwitchCommandsStateVersion.effectiveDefault
+    );
 
     systemd.user = {
       timers.home-manager-auto-upgrade = {

--- a/modules/services/home-manager-auto-upgrade.nix
+++ b/modules/services/home-manager-auto-upgrade.nix
@@ -88,7 +88,7 @@ in
     services.home-manager.autoUpgrade = {
       enable = lib.mkEnableOption ''
         the Home Manager upgrade service that periodically updates your Nix
-        configuration before running `home-manager switch`
+        configuration by running `home-manager switch`
       '';
 
       frequency = lib.mkOption {
@@ -98,7 +98,7 @@ in
           The interval at which the Home Manager auto upgrade is run.
           This value is passed to the systemd timer configuration
           as the `OnCalendar` option.
-          The format is described in systemd.time(7).
+          The format is described in {manpage}`systemd.time(7)`.
         '';
       };
 
@@ -107,6 +107,10 @@ in
         default = false;
         description = ''
           Whether to use flake-based Home Manager configuration.
+
+          Flake URI uses FQDN, long, and short hostnames, and you must configure the corresponding user@host key in `homeConfigurations`. For example: user@hostname or user@host.example.com.
+
+          Also check `services.home-manager.autoUpgrade.flakeDir` option.
         '';
       };
 
@@ -117,6 +121,7 @@ in
         example = "/home/user/dotfiles";
         description = ''
           Directory containing flake.nix.
+          Also check `services.home-manager.autoUpgrade.useFlake` option.
         '';
       };
 

--- a/modules/services/home-manager-auto-upgrade.nix
+++ b/modules/services/home-manager-auto-upgrade.nix
@@ -42,7 +42,7 @@ let
   };
 in
 {
-  meta.maintainers = [ lib.maintainers.pinage404 ];
+  meta.maintainers = [ lib.hm.maintainers.soracat ];
 
   options = {
     services.home-manager.autoUpgrade = {

--- a/modules/services/home-manager-auto-upgrade.nix
+++ b/modules/services/home-manager-auto-upgrade.nix
@@ -6,39 +6,79 @@
 }:
 
 let
-
   cfg = config.services.home-manager.autoUpgrade;
 
   homeManagerPackage = config.programs.home-manager.package;
 
+  hmExtraArgs = lib.escapeShellArgs cfg.flags;
+
+  legacyPreSwitchCommands = lib.warn ''
+    services.home-manager.autoUpgrade:
+    Implicit `nix flake update` before `home-manager switch` is deprecated.
+    Please set `services.home-manager.autoUpgrade.preSwitchCommands`
+    explicitly.
+  '' [ "nix flake update" ];
+
+  # null = legacy behavior
+  # []   = run nothing
+  preSwitchCommands =
+    if cfg.useFlake && cfg.preSwitchCommands == null then
+      legacyPreSwitchCommands
+    else if cfg.preSwitchCommands == null then
+      [ ]
+    else
+      cfg.preSwitchCommands;
+
+  hasPreSwitchCommands = preSwitchCommands != [ ];
+
+  preSwitchScript = lib.optionalString hasPreSwitchCommands (
+    lib.concatStringsSep "\n" (
+      [
+        ''echo "Running pre-switch commands"''
+        "set -o xtrace"
+      ]
+      ++ preSwitchCommands
+    )
+  );
+
   autoUpgradeApp = pkgs.writeShellApplication {
     name = "home-manager-auto-upgrade";
-    text =
-      if cfg.useFlake then
-        ''
-          set -e
-          if [[ ! -f "$FLAKE_DIR/flake.nix" ]]; then
-              echo "No flake.nix found in $FLAKE_DIR." >&2
-              exit 1
-          fi
-          echo "Changing to flake directory $FLAKE_DIR"
-          cd "$FLAKE_DIR"
-          echo "Update flake inputs"
-          nix flake update
-          echo "Upgrade Home Manager"
-          home-manager switch --flake .
-        ''
-      else
-        ''
-          echo "Update Nix's channels"
-          nix-channel --update
-          echo "Upgrade Home Manager"
-          home-manager switch
-        '';
+
     runtimeInputs = with pkgs; [
       homeManagerPackage
       nix
     ];
+
+    text =
+      if cfg.useFlake then
+        ''
+          set -euo pipefail
+
+          if [[ ! -f "$FLAKE_DIR/flake.nix" ]]; then
+            echo "No flake.nix found in $FLAKE_DIR." >&2
+            exit 1
+          fi
+
+          echo "Changing to flake directory $FLAKE_DIR"
+          cd "$FLAKE_DIR"
+
+          ${preSwitchScript}
+
+          echo "Upgrade Home Manager"
+          home-manager switch --flake . ${hmExtraArgs}
+        ''
+      else
+        ''
+          set -euo pipefail
+
+          echo "Update Nix channels"
+          nix-channel --update
+
+          ${preSwitchScript}
+
+          echo "Upgrade Home Manager"
+          home-manager switch ${hmExtraArgs}
+        '';
   };
 in
 {
@@ -48,7 +88,8 @@ in
     services.home-manager.autoUpgrade = {
       enable = lib.mkEnableOption ''
         the Home Manager upgrade service that periodically updates your Nix
-        channels before running `home-manager switch`'';
+        configuration before running `home-manager switch`
+      '';
 
       frequency = lib.mkOption {
         type = lib.types.str;
@@ -57,15 +98,16 @@ in
           The interval at which the Home Manager auto upgrade is run.
           This value is passed to the systemd timer configuration
           as the `OnCalendar` option.
-          The format is described in
-          {manpage}`systemd.time(7)`.
+          The format is described in systemd.time(7).
         '';
       };
 
       useFlake = lib.mkOption {
         type = lib.types.bool;
         default = false;
-        description = "Whether to use 'nix flake update' instead of 'nix-channel --update'.";
+        description = ''
+          Whether to use flake-based Home Manager configuration.
+        '';
       };
 
       flakeDir = lib.mkOption {
@@ -73,7 +115,39 @@ in
         default = "${config.xdg.configHome}/home-manager";
         defaultText = lib.literalExpression ''"''${config.xdg.configHome}/home-manager"'';
         example = "/home/user/dotfiles";
-        description = "The directory of the flake to update.";
+        description = ''
+          Directory containing flake.nix.
+        '';
+      };
+
+      flags = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [
+          "--impure"
+          "-b"
+          "hmbak"
+        ];
+        description = ''
+          Extra arguments passed to `home-manager switch`.
+        '';
+      };
+
+      preSwitchCommands = lib.mkOption {
+        type = lib.types.nullOr (lib.types.listOf lib.types.str);
+        default = null;
+        example = lib.literalExpression ''
+          [
+            "''${pkgs.gitMinimal}/bin/git pull"
+            "nix flake update"
+          ]
+        '';
+        description = ''
+          Shell commands executed before `home-manager switch`.
+
+          - null: use legacy behavior (deprecated)
+          - []: run no pre-switch commands
+        '';
       };
     };
   };
@@ -97,10 +171,17 @@ in
       };
 
       services.home-manager-auto-upgrade = {
-        Unit.Description = "Home Manager upgrade";
+        Unit = {
+          Description = "Home Manager upgrade";
+          X-SwitchMethod = "keep-old";
+        };
+
         Service = {
           ExecStart = "${autoUpgradeApp}/bin/home-manager-auto-upgrade";
-          Environment = lib.mkIf cfg.useFlake [ "FLAKE_DIR=${cfg.flakeDir}" ];
+
+          Environment = lib.mkIf cfg.useFlake [
+            "FLAKE_DIR=${cfg.flakeDir}"
+          ];
         };
       };
     };

--- a/tests/modules/services/home-manager-auto-upgrade/current-flake-configuration.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/current-flake-configuration.nix
@@ -6,7 +6,6 @@
     frequency = "daily";
     useFlake = true;
     flakeDir = "/tmp/my-flake";
-    preSwitchCommands = [ "nix flake update" ];
   };
 
   nmt.script = ''
@@ -15,6 +14,6 @@
     assertFileRegex "$serviceFile" "FLAKE_DIR=/tmp/my-flake"
 
     scriptPath=$(grep -oP 'ExecStart=\K.+' "$TESTED/$serviceFile")
-    assertFileRegex "$scriptPath" "nix flake update"
+    assertFileNotRegex "$scriptPath" "nix flake update"
   '';
 }

--- a/tests/modules/services/home-manager-auto-upgrade/default.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/default.nix
@@ -2,5 +2,7 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   home-manager-auto-upgrade-basic-configuration = ./basic-configuration.nix;
+  home-manager-auto-upgrade-current-flake-configuration = ./current-flake-configuration.nix;
+  home-manager-auto-upgrade-deprecated-flake-configuration = ./deprecated-flake-configuration.nix;
   home-manager-auto-upgrade-flake-configuration = ./flake-configuration.nix;
 }

--- a/tests/modules/services/home-manager-auto-upgrade/deprecated-flake-configuration.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/deprecated-flake-configuration.nix
@@ -1,0 +1,36 @@
+{
+  home.stateVersion = "25.11";
+
+  services.home-manager.autoUpgrade = {
+    enable = true;
+    frequency = "daily";
+    useFlake = true;
+    flakeDir = "/tmp/my-flake";
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      The default value of `services.home-manager.autoUpgrade.preSwitchCommands` has changed from `[
+        "nix flake update"
+      ]` to `[ ]`.
+      You are currently using the legacy default (`[
+        "nix flake update"
+      ]`) because `home.stateVersion` is less than "26.05".
+      To silence this warning and keep legacy behavior, set:
+        services.home-manager.autoUpgrade.preSwitchCommands = [
+        "nix flake update"
+      ];
+      To adopt the new default behavior, set:
+        services.home-manager.autoUpgrade.preSwitchCommands = [ ];
+    ''
+  ];
+
+  nmt.script = ''
+    serviceFile="home-files/.config/systemd/user/home-manager-auto-upgrade.service"
+    assertFileExists "$serviceFile"
+    assertFileRegex "$serviceFile" "FLAKE_DIR=/tmp/my-flake"
+
+    scriptPath=$(grep -oP 'ExecStart=\K.+' "$TESTED/$serviceFile")
+    assertFileRegex "$scriptPath" "nix flake update"
+  '';
+}

--- a/tests/modules/services/home-manager-auto-upgrade/flake-configuration.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/flake-configuration.nix
@@ -4,6 +4,7 @@
     frequency = "daily";
     useFlake = true;
     flakeDir = "/tmp/my-flake";
+    preSwitchCommands = [ "nix flake update" ];
   };
 
   nmt.script = ''


### PR DESCRIPTION
### Description

- Added a new preSwitchCommands option to allow users to run arbitrary commands before home-manager switch.
- Added a new flags option to allow users to pass additional options to home-manager switch
- fix #8349 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
