### PR TITLE
obsidian: allow partial module configuration

### DIFF
--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -570,7 +570,7 @@ in
             if [ -f "$OBSIDIAN_CONFIG" ]; then
               verboseEcho "Merging existing Obsidian config with generated template"
               tmp="$(mktemp)"
-              run ${lib.getExe pkgs.jq} -s '.[0] * .[1]' "$OBSIDIAN_CONFIG" "${template}" > "$tmp"
+              run ${lib.getExe pkgs.jq} -s '(.[0] // {}) * (.[1] // {})' "$OBSIDIAN_CONFIG" "${template}" > "$tmp"
               run install -m644 "$tmp" "$OBSIDIAN_CONFIG"
               rm -f "$tmp"
             else


### PR DESCRIPTION
### Description

Resolves https://github.com/nix-community/home-manager/issues/7906.
Resolves https://github.com/nix-community/home-manager/issues/8555.
Resolves https://github.com/nix-community/home-manager/issues/8657.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```
