### PR TITLE
treewide: remove AndersonTorres from maintainers.

### DIFF
--- a/modules/programs/bashmount.nix
+++ b/modules/programs/bashmount.nix
@@ -8,7 +8,7 @@ let
   cfg = config.programs.bashmount;
 in
 {
-  meta.maintainers = [ lib.maintainers.AndersonTorres ];
+  meta.maintainers = [ ];
 
   options.programs.bashmount = {
     enable = lib.mkEnableOption "bashmount";

--- a/modules/programs/havoc.nix
+++ b/modules/programs/havoc.nix
@@ -9,7 +9,7 @@ let
   iniFormat = pkgs.formats.ini { };
 in
 {
-  meta.maintainers = with lib.maintainers; [ AndersonTorres ];
+  meta.maintainers = with lib.maintainers; [ ];
 
   options.programs.havoc = {
     enable = lib.mkEnableOption "Havoc terminal";

--- a/modules/services/pueue.nix
+++ b/modules/services/pueue.nix
@@ -11,7 +11,7 @@ let
   pueuedBin = "${cfg.package}/bin/pueued";
 in
 {
-  meta.maintainers = [ lib.maintainers.AndersonTorres ];
+  meta.maintainers = [ ];
 
   options.services.pueue = {
     enable = lib.mkEnableOption "Pueue, CLI process scheduler and manager";

--- a/modules/services/window-managers/fluxbox.nix
+++ b/modules/services/window-managers/fluxbox.nix
@@ -11,7 +11,7 @@ let
 
 in
 {
-  meta.maintainers = [ lib.maintainers.AndersonTorres ];
+  meta.maintainers = [ ];
 
   options = {
     xsession.windowManager.fluxbox = {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
