### PR TITLE
floorp: Fix tests for floorp-bin change

### DIFF
--- a/tests/modules/programs/firefox/policies.nix
+++ b/tests/modules/programs/firefox/policies.nix
@@ -37,7 +37,7 @@ in
             if pkgs.stdenv.hostPlatform.isDarwin then
               "${cfg.finalPackage}/${darwinPath}"
             else
-              "${cfg.finalPackage}/lib/${cfg.wrappedPackageName}";
+              "${cfg.finalPackage}/lib/${cfg.finalPackage.unwrapped.libName or cfg.wrappedPackageName}";
           config_file = "${libDir}/distribution/policies.json";
         in
         ''

--- a/tests/modules/programs/firefox/profiles/bookmarks/default.nix
+++ b/tests/modules/programs/firefox/profiles/bookmarks/default.nix
@@ -92,7 +92,7 @@ in
             if pkgs.stdenv.hostPlatform.isDarwin then
               "${cfg.finalPackage}/${darwinPath}"
             else
-              "${cfg.finalPackage}/lib/${cfg.wrappedPackageName}";
+              "${cfg.finalPackage}/lib/${cfg.finalPackage.unwrapped.libName or cfg.wrappedPackageName}";
           config_file = "${libDir}/distribution/policies.json";
         in
         ''

--- a/tests/modules/programs/firefox/profiles/search/default.nix
+++ b/tests/modules/programs/firefox/profiles/search/default.nix
@@ -19,7 +19,7 @@ let
       substitutions = [
         "--replace"
         "@name@"
-        cfg.wrappedPackageName
+        cfg.package.meta.mainProgram
       ];
     };
 

--- a/tests/modules/programs/firefox/setup-firefox-mock-overlay.nix
+++ b/tests/modules/programs/firefox/setup-firefox-mock-overlay.nix
@@ -25,6 +25,7 @@ in
           binaryName = cfg.wrappedPackageName;
           gtk3 = null;
           meta.description = "I pretend to be ${cfg.name}";
+          meta.mainProgram = lib.toLower cfg.name;
         };
         outPath = null;
         buildScript =

--- a/tests/modules/programs/firefox/state-version-19_09.nix
+++ b/tests/modules/programs/firefox/state-version-19_09.nix
@@ -21,7 +21,7 @@ in
     // {
       nmt.script = ''
         assertFileRegex \
-          home-path/bin/${cfg.wrappedPackageName} \
+          home-path/bin/${cfg.finalPackage.meta.mainProgram} \
           MOZ_APP_LAUNCHER
       '';
     }


### PR DESCRIPTION
### Description
Several of the `floorp` tests were broken by the upstream switch to `floorp-bin`. Most  changes were to do with not being able to use`programs.floorp.wrappedPackageName` in expected results.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.