### PR TITLE
ssh-agent: only preserve $SSH_AUTH_SOCK if it stems from a forwarded agent

### DIFF
--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -57,18 +57,19 @@ in
               else
                 "$XDG_RUNTIME_DIR/${cfg.socket}";
 
+            # Preserve $SSH_AUTH_SOCK only if it stems from a forwarded agent,
+            # which is the case if both $SSH_AUTH_SOCK and $SSH_CONNECTION are
+            # set.
             bashIntegration = ''
-              if [ -z "$SSH_AUTH_SOCK" ]; then
+              if [ -z "$SSH_AUTH_SOCK" -o -z "$SSH_CONNECTION" ]; then
                 export SSH_AUTH_SOCK=${socketPath}
               fi
             '';
-
             fishIntegration = ''
-              if test -z "$SSH_AUTH_SOCK"
+              if test -z "$SSH_AUTH_SOCK"; or test -z "$SSH_CONNECTION"
                 set -x SSH_AUTH_SOCK ${socketPath}
               end
             '';
-
             nushellIntegration =
               let
                 unsetOrEmpty = var: ''("${var}" not-in $env) or ($env.${var} | is-empty)'';
@@ -79,7 +80,7 @@ in
                     ''$"($env.XDG_RUNTIME_DIR)/${cfg.socket}"'';
               in
               ''
-                if ${unsetOrEmpty "SSH_AUTH_SOCK"} {
+                if ${unsetOrEmpty "SSH_AUTH_SOCK"} or ${unsetOrEmpty "SSH_CONNECTION"} {
                   $env.SSH_AUTH_SOCK = ${socketPath}
                 }
               '';


### PR DESCRIPTION
### Description

This PR solves the problem that `$SSH_AUTH_SOCK` is not set to the socket of Home Manager's `ssh-agent` if the variable is already set by another `ssh-agent` instance, like e.g. on macOS. With this PR, `$SSH_AUTH_SOCK` is only preserved if it stems from a forwarded agent which is the case when `$SSH_AGENT_SOCK` and `$SSH_CONNECTION` are both non-empty.

It was inspired by https://github.com/nix-community/home-manager/pull/7355.

While adjusting this, I also encountered that the supposed check for emptiness in the Nushell integration code succeeds on unset variables but fails on empty variables, and fixed that accordingly.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
