### PR TITLE
redshift-gammastep: migrate to lib.cli.toCommandLineShellGNU

### DIFF
--- a/modules/services/redshift-gammastep/lib/options.nix
+++ b/modules/services/redshift-gammastep/lib/options.nix
@@ -239,7 +239,7 @@ in
             configFullPath = config.xdg.configHome + "/${xdgConfigFilePath}";
           in
           "${cfg.package}/bin/${command} "
-          + lib.cli.toGNUCommandLineShell { } {
+          + lib.cli.toCommandLineShellGNU { } {
             v = cfg.enableVerboseLogging;
             c = configFullPath;
           };

--- a/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@gammastep@/bin/gammastep -c /home/hm-user/.config/gammastep/config.ini
+ExecStart=@gammastep@/bin/gammastep -c/home/hm-user/.config/gammastep/config.ini
 Restart=on-failure
 RestartSec=3
 

--- a/tests/modules/services/redshift-gammastep/gammastep-tray-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/gammastep-tray-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@gammastep@/bin/gammastep-indicator -c /home/hm-user/.config/gammastep/config.ini
+ExecStart=@gammastep@/bin/gammastep-indicator -c/home/hm-user/.config/gammastep/config.ini
 Restart=on-failure
 RestartSec=3
 

--- a/tests/modules/services/redshift-gammastep/redshift-basic-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/redshift-basic-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@redshift@/bin/redshift -c /home/hm-user/.config/redshift/redshift.conf
+ExecStart=@redshift@/bin/redshift -c/home/hm-user/.config/redshift/redshift.conf
 Restart=on-failure
 RestartSec=3
 

--- a/tests/modules/services/redshift-gammastep/redshift-tray-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/redshift-tray-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@redshift@/bin/redshift-gtk -c /home/hm-user/.config/redshift/redshift.conf
+ExecStart=@redshift@/bin/redshift-gtk -c/home/hm-user/.config/redshift/redshift.conf
 Restart=on-failure
 RestartSec=3
 


### PR DESCRIPTION
Migrates from the deprecated toCommandLineShell to toCommandLineShellGNU.

This changes the output format from space-separated short options
(-c /path) to concatenated GNU-style options (-c/path). Both formats
were verified to work correctly with redshift and gammastep.

### Description

Splitting off from https://github.com/nix-community/home-manager/pull/8506
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
