### PR TITLE
Anki: add `profiles` option

### DIFF
--- a/modules/programs/anki/default.nix
+++ b/modules/programs/anki/default.nix
@@ -17,12 +17,31 @@ in
 {
   meta.maintainers = [ lib.maintainers.junestepp ];
 
-  imports = [
-    (lib.mkRenamedOptionModule
-      [ "programs" "anki" "sync" "passwordFile" ]
-      [ "programs" "anki" "sync" "keyFile" ]
+  imports =
+    (map
+      (
+        x:
+        lib.mkRenamedOptionModule
+          [ "programs" "anki" "sync" x ]
+          [ "programs" "anki" "profiles" "User 1" "sync" x ]
+      )
+      [
+        "username"
+        "usernameFile"
+        "keyFile"
+        "url"
+        "autoSync"
+        "syncMedia"
+        "autoSyncMediaMinutes"
+        "networkTimeout"
+      ]
     )
-  ];
+    ++ [
+      (lib.mkRenamedOptionModule
+        [ "programs" "anki" "sync" "passwordFile" ]
+        [ "programs" "anki" "profiles" "User 1" "sync" "keyFile" ]
+      )
+    ];
 
   options.programs.anki = {
     enable = lib.mkEnableOption "Anki";
@@ -201,80 +220,6 @@ in
       '';
     };
 
-    sync = {
-      username = lib.mkOption {
-        type = with lib.types; nullOr str;
-        default = null;
-        example = "lovelearning@email.com";
-        description = "Sync account username.";
-      };
-
-      usernameFile = lib.mkOption {
-        type = with lib.types; nullOr path;
-        default = null;
-        description = "Path to a file containing the sync account username.";
-      };
-
-      keyFile = lib.mkOption {
-        type = with lib.types; nullOr path;
-        default = null;
-        description = ''
-          Path to a file containing the sync account sync key. This is different from
-          the account password.
-
-          To get the sync key, follow these steps:
-
-          - Enable this Home Manager module: `programs.anki.enable = true`
-          - Open Anki.
-          - Navigate to the sync settings page. (Tools > Preferences > Syncing)
-          - Log in to your AnkiWeb account.
-          - Select "Yes" to the prompt about saving preferences and syncing.
-          - A Home Manager warning prompt will show. Select "Show details...".
-          - Get your sync key from the message: "syncKey changed from \`None\` to \`<YOUR SYNC KEY WILL BE HERE>\`"
-        '';
-      };
-
-      url = lib.mkOption {
-        type = with lib.types; nullOr str;
-        default = null;
-        example = "http://example.com/anki-sync/";
-        description = ''
-          Custom sync server URL. See <https://docs.ankiweb.net/sync-server.html>.
-        '';
-      };
-
-      autoSync = lib.mkOption {
-        type = with lib.types; nullOr bool;
-        default = null;
-        example = true;
-        description = "Automatically sync on profile open/close.";
-      };
-
-      syncMedia = lib.mkOption {
-        type = with lib.types; nullOr bool;
-        default = null;
-        example = true;
-        description = "Synchronize audio and images too.";
-      };
-
-      autoSyncMediaMinutes = lib.mkOption {
-        type = with lib.types; nullOr ints.unsigned;
-        default = null;
-        example = 15;
-        description = ''
-          Automatically sync media every X minutes. Set this to 0 to disable
-          periodic media syncing.
-        '';
-      };
-
-      networkTimeout = lib.mkOption {
-        type = with lib.types; nullOr ints.unsigned;
-        default = null;
-        example = 60;
-        description = "Network timeout in seconds.";
-      };
-    };
-
     addons = lib.mkOption {
       type = with lib.types; listOf package;
       default = [ ];
@@ -310,15 +255,112 @@ in
       '';
       description = "List of Anki add-on packages to install.";
     };
+
+    profiles = lib.mkOption {
+      description = ''
+        Anki profiles and their settings.
+        Profiles are primarily intended to be one per person, and are not recommended for splitting up your own content.
+      '';
+      default = {
+        "User 1" = { };
+      };
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options = {
+            default = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Open this profile on startup.";
+            };
+            sync = {
+              username = lib.mkOption {
+                type = with lib.types; nullOr str;
+                default = null;
+                example = "lovelearning@email.com";
+                description = "Sync account username.";
+              };
+
+              usernameFile = lib.mkOption {
+                type = with lib.types; nullOr path;
+                default = null;
+                description = "Path to a file containing the sync account username.";
+              };
+
+              keyFile = lib.mkOption {
+                type = with lib.types; nullOr path;
+                default = null;
+                description = ''
+                  Path to a file containing the sync account sync key. This is different from
+                  the account password.
+
+                  To get the sync key, follow these steps:
+
+                  - Enable this Home Manager module: `programs.anki.enable = true`
+                  - Open Anki.
+                  - Navigate to the sync settings page. (Tools > Preferences > Syncing)
+                  - Log in to your AnkiWeb account.
+                  - Select "Yes" to the prompt about saving preferences and syncing.
+                  - A Home Manager warning prompt will show. Select "Show details...".
+                  - Get your sync key from the message: "syncKey changed from \`None\` to \`<YOUR SYNC KEY WILL BE HERE>\`"
+                '';
+              };
+
+              url = lib.mkOption {
+                type = with lib.types; nullOr str;
+                default = null;
+                example = "http://example.com/anki-sync/";
+                description = ''
+                  Custom sync server URL. See <https://docs.ankiweb.net/sync-server.html>.
+                '';
+              };
+
+              autoSync = lib.mkOption {
+                type = with lib.types; nullOr bool;
+                default = null;
+                example = true;
+                description = "Automatically sync on profile open/close.";
+              };
+
+              syncMedia = lib.mkOption {
+                type = with lib.types; nullOr bool;
+                default = null;
+                example = true;
+                description = "Synchronize audio and images too.";
+              };
+
+              autoSyncMediaMinutes = lib.mkOption {
+                type = with lib.types; nullOr ints.unsigned;
+                default = null;
+                example = 15;
+                description = ''
+                  Automatically sync media every X minutes. Set this to 0 to disable
+                  periodic media syncing.
+                '';
+              };
+
+              networkTimeout = lib.mkOption {
+                type = with lib.types; nullOr ints.unsigned;
+                default = null;
+                example = 60;
+                description = "Network timeout in seconds (clamped between 30 and 99999).";
+              };
+            };
+          };
+        }
+      );
+    };
   };
 
   config = lib.mkIf cfg.enable {
     assertions = [
       {
-        assertion = !(cfg.sync.username != null && cfg.sync.usernameFile != null);
+        assertion =
+          let
+            defaultProfiles = lib.filterAttrs (_: prof: prof.default) cfg.profiles;
+          in
+          lib.length (lib.attrNames defaultProfiles) <= 1;
         message = ''
-          The `programs.anki.sync` `username` option is mutually exclusive with
-          the `usernameFile` option.
+          Only one profile in `programs.anki.profiles` can be marked as default.
         '';
       }
       {
@@ -328,7 +370,34 @@ in
           add-ons. Make sure you are using `pkgs.anki`.
         '';
       }
-    ];
+    ]
+    ++ lib.concatLists (
+      lib.mapAttrsToList (
+        name: profile:
+        let
+          # Profile name must be a valid filename.
+          profileNameInvalidChars = lib.concatLists (
+            lib.filter (val: lib.isList val) (lib.split ''([.:?\"<>|\*\\\/])'' name)
+          );
+        in
+        [
+          {
+            assertion = profileNameInvalidChars == [ ];
+            message = ''
+              `programs.anki.profiles.${lib.strings.escapeNixString name}` has invalid
+              character(s) in its name: ${lib.concatStrings profileNameInvalidChars}
+            '';
+          }
+          {
+            assertion = !(profile.sync.username != null && profile.sync.usernameFile != null);
+            message = ''
+              The `programs.anki.profiles.${lib.strings.escapeNixString name}.sync`
+              `username` option is mutually exclusive with the `usernameFile` option.
+            '';
+          }
+        ]
+      ) cfg.profiles
+    );
 
     home.packages = [
       (cfg.package.withAddons (

--- a/tests/modules/programs/anki/full-config.nix
+++ b/tests/modules/programs/anki/full-config.nix
@@ -1,7 +1,8 @@
 { pkgs, ... }:
 let
   # This would normally not be a file in the store for security reasons.
-  testKeyFile = pkgs.writeText "test-key-file" "a-sync-key";
+  fooKeyFile = pkgs.writeText "foo-key-file" "a-sync-key";
+  barKeyFile = pkgs.writeText "bar-key-file" "a-sync-key";
 in
 {
   programs.anki = {
@@ -30,14 +31,30 @@ in
     theme = "dark";
     uiScale = 1.0;
     videoDriver = "opengl";
-    sync = {
-      autoSync = true;
-      syncMedia = true;
-      autoSyncMediaMinutes = 15;
-      networkTimeout = 60;
-      url = "http://example.com/anki-sync/";
-      username = "lovelearning@email.com";
-      keyFile = testKeyFile;
+    profiles = {
+      foo = {
+        default = true;
+        sync = {
+          autoSync = true;
+          syncMedia = true;
+          autoSyncMediaMinutes = 15;
+          networkTimeout = 60;
+          url = "http://foo.com/anki-sync/";
+          username = "foo@email.com";
+          keyFile = fooKeyFile;
+        };
+      };
+      bar = {
+        sync = {
+          autoSync = false;
+          syncMedia = false;
+          autoSyncMediaMinutes = 30;
+          networkTimeout = 120;
+          url = "http://foo.com/anki-sync/";
+          username = "bar@email.com";
+          keyFile = barKeyFile;
+        };
+      };
     };
   };
 


### PR DESCRIPTION
### Description

Added a `anki.profiles` option.
Fixes #8481.

The existing `anki.sync` option is deprecated.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
