### PR TITLE
lib.darwin: simplify `assertInterval`

### DIFF
--- a/modules/lib/darwin.nix
+++ b/modules/lib/darwin.nix
@@ -63,12 +63,12 @@ let
   intervalsString = lib.concatStringsSep ", " intervals;
 
   assertInterval = option: interval: pkgs: {
-    assertion = (!pkgs.stdenv.isDarwin) || (lib.elem interval intervals);
-    message = "On Darwin ${option} must be one of: ${intervalsString}.";
+    assertion = pkgs.stdenv.isDarwin -> lib.elem interval intervals;
+    message = "On Darwin, ${option} must be one of: ${intervalsString}.";
   };
 
   intervalDocumentation = ''
-    On Darwin it must be one of: ${intervalsString}, which are implemented as defined in {manpage}`systemd.time(7)`.
+    On Darwin, it must be one of: ${intervalsString}, which are implemented as defined in {manpage}`systemd.time(7)`.
   '';
 in
 {

--- a/tests/modules/services/borgmatic/darwin/frequency-assertion.nix
+++ b/tests/modules/services/borgmatic/darwin/frequency-assertion.nix
@@ -5,6 +5,6 @@
   };
 
   test.asserts.assertions.expected = [
-    "On Darwin services.borgmatic.frequency must be one of: hourly, daily, weekly, monthly, semiannually, annually."
+    "On Darwin, services.borgmatic.frequency must be one of: hourly, daily, weekly, monthly, semiannually, annually."
   ];
 }

--- a/tests/modules/services/home-manager-auto-expire/darwin/frequency-assertion.nix
+++ b/tests/modules/services/home-manager-auto-expire/darwin/frequency-assertion.nix
@@ -5,6 +5,6 @@
   };
 
   test.asserts.assertions.expected = [
-    "On Darwin services.home-manager.autoExpire.frequency must be one of: hourly, daily, weekly, monthly, semiannually, annually."
+    "On Darwin, services.home-manager.autoExpire.frequency must be one of: hourly, daily, weekly, monthly, semiannually, annually."
   ];
 }

--- a/tests/modules/services/nix-gc/darwin/darwin-nix-gc-interval-assertion.nix
+++ b/tests/modules/services/nix-gc/darwin/darwin-nix-gc-interval-assertion.nix
@@ -5,6 +5,6 @@
   };
 
   test.asserts.assertions.expected = [
-    "On Darwin nix.gc.dates.* must be one of: hourly, daily, weekly, monthly, semiannually, annually."
+    "On Darwin, nix.gc.dates.* must be one of: hourly, daily, weekly, monthly, semiannually, annually."
   ];
 }


### PR DESCRIPTION
### Description

Use of the idiomatic `->` syntax for implications and adds missing commas.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
