### PR TITLE
wlsunset: migrate to lib.cli.toCommandLineShellGNU

### DIFF
--- a/modules/services/wlsunset.nix
+++ b/modules/services/wlsunset.nix
@@ -134,7 +134,7 @@ in
       Service = {
         ExecStart =
           let
-            args = lib.cli.toGNUCommandLineShell { } {
+            args = lib.cli.toCommandLineShellGNU { } {
               t = cfg.temperature.night;
               T = cfg.temperature.day;
               g = cfg.gamma;

--- a/tests/modules/services/wlsunset/wlsunset-service-expected.service
+++ b/tests/modules/services/wlsunset/wlsunset-service-expected.service
@@ -2,7 +2,7 @@
 WantedBy=test.target
 
 [Service]
-ExecStart=@wlsunset@/bin/wlsunset -L 128.8 -T 6000 -g 0.6 -l 12.3 -t 3500
+ExecStart=@wlsunset@/bin/wlsunset -L128.8 -T6000 -g0.6 -l12.3 -t3500
 
 [Unit]
 After=test.target


### PR DESCRIPTION
Migrates from the deprecated toGNUCommandLineShell to toCommandLineShellGNU.

This changes the output format from space-separated short options
(-t 3500) to concatenated GNU-style options (-t3500). Both formats
were verified to work correctly with wlsunset.

### Description

Splitting off from https://github.com/nix-community/home-manager/pull/8506
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
