### PR TITLE
less: migrate to lib.cli.toCommandLineGNU

### DIFF
--- a/modules/programs/less.nix
+++ b/modules/programs/less.nix
@@ -45,7 +45,7 @@ in
             ];
             attrs = attrsOf (either scalar (listOf scalar));
           in
-          coercedTo attrs (lib.cli.toGNUCommandLine { }) (listOf str);
+          coercedTo attrs (lib.cli.toCommandLineGNU { }) (listOf str);
         default = [ ];
         description = "Options to be set via {env}`$LESS`.";
         example = {

--- a/tests/modules/programs/less/correct-option-order.nix
+++ b/tests/modules/programs/less/correct-option-order.nix
@@ -24,7 +24,7 @@
     assertFileExists home-files/.config/lesskey
     assertFileContent home-files/.config/lesskey ${builtins.toFile "lesskey.expected" ''
       #env
-      LESS = --quiet --use-color --color HkK --color Mkb --prompt s%f
+      LESS = --quiet --use-color --color=HkK --color=Mkb --prompt=s%f
     ''}
   '';
 }

--- a/tests/modules/programs/less/custom-options-and-config.nix
+++ b/tests/modules/programs/less/custom-options-and-config.nix
@@ -23,7 +23,7 @@ in
     assertFileExists home-files/.config/lesskey
     assertFileContent home-files/.config/lesskey ${builtins.toFile "less.expected" ''
       #env
-      LESS = --RAW-CONTROL-CHARS --quiet --wheel-lines 3 --wheel-lines 1
+      LESS = --RAW-CONTROL-CHARS --quiet --wheel-lines=3 --wheel-lines=1
 
       ${config}''}
   '';

--- a/tests/modules/programs/less/custom-options.nix
+++ b/tests/modules/programs/less/custom-options.nix
@@ -15,7 +15,7 @@
     assertFileExists home-files/.config/lesskey
     assertFileContent home-files/.config/lesskey ${builtins.toFile "lesskey.expected" ''
       #env
-      LESS = --RAW-CONTROL-CHARS --quiet --wheel-lines 3 --wheel-lines 1
+      LESS = --RAW-CONTROL-CHARS --quiet --wheel-lines=3 --wheel-lines=1
     ''}
   '';
 }


### PR DESCRIPTION
Migrates from the deprecated toCommandLine to toCommandLineGNU.

This changes the output format to use GNU-style options with equals
(--wheel-lines=3). Both formats were verified to work correctly with less.


Splitting off from https://github.com/nix-community/home-manager/pull/8506

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
