### PR TITLE
thunderbird: add configPath option

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -50,10 +50,7 @@ let
   );
   enabledContactAccountsWithId = addId enabledContactAccounts;
 
-  thunderbirdConfigPath = if isDarwin then "Library/Thunderbird" else ".thunderbird";
-
-  thunderbirdProfilesPath =
-    if isDarwin then "${thunderbirdConfigPath}/Profiles" else thunderbirdConfigPath;
+  thunderbirdProfilesPath = if isDarwin then "${cfg.configPath}/Profiles" else cfg.configPath;
 
   profilesWithId = lib.imap0 (i: v: v // { id = toString i; }) (attrValues cfg.profiles);
 
@@ -323,6 +320,17 @@ in
         type = types.nullOr types.ints.unsigned;
         default = if isDarwin then null else 2;
         description = "profile version, set null for nix-darwin";
+      };
+
+      configPath = mkOption {
+        type = types.str;
+        default = if isDarwin then "Library/Thunderbird" else ".thunderbird";
+        description = ''
+          The path to the Thunderbird config directory. This option does not
+          change where Thunderbird looks for config files, only where generated
+          files are placed. Only change if you have a nonstandard installation,
+          such as when overriding $HOME in a wrapped package.
+        '';
       };
 
       nativeMessagingHosts = mkOption {
@@ -898,7 +906,7 @@ in
     home.file = lib.mkMerge (
       [
         {
-          "${thunderbirdConfigPath}/profiles.ini" = mkIf (cfg.profiles != { }) {
+          "${cfg.configPath}/profiles.ini" = mkIf (cfg.profiles != { }) {
             text = lib.generators.toINI { } profilesIni;
           };
         }


### PR DESCRIPTION
### Description

Adds an option to override the path to the Thunderbird config directory. The option doesn't change where the binary looks for its config, only where home-manager generates its config files (as is made clear in the option description). Previously this was hardcoded to `Library/Thunderbird` on macOS and `.thunderbird` on Linux.

Currently, this option is essential for those who like to wrap XDG non-compliant programs and give them their own `$HOME` to be messy in. In the future, this will also provide a way for users to opt-in to the new XDG-compliant config directory (see #8200 for that discussion).


### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
