### PR TITLE
syncthing: more reliable syncthing launchd agent

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -840,6 +840,8 @@ in
               SuccessfulExit = false;
             };
             ProcessType = "Background";
+            StandardOutPath = "${config.home.homeDirectory}/Library/Logs/Syncthing/syncthing-stdout.log";
+            StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/Syncthing/syncthing-stderr.log";
           };
         };
 
@@ -849,6 +851,8 @@ in
             ProgramArguments = [ "${updateConfig}" ];
             ProcessType = "Background";
             RunAtLoad = true;
+            StandardOutPath = "${config.home.homeDirectory}/Library/Logs/Syncthing/syncthing-init-stdout.log";
+            StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/Syncthing/syncthing-init-stderr.log";
           };
         };
       };

--- a/tests/modules/services/syncthing/expected-agent.plist
+++ b/tests/modules/services/syncthing/expected-agent.plist
@@ -17,5 +17,9 @@
 	<array>
 		<string>@syncthing-wrapper@</string>
 	</array>
+	<key>StandardErrorPath</key>
+	<string>/home/hm-user/Library/Logs/Syncthing/syncthing-stderr.log</string>
+	<key>StandardOutPath</key>
+	<string>/home/hm-user/Library/Logs/Syncthing/syncthing-stdout.log</string>
 </dict>
 </plist>


### PR DESCRIPTION
### Description

This PR fixes #6542 (unreliability of synching's configuration updates under macOS). It starts the `syncthing-init` launchd agent (responsible for updating the configuration) as a oneshot agent instead of via `WatchPaths` (the latter is too unreliable).

Ideally, the `syncthing-init` agent should be started **after** the `syncthing` agent started the Syncthing server, since `syncthing-init` updates the configuration using API calls to the Syncthing server. The Linux systemd service versions handle this via the `Requires` and `After` attribute. Launchd under macOS is missing a reliable way to order agents. Theoretically, one can achieve similar things via, e.g., `WatchPaths` (used before this commit). But this is known to be very unreliable (see also [my comment](https://github.com/nix-community/home-manager/issues/6542#issuecomment-2845064207) in issue #6542). Thus, we just start `syncthing-init` and rely on the wrapped curl bash function (see `curlShellFunction` in nix file) to wait for the Syncthing server to be up and running.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.