### PR TITLE
meli: support jmap

### DIFF
--- a/modules/programs/meli.nix
+++ b/modules/programs/meli.nix
@@ -34,6 +34,13 @@ let
       send_mail = mkSmtp account;
       mailboxes = account.meli.mailboxAliases;
     }
+    // lib.optionalAttrs (account.flavor == "fastmail.com") {
+      server_username = account.userName;
+      server_password_command = lib.concatMapStringsSep " " lib.escapeShellArg account.passwordCommand;
+      format = "jmap";
+      server_url = "https://api.fastmail.com/jmap/session";
+      use_token = true;
+    }
     // account.meli.settings
   );
 


### PR DESCRIPTION

### Description

Enabled when flavor == fastmail.com
Right now I have an authentification error but my fork used to work so I might wait a bit before merging to confirm where the issue comes from.
If anyone can confirm this works before I do, I'll merge

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
