### PR TITLE
vscode: add argv.json support

### DIFF
--- a/modules/programs/vscode/default.nix
+++ b/modules/programs/vscode/default.nix
@@ -81,6 +81,7 @@ let
     else
       "${config.xdg.configHome}/${configDir}/User";
 
+  argvPath = "${configDir}/argv.json";
   configFilePath =
     name: "${userDir}/${optionalString (name != "default") "profiles/${name}/"}settings.json";
   tasksFilePath =
@@ -371,6 +372,21 @@ in
       '';
     };
 
+    argvSettings = mkOption {
+      type = types.either types.path jsonFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          enable-crash-reporter = false;
+        }
+      '';
+      description = ''
+        Configuration written to Visual Studio Code's
+        {file}`argv.json`.
+        This can be a JSON object or a path to a custom JSON file.
+      '';
+    };
+
     profiles = mkOption {
       type = types.attrsOf profileType;
       default = { };
@@ -441,6 +457,14 @@ in
     );
 
     home.file = lib.mkMerge (flatten [
+      (mkIf (cfg.argvSettings != { }) {
+        "${argvPath}".source =
+          if isPath cfg.argvSettings then
+            cfg.argvSettings
+          else
+            jsonFormat.generate "vscode-argv" cfg.argvSettings;
+      })
+
       (mapAttrsToList (n: v: [
         (mkIf ((mergedUserSettings v.userSettings v.enableUpdateCheck v.enableExtensionUpdateCheck) != { })
           {

--- a/tests/modules/programs/vscode/argv.nix
+++ b/tests/modules/programs/vscode/argv.nix
@@ -1,0 +1,36 @@
+package:
+
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.vscode;
+  willUseIfd = package.pname != "vscode";
+
+  argvPath = "${cfg.nameShort}/argv.json";
+
+  content = ''
+    {
+      "enable-crash-reporter": false
+    }
+  '';
+
+  expectedArgvSettings = pkgs.writeText "custom-argv.json" content;
+in
+
+lib.mkIf (willUseIfd -> config.test.enableLegacyIfd) {
+  programs.vscode = {
+    enable = true;
+    inherit package;
+    argvSettings.enable-crash-reporter = false;
+  };
+
+  argv.script = ''
+    assertFileExists "home-files/${argvPath}"
+    assertFileContent "home-files/${argvPath}" "${expectedArgvSettings}"
+  '';
+}

--- a/tests/modules/programs/vscode/default.nix
+++ b/tests/modules/programs/vscode/default.nix
@@ -21,6 +21,7 @@ let
   };
 
   tests = {
+    argv = import ./argv.nix;
     keybindings = import ./keybindings.nix;
     tasks = import ./tasks.nix;
     mcp = import ./mcp.nix;


### PR DESCRIPTION
### Description

Addresses #5990

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
