### PR TITLE
direnv: make Fish integration read-write

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -75,25 +75,7 @@ in
 
     enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableFishIntegration =
-      lib.hm.shell.mkFishIntegrationOption {
-        inherit config;
-        extraDescription = ''
-          Note, enabling the direnv module will always activate its functionality
-          for Fish since the direnv package automatically gets loaded in Fish.
-          If this is not the case try adding
-
-          ```nix
-          environment.pathsToLink = [ "/share/fish" ];
-          ```
-
-          to the system configuration.
-        '';
-      }
-      // {
-        default = true;
-        readOnly = true;
-      };
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
     enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 


### PR DESCRIPTION
### Description

Once https://github.com/NixOS/nixpkgs/pull/475992 is merged, we can make this option read-write.

Depends-on: https://github.com/NixOS/nixpkgs/pull/475992

See https://github.com/Mic92/direnv-instant/issues/35

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
