### PR TITLE
television: fix keybindings

### DIFF
--- a/modules/programs/television.nix
+++ b/modules/programs/television.nix
@@ -106,13 +106,13 @@ in
     ];
 
     programs.bash.initExtra = lib.mkIf cfg.enableBashIntegration ''
-      eval "$(${lib.getExe cfg.package} init bash)"
+      source ${cfg.package}/share/television/completion.bash
     '';
     programs.zsh.initContent = lib.mkIf cfg.enableZshIntegration ''
-      eval "$(${lib.getExe cfg.package} init zsh)"
+      source ${cfg.package}/share/television/completion.zsh
     '';
     programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
-      ${lib.getExe cfg.package} init fish | source
+      source ${cfg.package}/share/television/completion.fish
     '';
   };
 }


### PR DESCRIPTION
### Description

This is in sync with https://github.com/NixOS/nixpkgs/pull/472586, which swapped the use of completion files and generated completions.

The keybindings are already broken as a result of https://github.com/NixOS/nixpkgs/pull/467061, however, even before this change, we didn't do it correctly. The keybindings are only in completion files, not in generated completions.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
