### PR TITLE
generic-linux-gpu: put systemd unit in lib/systemd

### DIFF
--- a/modules/targets/generic-linux/gpu/setup/default.nix
+++ b/modules/targets/generic-linux/gpu/setup/default.nix
@@ -18,13 +18,14 @@ stdenv.mkDerivation {
   src = ./.;
   patchPhase = ''
     substituteInPlace non-nixos-gpu* \
-      --replace '@@resources@@' "$out/resources" \
-      --replace '@@statedir@@' '${nixStateDirectory}' \
-      --replace '@@env@@' "${nonNixosGpuEnv}"
+      --replace-quiet '@@resources@@' "$out/resources" \
+      --replace-quiet '@@statedir@@' '${nixStateDirectory}' \
+      --replace-quiet '@@systemddir@@' "$out/lib/systemd/system" \
+      --replace-quiet '@@env@@' "${nonNixosGpuEnv}"
   '';
   installPhase = ''
-    mkdir -p $out/{bin,resources}
+    mkdir -p $out/{bin,resources,lib/systemd/system}
     cp non-nixos-gpu-setup $out/bin
-    cp non-nixos-gpu.service $out/resources
+    cp non-nixos-gpu.service $out/lib/systemd/system
   '';
 }

--- a/modules/targets/generic-linux/gpu/setup/non-nixos-gpu-setup
+++ b/modules/targets/generic-linux/gpu/setup/non-nixos-gpu-setup
@@ -5,7 +5,7 @@ set -e
 # Install the systemd service file and ensure that the store path won't be
 # garbage-collected as long as it's installed.
 unit_path=/etc/systemd/system/non-nixos-gpu.service
-ln -sf @@resources@@/non-nixos-gpu.service "$unit_path"
+ln -sf @@systemddir@@/non-nixos-gpu.service "$unit_path"
 ln -sf "$unit_path" "@@statedir@@"/gcroots/non-nixos-gpu.service
 
 systemctl daemon-reload

--- a/tests/modules/targets-linux/generic-linux-gpu/nvidia-enabled.nix
+++ b/tests/modules/targets-linux/generic-linux-gpu/nvidia-enabled.nix
@@ -39,11 +39,12 @@ in
     setupScript="$TESTED/home-path/bin/non-nixos-gpu-setup"
     assertFileExists "$setupScript"
 
-    # Find the resources directory
-    resourcesPath=$(grep -oP '/nix/store/[^/]+-non-nixos-gpu/resources' "$setupScript" | head -1)
+    # Find the service file
+    storePath="$(dirname "$(readlink "''${setupScript}")")"/../
+    servicePath="$storePath/lib/systemd/system/non-nixos-gpu.service"
 
     # Extract the GPU environment path
-    envPath=$(grep -oP '/nix/store/[^/]+-non-nixos-gpu' "$resourcesPath/non-nixos-gpu.service" | head -1)
+    envPath=$(grep -oP '/nix/store/[^/]+-non-nixos-gpu' "$servicePath" | head -1)
 
     if [[ -z "$envPath" ]]; then
       fail "Could not find GPU environment path in service file"

--- a/tests/modules/targets-linux/generic-linux-gpu/setup-package-contents.nix
+++ b/tests/modules/targets-linux/generic-linux-gpu/setup-package-contents.nix
@@ -11,19 +11,22 @@
     assertFileExists "$setupScript"
     assertFileIsExecutable "$setupScript"
 
-    # Find and check the resources directory
-    resourcesPath=$(grep -oP '/nix/store/[^/]+-non-nixos-gpu/resources' "$setupScript" | head -1)
-    assertDirectoryExists "$resourcesPath"
-
     # Check that gcroots dir was set
     cat "$setupScript"
     assertFileRegex "$setupScript" ' "/custom/state/directory"/gcroots'
 
-    serviceFile="$resourcesPath/non-nixos-gpu.service"
-    assertFileExists "$serviceFile"
-
     # Check that no placeholders remain
-    assertFileNotRegex "$serviceFile" '@@[^@]\+@@'
     assertFileNotRegex "$setupScript" '@@[^@]\+@@'
+
+    # Check that expected files are present and free of placeholders
+    storePath="$(dirname "$(readlink "''${setupScript}")")"/../
+    expectedFiles=(
+      lib/systemd/system/non-nixos-gpu.service
+    )
+
+    for f in "''${expectedFiles[@]}"; do
+      assertFileExists "$storePath/$f"
+      assertFileNotRegex "$storePath/$f" '@@[^@]\+@@'
+    done
   '';
 }


### PR DESCRIPTION


### Description

This is where unit files are expected to be, making GPU setup compatible with things like selinux. Fixes #8438. The `resources/` directory was kept because it is expected to be used in the future.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

