### PR TITLE
update-flake-inputs: init

### DIFF
--- a/modules/misc/news/2025/11/2025-11-26_22-47-26.nix
+++ b/modules/misc/news/2025/11/2025-11-26_22-47-26.nix
@@ -1,0 +1,42 @@
+{
+  time = "2025-11-26T21:47:26+00:00";
+  condition = true;
+  message = ''
+    A new module `services.update-flake-inputs` is now available to automate
+    Nix flake input updates safely. For each entry in
+    `services.update-flake-inputs.directories`, this service will do the
+    following:
+
+    1. Check that there are no changes to `flake.lock`. Otherwise it
+       will skip the directory and set exit code 80.
+    2. Check that there are no staged changes to tracked files in the Git
+       repository. Otherwise it will skip the directory and set exit code 81.
+    3. If everything is clean, it will do the following for each flake input:
+       1. Update the input. If this fails, it will revert `flake.lock`,
+          set exit code 82, and skip the input.
+       2. Check whether `flake.lock` was actually changed. If not, it
+          will skip the input as there's nothing to do.
+       3. Run `nix flake check` to make sure the update passes the
+          built-in checks in the repository. If this fails, it will revert
+          `flake.lock`, set exit code 83, and skip the input.
+
+          If you want to run a stricter check than the basic one you can set
+          `systemd.user.services.update-flake-inputs.Service.Environment = ["NIX_ABORT_ON_WARN=true"]`
+          or add custom checks.
+       4. Build the flake outputs:
+
+          - NixOS configurations
+          - Dev shells for the current architecture
+          - Packages for the current architecture
+
+          If any of them fail, it will revert `flake.lock`, set exit
+          code 84, and skip the input.
+       5. Run the Nix formatter. If this fails, it will revert
+          `flake.lock`, set exit code 85, and skip the input.
+       6. Commit `flake.lock`. If this fails, it will, you guessed it,
+          revert `flake.lock`, set exit code 86, and skip the input.
+
+    The script returns the last non-zero exit code, or zero if everything was
+    successful.
+  '';
+}

