### PR TITLE
ghostty: reload service on configuration change

### DIFF
--- a/modules/programs/ghostty.nix
+++ b/modules/programs/ghostty.nix
@@ -231,6 +231,15 @@ in
         xdg.configFile."systemd/user/app-com.mitchellh.ghostty.service.d/overrides.conf".text = ''
           [Unit]
           X-SwitchMethod=keep-old
+          X-Reload-Triggers=${
+            let
+              storePathOf = name: config.xdg.configFile.${name}.source;
+            in
+            toString (
+              lib.optionals (cfg.settings != { }) [ (storePathOf "ghostty/config") ]
+              ++ lib.mapAttrsToList (name: _: storePathOf "ghostty/themes/${name}") cfg.themes
+            )
+          }
         '';
 
         dbus.packages = [ cfg.package ];

--- a/tests/modules/programs/ghostty/systemd-service.nix
+++ b/tests/modules/programs/ghostty/systemd-service.nix
@@ -8,6 +8,33 @@
       theme = "catppuccin-mocha";
       font-size = 10;
     };
+    themes = {
+      catppuccin-mocha = {
+        palette = [
+          "0=#45475a"
+          "1=#f38ba8"
+          "2=#a6e3a1"
+          "3=#f9e2af"
+          "4=#89b4fa"
+          "5=#f5c2e7"
+          "6=#94e2d5"
+          "7=#bac2de"
+          "8=#585b70"
+          "9=#f38ba8"
+          "10=#a6e3a1"
+          "11=#f9e2af"
+          "12=#89b4fa"
+          "13=#f5c2e7"
+          "14=#94e2d5"
+          "15=#a6adc8"
+        ];
+        background = "1e1e2e";
+        foreground = "cdd6f4";
+        cursor-color = "f5e0dc";
+        selection-background = "353749";
+        selection-foreground = "cdd6f4";
+      };
+    };
   };
 
   nmt.script = ''
@@ -15,10 +42,11 @@
     serviceOverridesPath=$servicePath.d/overrides.conf
 
     assertFileExists $serviceOverridesPath
-    assertFileContent $serviceOverridesPath \
+    assertFileContent $(normalizeStorePaths $serviceOverridesPath) \
       ${builtins.toFile "ghostty-service-overrides" ''
         [Unit]
         X-SwitchMethod=keep-old
+        X-Reload-Triggers=/nix/store/00000000000000000000000000000000-ghostty-config /nix/store/00000000000000000000000000000000-ghostty-catppuccin-mocha-theme
       ''}
 
     assertFileContent \


### PR DESCRIPTION
### Description

Adds basic support for reloading the Ghostty systemd service when the configuration changes.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
