### PR TITLE
ssh-agent: add pkcs11Whitelist option

### DIFF
--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -37,6 +37,17 @@ in
       '';
     };
 
+    pkcs11Whitelist = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = lib.literalExpression ''[ "''${pkgs.tpm2-pkcs11}/lib/*" ]'';
+      description = ''
+        Specify a list of approved path patterns for PKCS#11 and FIDO authenticator middleware libraries. When using the -s or -S options with {manpage}`ssh-add(1)`, only libraries matching these patterns will be accepted.
+
+        See {manpage}`ssh-agent(1)`.
+      '';
+    };
+
     enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
@@ -101,6 +112,10 @@ in
         lib.optionalString (
           cfg.defaultMaximumIdentityLifetime != null
         ) " -t ${toString cfg.defaultMaximumIdentityLifetime}"
+      }${
+        lib.optionalString (
+          cfg.pkcs11Whitelist != [ ]
+        ) " -P '${lib.concatStringsSep "," cfg.pkcs11Whitelist}'"
       }";
     };
 
@@ -114,6 +129,10 @@ in
             lib.optionalString (
               cfg.defaultMaximumIdentityLifetime != null
             ) " -t ${toString cfg.defaultMaximumIdentityLifetime}"
+          }${
+            lib.optionalString (
+              cfg.pkcs11Whitelist != [ ]
+            ) " -P '${lib.concatStringsSep "," cfg.pkcs11Whitelist}'"
           }''
         ];
         KeepAlive = {
@@ -124,7 +143,5 @@ in
         RunAtLoad = true;
       };
     };
-
   };
-
 }

--- a/tests/modules/services/ssh-agent/darwin/default.nix
+++ b/tests/modules/services/ssh-agent/darwin/default.nix
@@ -1,6 +1,7 @@
 {
   ssh-agent-darwin-basic-service = ./basic-service.nix;
   ssh-agent-darwin-timeout-service = ./timeout-service.nix;
+  ssh-agent-darwin-pkcs11-service = ./pkcs11-service.nix;
   ssh-agent-darwin-bash-integration = ./bash-integration.nix;
   ssh-agent-darwin-nushell-integration = ./nushell-integration.nix;
 }

--- a/tests/modules/services/ssh-agent/darwin/pkcs11-service-expected.plist
+++ b/tests/modules/services/ssh-agent/darwin/pkcs11-service-expected.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>KeepAlive</key>
+	<dict>
+		<key>Crashed</key>
+		<true/>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+	<key>Label</key>
+	<string>org.nix-community.home.ssh-agent</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>@bash-interactive@/bin/bash</string>
+		<string>-c</string>
+		<string>@openssh@/bin/ssh-agent -D -a &quot;$(@getconf-system_cmds@/bin/getconf DARWIN_USER_TEMP_DIR)/ssh-agent&quot; -P &apos;/usr/lib/libpkcs11.so,/usr/lib/other.so&apos;</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/modules/services/ssh-agent/darwin/pkcs11-service.nix
+++ b/tests/modules/services/ssh-agent/darwin/pkcs11-service.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  ...
+}:
+
+{
+  services.ssh-agent = {
+    enable = true;
+    pkcs11Whitelist = [
+      "/usr/lib/libpkcs11.so"
+      "/usr/lib/other.so"
+    ];
+    package = config.lib.test.mkStubPackage { outPath = "@openssh@"; };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      LaunchAgents/org.nix-community.home.ssh-agent.plist \
+      ${./pkcs11-service-expected.plist}
+  '';
+}

--- a/tests/modules/services/ssh-agent/linux/default.nix
+++ b/tests/modules/services/ssh-agent/linux/default.nix
@@ -1,4 +1,5 @@
 {
   ssh-agent-basic-service = ./basic-service.nix;
   ssh-agent-timeout-service = ./timeout-service.nix;
+  ssh-agent-pkcs11-service = ./pkcs11-service.nix;
 }

--- a/tests/modules/services/ssh-agent/linux/pkcs11-service-expected.service
+++ b/tests/modules/services/ssh-agent/linux/pkcs11-service-expected.service
@@ -1,0 +1,9 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecStart=@openssh@/bin/ssh-agent -D -a %t/ssh-agent -P '/nix/store/*/lib,/usr/lib/libpkcs11.so,/usr/lib/other.so'
+
+[Unit]
+Description=SSH authentication agent
+Documentation=man:ssh-agent(1)

--- a/tests/modules/services/ssh-agent/linux/pkcs11-service.nix
+++ b/tests/modules/services/ssh-agent/linux/pkcs11-service.nix
@@ -1,0 +1,16 @@
+{
+  services.ssh-agent = {
+    enable = true;
+    pkcs11Whitelist = [
+      "/nix/store/*/lib"
+      "/usr/lib/libpkcs11.so"
+      "/usr/lib/other.so"
+    ];
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/systemd/user/ssh-agent.service \
+      ${./pkcs11-service-expected.service}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a new option `pkcs11Whitelist` to the services.ssh-agent module. This option allows users to specify a list of allowed PKCS#11 providers, which is passed to ssh-agent using the -P flag.

This is important since by default, `ssh-agent` refuses to load PKCS#11 modules outside a whitelist of trusted paths, and /nix/store paths are not included in this default list.

I do not have a darwin machine though. Need some help to test this there.

Related: https://github.com/nix-community/home-manager/issues/8321

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
