### PR TITLE
Revert "hyprland: dont recompile when disabling xwayland"

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -164,6 +164,14 @@ in
 
     xwayland.enable = lib.mkEnableOption "XWayland" // {
       default = true;
+      description = ''
+        Whether or not to enable XWayland.
+
+        Overrides the `enableXWayland` option of the Hyprland package.
+
+        In newer versions of Hyprland, you can use the {option}`wayland.windowManager.hyprland.settings.xwayland`
+        option to avoid recompiling Hyprland.
+      '';
     };
 
     settings = lib.mkOption {


### PR DESCRIPTION
Reverts nix-community/home-manager#8462

Setting not supported in current version in nixpkgs. We should not be forcing an invalid configuration. 

> 
> Hmm I'd leave it as is. If people don't want xwayland linked this is their only option aside from manual override.
> 
> I'd suggest expanding the description of this option to mention the settings.xwayland option as well.

This seems more logical imo. The top level option is to use a top level override. Users can use the freeform setting, as they wish already. No reason to force everyone to use that. 