### PR TITLE
mcp: add strict type schema for MCP server configurations

### DIFF
--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -17,18 +17,34 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
-  mkMcpServer =
-    server:
-    (removeAttrs server [ "disabled" ])
-    // (optionalAttrs (server ? url) { type = "http"; })
-    // (optionalAttrs (server ? command) { type = "stdio"; })
-    // {
-      enabled = !(server.disabled or false);
-    };
+  transformMcpServer = name: server: {
+    inherit name;
+    value = {
+      inherit (server) type;
+    }
+    // (
+      if server.type == "stdio" then
+        {
+          inherit (server) command args env;
+        }
+      else if server.type == "sse" || server.type == "http" then
+        {
+          inherit (server) url headers;
+        }
+      else
+        throw "Unexpected MCP server type: ${server.type}"
+    );
+  };
 
-  transformedMcpServers = optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
-    lib.mapAttrs (_name: mkMcpServer) config.programs.mcp.servers
-  );
+  transformedMcpServers =
+    if cfg.enableMcpIntegration && config.programs.mcp.enable && config.programs.mcp.servers != { } then
+      lib.listToAttrs (
+        lib.mapAttrsToList transformMcpServer (
+          lib.filterAttrs (_: server: !server.disabled) config.programs.mcp.servers
+        )
+      )
+    else
+      { };
 
   mkContentOption =
     {

--- a/modules/programs/codex.nix
+++ b/modules/programs/codex.nix
@@ -224,21 +224,24 @@ in
       transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
         lib.mapAttrs (
           _name: server:
-          # NOTE: Convert shared programs.mcp fields to Codex config keys:
-          # - removeAttrs drops keys that Codex does not use directly
-          # - "disabled" becomes inverse "enabled"
-          # - "headers" is renamed to "http_headers"
+          # NOTE: Convert shared programs.mcp fields to Codex config keys.
           # See: https://developers.openai.com/codex/mcp#other-configuration-options
-          (lib.removeAttrs server [
-            "disabled"
-            "headers"
-          ])
-          // (lib.optionalAttrs (server ? headers && !(server ? http_headers)) {
-            http_headers = server.headers;
-          })
-          // {
-            enabled = !(server.disabled or false);
+          {
+            enabled = !server.disabled;
           }
+          // (
+            if server.type == "stdio" then
+              {
+                inherit (server) command args env;
+              }
+            else if server.type == "sse" || server.type == "http" then
+              {
+                inherit (server) url;
+                http_headers = server.headers;
+              }
+            else
+              throw "Unexpected MCP server type: ${server.type}"
+          )
         ) config.programs.mcp.servers
       );
 

