### PR TITLE
error: attribute 'genAttrs'' missing fix

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -291,33 +291,30 @@ in
         };
       };
     }
-    // (lib.genAttrs [ "qt5ct" "qt6ct" ] (
-      name:
-      lib.nameValuePair "${name}Settings" (
-        lib.mkOption {
-          type = lib.types.nullOr qtctFormat.type;
-          default = null;
-          example = lib.literalExpression ''
-            {
-              Appearance = {
-                style = "kvantum";
-                icon_theme = "Papirus-Dark";
-                standar_dialogs = "xdgdesktopportal";
-              };
-              Fonts = {
-                fixed = "\"DejaVuSansM Nerd Font Mono,12\"";
-                general = "\"DejaVu Sans,12\"";
-              };
-            }
-          '';
-          description = ''
-            Qtct configuration. Writes settings to `${name}/${name}.conf`
-            file. Lists will be translated to comma-separated strings.
-            Fonts must be quoted (see example).
-          '';
-        }
-      )
-    ));
+   // (lib.listToAttrs (map (name: lib.nameValuePair "${name}Settings" (
+      lib.mkOption {
+        type = lib.types.nullOr qtctFormat.type;
+        default = null;
+        example = lib.literalExpression ''
+          {
+            Appearance = {
+              style = "kvantum";
+              icon_theme = "Papirus-Dark";
+              standar_dialogs = "xdgdesktopportal";
+            };
+            Fonts = {
+              fixed = "\"DejaVuSansM Nerd Font Mono,12\"";
+              general = "\"DejaVu Sans,12\"";
+            };
+          }
+        '';
+        description = ''
+          Qtct configuration. Writes settings to `${name}/${name}.conf`
+          file. Lists will be translated to comma-separated strings.
+          Fonts must be quoted (see example).
+        '';
+      }
+    )) [ "qt5ct" "qt6ct" ]));
   };
 
   config =


### PR DESCRIPTION
### Description

Fix this error:
error: attribute 'genAttrs'' missing                                                                                                                   
       at /nix/store/9nnysjdjnjwn8ibzz69ixbgw5rr40rjf-source/modules/misc/qt.nix:294:9:                                                                       
          293|     }                                                                                                                                          
          294|     // (lib.genAttrs' [ "qt5ct" "qt6ct" ] (                                                                                                    
             |         ^                                                                                                                                      
          295|       name:                                                                                                                                    
       Did you mean one of genAttrs or getAttrs?     