### PR TITLE
zed-editor: add defaultEditor option

### DIFF
--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -55,6 +55,11 @@ let
     // (lib.optionalAttrs (mergedMcpServers != { }) {
       context_servers = mergedMcpServers;
     });
+
+  editorEnv = {
+    EDITOR = "${cfg.package.meta.mainProgram} --wait";
+    VISUAL = "${cfg.package.meta.mainProgram} --wait";
+  };
 in
 {
   meta.maintainers = [ lib.maintainers.alinnow ];
@@ -246,6 +251,15 @@ in
         );
         default = { };
       };
+
+      defaultEditor = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to set {command}`zeditor -w` as the default editor using the
+          {env}`EDITOR` and {env}`VISUAL` environment variables.
+        '';
+      };
     };
   };
 
@@ -254,6 +268,10 @@ in
       {
         assertion = cfg.extraPackages != [ ] -> cfg.package != null;
         message = "{option}programs.zed-editor.extraPackages requires non null {option}programs.zed-editor.package";
+      }
+      {
+        assertion = cfg.defaultEditor -> cfg.package != null;
+        message = "{option}programs.zed-editor.defaultEditor requires non null {option}programs.zed-editor.package";
       }
     ];
 
@@ -345,5 +363,7 @@ in
         "zed/debug.json".source = jsonFormat.generate "zed-user-debug" cfg.userDebug;
       })
     ];
+
+    home.sessionVariables = mkIf cfg.defaultEditor editorEnv;
   };
 }

--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -62,7 +62,10 @@ let
   };
 in
 {
-  meta.maintainers = [ lib.maintainers.alinnow ];
+  meta.maintainers = [
+    lib.maintainers.alinnow
+    lib.maintainers.zh4ngx
+  ];
 
   options = {
     programs.zed-editor = {


### PR DESCRIPTION
### Description

This adds a 'defaultEditor' option to the zed-editor module. When enabled, it sets the EDITOR and VISUAL environment variables to 'zed --wait' (or 'zeditor --wait' depending on the package).

These variables are set in both home.sessionVariables and systemd.user.sessionVariables to ensure consistency across interactive shells and user services.

fixed #8451 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- x ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
