### PR TITLE
ssh: add pubkeyAuthentication option

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -146,6 +146,27 @@ let
         '';
       };
 
+      pubkeyAuthentication = mkOption {
+        type = types.nullOr (
+          types.enum [
+            "yes"
+            "no"
+            "unbound"
+            "host-bound"
+          ]
+        );
+        default = null;
+        description = ''
+          Specifies whether to try public key authentication.
+          The argument must be yes (the default), no, unbound, or host-bound.
+          The final two options enable public key authentication while
+          respectively disabling or enabling the OpenSSH host-bound
+          authentication protocol extension required for restricted
+          {command}`ssh-agent(1)` forwarding.
+          Omitted from the host block when `null`.
+        '';
+      };
+
       identityFile = mkOption {
         type = with types; either (listOf str) (nullOr str);
         default = [ ];
@@ -411,6 +432,7 @@ let
       ++ optional cf.forwardX11 "  ForwardX11 yes"
       ++ optional cf.forwardX11Trusted "  ForwardX11Trusted yes"
       ++ optional cf.identitiesOnly "  IdentitiesOnly yes"
+      ++ optional (cf.pubkeyAuthentication != null) "  PubkeyAuthentication ${cf.pubkeyAuthentication}"
       ++ optional (cf.user != null) "  User ${cf.user}"
       ++ optional (cf.hostname != null) "  HostName ${cf.hostname}"
       ++ optional (cf.addressFamily != null) "  AddressFamily ${cf.addressFamily}"

--- a/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
+++ b/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
@@ -20,6 +20,22 @@ Host xyz
 Host ordered
   Port 1
 
+Host pubkey-host-bound
+  PubkeyAuthentication host-bound
+  HostName pubkey-host-bound.example.com
+
+Host pubkey-no
+  PubkeyAuthentication no
+  HostName pubkey-no.example.com
+
+Host pubkey-unbound
+  PubkeyAuthentication unbound
+  HostName pubkey-unbound.example.com
+
+Host pubkey-yes
+  PubkeyAuthentication yes
+  HostName pubkey-yes.example.com
 
 
-  
+
+

--- a/tests/modules/programs/ssh/match-blocks-attrs.nix
+++ b/tests/modules/programs/ssh/match-blocks-attrs.nix
@@ -53,6 +53,26 @@
           ];
           port = 516;
         };
+
+        "pubkey-yes" = {
+          hostname = "pubkey-yes.example.com";
+          pubkeyAuthentication = "yes";
+        };
+
+        "pubkey-no" = {
+          hostname = "pubkey-no.example.com";
+          pubkeyAuthentication = "no";
+        };
+
+        "pubkey-unbound" = {
+          hostname = "pubkey-unbound.example.com";
+          pubkeyAuthentication = "unbound";
+        };
+
+        "pubkey-host-bound" = {
+          hostname = "pubkey-host-bound.example.com";
+          pubkeyAuthentication = "host-bound";
+        };
       };
     };
 


### PR DESCRIPTION

### Description
Adds support for the PubkeyAuthentication SSH config option with all four valid values: yes, no, unbound, and host-bound. The latter two control the OpenSSH host-bound authentication protocol extension for restricted ssh-agent forwarding.


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
