### PR TITLE
lib.generators.toHyprconf: support strings and attrs in sections

### DIFF
--- a/tests/lib/generators/default.nix
+++ b/tests/lib/generators/default.nix
@@ -1,4 +1,5 @@
 {
+  generators-hyprconf = ./tohyprconf.nix;
   generators-tokdl = ./tokdl.nix;
   generators-toscfg-empty = ./toscfg-empty.nix;
   generators-toscfg-example = ./toscfg-example.nix;

--- a/tests/lib/generators/tohyprconf-result.txt
+++ b/tests/lib/generators/tohyprconf-result.txt
@@ -1,0 +1,93 @@
+$important=123
+attrs-section {
+  bool=true
+  float=0.800000
+  int=5
+  null=null
+  string=abc
+}
+
+combined-attrs-nested-section {
+  a {
+    a=123
+  }
+
+  a {
+    b=123
+  }
+
+  a {
+    c=123
+  }
+
+  b {
+    a=123
+  }
+
+  b {
+    b=123
+  }
+
+  b {
+    c=123
+  }
+}
+
+combined-list-nested-section {
+  b {
+    c {
+      abc=123
+    }
+  }
+}
+
+combined-list-nested-section {
+  bar {
+    baz {
+      aaa=111
+    }
+  }
+}
+
+list-section=foo
+list-section=bar
+list-section=baz
+
+list-with-strings-and-attrs=abc
+list-with-strings-and-attrs {
+  a=123
+}
+list-with-strings-and-attrs=foo
+list-with-strings-and-attrs {
+  b=321
+}
+
+nested-attrs-section {
+  a {
+    b {
+      c {
+        abc=123
+      }
+    }
+  }
+
+  foo {
+    bar {
+      baz {
+        aaa=111
+      }
+    }
+  }
+}
+
+nested-list-section {
+  a=123
+}
+
+nested-list-section {
+  b=123
+}
+
+nested-list-section {
+  c=123
+}

--- a/tests/lib/generators/tohyprconf.nix
+++ b/tests/lib/generators/tohyprconf.nix
@@ -1,0 +1,70 @@
+{ lib, ... }:
+
+{
+  home.file."tohyprconf-result.txt".text = lib.hm.generators.toHyprconf {
+    attrs = rec {
+      "$important" = 123;
+
+      list-section = [
+        "foo"
+        "bar"
+        "baz"
+      ];
+
+      attrs-section = {
+        string = "abc";
+        int = 5;
+        float = 0.8;
+        bool = true;
+        null = null;
+      };
+
+      nested-attrs-section = {
+        a = {
+          b = {
+            c = {
+              abc = 123;
+            };
+          };
+        };
+
+        foo = {
+          bar = {
+            baz = {
+              aaa = 111;
+            };
+          };
+        };
+      };
+
+      nested-list-section = [
+        { a = 123; }
+        { b = 123; }
+        { c = 123; }
+      ];
+
+      combined-list-nested-section = [
+        nested-attrs-section.a
+        nested-attrs-section.foo
+      ];
+
+      combined-attrs-nested-section = {
+        a = nested-list-section;
+        b = nested-list-section;
+      };
+
+      list-with-strings-and-attrs = [
+        "abc"
+        { a = 123; }
+        "foo"
+        { b = 321; }
+      ];
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/tohyprconf-result.txt \
+      ${./tohyprconf-result.txt}
+  '';
+}

--- a/tests/modules/services/hyprland/multiple-devices-config.conf
+++ b/tests/modules/services/hyprland/multiple-devices-config.conf
@@ -13,6 +13,10 @@ animations {
   enabled=true
 }
 
+bindm=$mod, mouse:272, movewindow
+bindm=$mod, mouse:273, resizewindow
+bindm=$mod ALT, mouse:272, resizewindow
+
 decoration {
   col.shadow=rgba(00000099)
   shadow_offset=0 5
@@ -45,9 +49,6 @@ plugin {
     dummy=plugin setting
   }
 }
-bindm=$mod, mouse:272, movewindow
-bindm=$mod, mouse:273, resizewindow
-bindm=$mod ALT, mouse:272, resizewindow
 # window resize
 bind = $mod, S, submap, resize
 

--- a/tests/modules/services/hyprland/simple-config.conf
+++ b/tests/modules/services/hyprland/simple-config.conf
@@ -13,6 +13,10 @@ animations {
   enabled=true
 }
 
+bindm=$mod, mouse:272, movewindow
+bindm=$mod, mouse:273, resizewindow
+bindm=$mod ALT, mouse:272, resizewindow
+
 decoration {
   col.shadow=rgba(00000099)
   shadow_offset=0 5
@@ -48,9 +52,6 @@ plugin {
     dummy=plugin setting
   }
 }
-bindm=$mod, mouse:272, movewindow
-bindm=$mod, mouse:273, resizewindow
-bindm=$mod ALT, mouse:272, resizewindow
 # window resize
 bind = $mod, S, submap, resize
 

--- a/tests/modules/services/hyprland/sourceFirst-false-config.conf
+++ b/tests/modules/services/hyprland/sourceFirst-false-config.conf
@@ -10,4 +10,5 @@ input {
   follow_mouse=1
   kb_layout=ro
 }
+
 source=sourced.conf

--- a/tests/modules/services/hyprland/submaps-config.conf
+++ b/tests/modules/services/hyprland/submaps-config.conf
@@ -17,6 +17,7 @@ submap = reset
 submap = resize
 bind=, escape, submap, reset
 bind=, return, submap, reset
+
 binde=, right, resizeactive, 10 0
 binde=, left, resizeactive, -10 0
 binde=, up, resizeactive, 0 -10

--- a/tests/modules/services/hyprpaper/hyprpaper.conf
+++ b/tests/modules/services/hyprpaper/hyprpaper.conf
@@ -1,7 +1,8 @@
-ipc=on
 preload=/share/wallpapers/buttons.png
 preload=/share/wallpapers/cat_pacman.png
-splash=false
-splash_offset=2.000000
+
 wallpaper=DP-3,/share/wallpapers/buttons.png
 wallpaper=DP-1,/share/wallpapers/cat_pacman.png
+ipc=on
+splash=false
+splash_offset=2.000000


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adds support for

```nix
section = [
  "abc"
  { a = 123; }
];
```

Which gets generated to

```
section=abc

section {
  a=123
}
```

This is very useful with the new `windowrule` syntax, where you can create anonymous window rules as strings and named rules as attribute sets.
https://wiki.hypr.land/Configuring/Window-Rules/

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
