### PR TITLE
nixos: flip `&&` to prevent recursion errors

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -89,7 +89,7 @@ in
       };
     }
 
-    (mkIf (cfg.users != { } && !cfg.startAsUserService) {
+    (mkIf (!cfg.startAsUserService && cfg.users != { }) {
       systemd.services = lib.mapAttrs' (
         _: usercfg:
         let
@@ -140,7 +140,7 @@ in
       ) cfg.users;
     })
 
-    (mkIf (cfg.users != { } && cfg.startAsUserService) {
+    (mkIf (cfg.startAsUserService && cfg.users != { }) {
       systemd.user.services.home-manager = baseUnit "%u" // {
         # this _should_ depend on nix-daemon.socket, as the system-service
         # version of this unit does, but systemd doesn't allow user units


### PR DESCRIPTION
### Description

The recent change to add the ability to use systemd units for users made it so configs with `home-manager.users` dependent on `config.users.users` failed with recursion errors. Simply flipping the `&&`s so it avoids running the check if the feature is disabled fixes this.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.