### PR TITLE
vicinae: Use a simpler raycast extension in the test to avoid npm issues

### DIFF
--- a/tests/modules/programs/vicinae/example-settings.nix
+++ b/tests/modules/programs/vicinae/example-settings.nix
@@ -62,9 +62,9 @@
 
     extensions = [
       (config.lib.vicinae.mkRayCastExtension {
-        name = "gif-search";
-        sha256 = "sha256-G7il8T1L+P/2mXWJsb68n4BCbVKcrrtK8GnBNxzt73Q=";
-        rev = "4d417c2dfd86a5b2bea202d4a7b48d8eb3dbaeb1";
+        name = "cdnjs";
+        sha256 = "sha256-k3YfruMxSOMf8K65iTW84aZxiknADCcntJOAE89agYc=";
+        rev = "ac7c50844bf77d0cf51daa840e369d999f2add59";
       })
       (config.lib.vicinae.mkExtension {
         name = "test-extension";
@@ -88,7 +88,7 @@
     assertFileExists      "home-files/.config/vicinae/settings.json"
     assertFileExists      "home-files/.config/systemd/user/vicinae.service"
     assertFileExists      "home-files/.local/share/vicinae/themes/catppuccin-mocha.toml"
-    assertFileExists      "home-files/.local/share/vicinae/extensions/gif-search/package.json"
+    assertFileExists      "home-files/.local/share/vicinae/extensions/cdnjs/package.json"
     assertFileExists      "home-files/.local/share/vicinae/extensions/test-extension/package.json"
     assertFileContent     "home-files/.config/systemd/user/vicinae.service"  ${./service.service}
   '';


### PR DESCRIPTION

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
