### PR TITLE
kitty: quote string values to preserve leading/trailing spaces

### DIFF
--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -33,7 +33,13 @@ let
     mkKeyValue =
       key: value:
       let
-        value' = (if lib.isBool value then lib.hm.booleans.yesNo else toString) value;
+        value' =
+          if lib.isBool value then
+            lib.hm.booleans.yesNo value
+          else if lib.isString value then
+            ''"${value}"''
+          else
+            toString value;
       in
       "${key} ${value'}";
   };

--- a/tests/modules/programs/kitty/example-settings-expected.conf
+++ b/tests/modules/programs/kitty/example-settings-expected.conf
@@ -9,6 +9,7 @@ shell_integration no-rc
 background_opacity 0.500000
 enable_audio_bell no
 scrollback_lines 10000
+tab_separator " | "
 update_check_interval 0
 
 action_alias launch_tab launch --cwd=current --type=tab

--- a/tests/modules/programs/kitty/example-settings.nix
+++ b/tests/modules/programs/kitty/example-settings.nix
@@ -15,6 +15,8 @@
         enable_audio_bell = false;
         update_check_interval = 0;
         background_opacity = 0.5;
+        # Test string with leading/trailing spaces
+        tab_separator = " | ";
       };
 
       font.name = "DejaVu Sans";


### PR DESCRIPTION
### Description

The `toKittyConfig` function now quotes string values when generating the Kitty configuration file. This ensures that leading and trailing spaces are preserved, as Kitty's config parser would otherwise trim them.

This fixes an issue where setting values like `tab_separator = " | "` would have their spaces stripped in the generated config file.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.
- [x] Code tested through `nix run .#tests -- test-all` or `nix-shell --pure tests -A run.all`.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

Fixes #8587