### PR TITLE
neovim: enable autoconfigure by default

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -152,6 +152,15 @@ in
         '';
       };
 
+      autoconfigure = mkOption {
+        type = types.bool;
+        default = true;
+        visible = false;
+        description = ''
+          Whether to automatically add the recommended lua configuration specified in nixpkgs for
+          some plugins in their passthru.initLua.
+        '';
+      };
       autowrapRuntimeDeps = mkOption {
         type = types.bool;
         default = true;
@@ -437,6 +446,7 @@ in
         plugins = map suppressNotVimlConfig pluginsNormalized;
 
         inherit (cfg)
+          autoconfigure
           extraPython3Packages
           withPython3
           withRuby

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -20,6 +20,7 @@ lib.mkIf config.test.enableBig {
           let g:hmPlugins='HM_PLUGINS_CONFIG'
         '';
       }
+      unicode-vim
       {
         plugin = vim-nix;
         type = "lua";


### PR DESCRIPTION

### Description


'autoconfigure' is a setting available in neovim nixpkgs' wrapper.

Enabling it automatically adds the recommended lua configuration specified in nixpkgs for some plugins in their passthru.initLua.

I've added the setting to let the user disable it but made it invisible since there is no reason I can think of to disable it apart from extreme configuration.

Setting as draft 'till I fix the test.
I tried upgrading the tests so the test failure is expected.
The test runner failure is not graceful. Maybe I need to pass a --verbose flag ? otherwise I will fallback to the old method.
cc @khaneliman 
```
➜ nix run .#tests -- neovim
warning: Git tree '/home/teto/hm' is dirty
ℹ️ Discovering tests...
ℹ️ Running 6 test(s)...

--- Running test 1/6: test-neovim-coc-config ---
✅ Test passed: test-neovim-coc-config

--- Running test 2/6: test-neovim-extra-lua-init ---
✅ Test passed: test-neovim-extra-lua-init

--- Running test 3/6: test-neovim-no-init ---
✅ Test passed: test-neovim-no-init

--- Running test 4/6: test-neovim-plugin-config ---
Traceback (most recent call last):
  File "/nix/store/i1jxs2mzrp9drfw85qm052awjpzg8npz-source/tests/tests.py", line 243, in <module>
    main()
    ~~~~^^
  File "/nix/store/i1jxs2mzrp9drfw85qm052awjpzg8npz-source/tests/tests.py", line 235, in main
    if not runner.run_tests(tests_to_run, nix_args):
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i1jxs2mzrp9drfw85qm052awjpzg8npz-source/tests/tests.py", line 113, in run_tests
    result = subprocess.run(cmd, check=True, cwd=self.repo_root, capture_output=True, text=True)
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/subprocess.py", line 556, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
                     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/subprocess.py", line 1222, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
                     ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/subprocess.py", line 2173, in _communicate
    stderr = self._translate_newlines(stderr,
                                      self.stderr.encoding,
                                      self.stderr.errors)
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/subprocess.py", line 1099, in _translate_newlines
    data = data.decode(encoding, errors)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 2269: invalid start byte
```

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
