### PR TITLE
hyprland: import `XDG_SESSION_TYPE` for systemd

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -130,6 +130,7 @@ in
           - `HYPRLAND_INSTANCE_SIGNATURE`
           - `WAYLAND_DISPLAY`
           - `XDG_CURRENT_DESKTOP`
+          - `XDG_SESSION_TYPE`
         '';
       };
 
@@ -140,6 +141,7 @@ in
           "HYPRLAND_INSTANCE_SIGNATURE"
           "WAYLAND_DISPLAY"
           "XDG_CURRENT_DESKTOP"
+          "XDG_SESSION_TYPE"
         ];
         example = [ "--all" ];
         description = ''

--- a/tests/modules/services/hyprland/multiple-devices-config.conf
+++ b/tests/modules/services/hyprland/multiple-devices-config.conf
@@ -1,4 +1,4 @@
-exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
+exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
 exec-once=hyprctl plugin load /path/to/plugin1
 exec-once=hyprctl plugin load /nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
 $mod=SUPER

--- a/tests/modules/services/hyprland/null-package-config.conf
+++ b/tests/modules/services/hyprland/null-package-config.conf
@@ -1,4 +1,4 @@
-exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
+exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
 exec-once=hyprctl plugin load /path/to/plugin1
 exec-once=hyprctl plugin load /nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
 cursor {

--- a/tests/modules/services/hyprland/simple-config.conf
+++ b/tests/modules/services/hyprland/simple-config.conf
@@ -1,4 +1,4 @@
-exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
+exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
 exec-once=hyprctl plugin load /path/to/plugin1
 exec-once=hyprctl plugin load /nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
 $mod=SUPER

--- a/tests/modules/services/hyprland/sourceFirst-false-config.conf
+++ b/tests/modules/services/hyprland/sourceFirst-false-config.conf
@@ -1,4 +1,4 @@
-exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
+exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
 bezier=smoothOut, 0.36, 0, 0.66, -0.56
 bezier=smoothIn, 0.25, 1, 0.5, 1
 bezier=overshot, 0.4,0.8,0.2,1.2

--- a/tests/modules/services/hyprland/submaps-config.conf
+++ b/tests/modules/services/hyprland/submaps-config.conf
@@ -1,4 +1,4 @@
-exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
+exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
 $mod=SUPER
 bind=$mod, S, submap, resize
 bind=$mod, M, submap, move_focus


### PR DESCRIPTION
### Description

This adds the `XDG_SESSION_TYPE` environment variable to be imported for systemd and D-Bus by default, which should fix behavior like https://github.com/nix-community/home-manager/issues/8483.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
