### PR TITLE
neovim: move plugins where expected

### DIFF
--- a/modules/misc/news/2026/01/2026-01-19_02-17-02.nix
+++ b/modules/misc/news/2026/01/2026-01-19_02-17-02.nix
@@ -1,0 +1,8 @@
+{ config, ... }:
+{
+  time = "2026-01-19T01:17:02+00:00";
+  condition = config.programs.neovim.enable;
+  message = ''
+    The neovim module now symlinks its plugins into xdg.dataFile."nvim/site/pack/hm" ( ~/.local/share/nvim) instead of modifying the runtimepath via wrapper arguments.
+  '';
+}


### PR DESCRIPTION
### Description

so we dont have to add some nix store path to rtp in the wrapper. Makes the setup more in line with what neovim users are used to. Also it means other neovim GUIs can see the plugins without wrapping.

A first version of this PR conflicted with existing ~/.local/share/nvim/site folders but this should be fine as it makes only a subfolder readonly. 
I am able to mix rocks.nvim/vim.pack vim packages along with the home-manager one for instance.


This PR in the spiritual successor of:
https://github.com/nix-community/home-manager/pull/3717
https://github.com/nix-community/home-manager/pull/5964

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
