### PR TITLE
vscode: fix argv.json path

### DIFF
--- a/modules/misc/news/2026/01/2026-01-18_15-07-27.nix
+++ b/modules/misc/news/2026/01/2026-01-18_15-07-27.nix
@@ -1,0 +1,8 @@
+{
+  time = "2026-01-18T14:07:27+00:00";
+  condition = true;
+  message = ''
+    A new 'programs.vscode.argvSettings' option is available to configure VS
+    Code this creates the `argv.json` file.
+  '';
+}

--- a/modules/programs/vscode/default.nix
+++ b/modules/programs/vscode/default.nix
@@ -81,7 +81,7 @@ let
     else
       "${config.xdg.configHome}/${configDir}/User";
 
-  argvPath = "${configDir}/argv.json";
+  argvPath = "${extensionDir}/argv.json";
   configFilePath =
     name: "${userDir}/${optionalString (name != "default") "profiles/${name}/"}settings.json";
   tasksFilePath =

--- a/tests/modules/programs/vscode/argv.nix
+++ b/tests/modules/programs/vscode/argv.nix
@@ -11,7 +11,7 @@ let
   cfg = config.programs.vscode;
   willUseIfd = package.pname != "vscode";
 
-  argvPath = "${cfg.nameShort}/argv.json";
+  argvPath = "${cfg.dataFolderName}/argv.json";
 
   content = ''
     {


### PR DESCRIPTION
### Description

Will using #8582 i noticed I put the file to the wrong location.

```console
> find ~ -name argv.json
/home/rhoriguchi/.vscode/argv.json
/home/rhoriguchi/.kiro/argv.json
/home/rhoriguchi/Code/argv.json # Added by the wrong code
```

I also added some update news as proposed by @khaneliman

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
