### PR TITLE
sftpman: add missing options

### DIFF
--- a/modules/programs/sftpman.nix
+++ b/modules/programs/sftpman.nix
@@ -40,6 +40,12 @@ let
         description = "The remote path to mount.";
       };
 
+      mountDestPath = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "The path on the current machine where the remote path would be mounted.";
+      };
+
       authType = mkOption {
         type = types.enum [
           "password"
@@ -47,6 +53,7 @@ let
           "hostbased"
           "keyboard-interactive"
           "gssapi-with-mic"
+          "authentication-agent"
         ];
         default = "publickey";
         description = "The authentication method to use.";

--- a/tests/modules/programs/sftpman/example-settings.nix
+++ b/tests/modules/programs/sftpman/example-settings.nix
@@ -23,6 +23,13 @@
         user = "user";
         sshKey = "/home/user/.ssh/id_rsa";
       };
+      mount4 = {
+        host = "host4.example.com";
+        mountPoint = "/another/path/somewhere/else";
+        user = "user";
+        authType = "authentication-agent";
+        mountDestPath = "/mnt/host4";
+      };
     };
   };
 
@@ -36,5 +43,8 @@
     assertFileContent \
       home-files/.config/sftpman/mounts/mount3.json \
       ${./expected-mount3.json}
+    assertFileContent \
+      home-files/.config/sftpman/mounts/mount4.json \
+      ${./expected-mount4.json}
   '';
 }

--- a/tests/modules/programs/sftpman/expected-mount1.json
+++ b/tests/modules/programs/sftpman/expected-mount1.json
@@ -3,6 +3,7 @@
   "beforeMount": "true",
   "host": "host1.example.com",
   "id": "mount1",
+  "mountDestPath": null,
   "mountOptions": [
     "idmap=user"
   ],

--- a/tests/modules/programs/sftpman/expected-mount2.json
+++ b/tests/modules/programs/sftpman/expected-mount2.json
@@ -3,6 +3,7 @@
   "beforeMount": "true",
   "host": "host2.example.com",
   "id": "mount2",
+  "mountDestPath": null,
   "mountOptions": [],
   "mountPoint": "/another/path",
   "port": 22,

--- a/tests/modules/programs/sftpman/expected-mount3.json
+++ b/tests/modules/programs/sftpman/expected-mount3.json
@@ -3,6 +3,7 @@
   "beforeMount": "true",
   "host": "host3.example.com",
   "id": "mount3",
+  "mountDestPath": null,
   "mountOptions": [],
   "mountPoint": "/yet/another/path",
   "port": 22,

--- a/tests/modules/programs/sftpman/expected-mount4.json
+++ b/tests/modules/programs/sftpman/expected-mount4.json
@@ -1,0 +1,12 @@
+{
+  "authType": "authentication-agent",
+  "beforeMount": "true",
+  "host": "host4.example.com",
+  "id": "mount4",
+  "mountDestPath": "/mnt/host4",
+  "mountOptions": [],
+  "mountPoint": "/another/path/somewhere/else",
+  "port": 22,
+  "sshKey": "/home/user/.ssh/id_ed25519",
+  "user": "user"
+}


### PR DESCRIPTION
- `authType` is missing the `authentication-agent` enum value [ref](https://github.com/spantaleev/sftpman-rs/blob/ee0df8cb27c2a3cfbf8baa12b2a42ee70b0f0e92/src/auth_type.rs#L43)
- `mountDestPath` is missing completely [ref](https://github.com/spantaleev/sftpman-rs/blob/ee0df8cb27c2a3cfbf8baa12b2a42ee70b0f0e92/src/model/filesystem_mount_definition.rs#L72)

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
