### PR TITLE
linux-wallpaperengine: add examples and clarify options usage

### DIFF
--- a/modules/services/linux-wallpaperengine.nix
+++ b/modules/services/linux-wallpaperengine.nix
@@ -21,6 +21,7 @@ in
       type = types.nullOr types.path;
       default = null;
       description = "Path to the assets directory.";
+      example = "~/.local/share/Steam/steamapps/common/wallpaper_engine/assets";
     };
 
     clamping = mkOption {
@@ -42,17 +43,23 @@ in
             monitor = mkOption {
               type = types.str;
               description = "Which monitor to display the wallpaper.";
+              example = "HDMI-A-1";
             };
 
             wallpaperId = mkOption {
               type = types.str;
-              description = "Wallpaper ID to be used.";
+              description = "Wallpaper to be used. Can either be a Steam Workshop ID or the path to the background folder.";
+              example = "3527223773";
             };
 
             extraOptions = mkOption {
               type = types.listOf types.str;
               default = [ ];
               description = "Extra arguments to pass to the linux-wallpaperengine command for this wallpaper.";
+              example = [
+                "--scaling fill"
+                "--fps 12"
+              ];
             };
 
             scaling = mkOption {


### PR DESCRIPTION
### Description

This amends the description of `services.linux-wallpaperengine.wallpapers.wallpaperId` following the confusion in #8577, and provides some examples to existing options.

This is only a document change without altering any functional part.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
