### PR TITLE
pimsync: use 'users' as group and dont make calendar world-readable

### DIFF
--- a/modules/programs/pimsync/default.nix
+++ b/modules/programs/pimsync/default.nix
@@ -119,7 +119,7 @@
       contactLocalStorageDirs = lib.mapAttrsToList localStorageDir contactAccounts;
       localStorageDirs = calendarLocalStorageDirs ++ contactLocalStorageDirs;
 
-      mkTmpFileRule = (dir: "d ${dir} 0755 ${config.home.username} ${config.home.username} - -");
+      mkTmpFileRule = (dir: "d ${dir} 0750 ${config.home.username} users - -");
       tmpFileRules = map mkTmpFileRule localStorageDirs;
     in
     lib.mkIf cfg.enable {


### PR DESCRIPTION
Using username as unix group doesnt work by default (at least on nixos): janv. 14 14:54:14 jedha hm-activate-teto[100922]: removed '/home/teto/.local/state/home-manager/gcroots/new-home' janv. 14 14:54:14 jedha systemd-tmpfiles[100921]: /home/teto/home/config/user-tmpfiles.d/home-manager.conf:4: Failed to resolve group 'teto': No such process

use "users" instead

See https://github.com/nix-community/home-manager/pull/8359#issuecomment-3749711997

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
