### PR TITLE
services/gpg-agent: fix service on darwin

### DIFF
--- a/modules/launchd/launchd.nix
+++ b/modules/launchd/launchd.nix
@@ -888,11 +888,12 @@ in
                   types.enum [
                     "IPv4"
                     "IPv6"
+                    "Unix"
                   ]
                 );
                 default = null;
                 description = ''
-                  This optional key can be used to specifically request that "IPv4" or "IPv6" socket(s) be created.
+                  This optional key can be used to specifically request that "IPv4" or "IPv6" or "Unix" socket(s) be created.
                 '';
               };
 

--- a/modules/services/gpg-agent/wrapper.c
+++ b/modules/services/gpg-agent/wrapper.c
@@ -1,0 +1,97 @@
+// Simple wrapper to activate launchd sockets
+// and set them up in the same way systemd would
+// so that we can use gpg-agent in --supervised mode
+
+#include <errno.h>
+#include <err.h>
+#include <unistd.h>
+#include <launch.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+int get_launchd_socket(const char *sockName)
+{
+  // Get our sockets from launchd
+  int *fds = NULL;
+  size_t count = 0;
+  errno = launch_activate_socket(sockName, &fds, &count);
+
+  if (errno != 0 || fds == NULL || count < 1)
+  {
+    warn("Error getting socket FD from launchd");
+    return 0;
+  }
+
+  if (count != 1)
+  {
+    warnx("Expected one FD from launchd, got %zu. Only using first socket.", count);
+  }
+
+  // Unset FD_CLOEXEC bit
+  fcntl(fds[0], F_SETFD, fcntl(fds[0], F_GETFD, 0) & ~FD_CLOEXEC);
+
+  if (fds)
+  {
+    free(fds);
+  }
+
+  return 1;
+}
+
+int main(int argc, char **argv)
+{
+  // List of sockets we're going to check for
+  const char *sockets[] = {
+      "ssh",
+      "browser",
+      "extra",
+      "std"};
+  int fds = 0;
+  char *fdsString = NULL;
+  char *fdNames = NULL;
+  char *tmpfdNames = NULL;
+
+  // Activate the sockets and count and store names
+  for (int i = 0; i < sizeof(sockets) / sizeof(sockets[0]); i++)
+  {
+    if (get_launchd_socket(sockets[i]))
+    {
+      fds++;
+      asprintf(&fdNames, (tmpfdNames == NULL ? "%s%s" : "%s:%s"), (tmpfdNames == NULL ? "" : tmpfdNames), sockets[i]);
+      if (tmpfdNames)
+      {
+        free(tmpfdNames);
+      }
+      tmpfdNames = fdNames;
+    }
+  }
+
+  // Set the ENV var for our PID
+  char *pidString = NULL;
+  asprintf(&pidString, "%ld", (long)getpid());
+  setenv("LISTEN_PID", pidString, 0);
+  free(pidString);
+
+  // Set the number of FDs we've opened
+  asprintf(&fdsString, "%d", fds);
+  setenv("LISTEN_FDS", fdsString, 0);
+  free(fdsString);
+
+  // And their names
+  setenv("LISTEN_FDNAMES", (fdNames == NULL ? "" : fdNames), 0);
+  free(fdNames);
+
+  // Launch the command we were passed
+  ++argv;
+  if (*argv)
+  {
+    execvp(*argv, argv);
+    err(1, "Error executing command");
+  }
+  else
+  {
+    errx(1, "No command specified");
+  }
+}
+

--- a/tests/modules/services/gpg-agent/expected-agent.plist
+++ b/tests/modules/services/gpg-agent/expected-agent.plist
@@ -20,6 +20,7 @@
 	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
+		<string>@gpg-agent-wrapper@/bin/gpg-agent-wrapper</string>
 		<string>@gpg@/bin/gpg-agent</string>
 		<string>--supervised</string>
 	</array>
@@ -27,14 +28,14 @@
 	<false/>
 	<key>Sockets</key>
 	<dict>
-		<key>Agent</key>
+		<key>std</key>
 		<dict>
+			<key>SockFamily</key>
+			<string>Unix</string>
 			<key>SockPathMode</key>
 			<integer>384</integer>
 			<key>SockPathName</key>
 			<string>/private/var/run/org.nix-community.home.gpg-agent/d.wp4h7ks5zxy4dodqadgpbbpz/S.gpg-agent</string>
-			<key>SockType</key>
-			<string>stream</string>
 		</dict>
 	</dict>
 </dict>

--- a/tests/modules/services/gpg-agent/override-homedir.nix
+++ b/tests/modules/services/gpg-agent/override-homedir.nix
@@ -4,6 +4,15 @@ let
   inherit (pkgs.stdenv) isDarwin;
 in
 {
+  test.unstubs = [
+    (_: _: {
+      runCommandCC = (
+        _: _: _:
+        "@gpg-agent-wrapper@"
+      );
+    })
+  ];
+
   services.gpg-agent.enable = true;
   programs.gpg = {
     enable = true;


### PR DESCRIPTION
- **services/gpg-agent: fix supervised mode on darwin**

### Description

gpg agent supervised mode requires the sockfds to passed into it, and darwins declarations in the plist arent as simple as linux wherein they can just be passed in easily. Unfortunately, launch_activate_socket has to be called and passed into the program and this uses a c wrapper to pass the launchctl sockets into the gpg-agent program

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
