### PR TITLE
Add module and git integration for diffnav

### DIFF
--- a/modules/misc/news/2026/01/2026-01-10_10-27-41.nix
+++ b/modules/misc/news/2026/01/2026-01-10_10-27-41.nix
@@ -1,0 +1,7 @@
+{
+  time = "2026-01-10T09:27:41+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.diffnav'.
+  '';
+}

--- a/modules/programs/diffnav.nix
+++ b/modules/programs/diffnav.nix
@@ -1,0 +1,70 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.diffnav;
+
+  yamlFormat = pkgs.formats.yaml { };
+
+  inherit (lib)
+    mkOption
+    types
+    ;
+in
+{
+  meta.maintainers = with lib.maintainers; [ matthiasbeyer ];
+
+  options.programs.diffnav = {
+    enable = lib.mkEnableOption "diffnav, a git diff pager based on delta but with a file tree, à la GitHub";
+
+    package = lib.mkPackageOption pkgs "diffnav" { nullable = true; };
+
+    settings = mkOption {
+      type = pkgs.formats.yaml;
+
+      default = { };
+
+      example = {
+        ui = {
+          hideHeader = true;
+          hideFooter = true;
+          showFileTree = false;
+          fileTreeWidth = 30;
+          searchTreeWidth = 60;
+        };
+      };
+
+      description = ''
+        Options to configure diffnav.
+      '';
+    };
+
+    enableGitIntegration = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable git integration for diffnav.
+
+        When enabled, diffnav will be configured as git's diff filter.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."diffnav/config.yml" = lib.mkIf (cfg.options != { }) {
+      source = yamlFormat.generate "diffnav-config" cfg.options;
+    };
+
+    programs.git.iniContent = (
+      lib.mkIf cfg.enableGitIntegration {
+        interactive.diffFilter = "diffnav";
+        pager.diff = "diffnav";
+      }
+    );
+  };
+}

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -368,6 +368,7 @@ in
                   }
                   { name = "patdiff"; }
                   { name = "riff"; }
+                  { name = "diffnav"; }
                 ]
               );
             in


### PR DESCRIPTION
### Description

This PR adds a module for `diffnav`.

I based this on the `delta` module, but I have no experience with writing modules for home-manager, so please review this with that in mind.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible: Not sure, as the `programs.git` tree was changed.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
