### PR TITLE
yazi: fix unintended recursive calls

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -220,7 +220,7 @@ in
         bashIntegration = ''
           function ${cfg.shellWrapperName}() {
             local tmp="$(mktemp -t "yazi-cwd.XXXXX")"
-            yazi "$@" --cwd-file="$tmp"
+            command yazi "$@" --cwd-file="$tmp"
             if cwd="$(<"$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
               builtin cd -- "$cwd"
             fi
@@ -240,7 +240,7 @@ in
         nushellIntegration = ''
           def --env ${cfg.shellWrapperName} [...args] {
             let tmp = (mktemp -t "yazi-cwd.XXXXX")
-            yazi ...$args --cwd-file $tmp
+            ^yazi ...$args --cwd-file $tmp
             let cwd = (open $tmp)
             if $cwd != "" and $cwd != $env.PWD {
               cd $cwd

--- a/tests/modules/programs/yazi/bash-integration-enabled.nix
+++ b/tests/modules/programs/yazi/bash-integration-enabled.nix
@@ -10,7 +10,7 @@
     assertFileExists home-files/.bashrc
     assertFileContains home-files/.bashrc 'function yy() {'
     assertFileContains home-files/.bashrc 'local tmp="$(mktemp -t "yazi-cwd.XXXXX")"'
-    assertFileContains home-files/.bashrc 'yazi "$@" --cwd-file="$tmp"'
+    assertFileContains home-files/.bashrc 'command yazi "$@" --cwd-file="$tmp"'
     assertFileContains home-files/.bashrc 'if cwd="$(<"$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then'
     assertFileContains home-files/.bashrc 'builtin cd -- "$cwd"'
     assertFileContains home-files/.bashrc 'rm -f -- "$tmp"'

--- a/tests/modules/programs/yazi/nushell-integration-enabled.nix
+++ b/tests/modules/programs/yazi/nushell-integration-enabled.nix
@@ -4,7 +4,7 @@ let
   shellIntegration = ''
     def --env yy [...args] {
       let tmp = (mktemp -t "yazi-cwd.XXXXX")
-      yazi ...$args --cwd-file $tmp
+      ^yazi ...$args --cwd-file $tmp
       let cwd = (open $tmp)
       if $cwd != "" and $cwd != $env.PWD {
         cd $cwd

--- a/tests/modules/programs/yazi/zsh-integration-enabled.nix
+++ b/tests/modules/programs/yazi/zsh-integration-enabled.nix
@@ -10,7 +10,7 @@
     assertFileExists home-files/.zshrc
     assertFileContains home-files/.zshrc 'function yy() {'
     assertFileContains home-files/.zshrc 'local tmp="$(mktemp -t "yazi-cwd.XXXXX")"'
-    assertFileContains home-files/.zshrc 'yazi "$@" --cwd-file="$tmp"'
+    assertFileContains home-files/.zshrc 'command yazi "$@" --cwd-file="$tmp"'
     assertFileContains home-files/.zshrc 'if cwd="$(<"$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then'
     assertFileContains home-files/.zshrc 'builtin cd -- "$cwd"'
     assertFileContains home-files/.zshrc 'rm -f -- "$tmp"'


### PR DESCRIPTION
### Description

Use `command` (POSIX) and `^` (Nushell) to prevent recursive function calls when `cfg.shellWrapperName` is set to "yazi".

Previously, if `cfg.shellWrapperName` was set to "yazi", the invocation of `yazi` within the shell integration function triggered the function itself instead of the binary. This name conflict prevents users from using the binary name as-is when shell integration is enabled.

Hence, fix this by using shell-specific mechanisms to target the underlying executable, bypassing any name collisions.

This aligns with the official documentation:
- https://github.com/yazi-rs/yazi-rs.github.io/blob/2c839b37c80917ac3cf2d8c98949a392212d93ba/docs/quick-start.md?plain=1#L29
- https://github.com/yazi-rs/yazi-rs.github.io/blob/2c839b37c80917ac3cf2d8c98949a392212d93ba/docs/quick-start.md?plain=1#L56

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`. (Actually, I ran `nix run .#tests -- yazi` to only run the changed tests. I don't know why but running all tests takes too long for me...)

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
