### PR TITLE
lib.types.dagOf: Allow type merging in elemType in dagOf

### DIFF
--- a/modules/lib/types-dag.nix
+++ b/modules/lib/types-dag.nix
@@ -2,7 +2,6 @@
 
 let
   inherit (lib)
-    defaultFunctor
     hm
     mkIf
     mkOrder
@@ -11,6 +10,17 @@ let
     types
     ;
 
+  # Modified from nixpkgs/lib/types.nix https://github.com/NixOS/nixpkgs/blob/821647d8479ce41cafa8294de5abc081e87151e2/lib/types.nix#L84
+  # defers type merging to the elemType
+  elemTypeFunctor = type: name: payload: {
+    inherit payload type name;
+    binOp =
+      a: b:
+      let
+        merged = a.elemType.typeMerge b.elemType.functor;
+      in
+      if merged == null then null else { elemType = merged; };
+  };
   dagEntryOf =
     elemType:
     let
@@ -64,13 +74,17 @@ rec {
     in
     mkOptionType rec {
       name = "dagOf";
-      description = "DAG of ${elemType.description}";
+      description = "DAG of ${
+        types.optionDescriptionPhrase (class: class == "noun" || class == "composite") elemType
+      }";
+      descriptionClass = "composite";
       inherit (attrEquivalent) check merge emptyValue;
       getSubOptions = prefix: elemType.getSubOptions (prefix ++ [ "<name>" ]);
       inherit (elemType) getSubModules;
       substSubModules = m: dagOf (elemType.substSubModules m);
-      functor = (defaultFunctor name) // {
-        wrapped = elemType;
+      # Allow type merging for elemType
+      functor = (elemTypeFunctor dagOf name { inherit elemType; }) // {
+        type = payload: dagOf payload.elemType;
       };
       nestedTypes.elemType = elemType;
     };

--- a/tests/lib/types/dag-type-merge.nix
+++ b/tests/lib/types/dag-type-merge.nix
@@ -1,0 +1,75 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    concatStringsSep
+    hm
+    mkOption
+    types
+    ;
+
+  inherit (lib.hm) dag;
+
+  result =
+    let
+      sorted = dag.topoSort config.tested.dag;
+      data = map (e: "${e.name}:${e.data.name}:${e.data.value}") sorted.result;
+    in
+    concatStringsSep "\n" data + "\n";
+
+in
+{
+  imports = [
+    {
+      options.tested.dag = mkOption {
+        type = hm.types.dagOf (
+          types.submodule (
+            { dagName, ... }:
+            {
+              options.name = mkOption { type = types.str; };
+              config.name = "dn-${dagName}";
+            }
+          )
+        );
+      };
+    }
+    {
+      options.tested.dag = mkOption {
+        type = hm.types.dagOf (
+          types.submodule (
+            { dagName, ... }:
+            {
+              options.value = mkOption { type = types.str; };
+              config.value = "dv-${dagName}";
+            }
+          )
+        );
+      };
+    }
+  ];
+
+  config = {
+    tested.dag = {
+      after = { };
+      before = dag.entryBefore [ "after" ] { };
+      between = dag.entryBetween [ "after" ] [ "before" ] { };
+    };
+
+    home.file."result.txt".text = result;
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/result.txt \
+        ${pkgs.writeText "result.txt" ''
+          before:dn-before:dv-before
+          between:dn-between:dv-between
+          after:dn-after:dv-after
+        ''}
+    '';
+  };
+}

--- a/tests/lib/types/default.nix
+++ b/tests/lib/types/default.nix
@@ -1,6 +1,7 @@
 {
   lib-types-dag-submodule = ./dag-submodule.nix;
   lib-types-dag-merge = ./dag-merge.nix;
+  lib-types-dag-type-merge = ./dag-type-merge.nix;
 
   lib-types-either-suboptions-docs-lib = ./either-suboptions-docs-lib.nix;
 


### PR DESCRIPTION
### Description
Modified the `functor` in the definition of `dagOf` to allow type merging. Added a test to verify type merging is working. There is an upstream bug that can be worked see NixOS/nixpkgs#476219

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.