### PR TITLE
vicinae: Fix settings example

### DIFF
--- a/modules/programs/vicinae.nix
+++ b/modules/programs/vicinae.nix
@@ -133,26 +133,21 @@ in
     settings = lib.mkOption {
       inherit (jsonFormat) type;
       default = { };
-      description = "Settings written as JSON to `~/.config/vicinae/settings.json.";
       example = lib.literalExpression ''
         {
-          faviconService = "twenty";
-          font = {
-            size = 10;
-          };
-          popToRootOnClose = false;
-          rootSearch = {
-            searchFiles = false;
-          };
+          favicon_service = "twenty";
+          font.normal.size = 10;
+          pop_to_root_on_close=false;
+          search_files_in_root= false;
           theme = {
-            name = "vicinae-dark";
-          };
-          window = {
-           csd = true;
-           opacity = 0.95;
-           rounding = 10;
+            dark.name = "vicinae-dark";
+            light.name = "vicinae-light";
           };
         }
+      '';
+      description = ''
+        Settings written as JSON to {file}`~/.config/vicinae/settings.json`.
+        See {command}`vicinae config default`.
       '';
     };
   };


### PR DESCRIPTION
### Description
Minor changes to update the settings example. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
