### PR TITLE
Ensure minimal argument is correctly propagated from modules

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -23,7 +23,7 @@ let
   extendedLib = import ./lib/stdlib-extended.nix lib;
 
   hmModules = import ./modules.nix {
-    inherit check pkgs;
+    inherit check pkgs minimal;
     lib = extendedLib;
   };
 


### PR DESCRIPTION
### Description


I was experimenting with the new `minimal` setting, and noticed that setting it from a flake configuration was not working, as it was'nt being correctly propagated to module.nix. This seems to fix.

N.B. I also noticed that it wasn't possible to use the minimal module without turning off news with something like `news.entries = lib.mkForce [];`, because news refers to arbitrary configuration options. I wasn't sure how best to incorporate that though as it had rather tangled dependencies.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.  **Old behaivour was buggy, but this will break configurations where minimal is set**

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
