### PR TITLE
difftastic: migrate to lib.cli.toCommandLineShellGNU

### DIFF
--- a/modules/programs/difftastic.nix
+++ b/modules/programs/difftastic.nix
@@ -129,7 +129,7 @@ in
           enable = lib.mkDefault true;
           iniContent =
             let
-              difftCommand = "${lib.getExe cfg.package} ${lib.cli.toGNUCommandLineShell { } cfg.options}";
+              difftCommand = "${lib.getExe cfg.package} ${lib.cli.toCommandLineShellGNU { } cfg.options}";
             in
             mkMerge [
               {

--- a/tests/modules/programs/difftastic/difftastic-migration.nix
+++ b/tests/modules/programs/difftastic/difftastic-migration.nix
@@ -26,6 +26,6 @@
     # Git config should contain difftastic configuration (backward compatibility)
     assertFileExists home-files/.config/git/config
     assertFileContains home-files/.config/git/config '[diff]'
-    assertFileRegex home-files/.config/git/config 'external = .*/difft.*--color.*--display'
+    assertFileContains home-files/.config/git/config "external = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side'\""
   '';
 }

--- a/tests/modules/programs/difftastic/difftastic-with-git-difftool.nix
+++ b/tests/modules/programs/difftastic/difftastic-with-git-difftool.nix
@@ -17,9 +17,9 @@
     assertFileExists home-files/.config/git/config
     assertFileContains home-files/.config/git/config '[diff]'
     # Should have BOTH diff.external AND difftool config when diffToolMode is true
-    assertFileRegex home-files/.config/git/config 'external = .*/difft.*--color.*--display'
-    assertFileRegex home-files/.config/git/config 'tool = "difftastic"'
+    assertFileContains home-files/.config/git/config "external = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side'\""
+    assertFileContains home-files/.config/git/config 'tool = "difftastic"'
     assertFileContains home-files/.config/git/config '[difftool "difftastic"]'
-    assertFileRegex home-files/.config/git/config 'cmd = .*/difft.*--color.*--display.*\$LOCAL \$REMOTE'
+    assertFileContains home-files/.config/git/config "cmd = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side' \$LOCAL \$REMOTE\""
   '';
 }

--- a/tests/modules/programs/difftastic/difftastic-with-git-external-diff.nix
+++ b/tests/modules/programs/difftastic/difftastic-with-git-external-diff.nix
@@ -17,7 +17,7 @@
     assertFileExists home-files/.config/git/config
     assertFileContains home-files/.config/git/config '[diff]'
     # Should have diff.external set
-    assertFileRegex home-files/.config/git/config 'external = .*/difft.*--color.*--display'
+    assertFileContains home-files/.config/git/config "external = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side'\""
     # Should NOT have difftool config when diffToolMode is explicitly false
     assertFileNotRegex home-files/.config/git/config 'tool = "difftastic"'
     assertFileNotRegex home-files/.config/git/config '\[difftool "difftastic"\]'

--- a/tests/modules/programs/difftastic/difftastic-with-git-integration.nix
+++ b/tests/modules/programs/difftastic/difftastic-with-git-integration.nix
@@ -14,7 +14,7 @@
     assertFileExists home-files/.config/git/config
     assertFileContains home-files/.config/git/config '[diff]'
     # Should have diff.external set
-    assertFileRegex home-files/.config/git/config 'external = .*/difft.*--color.*--display'
+    assertFileContains home-files/.config/git/config "external = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side'\""
     # Should NOT have difftool config since diffToolMode is false
     assertFileNotRegex home-files/.config/git/config 'tool = "difftastic"'
     assertFileNotRegex home-files/.config/git/config '\[difftool "difftastic"\]'


### PR DESCRIPTION
### Description
Migrates from the deprecated toCommandLineShell to toCommandLineShellGNU.

This changes the output format to use GNU-style concatenated options
(--color=always) with shell escaping for git config values. Both formats
were verified to work correctly with difftastic.

Splitting off from https://github.com/nix-community/home-manager/pull/8506
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
