### PR TITLE
xdg-portal: include systemd user services

### DIFF
--- a/modules/misc/xdg-portal.nix
+++ b/modules/misc/xdg-portal.nix
@@ -179,6 +179,8 @@ in
         NIX_XDG_DESKTOP_PORTAL_DIR = portalsDir;
       };
 
+      systemd.user.packages = packages;
+
       xdg.configFile = lib.concatMapAttrs (
         desktop: conf:
         lib.optionalAttrs (conf != { }) {


### PR DESCRIPTION
### Description

This change fixes #4922 using `systemd.user.packages` option, introduced in #8540.

### TODO

- [x] Rebase after merge of #8540.
- [ ] Discuss if this change should be considered breaking or not. Perhaps it would be better to introduce a separate option to enable this behavior, e.g. `xdg.portal.systemd.enable`, or `xdg.portal.linkPortalUnits` (as proposed in https://github.com/nix-community/home-manager/issues/4922#issuecomment-1916556499). Or maybe adding a highlight to the release notes would be fine.

### Checklist

  - [ ] Change is backwards compatible.
  - [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.
  - [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
  - [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  - [x] Commit messages are formatted like
    ```
    {component}: {description}

    {long description}
    ```

If this PR adds a new module:

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

If this PR adds an exciting new feature or contains a breaking change:
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
