### PR TITLE
meli: support account specific settings

### DIFF
--- a/modules/programs/meli.nix
+++ b/modules/programs/meli.nix
@@ -24,7 +24,8 @@ let
   meliAccounts = (lib.attrsets.mapAttrs (name: value: (mkMeliAccounts name value)) enabledAccounts);
 
   mkMeliAccounts = (
-    name: account: {
+    name: account:
+    {
       root_mailbox = "${config.accounts.email.maildirBasePath}/${account.maildir.path}";
       format = "Maildir";
       identity = account.address;
@@ -33,6 +34,7 @@ let
       send_mail = mkSmtp account;
       mailboxes = account.meli.mailboxAliases;
     }
+    // account.meli.settings
   );
 
   mkSmtp = account: {
@@ -153,6 +155,14 @@ in
                 };
                 description = "Folder display name";
               };
+
+              settings = mkOption {
+                type = types.submodule {
+                  freeformType = tomlFormat.type;
+                };
+                default = { };
+                description = "Account specific meli configuration";
+              };
             };
           }
         )
@@ -160,6 +170,15 @@ in
     };
   };
   config = mkIf config.programs.meli.enable {
+    assertions = [
+      {
+        assertion = cfg.settings ? accounts == false;
+        message = ''
+          programs.meli.settings.accounts override the accounts.email values.
+                      Use per-email accounts.email.<ACCOUNT>.meli.settings instead'';
+      }
+    ];
+
     home.packages = [ config.programs.meli.package ];
 
     # Generate meli configuration from email accounts

--- a/tests/modules/programs/meli/expected.toml
+++ b/tests/modules/programs/meli/expected.toml
@@ -5,6 +5,9 @@ identity = "hm@example.com"
 root_mailbox = "/home/hm-user/Mail/hm@example.com"
 subscribed_mailboxes = ["Inbox", "Sent", "Trash", "Drafts"]
 
+[accounts."hm@example.com".listing]
+index_style = "compact"
+
 [accounts."hm@example.com".mailboxes]
 
 [accounts."hm@example.com".send_mail]

--- a/tests/modules/programs/meli/meli.nix
+++ b/tests/modules/programs/meli/meli.nix
@@ -16,7 +16,12 @@
   };
   accounts.email.accounts = {
     "hm@example.com" = {
-      meli.enable = true;
+      meli = {
+        enable = true;
+        settings = {
+          listing.index_style = "compact";
+        };
+      };
       smtp.port = 1848;
     };
   };


### PR DESCRIPTION

### Description

also assert when overriding accounts. I had overriden settings when testing this module, forgot about it and then wondered why my email accounts were ignored.

If you have set `programs.meli.settings.accounts`, then this will trigger an error so not backwards compatible but that's not a setting you should use anyway so it's not a problem. You can adjust your config by moving per-account overrides to accounts.email.<account>.meli.settings instead.

I will open a PR to support jmap next.

### Checklist



- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
