### PR TITLE
ssh-agent: add forceOverride option to override system SSH_AUTH_SOCK

### DIFF
--- a/modules/misc/news/2025/12/2025-12-23_11-10-24.nix
+++ b/modules/misc/news/2025/12/2025-12-23_11-10-24.nix
@@ -1,0 +1,16 @@
+{ config, pkgs, ... }:
+
+{
+  time = "2025-12-23T11:10:24+00:00";
+  condition = config.services.ssh-agent.enable && pkgs.stdenv.hostPlatform.isDarwin;
+  message = ''
+    A new option 'services.ssh-agent.forceOverride' has been added. When
+    enabled, this option unconditionally sets the 'SSH_AUTH_SOCK' environment
+    variable, overriding any existing value.
+
+    This is particularly useful on macOS where the system's ssh-agent sets
+    'SSH_AUTH_SOCK' by default, preventing Home Manager's ssh-agent from being
+    used. On macOS, 'forceOverride' defaults to 'true'; on Linux it defaults to
+    'false' to preserve the previous behavior.
+  '';
+}

--- a/tests/modules/services/ssh-agent/darwin/bash-integration-no-override.nix
+++ b/tests/modules/services/ssh-agent/darwin/bash-integration-no-override.nix
@@ -1,0 +1,15 @@
+{
+  services.ssh-agent = {
+    enable = true;
+    enableBashIntegration = true;
+    forceOverride = false;
+  };
+
+  programs.bash.enable = true;
+
+  nmt.script = ''
+    assertFileContains \
+      home-files/.profile \
+      'if [ -z "$SSH_AUTH_SOCK" ]; then'
+  '';
+}

--- a/tests/modules/services/ssh-agent/darwin/default.nix
+++ b/tests/modules/services/ssh-agent/darwin/default.nix
@@ -2,5 +2,7 @@
   ssh-agent-darwin-basic-service = ./basic-service.nix;
   ssh-agent-darwin-timeout-service = ./timeout-service.nix;
   ssh-agent-darwin-bash-integration = ./bash-integration.nix;
+  ssh-agent-darwin-bash-integration-no-override = ./bash-integration-no-override.nix;
   ssh-agent-darwin-nushell-integration = ./nushell-integration.nix;
+  ssh-agent-darwin-nushell-integration-no-override = ./nushell-integration-no-override.nix;
 }

--- a/tests/modules/services/ssh-agent/darwin/nushell-integration-no-override.nix
+++ b/tests/modules/services/ssh-agent/darwin/nushell-integration-no-override.nix
@@ -1,0 +1,15 @@
+{
+  services.ssh-agent = {
+    enable = true;
+    enableNushellIntegration = true;
+    forceOverride = false;
+  };
+
+  programs.nushell.enable = true;
+
+  nmt.script = ''
+    assertFileContains \
+      home-files/.config/nushell/config.nu \
+      'if "SSH_AUTH_SOCK" not-in $env {'
+  '';
+}

--- a/tests/modules/services/ssh-agent/linux/bash-integration-override.nix
+++ b/tests/modules/services/ssh-agent/linux/bash-integration-override.nix
@@ -1,0 +1,18 @@
+{
+  services.ssh-agent = {
+    enable = true;
+    enableBashIntegration = true;
+    forceOverride = true;
+  };
+
+  programs.bash.enable = true;
+
+  nmt.script = ''
+    assertFileContains \
+      home-files/.profile \
+      'export SSH_AUTH_SOCK=$XDG_RUNTIME_DIR/ssh-agent'
+    assertFileNotRegex \
+      home-files/.profile \
+      'if \[ -z "\$SSH_AUTH_SOCK" \]'
+  '';
+}

--- a/tests/modules/services/ssh-agent/linux/default.nix
+++ b/tests/modules/services/ssh-agent/linux/default.nix
@@ -1,4 +1,6 @@
 {
   ssh-agent-basic-service = ./basic-service.nix;
   ssh-agent-timeout-service = ./timeout-service.nix;
+  ssh-agent-bash-integration-override = ./bash-integration-override.nix;
+  ssh-agent-nushell-integration-override = ./nushell-integration-override.nix;
 }

--- a/tests/modules/services/ssh-agent/linux/nushell-integration-override.nix
+++ b/tests/modules/services/ssh-agent/linux/nushell-integration-override.nix
@@ -1,0 +1,18 @@
+{
+  services.ssh-agent = {
+    enable = true;
+    enableNushellIntegration = true;
+    forceOverride = true;
+  };
+
+  programs.nushell.enable = true;
+
+  nmt.script = ''
+    assertFileContains \
+      home-files/.config/nushell/config.nu \
+      '$env.SSH_AUTH_SOCK = $"($env.XDG_RUNTIME_DIR)/ssh-agent"'
+    assertFileNotRegex \
+      home-files/.config/nushell/config.nu \
+      'if "SSH_AUTH_SOCK" not-in \$env \{'
+  '';
+}


### PR DESCRIPTION
### Description

On macOS, the system ssh-agent sets SSH_AUTH_SOCK by default, which prevents Home Manager's ssh-agent from being used. This adds a forceOverride option (default true on macOS, false on Linux) that unconditionally sets SSH_AUTH_SOCK to override system settings.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
