### PR TITLE
easyeffects: Fix race condition on Wayland session startup

### DIFF
--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -117,6 +117,8 @@ in
     systemd.user.services.easyeffects = {
       Unit = {
         Description = "Easyeffects daemon";
+        After = [ "graphical-session.target" ];
+        PartOf = [ "graphical-session.target" ];
       };
 
       Install.WantedBy = [ "graphical-session.target" ];


### PR DESCRIPTION
### Description

Add systemd service ordering dependencies to prevent EasyEffects from starting before the Wayland compositor is ready.

EasyEffects would crash during login with "Failed to create wl_display (No such file or directory)" if started before the Wayland display server was fully initialized.

Declaring the "After" property ensures EasyEffects waits for the graphical session to be fully ready. The "PartOf" properly stops EasyEffects when logging out. Got the tip from https://github.com/wwmm/easyeffects/issues/1310.

Tested on NixOS 25.11 (Xantusia, 20251223.76701a1) and Home Manager 25.11 (0999ed8) with GNOME 49 on Wayland.

<details>
<summary>Logs showing the crash</summary>

```shell
$ journalctl --user --boot=0
Dec 27 11:49:19 kurisu easyeffects[3578]: Failed to create wl_display (No such file or directory)
...
Dec 27 11:49:19 kurisu easyeffects[3578]: Could not load the Qt platform plugin "wayland" in "" even though it was found.
Dec 27 11:49:19 kurisu easyeffects[3578]: This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
                                          
                                          Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vkkhrdisplay, vnc, wayland-brcm, wayland-egl, wayland, xcb.
...
Dec 27 11:49:19 kurisu systemd-coredump[3695]: [🡕] Process 3578 (.easyeffects-wr) of user 1000 dumped core.
                                               
                                               Module libtbbmalloc.so.2 without build-id.
                                               Module libunistring.so.5 without build-id.
                                               Module libselinux.so.1 without build-id.
                                               Module libpsl.so.5 without build-id.
                                               Module libssh2.so.1 without build-id.
                                               Module libidn2.so.0 without build-id.
                                               Module libnghttp2.so.14 without build-id.
                                               Module libngtcp2.so.16 without build-id.
                                               Module libngtcp2_crypto_ossl.so.0 without build-id.
                                               Module libnghttp3.so.9 without build-id.
                                               Module libduktape.so.207 without build-id.
                                               Module libXdmcp.so.6 without build-id.
                                               Module libXau.so.6 without build-id.
                                               Module libabsl_throw_delegate.so.2508.0.0 without build-id.
                                               Module libabsl_string_view.so.2508.0.0 without build-id.
                                               Module libabsl_int128.so.2508.0.0 without build-id.
                                               Module libabsl_strings_internal.so.2508.0.0 without build-id.
                                               Module libgomp.so.1 without build-id.
                                               Module libgraphite2.so.3 without build-id.
                                               Module libexpat.so.1 without build-id.
                                               Module libpcre2-8.so.0 without build-id.
                                               Module libffi.so.8 without build-id.
                                               Module libpxbackend-1.0.so without build-id.
                                               Module libbrotlicommon.so.1 without build-id.
                                               Module libkeyutils.so.1 without build-id.
                                               Module libkrb5support.so.0 without build-id.
                                               Module libcom_err.so.3 without build-id.
                                               Module libk5crypto.so.3 without build-id.
                                               Module libkrb5.so.3 without build-id.
                                               Module libxcb.so.1 without build-id.
                                               Module liblzma.so.5 without build-id.
                                               Module libbz2.so.1 without build-id.
                                               Module libcap.so.2 without build-id.
                                               Module libabsl_strings.so.2508.0.0 without build-id.
                                               Module libmp3lame.so.0 without build-id.
                                               Module libmpg123.so.0 without build-id.
                                               Module libogg.so.0 without build-id.
                                               Module libopus.so.0 without build-id.
                                               Module libvorbisenc.so.2 without build-id.
                                               Module libvorbis.so.0 without build-id.
                                               Module libFLAC.so.14 without build-id.
                                               Module libzix-0.so.0 without build-id.
                                               Module libsratom-0.so.0 without build-id.
                                               Module libsord-0.so.0 without build-id.
                                               Module libserd-0.so.0 without build-id.
                                               Module libGLdispatch.so.0 without build-id.
                                               Module libXext.so.6 without build-id.
                                               Module libpcre2-16.so.0 without build-id.
                                               Module libb2.so.1 without build-id.
                                               Module libdouble-conversion.so.3 without build-id.
                                               Module libicudata.so.76 without build-id.
                                               Module libicuuc.so.76 without build-id.
                                               Module libicui18n.so.76 without build-id.
                                               Module libfreetype.so.6 without build-id.
                                               Module libmd4c.so.0 without build-id.
                                               Module libharfbuzz.so.0 without build-id.
                                               Module libpng16.so.16 without build-id.
                                               Module libX11.so.6 without build-id.
                                               Module libfontconfig.so.1 without build-id.
                                               Module libEGL.so.1 without build-id.
                                               Module libvulkan.so without build-id.
                                               Module libproxy.so.1 without build-id.
                                               Module libzstd.so.1 without build-id.
                                               Module libbrotlidec.so.1 without build-id.
                                               Module libgssapi_krb5.so.2 without build-id.
                                               Module libz.so.1 without build-id.
                                               Module libxkbcommon.so.0 without build-id.
                                               Module libgcc_s.so.1 without build-id.
                                               Module libstdc++.so.6 without build-id.
                                               Module librnnoise.so.0 without build-id.
                                               Module libmysofa.so.1 without build-id.
                                               Module libabsl_spinlock_wait.so.2508.0.0 without build-id.
                                               Module libabsl_log_severity.so.2508.0.0 without build-id.
                                               Module libabsl_raw_logging_internal.so.2508.0.0 without build-id.
                                               Module libabsl_base.so.2508.0.0 without build-id.
                                               Module libwebrtc-audio-processing-2.so.1 without build-id.
                                               Module libSoundTouch.so.1 without build-id.
                                               Module libsndfile.so.1 without build-id.
                                               Module libbs2b.so.0 without build-id.
                                               Module libspeexdsp.so.1 without build-id.
                                               Module libfftw3f.so.3 without build-id.
                                               Module libfftw3.so.3 without build-id.
                                               Module libebur128.so.1 without build-id.
                                               Module liblilv-0.so.0 without build-id.
                                               Module libpipewire-0.3.so.0 without build-id.
                                               Module libOpenGL.so.0 without build-id.
                                               Module libGLX.so.0 without build-id.
                                               Module libzita-convolver.so.4 without build-id.
                                               Module libgslcblas.so.0 without build-id.
                                               Module libgsl.so.28 without build-id.
                                               Module libtbb.so.12 without build-id.
                                               Stack trace of thread 3578:
                                               #0  0x00007f339b69caac __pthread_kill_implementation (libc.so.6 + 0x9caac)
                                               #1  0x00007f339b64190e raise (libc.so.6 + 0x4190e)
                                               #2  0x00007f339b628942 abort (libc.so.6 + 0x28942)
                                               #3  0x00007f339c6d652b _Z6qAbortv (libQt6Core.so.6 + 0xd652b)
                                               #4  0x00007f339c72d629 _ZL10qt_message9QtMsgTypeRK18QMessageLogContextPKcP13__va_list_tag (libQt6Core.so.6 + 0x12d629)
                                               #5  0x00007f339c6d7d65 _ZNK14QMessageLogger5fatalEPKcz (libQt6Core.so.6 + 0xd7d65)
                                               #6  0x00007f339cf4775a _ZL13init_platformRK7QStringS1_S1_RiPPc.cold (libQt6Gui.so.6 + 0x14775a)
                                               #7  0x00007f339d000935 _ZN22QGuiApplicationPrivate25createPlatformIntegrationEv (libQt6Gui.so.6 + 0x200935)
                                               #8  0x00007f339d001478 _ZN22QGuiApplicationPrivate21createEventDispatcherEv (libQt6Gui.so.6 + 0x201478)
                                               #9  0x00007f339c7c41e5 _ZN23QCoreApplicationPrivate4initEv (libQt6Core.so.6 + 0x1c41e5)
                                               #10 0x00007f339d004d4d _ZN22QGuiApplicationPrivate4initEv (libQt6Gui.so.6 + 0x204d4d)
                                               #11 0x00007f33a0baac05 _ZN19QApplicationPrivate4initEv (libQt6Widgets.so.6 + 0x1aac05)
                                               #12 0x00005602ba55381d main (/nix/store/mmwgaw4f0m46nj1pzz0rbjhnmqmx5gn0-easyeffects-8.0.8/bin/.easyeffects-wrapped + 0x15681d)
                                               #13 0x00007f339b62a4d8 __libc_start_call_main (libc.so.6 + 0x2a4d8)
                                               #14 0x00007f339b62a59b __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x2a59b)
                                               #15 0x00005602ba562ba5 _start (/nix/store/mmwgaw4f0m46nj1pzz0rbjhnmqmx5gn0-easyeffects-8.0.8/bin/.easyeffects-wrapped + 0x165ba5)
                                               
                                               Stack trace of thread 3680:
                                               #0  0x00007f339b714a10 ppoll (libc.so.6 + 0x114a10)
                                               #1  0x00007f3399704f68 g_main_context_iterate_unlocked.isra.0 (libglib-2.0.so.0 + 0x65f68)
                                               #2  0x00007f339970570f g_main_context_iteration (libglib-2.0.so.0 + 0x6670f)
                                               #3  0x00007f339caf9833 _ZN20QEventDispatcherGlib13processEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE (libQt6Core.so.6 + 0x4f9833)
                                               #4  0x00007f339c7caaf3 _ZN10QEventLoop4execE6QFlagsINS_17ProcessEventsFlagEE (libQt6Core.so.6 + 0x1caaf3)
                                               #5  0x00007f339c8f5f29 _ZN7QThread4execEv (libQt6Core.so.6 + 0x2f5f29)
                                               #6  0x00007f339fd61541 _ZN22QDBusConnectionManager3runEv (libQt6DBus.so.6 + 0x45541)
                                               #7  0x00007f339c9a72dc _ZN14QThreadPrivate5startEPv (libQt6Core.so.6 + 0x3a72dc)
                                               #8  0x00007f339b69a97a start_thread (libc.so.6 + 0x9a97a)
                                               #9  0x00007f339b722d2c __clone3 (libc.so.6 + 0x122d2c)
                                               ELF object binary architecture: AMD x86-64
Dec 27 11:49:19 kurisu systemd[3457]: easyeffects.service: Main process exited, code=dumped, status=6/ABRT
Dec 27 11:49:19 kurisu systemd[3457]: easyeffects.service: Failed with result 'core-dump'.
Dec 27 11:49:19 kurisu systemd[3457]: easyeffects.service: Consumed 55ms CPU time, 137.5M memory peak.
...
Dec 27 11:49:20 kurisu gnome-shell[3622]: Using Wayland display name 'wayland-0'
```
</details>

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
