### PR TITLE
anki: fix `answerKeys` of length one

### DIFF
--- a/modules/programs/anki/helper.nix
+++ b/modules/programs/anki/helper.nix
@@ -112,7 +112,7 @@ let
 
     answer_keys: tuple[tuple[int, str], ...] = (${
       lib.strings.concatMapStringsSep ", " (val: "(${toString val.ease}, '${val.key}')") cfg.answerKeys
-    })
+    }${if cfg.answerKeys != [ ] then "," else ""})
     for ease, key in answer_keys:
       profile_manager.set_answer_key(ease, key)
 


### PR DESCRIPTION
### Description

Fix support for `anki.answerKeys` with only one element.

Fixes #8450.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```