--- a/modules/services/update-flake-inputs/default.nix
+++ b/modules/services/update-flake-inputs/default.nix
@@ -1,0 +1,194 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    maintainers
+    mkEnableOption
+    mkIf
+    mkOption
+    ;
+  inherit (lib.strings) escapeShellArgs;
+  inherit (lib.types)
+    bool
+    listOf
+    str
+    ;
+
+  cfg = config.services.${unitName};
+
+  unitName = "update-flake-inputs";
+in
+{
+  meta.maintainers = [
+    maintainers.l0b0
+  ];
+
+  options.services.${unitName} = {
+    enable = mkEnableOption ''
+      Whether to update Nix flake inputs on a schedule. For each entry in
+      {option}`services.${unitName}.directories`, this service will do the
+      following:
+
+      1. Check that there are no changes to {file}`flake.lock`. Otherwise it
+         will skip the directory and set exit code 80.
+      2. Check that there are no staged changes to tracked files in the Git
+         repository. Otherwise it will skip the directory and set exit code 81.
+      3. If everything is clean, it will do the following for each flake input:
+         1. Update the input. If this fails, it will revert {file}`flake.lock`,
+            set exit code 82, and skip the input.
+         2. Check whether {file}`flake.lock` was actually changed. If not, it
+            will skip the input as there's nothing to do.
+         3. Run {command}`nix flake check` to make sure the update passes the
+            built-in checks in the repository. If this fails, it will revert
+            {file}`flake.lock`, set exit code 83, and skip the input.
+
+            If you want to run a stricter check than the basic one you can set
+            {option}`systemd.user.services.${unitName}.Service.Environment = ["NIX_ABORT_ON_WARN=true"]`
+            or add custom checks.
+         4. Build the flake outputs:
+
+            - NixOS configurations
+            - Dev shells for the current architecture
+            - Packages for the current architecture
+
+            If any of them fail, it will revert {file}`flake.lock`, set exit
+            code 84, and skip the input.
+         5. Run the Nix formatter. If this fails, it will revert
+            {file}`flake.lock`, set exit code 85, and skip the input.
+         6. Commit {file}`flake.lock`. If this fails, it will, you guessed it,
+            revert {file}`flake.lock`, set exit code 86, and skip the input.
+
+      The script returns the last non-zero exit code, or zero if everything was
+      successful.
+    '';
+
+    directories = mkOption {
+      type = listOf str;
+      default = [ ];
+      example = [
+        "/home/user/foo"
+        "/home/user/my projects/bar"
+      ];
+      description = "Absolute paths of directories with flakes you want to update";
+    };
+
+    onCalendar = mkOption {
+      type = str;
+      default = "daily";
+      example = "04:40";
+      description = ''
+        How often or when update occurs.
+
+        The format is described in
+        {manpage}`systemd.time(7)`.
+      '';
+    };
+
+    randomizedDelaySec = mkOption {
+      default = "0";
+      type = str;
+      example = "45 minutes";
+      description = ''
+        Add a randomized delay before each run.
+        The delay will be chosen between zero and this value.
+        This value must be a time span in the format specified by
+        {manpage}`systemd.time(7)`
+      '';
+    };
+
+    fixedRandomDelay = mkOption {
+      default = false;
+      type = bool;
+      example = true;
+      description = ''
+        Make the randomized delay consistent between runs.
+        This reduces the jitter between automatic updates.
+        See {option}`services.${unitName}.randomizedDelaySec` for configuring
+        the randomized delay.
+      '';
+    };
+
+    persistent = mkOption {
+      default = true;
+      type = bool;
+      example = false;
+      description = ''
+        Takes a boolean argument. If true, the time when the service
+        unit was last triggered is stored on disk. When the timer is
+        activated, the service unit is triggered immediately if it
+        would have been triggered at least once during the time when
+        the timer was inactive. Such triggering is nonetheless
+        subject to the delay imposed by RandomizedDelaySec=. This is
+        useful to catch up on missed runs of the service when the
+        system was powered down.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.directories != [ ];
+        message = "You must specify some directories to act on.";
+      }
+    ];
+
+    systemd.user =
+      let
+        Description = "Update Nix flake inputs";
+      in
+      {
+        services.${unitName} =
+          let
+            updateFlakeInputs = pkgs.writeShellApplication {
+              name = unitName;
+              bashOptions = [ ];
+              runtimeInputs = [
+                pkgs.gitMinimal
+                pkgs.jq
+              ];
+              text = builtins.readFile ./update.bash;
+            };
+          in
+          {
+            Unit = {
+              inherit Description;
+              Documentation = [ "man:nix3-flake(1)" ];
+
+              After = [ "network-online.target" ];
+              Wants = [ "network-online.target" ];
+
+              X-StopOnRemoval = false;
+              X-RestartIfChanged = false;
+            };
+
+            Service = {
+              ExecStart = ''
+                ${getExe updateFlakeInputs} ${escapeShellArgs cfg.directories}
+              '';
+              Type = "oneshot";
+            };
+          };
+
+        timers.${unitName} = {
+          Install.WantedBy = [ "timers.target" ];
+
+          Timer = {
+            FixedRandomDelay = cfg.fixedRandomDelay;
+            OnCalendar = cfg.onCalendar;
+            Persistent = cfg.persistent;
+            RandomizedDelaySec = cfg.randomizedDelaySec;
+            Unit = "${unitName}.service";
+          };
+
+          Unit = { inherit Description; };
+        };
+      };
+  };
+
+}

