### PR TITLE
sway: fix keybindings on different keyboard layouts

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -40,7 +40,6 @@ let
         workspaceLayout
         workspaceAutoBackAndForth
         modifier
-        keycodebindings
         colors
         bars
         startup
@@ -114,28 +113,6 @@ let
           "${cfg.config.modifier}+Shift+space" = "floating toggle";
           "${cfg.config.modifier}+space" = "focus mode_toggle";
 
-          "${cfg.config.modifier}+1" = "workspace number 1";
-          "${cfg.config.modifier}+2" = "workspace number 2";
-          "${cfg.config.modifier}+3" = "workspace number 3";
-          "${cfg.config.modifier}+4" = "workspace number 4";
-          "${cfg.config.modifier}+5" = "workspace number 5";
-          "${cfg.config.modifier}+6" = "workspace number 6";
-          "${cfg.config.modifier}+7" = "workspace number 7";
-          "${cfg.config.modifier}+8" = "workspace number 8";
-          "${cfg.config.modifier}+9" = "workspace number 9";
-          "${cfg.config.modifier}+0" = "workspace number 10";
-
-          "${cfg.config.modifier}+Shift+1" = "move container to workspace number 1";
-          "${cfg.config.modifier}+Shift+2" = "move container to workspace number 2";
-          "${cfg.config.modifier}+Shift+3" = "move container to workspace number 3";
-          "${cfg.config.modifier}+Shift+4" = "move container to workspace number 4";
-          "${cfg.config.modifier}+Shift+5" = "move container to workspace number 5";
-          "${cfg.config.modifier}+Shift+6" = "move container to workspace number 6";
-          "${cfg.config.modifier}+Shift+7" = "move container to workspace number 7";
-          "${cfg.config.modifier}+Shift+8" = "move container to workspace number 8";
-          "${cfg.config.modifier}+Shift+9" = "move container to workspace number 9";
-          "${cfg.config.modifier}+Shift+0" = "move container to workspace number 10";
-
           "${cfg.config.modifier}+Shift+minus" = "move scratchpad";
           "${cfg.config.modifier}+minus" = "scratchpad show";
 
@@ -160,6 +137,50 @@ let
             "''${modifier}+Return" = "exec ''${cfg.config.terminal}";
             "''${modifier}+Shift+q" = "kill";
             "''${modifier}+d" = "exec ''${cfg.config.menu}";
+          }
+        '';
+      };
+
+      keycodebindings = mkOption {
+        type = types.attrsOf (types.nullOr types.str);
+        default = {
+          "${cfg.config.modifier}+10" = "workspace number 1";
+          "${cfg.config.modifier}+11" = "workspace number 2";
+          "${cfg.config.modifier}+12" = "workspace number 3";
+          "${cfg.config.modifier}+13" = "workspace number 4";
+          "${cfg.config.modifier}+14" = "workspace number 5";
+          "${cfg.config.modifier}+15" = "workspace number 6";
+          "${cfg.config.modifier}+16" = "workspace number 7";
+          "${cfg.config.modifier}+17" = "workspace number 8";
+          "${cfg.config.modifier}+18" = "workspace number 9";
+          "${cfg.config.modifier}+19" = "workspace number 0";
+
+          "${cfg.config.modifier}+Shift+10" = "move container to workspace number 1";
+          "${cfg.config.modifier}+Shift+11" = "move container to workspace number 2";
+          "${cfg.config.modifier}+Shift+12" = "move container to workspace number 3";
+          "${cfg.config.modifier}+Shift+13" = "move container to workspace number 4";
+          "${cfg.config.modifier}+Shift+14" = "move container to workspace number 5";
+          "${cfg.config.modifier}+Shift+15" = "move container to workspace number 6";
+          "${cfg.config.modifier}+Shift+16" = "move container to workspace number 7";
+          "${cfg.config.modifier}+Shift+17" = "move container to workspace number 8";
+          "${cfg.config.modifier}+Shift+18" = "move container to workspace number 9";
+          "${cfg.config.modifier}+Shift+19" = "move container to workspace number 0";
+        };
+        defaultText = "Default sway keycodebindings.";
+        description = ''
+          An attribute set that assigns a key press to an action using a key code.
+          See <https://i3wm.org/docs/userguide.html#keybindings>.
+
+          Consider to use `lib.mkOptionDefault` function to extend or override
+          default keybindings instead of specifying all of them from scratch.
+        '';
+        example = lib.literalExpression ''
+          let
+            modifier = config.wayland.windowManager.sway.config.modifier;
+          in lib.mkOptionDefault {
+            "''${modifier}+10" = "workspace number 1";
+            "''${modifier}+11" = "workspace number 2";
+            "''${modifier}+12" = "workspace number 3";
           }
         '';
       };


### PR DESCRIPTION
### Description

As said in the issue, I've moved the workspace-related keybindings definitions from using `bindsym` to `bindcode` so they work on all layouts.

Fixes #8401 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
