### PR TITLE
claude-code: add `enableMcpIntegration`

### DIFF
--- a/tests/modules/programs/claude-code/assertion.nix
+++ b/tests/modules/programs/claude-code/assertion.nix
@@ -47,7 +47,7 @@
   };
 
   test.asserts.assertions.expected = [
-    "`programs.claude-code.package` cannot be null when `mcpServers` is configured"
+    "`programs.claude-code.package` cannot be null when `mcpServers` or `enableMcpIntegration` is configured"
     "Cannot specify both `programs.claude-code.memory.text` and `programs.claude-code.memory.source`"
     "Cannot specify both `programs.claude-code.agents` and `programs.claude-code.agentsDir`"
     "Cannot specify both `programs.claude-code.commands` and `programs.claude-code.commandsDir`"

--- a/tests/modules/programs/claude-code/default.nix
+++ b/tests/modules/programs/claude-code/default.nix
@@ -2,6 +2,7 @@
   claude-code-basic = ./basic.nix;
   claude-code-full-config = ./full-config.nix;
   claude-code-mcp = ./mcp.nix;
+  claude-code-mcp-integration = ./mcp-integration.nix;
   claude-code-assertion = ./assertion.nix;
   claude-code-memory-management = ./memory-management.nix;
   claude-code-memory-from-source = ./memory-from-source.nix;

--- a/tests/modules/programs/claude-code/mcp-integration.nix
+++ b/tests/modules/programs/claude-code/mcp-integration.nix
@@ -1,0 +1,72 @@
+{ config, ... }:
+
+{
+  programs = {
+    claude-code = {
+      package = config.lib.test.mkStubPackage {
+        name = "claude-code";
+        buildScript = ''
+          mkdir -p $out/bin
+          touch $out/bin/claude
+          chmod 755 $out/bin/claude
+        '';
+      };
+      enable = true;
+
+      enableMcpIntagretion = true;
+
+      mcpServers = {
+        github = {
+          type = "http";
+          url = "https://api.githubcopilot.com/mcp/";
+        };
+        filesystem = {
+          type = "stdio";
+          command = "npx";
+          args = [
+            "-y"
+            "@modelcontextprotocol/server-filesystem"
+            "/tmp"
+          ];
+        };
+      };
+    };
+    mcp = {
+      enable = true;
+      servers = {
+        filesystem = {
+          type = "stdio";
+          command = "npx";
+          args = [
+            "-y"
+            "@modelcontextprotocol/server-filesystem"
+            "/other-tmp"
+          ];
+        };
+        database = {
+          command = "npx";
+          args = [
+            "-y"
+            "@bytebase/dbhub"
+            "--dsn"
+            "postgresql://user:pass@localhost:5432/db"
+          ];
+          env = {
+            DATABASE_URL = "postgresql://user:pass@localhost:5432/db";
+          };
+        };
+        customTransport = {
+          type = "websocket";
+          url = "wss://example.com/mcp";
+          customOption = "value";
+          timeout = 5000;
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    normalizedWrapper=$(normalizeStorePaths home-path/bin/claude)
+    assertFileContent $normalizedWrapper ${./expected-mcp-wrapper}
+  '';
+}


### PR DESCRIPTION
Add `enableMcpIntegration` option to merge MCP servers from `programs.mcp.servers` into Claude Code configuration. Claude Code servers take precedence over general MCP servers when both define the same server name.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