--- a/modules/services/update-flake-inputs/update.bash
+++ b/modules/services/update-flake-inputs/update.bash
@@ -1,0 +1,140 @@
+set -o errexit -o noclobber -o nounset -o pipefail
+shopt -s failglob inherit_errexit
+
+# shellcheck disable=SC2329
+cleanup() {
+  git checkout flake.lock
+}
+
+# shellcheck disable=SC2329
+update_flake_input() {
+  local \
+    dev_shell_name \
+    input \
+    machine_type \
+    nix_build_command \
+    nixos_configuration \
+    package_name \
+    raw_dev_shell_names \
+    raw_nixos_configurations \
+    raw_package_names \
+    update_check_command
+
+  input="$1"
+
+  if ! nix flake update "${input}"; then
+    cat <<EOF >&2
+${0}: Could not update input ${input} in directory ${PWD}!
+
+Please check the output for tips how to fix it.
+EOF
+    cleanup
+    return 82
+  fi
+
+  if git diff --quiet flake.lock; then
+    # Already up to date; nothing to do
+    return 0
+  fi
+
+  update_check_command=(nix flake check)
+  if ! "${update_check_command[@]}"; then
+    cat <<EOF >&2
+${0}: Flake check failed for updated input ${input} in directory ${PWD}; reverting!
+
+Make sure \`"${update_check_command[*]}"\` is working
+EOF
+    cleanup
+    return 83
+  fi
+
+  nix_build_command=(nix build --no-link --print-out-paths)
+
+  if raw_nixos_configurations="$(
+    nix eval --apply 'attrSet: builtins.toString (builtins.attrNames attrSet)' --raw \
+      .#.nixosConfigurations
+  )"; then
+    readarray -d ' ' -t nixos_configurations <<<"${raw_nixos_configurations}"
+    for nixos_configuration in "${nixos_configurations[@]}"; do
+      nix_build_command+=(".#.nixosConfigurations.${nixos_configuration%%$'\n'}.config.system.build.toplevel")
+    done
+  fi
+
+  machine_type="$(uname --machine)-linux"
+
+  if raw_dev_shell_names="$(
+    nix eval --apply 'attrSet: builtins.toString (builtins.attrNames attrSet)' --raw \
+      ".#.devShells.${machine_type}"
+  )"; then
+    readarray -d ' ' -t dev_shell_names <<<"${raw_dev_shell_names}"
+    for dev_shell_name in "${dev_shell_names[@]}"; do
+      nix_build_command+=(".#.devShells.${machine_type}.${dev_shell_name%%$'\n'}")
+    done
+  fi
+
+  if raw_package_names="$(
+    nix eval --apply 'attrSet: builtins.toString (builtins.attrNames attrSet)' --raw \
+      ".#.packages.${machine_type}"
+  )"; then
+    readarray -d ' ' -t package_names <<<"${raw_package_names}"
+    for package_name in "${package_names[@]}"; do
+      nix_build_command+=(".#.packages.${machine_type}.${package_name%%$'\n'}")
+    done
+  fi
+
+  if ! "${nix_build_command[@]}"; then
+    echo "${0}: Could not build after updating input ${input} in directory ${PWD}!"
+    cleanup
+    return 84
+  fi
+
+  if ! nix fmt; then
+    echo "$0: Formatting failed!" >&2
+    cleanup
+    return 85
+  fi
+
+  if ! git commit --message="build: Update Nix flake input '${input}'" --no-verify -- flake.lock; then
+    echo "$0: Committing failed!" >&2
+    cleanup
+    return 86
+  fi
+}
+
+for directory; do
+  cd "${directory}"
+
+  if ! git diff --quiet flake.lock; then
+    echo "$0: ${PWD}/flake.lock has changes; skipping!" >&2
+    exit_code=80
+    continue
+  fi
+
+  if ! git diff --cached --quiet; then
+    echo "$0: ${PWD} has staged changes; skipping!" >&2
+    exit_code=81
+    continue
+  fi
+
+  inputs_raw="$(nix flake metadata --json | jq --raw-output '.locks.nodes.root.inputs | keys[]')"
+  readarray -t inputs <<<"${inputs_raw}"
+
+  broken_inputs=()
+  for input in "${inputs[@]}"; do
+    # shellcheck disable=SC2310
+    if ! update_flake_input "${input}"; then
+      exit_code="$?"
+      broken_inputs+=("${input}")
+    fi
+  done
+
+  # Summarize at the end, to avoid mixing with the rest of the output
+  if ((${#broken_inputs[@]} != 0)); then
+    echo "Some flake inputs in ${PWD} can't be updated automatically:" >&2
+  fi
+  for broken_input in "${broken_inputs[@]}"; do
+    echo "- ${broken_input}" >&2
+  done
+done
+
+exit "${exit_code-0}"

--- a/tests/modules/services/update-flake-inputs/basic.nix
+++ b/tests/modules/services/update-flake-inputs/basic.nix
@@ -1,0 +1,14 @@
+{
+  services.update-flake-inputs = {
+    enable = true;
+    directories = [ "/some/path" ];
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/update-flake-inputs.service
+    normalizedServiceFile=$(normalizeStorePaths "$serviceFile")
+    assertFileContent $normalizedServiceFile ${./expected-basic.service}
+
+    assertFileContent home-files/.config/systemd/user/update-flake-inputs.timer ${./expected-basic.timer}
+  '';
+}

--- a/tests/modules/services/update-flake-inputs/default.nix
+++ b/tests/modules/services/update-flake-inputs/default.nix
@@ -1,0 +1,6 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  update-flake-inputs-basic = ./basic.nix;
+  update-flake-inputs-full = ./full.nix;
+}

--- a/tests/modules/services/update-flake-inputs/expected-basic.service
+++ b/tests/modules/services/update-flake-inputs/expected-basic.service
@@ -1,0 +1,12 @@
+[Service]
+ExecStart=/nix/store/00000000000000000000000000000000-update-flake-inputs/bin/update-flake-inputs /some/path
+
+Type=oneshot
+
+[Unit]
+After=network-online.target
+Description=Update Nix flake inputs
+Documentation=man:nix3-flake(1)
+Wants=network-online.target
+X-RestartIfChanged=false
+X-StopOnRemoval=false

--- a/tests/modules/services/update-flake-inputs/expected-basic.timer
+++ b/tests/modules/services/update-flake-inputs/expected-basic.timer
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=timers.target
+
+[Timer]
+FixedRandomDelay=false
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=0
+Unit=update-flake-inputs.service
+
+[Unit]
+Description=Update Nix flake inputs

--- a/tests/modules/services/update-flake-inputs/expected-full.service
+++ b/tests/modules/services/update-flake-inputs/expected-full.service
@@ -1,0 +1,12 @@
+[Service]
+ExecStart=/nix/store/00000000000000000000000000000000-update-flake-inputs/bin/update-flake-inputs '/some path' '/other path'
+
+Type=oneshot
+
+[Unit]
+After=network-online.target
+Description=Update Nix flake inputs
+Documentation=man:nix3-flake(1)
+Wants=network-online.target
+X-RestartIfChanged=false
+X-StopOnRemoval=false

--- a/tests/modules/services/update-flake-inputs/expected-full.timer
+++ b/tests/modules/services/update-flake-inputs/expected-full.timer
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=timers.target
+
+[Timer]
+FixedRandomDelay=true
+OnCalendar=04:00
+Persistent=false
+RandomizedDelaySec=45 minutes
+Unit=update-flake-inputs.service
+
+[Unit]
+Description=Update Nix flake inputs

--- a/tests/modules/services/update-flake-inputs/full.nix
+++ b/tests/modules/services/update-flake-inputs/full.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+{
+  services.update-flake-inputs = {
+    enable = true;
+    directories = [
+      "/some path"
+      "/other path"
+    ];
+    onCalendar = "04:00";
+    randomizedDelaySec = "45 minutes";
+    fixedRandomDelay = true;
+    persistent = false;
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/update-flake-inputs.service
+    normalizedServiceFile=$(normalizeStorePaths "$serviceFile")
+    assertFileContent $normalizedServiceFile ${./expected-full.service}
+
+    assertFileContent home-files/.config/systemd/user/update-flake-inputs.timer ${./expected-full.timer}
+  '';
+}


### PR DESCRIPTION
### Description

A user service which will run `nix flake update` on every flake input in
the specified directories, and commit/revert based on whether Nix checks
were successful.

1. Check that there are no changes to `flake.lock`. Otherwise it
   will skip the directory and set exit code 80.
2. Check that there are no staged changes to tracked files in the Git
   repository. Otherwise it will skip the directory and set exit code 81.
3. If everything is clean, it will do the following for each flake input:
   1. Update the input. If this fails, it will revert `flake.lock`,
      set exit code 82, and skip the input.
   2. Check whether `flake.lock` was actually changed. If not, it
      will skip the input as there's nothing to do.
   3. Run `nix flake check` to make sure the update passes the
      built-in checks in the repository. If this fails, it will revert
      `flake.lock`, set exit code 83, and skip the input.

      If you want to run a stricter check than the basic one you can set
      `systemd.user.services.update-flake-inputs.Service.Environment = ["NIX_ABORT_ON_WARN=true"]`
      or add custom checks.
   4. Build the flake outputs:

      - NixOS configurations
      - Dev shells for the current architecture
      - Packages for the current architecture

      If any of them fail, it will revert `flake.lock`, set exit
      code 84, and skip the input.
   5. Run the Nix formatter. If this fails, it will revert
      `flake.lock`, set exit code 85, and skip the input.
   6. Commit `flake.lock`. If this fails, it will, you guessed it,
      revert `flake.lock`, set exit code 86, and skip the input.

The script returns the last non-zero exit code, or zero if everything was
successful.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
