### PR TITLE
nix: add `assumeXdg` option

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -618,7 +618,7 @@ in
     home.profileDirectory =
       if config.submoduleSupport.enable && config.submoduleSupport.externalPackageInstall then
         "/etc/profiles/per-user/${cfg.username}"
-      else if config.nix.enable && (config.nix.settings.use-xdg-base-directories or false) then
+      else if config.nix.useXdg then
         "${config.xdg.stateHome}/nix/profile"
       else
         cfg.homeDirectory + "/.nix-profile";

--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -112,7 +112,7 @@ in
       in
       {
         NIX_PATH =
-          if config.nix.enable && (config.nix.settings.use-xdg-base-directories or false) then
+          if config.nix.useXdg then
             "${config.xdg.stateHome}/nix/defexpr/channels\${NIX_PATH:+:}$NIX_PATH"
           else
             "$HOME/.nix-defexpr/channels\${NIX_PATH:+:}$NIX_PATH";

--- a/tests/modules/misc/nix/default.nix
+++ b/tests/modules/misc/nix/default.nix
@@ -5,4 +5,5 @@
   nix-keep-old-nix-path = ./keep-old-nix-path.nix;
   nix-example-channels = ./example-channels.nix;
   nix-example-channels-xdg = ./example-channels-xdg.nix;
+  nix-use-xdg = ./use-xdg.nix;
 }

--- a/tests/modules/misc/nix/use-xdg.nix
+++ b/tests/modules/misc/nix/use-xdg.nix
@@ -1,0 +1,92 @@
+{ lib, pkgs, ... }:
+let
+  nixosLib = import /${pkgs.path}/nixos/lib { inherit lib; };
+  getUseXdg =
+    osNix: userNix:
+    (nixosLib.evalTest {
+      hostPkgs = pkgs;
+      nodes.machine.imports = [
+        ../../../../nixos
+        {
+          nix = osNix;
+          home-manager.users.user = {
+            home.stateVersion = "26.05";
+            nix = userNix;
+          };
+        }
+      ];
+    }).config.nodes.machine.home-manager.users.user.nix.useXdg;
+in
+{
+  nmt.script =
+    # Defaults to false
+    assert !getUseXdg { } { };
+
+    # Test OS config
+    assert !getUseXdg { enable = true; } { };
+    assert
+      !getUseXdg {
+        enable = false;
+        settings.use-xdg-base-directories = true;
+      } { };
+    assert getUseXdg {
+      enable = true;
+      settings.use-xdg-base-directories = true;
+    } { };
+
+    # Test user config
+    assert !getUseXdg { } { enable = true; };
+    assert
+      !getUseXdg { } {
+        enable = false;
+        settings.use-xdg-base-directories = true;
+      };
+    assert getUseXdg { } {
+      enable = true;
+      settings.use-xdg-base-directories = true;
+    };
+
+    # Fallback to OS config if user config is unset
+    assert getUseXdg
+      {
+        enable = true;
+        settings.use-xdg-base-directories = true;
+      }
+      {
+        enable = true;
+      };
+
+    # But user config takes precedence
+    assert
+      !getUseXdg
+        {
+          enable = true;
+          settings.use-xdg-base-directories = true;
+        }
+        {
+          enable = true;
+          settings.use-xdg-base-directories = false;
+        };
+    assert getUseXdg
+      {
+        enable = true;
+        settings.use-xdg-base-directories = false;
+      }
+      {
+        enable = true;
+        settings.use-xdg-base-directories = true;
+      };
+
+    # assumeXdg also takes precedence
+    assert getUseXdg { } { assumeXdg = true; };
+    assert getUseXdg
+      {
+        enable = true;
+        settings.use-xdg-base-directories = false;
+      }
+      {
+        enable = false;
+        assumeXdg = true;
+      };
+    "";
+}

--- a/tests/modules/targets-linux/default.nix
+++ b/tests/modules/targets-linux/default.nix
@@ -3,4 +3,5 @@
   targets-generic-linux-gpu-basic = ./generic-linux-gpu/basic-enable.nix;
   targets-generic-linux-gpu-setup-contents = ./generic-linux-gpu/setup-package-contents.nix;
   targets-generic-linux-gpu-nvidia = ./generic-linux-gpu/nvidia-enabled.nix;
+  targets-generic-linux-xdg = ./generic-linux-xdg.nix;
 }

--- a/tests/modules/targets-linux/generic-linux-xdg.nix
+++ b/tests/modules/targets-linux/generic-linux-xdg.nix
@@ -1,0 +1,39 @@
+{ lib, pkgs, ... }:
+let
+  expectedXdgDataDirs = lib.concatStringsSep ":" [
+    "\${NIX_STATE_DIR:-/nix/var/nix}/profiles/default/share"
+    "/home/hm-user/.local/state/nix/profile/share"
+    "/usr/share/ubuntu"
+    "/usr/local/share"
+    "/usr/share"
+    "/var/lib/snapd/desktop"
+    "/foo"
+  ];
+in
+{
+  config = {
+    targets.genericLinux.enable = true;
+
+    xdg.systemDirs.data = [ "/foo" ];
+
+    nix.assumeXdg = true;
+
+    nmt.script = ''
+      envFile=home-files/.config/environment.d/10-home-manager.conf
+      assertFileExists $envFile
+      assertFileContains $envFile \
+        'XDG_DATA_DIRS=${expectedXdgDataDirs}''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}'
+      assertFileContains $envFile \
+        'TERMINFO_DIRS=/home/hm-user/.local/state/nix/profile/share/terminfo:$TERMINFO_DIRS''${TERMINFO_DIRS:+:}/etc/terminfo:/lib/terminfo:/usr/share/terminfo'
+
+      sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
+      assertFileExists $sessionVarsFile
+      assertFileContains $sessionVarsFile \
+        '. "${pkgs.nix}/etc/profile.d/nix.sh"'
+
+      assertFileContains \
+        home-path/etc/profile.d/hm-session-vars.sh \
+        'export TERM="$TERM"'
+    '';
+  };
+}


### PR DESCRIPTION
The use-xdg-base-directories Nix setting can be set globally in /etc/nix/nix.conf, in which case Home Manager doesn't know about it. Users could fix that by also setting it, redundantly, in `nix.settings`, but then Nix issues a lot of spurious warnings about use-xdg-base-directories being a restricted setting that untrusted users can't pass on to the daemon.

As an alternative, users can now set `nix.assumeXdg`, which makes Home Manager assume that use-xdg-base-directories is in effect without adding it to the user's nix.conf file.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
