### PR TITLE
nixGL: patch systemd and d-bus services references

### DIFF
--- a/modules/targets/generic-linux/nixgl.nix
+++ b/modules/targets/generic-linux/nixgl.nix
@@ -274,6 +274,26 @@ in
                   sed "s|${pkg.out}|$out|g" "$src" > "$dsk"
                 done
 
+                # Patch systemd user services
+                for svc in "$out/share/systemd/user"/*.service ; do
+                  if ! grep -q "${pkg.out}" "$svc"; then
+                    continue
+                  fi
+                  src="$(readlink "$svc")"
+                  rm "$svc"
+                  sed "s|${pkg.out}|$out|g" "$src" > "$svc"
+                done
+
+                # Patch DBus services
+                for svc in "$out/share/dbus-1/services"/*.service ; do
+                  if ! grep -q "${pkg.out}" "$svc"; then
+                    continue
+                  fi
+                  src="$(readlink "$svc")"
+                  rm "$svc"
+                  sed "s|${pkg.out}|$out|g" "$src" > "$svc"
+                done
+
                 shopt -u nullglob # Revert nullglob back to its normal default state
               '';
           }))


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Fix #8395 
Add package reference patches for dbus and systemd services when wrapping with nixgl

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
