### PR TITLE
kubecolor: fix improper KUBECOLOR_CONFIG variable setting

### DIFF
--- a/modules/programs/kubecolor.nix
+++ b/modules/programs/kubecolor.nix
@@ -61,7 +61,7 @@ in
 
       # https://github.com/kubecolor/kubecolor/pull/145
       configPathSuffix = lib.optionalString (
-        cfg.package.pname == "kubecolor" && lib.versionOlder (lib.getVersion cfg.package) "0.4"
+        cfg.package.pname == "kubecolor" && lib.versionAtLeast (lib.getVersion cfg.package) "0.4"
       ) "color.yaml";
 
     in

--- a/tests/modules/programs/kubecolor/config-default-env-legacy.nix
+++ b/tests/modules/programs/kubecolor/config-default-env-legacy.nix
@@ -1,0 +1,23 @@
+{ pkgs, config, ... }:
+
+let
+  configDir = if pkgs.stdenv.isDarwin then "Library/Application Support/kube" else ".kube";
+in
+{
+  programs.kubecolor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "kubecolor";
+      version = "0.3.0";
+    };
+    settings = {
+      kubectl = "kubectl";
+    };
+  };
+
+  nmt.script = ''
+    if [[ "${config.home.sessionVariables.KUBECOLOR_CONFIG}" != "${configDir}/" ]]; then
+      fail "Expected KUBECOLOR_CONFIG to be '${configDir}/', got '${config.home.sessionVariables.KUBECOLOR_CONFIG}'"
+    fi
+  '';
+}

--- a/tests/modules/programs/kubecolor/config-default-env-modern.nix
+++ b/tests/modules/programs/kubecolor/config-default-env-modern.nix
@@ -1,0 +1,23 @@
+{ pkgs, config, ... }:
+
+let
+  configDir = if pkgs.stdenv.isDarwin then "Library/Application Support/kube" else ".kube";
+in
+{
+  programs.kubecolor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "kubecolor";
+      version = "0.4.0";
+    };
+    settings = {
+      kubectl = "kubectl";
+    };
+  };
+
+  nmt.script = ''
+    if [[ "${config.home.sessionVariables.KUBECOLOR_CONFIG}" != "${configDir}/color.yaml" ]]; then
+      fail "Expected KUBECOLOR_CONFIG to be '${configDir}/color.yaml', got '${config.home.sessionVariables.KUBECOLOR_CONFIG}'"
+    fi
+  '';
+}

--- a/tests/modules/programs/kubecolor/config-xdg-env-legacy.nix
+++ b/tests/modules/programs/kubecolor/config-xdg-env-legacy.nix
@@ -1,0 +1,23 @@
+{ config, ... }:
+
+{
+  xdg.enable = true;
+  home.preferXdgDirectories = true;
+
+  programs.kubecolor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "kubecolor";
+      version = "0.3.0";
+    };
+    settings = {
+      kubectl = "kubectl";
+    };
+  };
+
+  nmt.script = ''
+    if [[ "${config.home.sessionVariables.KUBECOLOR_CONFIG}" != "/home/hm-user/.config/kube/" ]]; then
+      fail "Expected KUBECOLOR_CONFIG to be '/home/hm-user/.config/kube/', got '${config.home.sessionVariables.KUBECOLOR_CONFIG}'"
+    fi
+  '';
+}

--- a/tests/modules/programs/kubecolor/config-xdg-env-modern.nix
+++ b/tests/modules/programs/kubecolor/config-xdg-env-modern.nix
@@ -1,0 +1,23 @@
+{ config, ... }:
+
+{
+  xdg.enable = true;
+  home.preferXdgDirectories = true;
+
+  programs.kubecolor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "kubecolor";
+      version = "0.4.0";
+    };
+    settings = {
+      kubectl = "kubectl";
+    };
+  };
+
+  nmt.script = ''
+    if [[ "${config.home.sessionVariables.KUBECOLOR_CONFIG}" != "/home/hm-user/.config/kube/color.yaml" ]]; then
+      fail "Expected KUBECOLOR_CONFIG to be '/home/hm-user/.config/kube/color.yaml', got '${config.home.sessionVariables.KUBECOLOR_CONFIG}'"
+    fi
+  '';
+}

--- a/tests/modules/programs/kubecolor/default.nix
+++ b/tests/modules/programs/kubecolor/default.nix
@@ -1,4 +1,8 @@
 {
+  kubecolor-config-default-env-legacy = ./config-default-env-legacy.nix;
+  kubecolor-config-default-env-modern = ./config-default-env-modern.nix;
+  kubecolor-config-xdg-env-legacy = ./config-xdg-env-legacy.nix;
+  kubecolor-config-xdg-env-modern = ./config-xdg-env-modern.nix;
   kubecolor-empty-config = ./empty-config.nix;
   kubecolor-example-config-default-paths = ./example-config-default-paths.nix;
   kubecolor-example-config-xdg-paths = ./example-config-xdg-paths.nix;


### PR DESCRIPTION
### Description

PR #8497 introduced regression in `kubecolor` which I didn't catch up during review - sorry. The `KUBECOLOR_CONFIG` should be set to `.kube/` for versions older than 0.4 and to `.kube/color.yaml` for 0.4 and onwards. The change introduced the opposite logic with `versionOlder` instead of `versionAtLeast`. This patch fixes that, and also adds corresponding tests.

### Checklist

- [ ] Change is backwards compatible.
  - It is not, but because regression was introduced. It's compatible with "pre-regression" logic.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
