### PR TITLE
programs.neovim: builtins.groupBy -> lib.groupBy

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -459,7 +459,7 @@ in
 
         generatedConfigs =
           let
-            grouped = builtins.groupBy (x: x.type) pluginsNormalized;
+            grouped = lib.groupBy (x: x.type) pluginsNormalized;
             configsOnly = lib.foldl (acc: p: if p.config != null then acc ++ [ p.config ] else acc) [ ];
           in
           lib.mapAttrs (_name: vals: lib.concatStringsSep "\n" (configsOnly vals)) grouped;


### PR DESCRIPTION
lib.groupBy is an alias for builtins.groupBy which should be preferred, as it also has a compatibility shim in case the Nix implementation doesn't have the builtin function.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

