### PR TITLE
linux-wallpaperengine: migrate to lib.cli.toCommandLineGNU

### DIFF
--- a/modules/services/linux-wallpaperengine.nix
+++ b/modules/services/linux-wallpaperengine.nix
@@ -117,23 +117,19 @@ in
         args = lib.lists.forEach cfg.wallpapers (
           each:
           lib.concatStringsSep " " (
-            lib.cli.toCommandLine
-              (optionName: {
-                option = if builtins.stringLength optionName > 1 then "--${optionName}" else "-${optionName}";
-                sep = null;
-                explicitBool = false;
-              })
-              {
-                screen-root = each.monitor;
-                inherit (each) scaling fps;
-                inherit (each.audio) silent;
-                noautomute = !each.audio.automute;
-                no-audio-processing = !each.audio.processing;
-              }
+            lib.cli.toCommandLineGNU { } {
+              screen-root = each.monitor;
+              inherit (each) scaling fps;
+              inherit (each.audio) silent;
+              noautomute = !each.audio.automute;
+              no-audio-processing = !each.audio.processing;
+            }
             ++ each.extraOptions
+            ++ [
+              "--bg"
+              each.wallpaperId
+            ]
           )
-          # This has to be the last argument in each group
-          + " --bg ${each.wallpaperId}"
         );
       in
       {

--- a/tests/modules/services/linux-wallpaperengine/basic-configuration-expected.service
+++ b/tests/modules/services/linux-wallpaperengine/basic-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@linux-wallpaperengine@/bin/linux-wallpaperengine --assets-dir /some/path/to/assets --clamping border --fps 6 --scaling fit --screen-root HDMI-1 --bg 12345678 --no-audio-processing --noautomute --screen-root DP-1 --silent --scaling fill --fps 12 --bg 87654321
+ExecStart=@linux-wallpaperengine@/bin/linux-wallpaperengine --assets-dir /some/path/to/assets --clamping border --fps=6 --scaling=fit --screen-root=HDMI-1 --bg 12345678 --no-audio-processing --noautomute --screen-root=DP-1 --silent --scaling fill --fps 12 --bg 87654321
 Restart=on-failure
 
 [Unit]

--- a/tests/modules/services/linux-wallpaperengine/missing-spaces-expected.service
+++ b/tests/modules/services/linux-wallpaperengine/missing-spaces-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@linux-wallpaperengine@/bin/linux-wallpaperengine --screen-root HDMI-A-1 --bg 2902931482
+ExecStart=@linux-wallpaperengine@/bin/linux-wallpaperengine --screen-root=HDMI-A-1 --bg 2902931482
 Restart=on-failure
 
 [Unit]


### PR DESCRIPTION
Replace deprecated lib.cli.toGNUCommandLine with lib.cli.toCommandLine using custom optionFormat to maintain space-separated argument format (sep = null) for backward compatibility.

### Description

Splitting off from https://github.com/nix-community/home-manager/pull/8506
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
