### PR TITLE
Add glow

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -344,6 +344,13 @@
     github = "miku4k";
     githubId = 89653242;
   };
+  m-vz = {
+    name = "milan";
+    github = "m-vz";
+    githubId = 4547497;
+    email = "milan@milan.wtf";
+    matrix = "@m-vz:matrix.org";
+  };
   mager = {
     email = "andreas@mager.eu";
     github = "AndreasMager";

--- a/modules/misc/news/2025/12/2025-12-18_23-11-03.nix
+++ b/modules/misc/news/2025/12/2025-12-18_23-11-03.nix
@@ -1,0 +1,9 @@
+{
+  time = "2025-12-18T22:11:03+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.glow'.
+
+    Glow is a CLI markdown renderer.
+  '';
+}

--- a/modules/programs/glow.nix
+++ b/modules/programs/glow.nix
@@ -1,0 +1,58 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.programs.glow;
+  yamlFormat = pkgs.formats.yaml { };
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+in
+{
+  meta.maintainers = [ maintainers.m-vz ];
+
+  options.programs.glow = {
+    enable = mkEnableOption "Glow, a terminal based markdown reader";
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          # style name or JSON path (default "auto")
+          style = "auto";
+          # mouse support (TUI-mode only)
+          mouse = false;
+          # use pager to display markdown
+          pager = false;
+          # word-wrap at width
+          width = 80;
+          # show all files, including hidden and ignored.
+          all = false;
+        }
+      '';
+      description = ''
+        Configuration written to `~/.config/glow/glow.yml` on Linux
+        or `~/Library/Preferences/glow/glow.yml` on Darwin.
+        See <https://github.com/charmbracelet/glow#the-config-file>
+        for supported values.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.glow ];
+
+    home.file."Library/Preferences/glow/glow.yml" = mkIf (cfg.settings != { } && isDarwin) {
+      source = yamlFormat.generate "glow.yml" cfg.settings;
+    };
+
+    xdg.configFile."glow/glow.yml" = mkIf (cfg.settings != { } && !isDarwin) {
+      source = yamlFormat.generate "glow.yml" cfg.settings;
+    };
+  };
+}

--- a/modules/programs/glow.nix
+++ b/modules/programs/glow.nix
@@ -13,7 +13,7 @@ let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
 in
 {
-  meta.maintainers = [ maintainers.m-vz ];
+  meta.maintainers = [ hm.maintainers.m-vz ];
 
   options.programs.glow = {
     enable = mkEnableOption "Glow, a terminal based markdown reader";

--- a/modules/programs/glow.nix
+++ b/modules/programs/glow.nix
@@ -5,23 +5,21 @@
   ...
 }:
 
-with lib;
-
 let
   cfg = config.programs.glow;
   yamlFormat = pkgs.formats.yaml { };
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
 in
 {
-  meta.maintainers = [ hm.maintainers.m-vz ];
+  meta.maintainers = [ lib.hm.maintainers.m-vz ];
 
   options.programs.glow = {
-    enable = mkEnableOption "Glow, a terminal based markdown reader";
+    enable = lib.mkEnableOption "Glow, a terminal based markdown reader";
 
-    settings = mkOption {
+    settings = lib.mkOption {
       type = yamlFormat.type;
       default = { };
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           # style name or JSON path (default "auto")
           style = "auto";
@@ -44,14 +42,14 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     home.packages = [ pkgs.glow ];
 
-    home.file."Library/Preferences/glow/glow.yml" = mkIf (cfg.settings != { } && isDarwin) {
+    home.file."Library/Preferences/glow/glow.yml" = lib.mkIf (cfg.settings != { } && isDarwin) {
       source = yamlFormat.generate "glow.yml" cfg.settings;
     };
 
-    xdg.configFile."glow/glow.yml" = mkIf (cfg.settings != { } && !isDarwin) {
+    xdg.configFile."glow/glow.yml" = lib.mkIf (cfg.settings != { } && !isDarwin) {
       source = yamlFormat.generate "glow.yml" cfg.settings;
     };
   };

--- a/tests/modules/programs/glow/custom-config.nix
+++ b/tests/modules/programs/glow/custom-config.nix
@@ -1,0 +1,28 @@
+{ pkgs, ... }:
+
+{
+  config = {
+    programs.glow = {
+      enable = true;
+      settings = {
+        style = "auto";
+        mouse = false;
+        width = 80;
+      };
+    };
+
+    nmt.script =
+      let
+        inherit (pkgs.stdenv.hostPlatform) isDarwin;
+        configPath =
+          if isDarwin then
+            "home-files/Library/Preferences/glow/glow.yml"
+          else
+            "home-files/.config/glow/glow.yml";
+      in
+      ''
+        assertFileExists ${configPath}
+        assertFileContent ${configPath} ${./expected-config.yml}
+      '';
+  };
+}

--- a/tests/modules/programs/glow/default.nix
+++ b/tests/modules/programs/glow/default.nix
@@ -1,0 +1,1 @@
+{ glow-custom-config = ./custom-config.nix; }

--- a/tests/modules/programs/glow/expected-config.yml
+++ b/tests/modules/programs/glow/expected-config.yml
@@ -1,0 +1,3 @@
+mouse: false
+style: auto
+width: 80


### PR DESCRIPTION
### Description

Add Glow, a terminal-based markdown reader.
As this is my first contribution to home-manager, feel free to correct me on any mistakes I made.
This supercedes and closes https://github.com/nix-community/home-manager/pull/2332.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)
