### PR TITLE
podman-linux: Fix tests expected results and modules

### DIFF
--- a/tests/modules/services/podman-linux/build-expected.service
+++ b/tests/modules/services/podman-linux/build-expected.service
@@ -26,5 +26,5 @@ Type=oneshot
 Wants=podman-user-wait-network-online.service
 After=podman-user-wait-network-online.service
 Description=Service for build my-bld
-RequiresMountsFor=%t/containers
 SourcePath=/nix/store/00000000000000000000000000000000-home-build-podman-my-bld/quadlets/podman-my-bld.build
+RequiresMountsFor=%t/containers

--- a/tests/modules/services/podman-linux/build.nix
+++ b/tests/modules/services/podman-linux/build.nix
@@ -4,50 +4,50 @@
   pkgs,
   ...
 }:
-
-lib.mkIf config.test.enableLegacyIfd {
+{
   imports = [ ./podman-stubs.nix ];
+  config = lib.mkIf config.test.enableLegacyIfd {
+    services.podman = {
+      enable = true;
+      builds = {
+        "my-bld" = {
+          file =
+            let
+              containerFile = pkgs.writeTextFile {
+                name = "Containerfile";
+                text = ''
+                  FROM docker.io/alpine:latest
+                '';
+              };
+            in
+            "${containerFile}";
+        };
 
-  services.podman = {
-    enable = true;
-    builds = {
-      "my-bld" = {
-        file =
-          let
-            containerFile = pkgs.writeTextFile {
-              name = "Containerfile";
-              text = ''
-                FROM docker.io/alpine:latest
-              '';
-            };
-          in
-          "${containerFile}";
-      };
-
-      "my-bld-2" = {
-        file = "https://www.github.com/././Containerfile";
-        extraConfig = {
-          Build.ImageTag = [
-            "locahost/somethingelse"
-            "localhost/anothertag"
-          ];
+        "my-bld-2" = {
+          file = "https://www.github.com/././Containerfile";
+          extraConfig = {
+            Build.ImageTag = [
+              "locahost/somethingelse"
+              "localhost/anothertag"
+            ];
+          };
         };
       };
     };
+
+    test.asserts.assertions.expected = [
+      ''In 'my-bld-2' config. Build.ImageTag: '[ "locahost/somethingelse" "localhost/anothertag" ]' does not contain 'homemanager/my-bld-2'.''
+    ];
+
+    nmt.script = ''
+      configPath=home-files/.config/systemd/user
+      buildFile=$configPath/podman-my-bld-build.service
+
+      assertFileExists $buildFile
+
+      buildFile=$(normalizeStorePaths $buildFile)
+
+      assertFileContent $buildFile ${./build-expected.service}
+    '';
   };
-
-  test.asserts.assertions.expected = [
-    ''In 'my-bld-2' config. Build.ImageTag: '[ "locahost/somethingelse" "localhost/anothertag" ]' does not contain 'homemanager/my-bld-2'.''
-  ];
-
-  nmt.script = ''
-    configPath=home-files/.config/systemd/user
-    buildFile=$configPath/podman-my-bld-build.service
-
-    assertFileExists $buildFile
-
-    buildFile=$(normalizeStorePaths $buildFile)
-
-    assertFileContent $buildFile ${./build-expected.service}
-  '';
 }

--- a/tests/modules/services/podman-linux/container-expected.service
+++ b/tests/modules/services/podman-linux/container-expected.service
@@ -27,18 +27,18 @@ WantedBy=default.target
 WantedBy=multi-user.target
 
 [Service]
-Environment=PATH=/run/wrappers/bin:/run/current-system/sw/bin:/home/hm-user/.nix-profile/bin:@systemd@/bin
+Environment=PATH=/run/wrappers/bin:/run/current-system/sw/bin:@nftables@/bin:/home/hm-user/.nix-profile/bin:@systemd@/bin
 Restart=on-failure
 TimeoutStopSec=30
 Environment=PODMAN_SYSTEMD_UNIT=%n
 KillMode=mixed
-ExecStop=/nix/store/00000000000000000000000000000000-podman/bin/podman rm -v -f -i --cidfile=%t/%N.cid
-ExecStopPost=-/nix/store/00000000000000000000000000000000-podman/bin/podman rm -v -f -i --cidfile=%t/%N.cid
+ExecStop=/nix/store/00000000000000000000000000000000-podman/bin/podman rm -v -f -i my-container
+ExecStopPost=-/nix/store/00000000000000000000000000000000-podman/bin/podman rm -v -f -i my-container
 Delegate=yes
 Type=notify
 NotifyAccess=all
 SyslogIdentifier=%N
-ExecStart=/nix/store/00000000000000000000000000000000-podman/bin/podman run --name my-container --cidfile=%t/%N.cid --replace --rm --cgroups=split --entrypoint /sleep.sh --network-alias test-alias-1 --network-alias test-alias-2 --read-only-tmpfs --network mynet --sdnotify=conmon -d --device /dev/null:/dev/null -v /tmp:/tmp --label io.containers.autoupdate=registry --publish 8080:80 --env VAL_A=A --env VAL_B=2 --env VAL_C=false --label nix.home-manager.managed=true --security-opt=no-new-privileges docker.io/alpine:latest
+ExecStart=/nix/store/00000000000000000000000000000000-podman/bin/podman run --name my-container --replace --rm --cgroups=split --entrypoint /sleep.sh --network-alias test-alias-1 --network-alias test-alias-2 --read-only-tmpfs --network mynet --sdnotify=conmon -d --device /dev/null:/dev/null -v /tmp:/tmp --label io.containers.autoupdate=registry --publish 8080:80 --env VAL_A=A --env VAL_B=2 --env VAL_C=false --label nix.home-manager.managed=true --security-opt=no-new-privileges docker.io/alpine:latest
 
 [Unit]
 Wants=podman-user-wait-network-online.service

--- a/tests/modules/services/podman-linux/container.nix
+++ b/tests/modules/services/podman-linux/container.nix
@@ -1,61 +1,62 @@
 { config, lib, ... }:
-
-lib.mkIf config.test.enableLegacyIfd {
+{
   imports = [ ./podman-stubs.nix ];
+  config = lib.mkIf config.test.enableLegacyIfd {
 
-  services.podman = {
-    enable = true;
-    containers = {
-      "my-container" = {
-        description = "home-manager test";
-        autoStart = true;
-        autoUpdate = "registry";
-        devices = [ "/dev/null:/dev/null" ];
-        entrypoint = "/sleep.sh";
-        environment = {
-          "VAL_A" = "A";
-          "VAL_B" = 2;
-          "VAL_C" = false;
-        };
-        extraPodmanArgs = [ "--security-opt=no-new-privileges" ];
-        extraConfig = {
-          Container = {
-            ReadOnlyTmpfs = true;
-            NetworkAlias = "test-alias-2";
+    services.podman = {
+      enable = true;
+      containers = {
+        "my-container" = {
+          description = "home-manager test";
+          autoStart = true;
+          autoUpdate = "registry";
+          devices = [ "/dev/null:/dev/null" ];
+          entrypoint = "/sleep.sh";
+          environment = {
+            "VAL_A" = "A";
+            "VAL_B" = 2;
+            "VAL_C" = false;
           };
-          Service.Restart = "on-failure";
-          Unit.Before = "fake.target";
+          extraPodmanArgs = [ "--security-opt=no-new-privileges" ];
+          extraConfig = {
+            Container = {
+              ReadOnlyTmpfs = true;
+              NetworkAlias = "test-alias-2";
+            };
+            Service.Restart = "on-failure";
+            Unit.Before = "fake.target";
+          };
+          image = "docker.io/alpine:latest";
+          # Should not generate Requires/After for network because there is no
+          # services.podman.networks.mynet.
+          network = "mynet";
+          networkAlias = [ "test-alias-1" ];
+          ports = [ "8080:80" ];
+          volumes = [ "/tmp:/tmp" ];
         };
-        image = "docker.io/alpine:latest";
-        # Should not generate Requires/After for network because there is no
-        # services.podman.networks.mynet.
-        network = "mynet";
-        networkAlias = [ "test-alias-1" ];
-        ports = [ "8080:80" ];
-        volumes = [ "/tmp:/tmp" ];
-      };
 
-      "my-container-2" = {
-        image = "docker.io/alpine:latest";
-        extraConfig = {
-          Container.ContainerName = "some-other-container-name";
+        "my-container-2" = {
+          image = "docker.io/alpine:latest";
+          extraConfig = {
+            Container.ContainerName = "some-other-container-name";
+          };
         };
       };
     };
+
+    test.asserts.assertions.expected = [
+      ''In 'my-container-2' config. Container.ContainerName: 'some-other-container-name' does not match expected type: value "my-container-2" (singular enum)''
+    ];
+
+    nmt.script = ''
+      configPath=home-files/.config/systemd/user
+      containerFile=$configPath/podman-my-container.service
+
+      assertFileExists $containerFile
+
+      containerFile=$(normalizeStorePaths $containerFile)
+
+      assertFileContent $containerFile ${./container-expected.service}
+    '';
   };
-
-  test.asserts.assertions.expected = [
-    ''In 'my-container-2' config. Container.ContainerName: 'some-other-container-name' does not match expected type: value "my-container-2" (singular enum)''
-  ];
-
-  nmt.script = ''
-    configPath=home-files/.config/systemd/user
-    containerFile=$configPath/podman-my-container.service
-
-    assertFileExists $containerFile
-
-    containerFile=$(normalizeStorePaths $containerFile)
-
-    assertFileContent $containerFile ${./container-expected.service}
-  '';
 }

--- a/tests/modules/services/podman-linux/image.nix
+++ b/tests/modules/services/podman-linux/image.nix
@@ -1,24 +1,24 @@
 { config, lib, ... }:
-
-lib.mkIf config.test.enableLegacyIfd {
+{
   imports = [ ./podman-stubs.nix ];
-
-  services.podman = {
-    enable = true;
-    images = {
-      "my-img" = {
-        image = "docker.io/alpine:latest";
+  config = lib.mkIf config.test.enableLegacyIfd {
+    services.podman = {
+      enable = true;
+      images = {
+        "my-img" = {
+          image = "docker.io/alpine:latest";
+        };
       };
     };
+
+    nmt.script = ''
+      configPath=home-files/.config/systemd/user
+      imageFile=$configPath/podman-my-img-image.service
+      assertFileExists $imageFile
+
+      imageFile=$(normalizeStorePaths $imageFile)
+
+      assertFileContent $imageFile ${./image-expected.service}
+    '';
   };
-
-  nmt.script = ''
-    configPath=home-files/.config/systemd/user
-    imageFile=$configPath/podman-my-img-image.service
-    assertFileExists $imageFile
-
-    imageFile=$(normalizeStorePaths $imageFile)
-
-    assertFileContent $imageFile ${./image-expected.service}
-  '';
 }

--- a/tests/modules/services/podman-linux/integration-build-expected.service
+++ b/tests/modules/services/podman-linux/integration-build-expected.service
@@ -26,5 +26,5 @@ Type=oneshot
 Wants=podman-user-wait-network-online.service
 After=podman-user-wait-network-online.service
 Description=Service for build my-bld
-RequiresMountsFor=%t/containers
 SourcePath=/nix/store/00000000000000000000000000000000-home-container-podman-my-container-bld/quadlets/podman-my-bld.build
+RequiresMountsFor=%t/containers

--- a/tests/modules/services/podman-linux/integration-container-bld-expected.service
+++ b/tests/modules/services/podman-linux/integration-container-bld-expected.service
@@ -15,24 +15,24 @@ WantedBy=default.target
 WantedBy=multi-user.target
 
 [Service]
-Environment=PATH=/run/wrappers/bin:/run/current-system/sw/bin:/home/hm-user/.nix-profile/bin:@systemd@/bin
+Environment=PATH=/run/wrappers/bin:/run/current-system/sw/bin:@nftables@/bin:/home/hm-user/.nix-profile/bin:@systemd@/bin
 Restart=always
 TimeoutStopSec=30
 Environment=PODMAN_SYSTEMD_UNIT=%n
 KillMode=mixed
-ExecStop=/nix/store/00000000000000000000000000000000-podman/bin/podman rm -v -f -i --cidfile=%t/%N.cid
-ExecStopPost=-/nix/store/00000000000000000000000000000000-podman/bin/podman rm -v -f -i --cidfile=%t/%N.cid
+ExecStop=/nix/store/00000000000000000000000000000000-podman/bin/podman rm -v -f -i my-container-bld
+ExecStopPost=-/nix/store/00000000000000000000000000000000-podman/bin/podman rm -v -f -i my-container-bld
 Delegate=yes
 Type=notify
 NotifyAccess=all
 SyslogIdentifier=%N
-ExecStart=/nix/store/00000000000000000000000000000000-podman/bin/podman run --name my-container-bld --cidfile=%t/%N.cid --replace --rm --cgroups=split --sdnotify=conmon -d --label nix.home-manager.managed=true homemanager/my-bld
+ExecStart=/nix/store/00000000000000000000000000000000-podman/bin/podman run --name my-container-bld --replace --rm --cgroups=split --sdnotify=conmon -d --label nix.home-manager.managed=true homemanager/my-bld
 
 [Unit]
 Wants=podman-user-wait-network-online.service
 After=podman-user-wait-network-online.service
 Description=Service for container my-container-bld
 SourcePath=/nix/store/00000000000000000000000000000000-home-container-podman-my-container-bld/quadlets/podman-my-container-bld.container
+RequiresMountsFor=%t/containers
 Requires=podman-my-bld-build.service
 After=podman-my-bld-build.service
-RequiresMountsFor=%t/containers

--- a/tests/modules/services/podman-linux/integration-container-expected.service
+++ b/tests/modules/services/podman-linux/integration-container-expected.service
@@ -18,27 +18,27 @@ WantedBy=default.target
 WantedBy=multi-user.target
 
 [Service]
-Environment=PATH=/run/wrappers/bin:/run/current-system/sw/bin:/home/hm-user/.nix-profile/bin:@systemd@/bin
+Environment=PATH=/run/wrappers/bin:/run/current-system/sw/bin:@nftables@/bin:/home/hm-user/.nix-profile/bin:@systemd@/bin
 Restart=always
 TimeoutStopSec=30
 Environment=PODMAN_SYSTEMD_UNIT=%n
 KillMode=mixed
-ExecStop=/nix/store/00000000000000000000000000000000-podman/bin/podman rm -v -f -i --cidfile=%t/%N.cid
-ExecStopPost=-/nix/store/00000000000000000000000000000000-podman/bin/podman rm -v -f -i --cidfile=%t/%N.cid
+ExecStop=/nix/store/00000000000000000000000000000000-podman/bin/podman rm -v -f -i my-container
+ExecStopPost=-/nix/store/00000000000000000000000000000000-podman/bin/podman rm -v -f -i my-container
 Delegate=yes
 Type=notify
 NotifyAccess=all
 SyslogIdentifier=%N
-ExecStart=/nix/store/00000000000000000000000000000000-podman/bin/podman run --name my-container --cidfile=%t/%N.cid --replace --rm --cgroups=split --network my-app --network externalnet --sdnotify=conmon -d -v my-app:/data --label nix.home-manager.managed=true docker.io/alpine:latest
+ExecStart=/nix/store/00000000000000000000000000000000-podman/bin/podman run --name my-container --replace --rm --cgroups=split --network my-app --network externalnet --sdnotify=conmon -d -v my-app:/data --label nix.home-manager.managed=true docker.io/alpine:latest
 
 [Unit]
 Wants=podman-user-wait-network-online.service
 After=podman-user-wait-network-online.service
 Description=Service for container my-container
 SourcePath=/nix/store/00000000000000000000000000000000-home-container-podman-my-container/quadlets/podman-my-container.container
+RequiresMountsFor=%t/containers
 Requires=podman-my-img-image.service
 After=podman-my-img-image.service
-RequiresMountsFor=%t/containers
 Requires=podman-my-app-network.service
 After=podman-my-app-network.service
 Requires=podman-my-app-volume.service

--- a/tests/modules/services/podman-linux/integration.nix
+++ b/tests/modules/services/podman-linux/integration.nix
@@ -4,78 +4,79 @@
   pkgs,
   ...
 }:
-
-lib.mkIf config.test.enableLegacyIfd {
+{
   imports = [ ./podman-stubs.nix ];
 
-  services.podman = {
-    enable = true;
-    builds."my-bld" = {
-      file =
-        let
-          containerFile = pkgs.writeTextFile {
-            name = "Containerfile";
-            text = ''
-              FROM docker.io/alpine:latest
-            '';
-          };
-        in
-        "${containerFile}";
-    };
-    containers = {
-      "my-container" = {
-        image = "my-img.image";
-        network = [
-          "my-app.network"
-          "externalnet"
-        ];
-        volumes = [ "my-app.volume:/data" ];
+  config = lib.mkIf config.test.enableLegacyIfd {
+    services.podman = {
+      enable = true;
+      builds."my-bld" = {
+        file =
+          let
+            containerFile = pkgs.writeTextFile {
+              name = "Containerfile";
+              text = ''
+                FROM docker.io/alpine:latest
+              '';
+            };
+          in
+          "${containerFile}";
       };
-      "my-container-bld" = {
-        image = "my-bld.build";
+      containers = {
+        "my-container" = {
+          image = "my-img.image";
+          network = [
+            "my-app.network"
+            "externalnet"
+          ];
+          volumes = [ "my-app.volume:/data" ];
+        };
+        "my-container-bld" = {
+          image = "my-bld.build";
+        };
+      };
+      images."my-img" = {
+        image = "docker.io/alpine:latest";
+      };
+      networks."my-app" = {
+        gateway = "192.168.123.1";
+        subnet = "192.168.123.0/24";
+      };
+      volumes."my-app" = {
+        device = "tmpfs";
+        preserve = false;
+        type = "tmpfs";
       };
     };
-    images."my-img" = {
-      image = "docker.io/alpine:latest";
-    };
-    networks."my-app" = {
-      gateway = "192.168.123.1";
-      subnet = "192.168.123.0/24";
-    };
-    volumes."my-app" = {
-      device = "tmpfs";
-      preserve = false;
-      type = "tmpfs";
-    };
+
+    nmt.script = ''
+      configPath=home-files/.config/systemd/user
+      buildFile=$configPath/podman-my-bld-build.service
+      containerFile=$configPath/podman-my-container.service
+      containerBldFile=$configPath/podman-my-container-bld.service
+      imageFile=$configPath/podman-my-img-image.service
+      networkFile=$configPath/podman-my-app-network.service
+      volumeFile=$configPath/podman-my-app-volume.service
+      assertFileExists $buildFile
+      assertFileExists $containerFile
+      assertFileExists $containerBldFile
+      assertFileExists $imageFile
+      assertFileExists $networkFile
+      assertFileExists $volumeFile
+
+      buildFile=$(normalizeStorePaths $buildFile)
+      containerFile=$(normalizeStorePaths $containerFile)
+      containerBldFile=$(normalizeStorePaths $containerBldFile)
+      imageFile=$(normalizeStorePaths $imageFile)
+      networkFile=$(normalizeStorePaths $networkFile)
+      volumeFile=$(normalizeStorePaths $volumeFile)
+
+      assertFileContent $buildFile ${./integration-build-expected.service}
+      assertFileContent $containerFile ${./integration-container-expected.service}
+      assertFileContent $containerBldFile ${./integration-container-bld-expected.service}
+      assertFileContent $imageFile ${./integration-image-expected.service}
+      assertFileContent $networkFile ${./integration-network-expected.service}
+      assertFileContent $volumeFile ${./integration-volume-expected.service}
+    '';
   };
-
-  nmt.script = ''
-    configPath=home-files/.config/systemd/user
-    buildFile=$configPath/podman-my-bld-build.service
-    containerFile=$configPath/podman-my-container.service
-    containerBldFile=$configPath/podman-my-container-bld.service
-    imageFile=$configPath/podman-my-img-image.service
-    networkFile=$configPath/podman-my-app-network.service
-    volumeFile=$configPath/podman-my-app-volume.service
-    assertFileExists $buildFile
-    assertFileExists $containerFile
-    assertFileExists $containerBldFile
-    assertFileExists $imageFile
-    assertFileExists $networkFile
-    assertFileExists $volumeFile
-
-    buildFile=$(normalizeStorePaths $buildFile)
-    containerFile=$(normalizeStorePaths $containerFile)
-    containerBldFile=$(normalizeStorePaths $containerBldFile)
-    imageFile=$(normalizeStorePaths $imageFile)
-    networkFile=$(normalizeStorePaths $networkFile)
-    volumeFile=$(normalizeStorePaths $volumeFile)
-
-    assertFileContent $buildFile ${./integration-build-expected.service}
-    assertFileContent $containerFile ${./integration-container-expected.service}
-    assertFileContent $containerBldFile ${./integration-container-bld-expected.service}
-    assertFileContent $imageFile ${./integration-image-expected.service}
-    assertFileContent $networkFile ${./integration-network-expected.service}
-    assertFileContent $volumeFile ${./integration-volume-expected.service}
-  '';
 }

--- a/tests/modules/services/podman-linux/manifest.nix
+++ b/tests/modules/services/podman-linux/manifest.nix
@@ -1,62 +1,62 @@
 { config, lib, ... }:
-
-lib.mkIf config.test.enableLegacyIfd {
+{
   imports = [ ./podman-stubs.nix ];
+  config = lib.mkIf config.test.enableLegacyIfd {
+    services.podman = {
+      enable = true;
+      containers."my-container-1" = {
+        description = "home-manager test";
+        autoUpdate = "registry";
+        autoStart = true;
+        image = "docker.io/alpine:latest";
+        entrypoint = "sleep 1000";
+        environment = {
+          "VAL_A" = "A";
+          "VAL_B" = 2;
+          "VAL_C" = false;
+        };
+      };
+    };
 
-  services.podman = {
-    enable = true;
-    containers."my-container-1" = {
+    services.podman.containers."my-container-2" = {
       description = "home-manager test";
       autoUpdate = "registry";
       autoStart = true;
       image = "docker.io/alpine:latest";
       entrypoint = "sleep 1000";
       environment = {
-        "VAL_A" = "A";
-        "VAL_B" = 2;
-        "VAL_C" = false;
+        "VAL_A" = "B";
+        "VAL_B" = 3;
+        "VAL_C" = true;
       };
     };
-  };
 
-  services.podman.containers."my-container-2" = {
-    description = "home-manager test";
-    autoUpdate = "registry";
-    autoStart = true;
-    image = "docker.io/alpine:latest";
-    entrypoint = "sleep 1000";
-    environment = {
-      "VAL_A" = "B";
-      "VAL_B" = 3;
-      "VAL_C" = true;
+    services.podman.networks."mynet-1" = {
+      subnet = "192.168.1.0/24";
+      gateway = "192.168.1.1";
     };
+    services.podman.networks."mynet-2" = {
+      subnet = "192.168.2.0/24";
+      gateway = "192.168.2.1";
+    };
+
+    nmt.script = ''
+      configPath=home-files/.config/podman
+      containerManifest=$configPath/containers.manifest
+      networkManifest=$configPath/networks.manifest
+
+      assertFileExists $containerManifest
+      assertFileExists $networkManifest
+
+      assertFileContent $containerManifest ${builtins.toFile "containers.expected" ''
+        my-container-1
+        my-container-2
+      ''}
+
+      assertFileContent $networkManifest ${builtins.toFile "networks.expected" ''
+        mynet-1
+        mynet-2
+      ''}
+    '';
   };
-
-  services.podman.networks."mynet-1" = {
-    subnet = "192.168.1.0/24";
-    gateway = "192.168.1.1";
-  };
-  services.podman.networks."mynet-2" = {
-    subnet = "192.168.2.0/24";
-    gateway = "192.168.2.1";
-  };
-
-  nmt.script = ''
-    configPath=home-files/.config/podman
-    containerManifest=$configPath/containers.manifest
-    networkManifest=$configPath/networks.manifest
-
-    assertFileExists $containerManifest
-    assertFileExists $networkManifest
-
-    assertFileContent $containerManifest ${builtins.toFile "containers.expected" ''
-      my-container-1
-      my-container-2
-    ''}
-
-    assertFileContent $networkManifest ${builtins.toFile "networks.expected" ''
-      mynet-1
-      mynet-2
-    ''}
-  '';
 }

--- a/tests/modules/services/podman-linux/network.nix
+++ b/tests/modules/services/podman-linux/network.nix
@@ -1,52 +1,52 @@
 { config, lib, ... }:
-
-lib.mkIf config.test.enableLegacyIfd {
+{
   imports = [ ./podman-stubs.nix ];
-
-  services.podman = {
-    enable = true;
-    networks = {
-      "my-net" = {
-        subnet = "192.168.1.0/24";
-        gateway = "192.168.1.1";
-        extraPodmanArgs = [ "--ipam-driver dhcp" ];
-        extraConfig = {
-          Network = {
-            NetworkName = "my-net";
-            Options = {
-              isolate = "true";
+  config = lib.mkIf config.test.enableLegacyIfd {
+    services.podman = {
+      enable = true;
+      networks = {
+        "my-net" = {
+          subnet = "192.168.1.0/24";
+          gateway = "192.168.1.1";
+          extraPodmanArgs = [ "--ipam-driver dhcp" ];
+          extraConfig = {
+            Network = {
+              NetworkName = "my-net";
+              Options = {
+                isolate = "true";
+              };
+              PodmanArgs = [
+                "--dns=192.168.55.1"
+                "--log-level=debug"
+              ];
             };
-            PodmanArgs = [
-              "--dns=192.168.55.1"
-              "--log-level=debug"
-            ];
           };
         };
-      };
 
-      "my-net-2" = {
-        subnet = "192.168.2.0/24";
-        gateway = "192.168.2.1";
-        extraConfig = {
-          Network = {
-            NetworkName = "some-other-network-name";
+        "my-net-2" = {
+          subnet = "192.168.2.0/24";
+          gateway = "192.168.2.1";
+          extraConfig = {
+            Network = {
+              NetworkName = "some-other-network-name";
+            };
           };
         };
       };
     };
+
+    test.asserts.assertions.expected = [
+      ''In 'my-net-2' config. Network.NetworkName: 'some-other-network-name' does not match expected type: value "my-net-2" (singular enum)''
+    ];
+
+    nmt.script = ''
+      configPath=home-files/.config/systemd/user
+      networkFile=$configPath/podman-my-net-network.service
+      assertFileExists $networkFile
+
+      networkFile=$(normalizeStorePaths $networkFile)
+
+      assertFileContent $networkFile ${./network-expected.service}
+    '';
   };
-
-  test.asserts.assertions.expected = [
-    ''In 'my-net-2' config. Network.NetworkName: 'some-other-network-name' does not match expected type: value "my-net-2" (singular enum)''
-  ];
-
-  nmt.script = ''
-    configPath=home-files/.config/systemd/user
-    networkFile=$configPath/podman-my-net-network.service
-    assertFileExists $networkFile
-
-    networkFile=$(normalizeStorePaths $networkFile)
-
-    assertFileContent $networkFile ${./network-expected.service}
-  '';
 }

--- a/tests/modules/services/podman-linux/volume.nix
+++ b/tests/modules/services/podman-linux/volume.nix
@@ -1,44 +1,44 @@
 { config, lib, ... }:
-
-lib.mkIf config.test.enableLegacyIfd {
+{
   imports = [ ./podman-stubs.nix ];
-
-  services.podman = {
-    enable = true;
-    volumes = {
-      "my-vol" = {
-        device = "tmpfs";
-        extraConfig = {
-          Volume = {
-            User = 1000;
+  config = lib.mkIf config.test.enableLegacyIfd {
+    services.podman = {
+      enable = true;
+      volumes = {
+        "my-vol" = {
+          device = "tmpfs";
+          extraConfig = {
+            Volume = {
+              User = 1000;
+            };
           };
+          extraPodmanArgs = [ "--module=/etc/nvd.conf" ];
+          group = 1000;
+          type = "tmpfs";
         };
-        extraPodmanArgs = [ "--module=/etc/nvd.conf" ];
-        group = 1000;
-        type = "tmpfs";
-      };
 
-      "my-vol-2" = {
-        extraConfig = {
-          Volume = {
-            VolumeName = "some-other-volume-name";
+        "my-vol-2" = {
+          extraConfig = {
+            Volume = {
+              VolumeName = "some-other-volume-name";
+            };
           };
         };
       };
     };
+
+    test.asserts.assertions.expected = [
+      ''In 'my-vol-2' config. Volume.VolumeName: 'some-other-volume-name' does not match expected type: value "my-vol-2" (singular enum)''
+    ];
+
+    nmt.script = ''
+      configPath=home-files/.config/systemd/user
+      volumeFile=$configPath/podman-my-vol-volume.service
+      assertFileExists $volumeFile
+
+      volumeFile=$(normalizeStorePaths $volumeFile)
+
+      assertFileContent $volumeFile ${./volume-expected.service}
+    '';
   };
-
-  test.asserts.assertions.expected = [
-    ''In 'my-vol-2' config. Volume.VolumeName: 'some-other-volume-name' does not match expected type: value "my-vol-2" (singular enum)''
-  ];
-
-  nmt.script = ''
-    configPath=home-files/.config/systemd/user
-    volumeFile=$configPath/podman-my-vol-volume.service
-    assertFileExists $volumeFile
-
-    volumeFile=$(normalizeStorePaths $volumeFile)
-
-    assertFileContent $volumeFile ${./volume-expected.service}
-  '';
 }


### PR DESCRIPTION
### Description
Update the expected results to match changes in the podman generator and fix not importing the podman stub overlay with module import behind `mkIf` introduced in #6905


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
