### PR TITLE
mpd: fix incorrect use of mkIf

### DIFF
--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -166,10 +166,14 @@ in
     mkIf cfg.enable {
       home = {
         packages = [ cfg.package ];
-        sessionVariables = mkIf cfg.enableSessionVariables {
-          MPD_HOST = mkIf (cfg.network.listenAddress != "any") cfg.network.listenAddress;
-          MPD_PORT = builtins.toString cfg.network.port;
-        };
+        sessionVariables = mkIf cfg.enableSessionVariables (
+          {
+            MPD_PORT = builtins.toString cfg.network.port;
+          }
+          // lib.optionalAttrs (cfg.network.listenAddress != "any") {
+            MPD_HOST = cfg.network.listenAddress;
+          }
+        );
       };
 
       services.mpd = lib.mkMerge [


### PR DESCRIPTION
Currently, if cfg.network.listenAddress is set to "any", MPD_HOST causes partial evaluation which fails the check while trying to build a home-manager generation. Hence make a separate attrset for MPD_HOST which will be evaluated conditionally and then concatenated.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
