### PR TITLE
anki: fix UI scale configuration

### DIFF
--- a/modules/programs/anki/default.nix
+++ b/modules/programs/anki/default.nix
@@ -82,7 +82,7 @@ in
     };
 
     uiScale = lib.mkOption {
-      type = with lib.types; nullOr (numbers.between 0.0 1.0);
+      type = with lib.types; nullOr (numbers.between 1.0 2.0);
       default = null;
       example = 1.0;
       description = "User interface scale.";


### PR DESCRIPTION
### Description

Anki's [ProfileManager.uiScale()](https://github.com/ankitects/anki/blob/main/qt/aqt/profiles.py#L532) implementation clamps values below 1.0 to 1.0:
```python
def uiScale(self) -> float:
    scale = self.meta.get("uiScale", 1.0)
    return max(scale, 1)
```
The app's UI settings restrict scaling to 100%-200%, making 1.0-2.0 the only effective range.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
