### PR TITLE
treewide: XDG_CONFIG_HOME/.config -> XDG_CONFIG_HOME

### DIFF
--- a/modules/programs/gurk-rs.nix
+++ b/modules/programs/gurk-rs.nix
@@ -21,7 +21,7 @@ in
       inherit (tomlFormat) type;
       default = { };
       description = ''
-        Configuration written to {file}`$XDG_CONFIG_HOME/.config/gurk/gurk.toml`
+        Configuration written to {file}`$XDG_CONFIG_HOME/gurk/gurk.toml`
         or {file}`Library/Application Support/gurk/gurk.toml`. Options are
         declared at <https://github.com/boxdot/gurk-rs/blob/main/src/config.rs>.
         Note that `signal_db_path` should be set.

--- a/modules/programs/mcp.nix
+++ b/modules/programs/mcp.nix
@@ -44,7 +44,7 @@ in
       '';
       description = ''
         MCP server configurations written to
-        {file}`XDG_CONFIG_HOME/.config/mcp/mcp.json`
+        {file}`XDG_CONFIG_HOME/mcp/mcp.json`
       '';
     };
   };

--- a/modules/services/podman/default.nix
+++ b/modules/services/podman/default.nix
@@ -96,7 +96,7 @@ in
 
     services.podman.settings.storage.storage.driver = lib.mkDefault "overlay";
 
-    # Configuration files are written to `$XDG_CONFIG_HOME/.config/containers`
+    # Configuration files are written to `$XDG_CONFIG_HOME/containers`
     # On Linux: podman reads them directly from this location
     # On Darwin: these files are automatically mounted into the podman machine VM
     #            (see darwin.nix for the volume mount configuration)


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

`$XDG_CONFIG_HOME` already contains the `.config` subdir, right?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