--- a/modules/programs/gemini-cli.nix
+++ b/modules/programs/gemini-cli.nix
@@ -230,9 +230,25 @@ in
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
-        programs.gemini-cli.settings.mcpServers = lib.mkIf (
-          cfg.enableMcpIntegration && config.programs.mcp.enable
-        ) (lib.mapAttrs (_n: lib.mkDefault) config.programs.mcp.servers);
+        programs.gemini-cli.settings.mcpServers =
+          lib.mkIf (cfg.enableMcpIntegration && config.programs.mcp.enable)
+            (
+              lib.mapAttrs (
+                _name: server:
+                lib.mkDefault (
+                  if server.type == "stdio" then
+                    {
+                      inherit (server) command args env;
+                    }
+                  else if server.type == "sse" || server.type == "http" then
+                    {
+                      inherit (server) url headers;
+                    }
+                  else
+                    throw "Unexpected MCP server type: ${server.type}"
+                )
+              ) (lib.filterAttrs (_: server: !server.disabled) config.programs.mcp.servers)
+            );
       }
       {
         home = {

--- a/modules/programs/mcp.nix
+++ b/modules/programs/mcp.nix
@@ -10,11 +10,103 @@ let
     mkEnableOption
     mkIf
     mkOption
+    types
     ;
 
   cfg = config.programs.mcp;
 
   jsonFormat = pkgs.formats.json { };
+
+  stdioServerType = types.addCheck (types.submodule {
+    options = {
+      type = mkOption {
+        type = types.enum [ "stdio" ];
+      };
+
+      command = mkOption {
+        type = types.str;
+        description = "Command to run the MCP server";
+        example = "npx";
+      };
+
+      args = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Arguments to pass to the MCP server command";
+        example = [
+          "-y"
+          "@modelcontextprotocol/server-filesystem"
+          "/home/user"
+        ];
+      };
+
+      env = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        description = "Environment variables for the MCP server";
+        example = {
+          GITHUB_TOKEN = "ghp_xxxxxxxxxxxx";
+        };
+      };
+
+      disabled = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to disable this MCP server";
+      };
+
+      timeout = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = "Timeout in milliseconds for server operations";
+        example = 5000;
+      };
+    };
+  }) (server: server.type or null == "stdio");
+
+  remoteServerType = types.addCheck (types.submodule {
+    options = {
+      type = mkOption {
+        type = types.enum [
+          "sse"
+          "http"
+        ];
+      };
+
+      url = mkOption {
+        type = types.str;
+        description = "Server endpoint URL";
+        example = "https://example.com/mcp";
+      };
+
+      headers = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        description = "HTTP headers for authentication";
+        example = {
+          Authorization = "Bearer token123";
+        };
+      };
+
+      disabled = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to disable this MCP server";
+      };
+
+      timeout = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = "Timeout in milliseconds for server operations";
+        example = 5000;
+      };
+    };
+  }) (server: server.type or null == "sse" || server.type or null == "http");
+
+  mcpServerType = types.oneOf [
+    stdioServerType
+    remoteServerType
+  ];
 in
 {
   meta.maintainers = with lib.maintainers; [ delafthi ];
@@ -23,11 +115,12 @@ in
     enable = mkEnableOption "mcp";
 
     servers = mkOption {
-      inherit (jsonFormat) type;
+      type = types.attrsOf mcpServerType;
       default = { };
       example = literalExpression ''
         {
           everything = {
+            type = "stdio";
             command = "npx";
             args = [
               "-y"
@@ -35,10 +128,15 @@ in
             ];
           };
           context7 = {
+            type = "http";
             url = "https://mcp.context7.com/mcp";
             headers = {
               CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";
             };
+          };
+          atlassian = {
+            type = "sse";
+            url = "https://mcp.atlassian.com/v1/sse";
           };
         }
       '';

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -21,24 +21,24 @@ let
   transformMcpServer = name: server: {
     inherit name;
     value = {
-      enabled = !(server.disabled or false);
+      enabled = !server.disabled;
     }
     // (
-      if server ? url then
-        {
-          type = "remote";
-          inherit (server) url;
-        }
-        // (lib.optionalAttrs (server ? headers) { inherit (server) headers; })
-      else if server ? command then
+      if server.type == "stdio" then
         {
           type = "local";
-          command = [ server.command ] ++ (server.args or [ ]);
+          command = [ server.command ] ++ server.args;
+          environment = server.env;
         }
-        // (lib.optionalAttrs (server ? env) { environment = server.env; })
+      else if server.type == "sse" || server.type == "http" then
+        {
+          inherit (server) url headers;
+          type = "remote";
+        }
       else
-        { }
-    );
+        throw "Unexpected MCP server type: ${server.type}"
+    )
+    // (lib.optionalAttrs (server.timeout != null) { inherit (server) timeout; });
   };
 
   transformedMcpServers =

--- a/modules/programs/vscode/default.nix
+++ b/modules/programs/vscode/default.nix
@@ -125,32 +125,27 @@ let
 
   isPath = p: builtins.isPath p || lib.isStorePath p;
 
