### PR TITLE
xsession: add xsession.sessionVariables

### DIFF
--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -95,6 +95,27 @@ in
         description = "Extra shell commands to run during initialization.";
       };
 
+      sessionVariables = mkOption {
+        default = { };
+        type =
+          with types;
+          lazyAttrsOf (oneOf [
+            str
+            path
+            int
+            float
+          ]);
+        example = {
+          EDITOR = "emacs";
+          GS_OPTIONS = "-sPAPERSIZE=a4";
+        };
+        description = ''
+          Environment variables to set in every X session in [](#opt-xsession.profilePath).
+
+          For more documentation see [](#opt-home.sessionVariables).
+        '';
+      };
+
       importedVariables = mkOption {
         type = types.listOf (types.strMatching "[a-zA-Z_][a-zA-Z0-9_]*");
         apply = lib.unique;
@@ -212,6 +233,8 @@ in
       if [ -e "$HOME/.profile" ]; then
         . "$HOME/.profile"
       fi
+
+      ${config.lib.shell.exportAll cfg.sessionVariables}
 
       # If there are any running services from a previous session.
       # Need to run this in xprofile because the NixOS xsession

--- a/tests/modules/misc/xsession/basic-xprofile-expected.txt
+++ b/tests/modules/misc/xsession/basic-xprofile-expected.txt
@@ -4,6 +4,8 @@ if [ -e "$HOME/.profile" ]; then
   . "$HOME/.profile"
 fi
 
+export EXTRA_XSESSION_VARIABLE="extra_xsession_variable_value"
+
 # If there are any running services from a previous session.
 # Need to run this in xprofile because the NixOS xsession
 # script starts up graphical-session.target.

--- a/tests/modules/misc/xsession/basic.nix
+++ b/tests/modules/misc/xsession/basic.nix
@@ -4,6 +4,7 @@
       enable = true;
       windowManager.command = "window manager command";
       importedVariables = [ "EXTRA_IMPORTED_VARIABLE" ];
+      sessionVariables.EXTRA_XSESSION_VARIABLE = "extra_xsession_variable_value";
       initExtra = "init extra commands";
       profileExtra = "profile extra commands";
     };


### PR DESCRIPTION


### Description

This adds an option to set environment variables specifically for the X session in the same way as for `home.sessionVariables`.
These session variables are set in xprofile before variables are imported into the systemd user session. Since `xsession.profileExtra` is only sourced after this, it cannot set a variable which is imported into this session.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` ~or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.~

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds an exciting new feature or contains a breaking change.
  ***Does it?***
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
