### PR TITLE
fish: migrate to lib.cli.toCommandLineShell

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -301,20 +301,13 @@ let
       let
         name = if isAttrs def && def.name != null then def.name else attrName;
         mods =
-          lib.cli.toGNUCommandLineShell
-            {
-              mkOption =
-                k: v:
-                if v == null then
-                  [ ]
-                else if k == "set-cursor" then
-                  [ "--${k}=${lib.generators.mkValueStringDefault { } v}" ]
-                else
-                  [
-                    "--${k}"
-                    (lib.generators.mkValueStringDefault { } v)
-                  ];
-            }
+          lib.cli.toCommandLineShell
+            (optionName: {
+              option = "--${optionName}";
+              sep = if optionName == "set-cursor" then "=" else null;
+              explicitBool = false;
+              formatArg = lib.generators.mkValueStringDefault { };
+            })
             {
               inherit (def)
                 position


### PR DESCRIPTION
Replace deprecated lib.cli.toGNUCommandLineShell with the new lib.cli.toCommandLineShell API, migrating from the old mkOption parameter format to the new optionFormat function.


Splitting off from https://github.com/nix-community/home-manager/pull/8506

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
