### PR TITLE
mpd: set network settings as environment variables

### DIFF
--- a/modules/misc/news/2026/01/2026-01-02_00-03-48.nix
+++ b/modules/misc/news/2026/01/2026-01-02_00-03-48.nix
@@ -1,0 +1,10 @@
+{ config, ... }:
+{
+  time = "2026-01-02T00:03:48+00:00";
+  condition = config.services.mpd.enable;
+  message = ''
+    `MPD_HOST` and `MPD_PORT` environment variables are now set automatically.
+
+    This can be disabled with `services.mpd.enableSessionVariables = false`.
+  '';
+}


### PR DESCRIPTION
### Description

https://mpd.readthedocs.io/en/stable/client.html#connecting-to-mpd

These environment variables are picked up by, amongst others, clients based on libmpdclient:

- https://github.com/MusicPlayerDaemon/libmpdclient/blob/2a42a100674bb85fdaa442e639bc20b0976df8b5/src/settings.c#L108
- https://github.com/MusicPlayerDaemon/libmpdclient/blob/2a42a100674bb85fdaa442e639bc20b0976df8b5/src/settings.c#L135

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