-  transformMcpServerForVscode =
-    name: server:
-    let
-      # Remove the disabled field from the server config
-      cleanServer = lib.filterAttrs (n: _v: n != "disabled") server;
-    in
-    {
-      inherit name;
-      value = {
-        enabled = !(server.disabled or false);
-      }
-      // (
-        if server ? url then
-          {
-            type = "http";
-          }
-          // cleanServer
-        else if server ? command then
-          {
-            type = "stdio";
-          }
-          // cleanServer
-        else
-          { }
-      );
-    };
+  transformMcpServerForVscode = name: server: {
+    inherit name;
+    value =
+      if server.type == "sse" then
+        {
+          type = "sse";
+          inherit (server) url headers;
+        }
+      else if server.type == "http" then
+        {
+          type = "http";
+          inherit (server) url headers;
+        }
+      else if server.type == "stdio" then
+        {
+          type = "stdio";
+          inherit (server) command args env;
+        }
+      else
+        throw "Unexpected MCP server type: ${server.type}";
+  };
 
   profileType = types.submodule {
     options = {
@@ -569,7 +564,11 @@ in
                 let
                   transformedMcpServers =
                     if v.enableMcpIntegration && config.programs.mcp.enable && config.programs.mcp.servers != { } then
-                      lib.listToAttrs (lib.mapAttrsToList transformMcpServerForVscode config.programs.mcp.servers)
+                      lib.listToAttrs (
+                        lib.mapAttrsToList transformMcpServerForVscode (
+                          lib.filterAttrs (_: server: !server.disabled) config.programs.mcp.servers
+                        )
+                      )
                     else
                       { };
                   # Merge MCP servers: transformed servers + user servers, with user servers taking precedence

--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -32,14 +32,23 @@ let
   transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
     lib.mapAttrs (
       _name: server:
-      # NOTE: Convert shared programs.mcp fields to Zed config keys:
-      # - removeAttrs drops keys that Zed does not use directly
-      # - "disabled" becomes inverse "enabled"
+      # NOTE: Convert shared programs.mcp fields to Zed config keys.
       # See: https://zed.dev/docs/ai/mcp
-      (lib.removeAttrs server [ "disabled" ])
-      // {
-        enabled = !(server.disabled or false);
+      {
+        enabled = !server.disabled;
       }
+      // (
+        if server.type == "stdio" then
+          {
+            inherit (server) command args env;
+          }
+        else if server.type == "sse" || server.type == "http" then
+          {
+            inherit (server) url headers;
+          }
+        else
+          throw "Unexpected MCP server type: ${server.type}"
+      )
     ) config.programs.mcp.servers
   );
 

--- a/tests/modules/programs/claude-code/mcp-integration.nix
+++ b/tests/modules/programs/claude-code/mcp-integration.nix
@@ -43,23 +43,24 @@
             "/other-tmp"
           ];
         };
-        database = {
-          command = "npx";
-          args = [
-            "-y"
-            "@bytebase/dbhub"
-            "--dsn"
-            "postgresql://user:pass@localhost:5432/db"
-          ];
-          env = {
-            DATABASE_URL = "postgresql://user:pass@localhost:5432/db";
+        context7 = {
+          type = "http";
+          url = "https://mcp.context7.com/mcp";
+          headers = {
+            API_KEY = "secret";
           };
         };
-        customTransport = {
-          type = "websocket";
-          url = "wss://example.com/mcp";
-          customOption = "value";
-          timeout = 5000;
+        atlassian = {
+          type = "sse";
+          url = "https://api-private.atlassian.com/mcp";
+          headers = {
+            Authorization = "Bearer token";
+          };
+        };
+        disabled = {
+          type = "stdio";
+          command = "echo";
+          disabled = true;
         };
       };
     };
@@ -74,9 +75,11 @@
     pluginDir="''${pluginDir#--plugin-dir }"
     assertFileContent "$pluginDir/.claude-plugin/plugin.json" ${./expected-plugin-manifest.json}
     assertFileRegex "$pluginDir/.mcp.json" '"github"'
-    assertFileRegex "$pluginDir/.mcp.json" '"database"'
+    assertFileRegex "$pluginDir/.mcp.json" '"context7"'
+    assertFileRegex "$pluginDir/.mcp.json" '"atlassian"'
     assertFileRegex "$pluginDir/.mcp.json" '"/tmp"'
     (! grep -q -- '/other-tmp' "$pluginDir/.mcp.json")
+    (! grep -q -- '"disabled"' "$pluginDir/.mcp.json")
     assertPathNotExists "$pluginDir/.lsp.json"
   '';
 }

