### PR TITLE
kubecolor: clean up the handling of config path

### DIFF
--- a/tests/modules/programs/kubecolor/empty-config.nix
+++ b/tests/modules/programs/kubecolor/empty-config.nix
@@ -1,8 +1,5 @@
-{ pkgs, config, ... }:
+{ config, ... }:
 
-let
-  configDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
-in
 {
   programs.kubecolor = {
     enable = true;
@@ -13,6 +10,7 @@ in
   };
 
   nmt.script = ''
-    assertPathNotExists 'home-files/${configDir}/kube/color.yaml'
+    assertPathNotExists 'home-files/.kube/color.yaml'
+    assertPathNotExists 'home-files/.config/kubecolor.yaml'
   '';
 }

--- a/tests/modules/programs/kubecolor/example-config-default-paths.nix
+++ b/tests/modules/programs/kubecolor/example-config-default-paths.nix
@@ -1,8 +1,5 @@
-{ pkgs, config, ... }:
+{ config, ... }:
 
-let
-  configDir = if pkgs.stdenv.isDarwin then "Library/Application Support/kube" else ".kube";
-in
 {
   programs.kubecolor = {
     enable = true;
@@ -20,8 +17,8 @@ in
   };
 
   nmt.script = ''
-    assertFileExists 'home-files/${configDir}/color.yaml'
-    assertFileContent 'home-files/${configDir}/color.yaml' \
+    assertFileExists 'home-files/.kube/color.yaml'
+    assertFileContent 'home-files/.kube/color.yaml' \
       ${builtins.toFile "expected.yaml" ''
         kubectl: kubectl
         objFreshThreshold: 0

--- a/tests/modules/programs/kubecolor/example-config-xdg-paths.nix
+++ b/tests/modules/programs/kubecolor/example-config-xdg-paths.nix
@@ -20,8 +20,8 @@
   };
 
   nmt.script = ''
-    assertFileExists 'home-files/.config/kube/color.yaml'
-    assertFileContent 'home-files/.config/kube/color.yaml' \
+    assertFileExists 'home-files/.config/kubecolor.yaml'
+    assertFileContent 'home-files/.config/kubecolor.yaml' \
       ${builtins.toFile "expected.yaml" ''
         kubectl: kubectl
         objFreshThreshold: 0


### PR DESCRIPTION
### Description

https://github.com/nix-community/home-manager/commit/bacad23b8cac6a390fa7118143e5af7021aeebe0 introduces a bug with the incorrect usage of `lib.versionOlder`, rendering the module unusable. This PR removes that logic entirely. kubecolor [0.4.0](https://github.com/kubecolor/kubecolor/releases/tag/v0.4.0) was released in September 2024. People shouldn't use a version even older than that anymore.

The PR also removes Darwin special treatment. `kubecolor` follows `kubectl` practice, using `~/.kube/` regardless of the platform the user is. The file path for XDG case is renamed to `~/.config/kubecolor.yaml`, as suggested in https://kubecolor.github.io/reference/config/. `~/.config/kube` (instead of `~/.config/kubecolor`) might falsely indicate that the directory can be used for any other K8s-related programs, which is not the case here.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
