### PR TITLE
dconf: remove bad words from enable.description

### DIFF
--- a/modules/misc/dconf.nix
+++ b/modules/misc/dconf.nix
@@ -58,7 +58,7 @@ in
         default = !pkgs.stdenv.hostPlatform.isDarwin;
         visible = false;
         description = ''
-          Whether to enable dconf settings.Add commentMore actions
+          Whether to enable dconf settings.
           Note, if you use NixOS then you must add
           `programs.dconf.enable = true`
           to your system configuration. Otherwise you will see a systemd error


### PR DESCRIPTION
### Description

Address a copy&paste mistake.

### Checklist

[removed] it's just text.