--- a/tests/modules/programs/codex/mcp-integration-with-override.nix
+++ b/tests/modules/programs/codex/mcp-integration-with-override.nix
@@ -3,6 +3,7 @@
     enable = true;
     servers = {
       everything = {
+        type = "stdio";
         command = "npx";
         args = [
           "-y"
@@ -10,6 +11,7 @@
         ];
       };
       context7 = {
+        type = "http";
         url = "https://mcp.context7.com/mcp";
         headers = {
           CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";

--- a/tests/modules/programs/codex/mcp-integration.nix
+++ b/tests/modules/programs/codex/mcp-integration.nix
@@ -3,6 +3,7 @@
     enable = true;
     servers = {
       everything = {
+        type = "stdio";
         command = "npx";
         args = [
           "-y"
@@ -10,12 +11,14 @@
         ];
       };
       context7 = {
+        type = "http";
         url = "https://mcp.context7.com/mcp";
         headers = {
           CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";
         };
       };
       disabled-server = {
+        type = "stdio";
         command = "echo";
         args = [ "test" ];
         disabled = true;

--- a/tests/modules/programs/codex/mcp-integration.toml
+++ b/tests/modules/programs/codex/mcp-integration.toml
@@ -10,7 +10,11 @@ args = ["test"]
 command = "echo"
 enabled = false
 
+[mcp_servers.disabled-server.env]
+
 [mcp_servers.everything]
 args = ["-y", "@modelcontextprotocol/server-everything"]
 command = "npx"
 enabled = true
+
+[mcp_servers.everything.env]

--- a/tests/modules/programs/gemini-cli/mcp.nix
+++ b/tests/modules/programs/gemini-cli/mcp.nix
@@ -25,6 +25,7 @@
       enable = true;
       servers = {
         filesystem = {
+          type = "stdio";
           command = "npx";
           args = [
             "-y"
@@ -33,6 +34,7 @@
           ];
         };
         database = {
+          type = "stdio";
           command = "npx";
           args = [
             "-y"

--- a/tests/modules/programs/mcp/mcp.json
+++ b/tests/modules/programs/mcp/mcp.json
@@ -1,17 +1,43 @@
 {
   "mcpServers": {
+    "atlassian": {
+      "disabled": false,
+      "headers": {
+        "Authorization": "Bearer token"
+      },
+      "timeout": 10000,
+      "type": "sse",
+      "url": "https://api-private.atlassian.com/mcp"
+    },
     "context7": {
+      "disabled": false,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },
-      "serverUrl": "https://mcp.context7.com/mcp"
+      "timeout": null,
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "disabled": {
+      "args": [],
+      "command": "echo",
+      "disabled": true,
+      "env": {},
+      "timeout": null,
+      "type": "stdio"
     },
     "everything": {
       "args": [
         "-y",
         "@modelcontextprotocol/server-everything"
       ],
-      "command": "npx"
+      "command": "npx",
+      "disabled": false,
+      "env": {
+        "DEBUG": "1"
+      },
+      "timeout": 5000,
+      "type": "stdio"
     }
   }
 }

--- a/tests/modules/programs/mcp/servers.nix
+++ b/tests/modules/programs/mcp/servers.nix
@@ -3,17 +3,39 @@
     enable = true;
     servers = {
       everything = {
+        type = "stdio";
         command = "npx";
         args = [
           "-y"
           "@modelcontextprotocol/server-everything"
         ];
+        env = {
+          DEBUG = "1";
+        };
+        timeout = 5000;
       };
+
       context7 = {
-        serverUrl = "https://mcp.context7.com/mcp";
+        type = "http";
+        url = "https://mcp.context7.com/mcp";
         headers = {
           CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";
         };
+      };
+
+      atlassian = {
+        type = "sse";
+        url = "https://api-private.atlassian.com/mcp";
+        headers = {
+          Authorization = "Bearer token";
+        };
+        timeout = 10000;
+      };
+
+      disabled = {
+        type = "stdio";
+        command = "echo";
+        disabled = true;
       };
     };
   };

--- a/tests/modules/programs/opencode/mcp-integration-with-override.nix
+++ b/tests/modules/programs/opencode/mcp-integration-with-override.nix
@@ -3,6 +3,7 @@
     enable = true;
     servers = {
       everything = {
+        type = "stdio";
         command = "npx";
         args = [
           "-y"
@@ -10,6 +11,7 @@
         ];
       };
       context7 = {
+        type = "sse";
         url = "https://mcp.context7.com/mcp";
         headers = {
           CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";

--- a/tests/modules/programs/opencode/mcp-integration.json
+++ b/tests/modules/programs/opencode/mcp-integration.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
+    "atlassian": {
+      "enabled": true,
+      "headers": {
+        "Authorization": "Bearer token"
+      },
+      "timeout": 8000,
+      "type": "remote",
+      "url": "https://api-private.atlassian.com/mcp"
+    },
     "context7": {
       "enabled": true,
       "headers": {
@@ -9,12 +18,12 @@
       "type": "remote",
       "url": "https://mcp.context7.com/mcp"
     },
-    "disabled-server": {
+    "disabled": {
       "command": [
-        "echo",
-        "test"
+        "echo"
       ],
       "enabled": false,
+      "environment": {},
       "type": "local"
     },
     "everything": {
@@ -24,6 +33,7 @@
         "@modelcontextprotocol/server-everything"
       ],
       "enabled": true,
+      "environment": {},
       "type": "local"
     }
   }

--- a/tests/modules/programs/opencode/mcp-integration.nix
+++ b/tests/modules/programs/opencode/mcp-integration.nix
@@ -3,6 +3,7 @@
     enable = true;
     servers = {
       everything = {
+        type = "stdio";
         command = "npx";
         args = [
           "-y"
@@ -10,14 +11,23 @@
         ];
       };
       context7 = {
+        type = "http";
         url = "https://mcp.context7.com/mcp";
         headers = {
           CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";
         };
       };
-      disabled-server = {
+      atlassian = {
+        type = "sse";
+        url = "https://api-private.atlassian.com/mcp";
+        headers = {
+          Authorization = "Bearer token";
+        };
+        timeout = 8000;
+      };
+      disabled = {
+        type = "stdio";
         command = "echo";
-        args = [ "test" ];
         disabled = true;
       };
     };

--- a/tests/modules/programs/vscode/mcp-integration-default.json
+++ b/tests/modules/programs/vscode/mcp-integration-default.json
@@ -1,17 +1,18 @@
 {
   "servers": {
+    "atlassian": {
+      "headers": {
+        "Authorization": "Bearer token"
+      },
+      "type": "sse",
+      "url": "https://api-private.atlassian.com/mcp"
+    },
     "context7": {
-      "enabled": true,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },
       "type": "http",
       "url": "https://mcp.context7.com/mcp"
-    },
-    "disabled-server": {
-      "command": "echo",
-      "enabled": false,
-      "type": "stdio"
     },
     "everything": {
       "args": [
@@ -19,7 +20,7 @@
         "@modelcontextprotocol/server-everything"
       ],
       "command": "npx",
-      "enabled": true,
+      "env": {},
       "type": "stdio"
     }
   }

--- a/tests/modules/programs/vscode/mcp-integration-with-override.json
+++ b/tests/modules/programs/vscode/mcp-integration-with-override.json
@@ -5,7 +5,6 @@
       "url": "https://example.com/mcp"
     },
     "context7": {
-      "enabled": true,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },

--- a/tests/modules/programs/vscode/mcp-integration-with-override.nix
+++ b/tests/modules/programs/vscode/mcp-integration-with-override.nix
@@ -29,6 +29,7 @@ lib.mkIf (willUseIfd -> config.test.enableLegacyIfd) {
     enable = true;
     servers = {
       everything = {
+        type = "stdio";
         command = "npx";
         args = [
           "-y"
@@ -36,6 +37,7 @@ lib.mkIf (willUseIfd -> config.test.enableLegacyIfd) {
         ];
       };
       context7 = {
+        type = "http";
         url = "https://mcp.context7.com/mcp";
         headers = {
           CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";

--- a/tests/modules/programs/vscode/mcp-integration.nix
+++ b/tests/modules/programs/vscode/mcp-integration.nix
@@ -29,6 +29,7 @@ lib.mkIf (willUseIfd -> config.test.enableLegacyIfd) {
     enable = true;
     servers = {
       everything = {
+        type = "stdio";
         command = "npx";
         args = [
           "-y"
@@ -36,12 +37,21 @@ lib.mkIf (willUseIfd -> config.test.enableLegacyIfd) {
         ];
       };
       context7 = {
+        type = "http";
         url = "https://mcp.context7.com/mcp";
         headers = {
           CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";
         };
       };
-      disabled-server = {
+      atlassian = {
+        type = "sse";
+        url = "https://api-private.atlassian.com/mcp";
+        headers = {
+          Authorization = "Bearer token";
+        };
+      };
+      disabled = {
+        type = "stdio";
         command = "echo";
         disabled = true;
       };

--- a/tests/modules/programs/zed-editor/mcp-integration-with-override.nix
+++ b/tests/modules/programs/zed-editor/mcp-integration-with-override.nix
@@ -10,6 +10,7 @@
     enable = true;
     servers = {
       everything = {
+        type = "stdio";
         command = "npx";
         args = [
           "-y"
@@ -65,7 +66,8 @@
                 "@modelcontextprotocol/server-everything"
               ],
               "command": "npx",
-              "enabled": true
+              "enabled": true,
+              "env": {}
             }
           }
         }

--- a/tests/modules/programs/zed-editor/mcp-integration.nix
+++ b/tests/modules/programs/zed-editor/mcp-integration.nix
@@ -10,6 +10,7 @@
     enable = true;
     servers = {
       everything = {
+        type = "stdio";
         command = "npx";
         args = [
           "-y"
@@ -17,12 +18,14 @@
         ];
       };
       context7 = {
+        type = "http";
         url = "https://mcp.context7.com/mcp";
         headers = {
           CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";
         };
       };
       disabled-server = {
+        type = "stdio";
         command = "echo";
         args = [ "test" ];
         disabled = true;
@@ -55,7 +58,8 @@
                 "test"
               ],
               "command": "echo",
-              "enabled": false
+              "enabled": false,
+              "env": {}
             },
             "everything": {
               "args": [
@@ -63,7 +67,8 @@
                 "@modelcontextprotocol/server-everything"
               ],
               "command": "npx",
-              "enabled": true
+              "enabled": true,
+              "env": {}
             }
           }
         }


### PR DESCRIPTION
### Description

Define proper type schemas for MCP servers instead of accepting arbitrary JSON, addressing issue #8591.

**Changes:**
- Add strict submodule types for stdio, SSE, and HTTP transports
- Add `enabled` (default: true) and `timeout` (nullable) options
- Transform MCP servers in claude-code, opencode, and vscode modules
- Filter out disabled servers in claude-code and vscode integrations
- Throw error for unexpected transport types
- Update all tests with comprehensive examples

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt`.
- [x] Code tested through `nix run .#tests -- mcp`.
- [x] Test cases updated/added.
- [x] Commit messages are formatted correctly.

Closes: #8591