### PR TITLE
neovim: refactor to use neovimUtils.makeVimPackageInfo

### DIFF
--- a/tests/modules/programs/neovim/plugin-config.expected
+++ b/tests/modules/programs/neovim/plugin-config.expected
@@ -1,3 +1,6 @@
 vim.cmd [[source /nix/store/00000000000000000000000000000000-nvim-init-home-manager.vim]]
+-- user-associated plugin config {{{
 function HM_PLUGIN_LUA_CONFIG ()
 end
+
+-- }}}


### PR DESCRIPTION
### Description

testing with https://github.com/NixOS/nixpkgs/pull/474920

It should unblock the following:
- ability for user to inject their config more precisely in the generated file
- let home-manager support runtimeDeps and advised plugin config
- remove the rtp/packpath from the wrapper such that any neovim GUI can load the full config (there are various things that the user might need to tweak but I would like us to get there eventually)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
