### PR TITLE
obsidian: create parent directory before installing config

### DIFF
--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -555,6 +555,7 @@ in
               install -m644 "$tmp" "$OBSIDIAN_CONFIG"
               rm -f "$tmp"
             else
+              mkdir -p "$(dirname "$OBSIDIAN_CONFIG")"
               install -m644 ${template} "$OBSIDIAN_CONFIG"
             fi
           '';


### PR DESCRIPTION
### Description

Fixes activation failure when `~/.config/obsidian/` doesn't exist on first-time setup.

The obsidian module's activation script uses `install(1)` to create the config file at `~/.config/obsidian/obsidian.json`, but `install` doesn't create parent directories. This causes the activation to fail on first-time setup when the directory doesn't exist yet:

```
warning: the following units failed: home-manager-<user>.service
```

This PR adds `mkdir -p "$(dirname "$OBSIDIAN_CONFIG")"` before the `install` command in the else branch (first-time setup case) to ensure the parent directory exists.

Tested manually on NixOS where the directory didn't exist - activation now succeeds and the config file is created properly.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.