### PR TITLE
restic: fix evaluation error in `rcloneOptions`

### DIFF
--- a/modules/services/restic.nix
+++ b/modules/services/restic.nix
@@ -24,10 +24,11 @@ let
     lib.pipe opt [
       (lib.replaceStrings [ "-" ] [ "_" ])
       lib.toUpper
-      (lib.add "RCLONE_")
+      (upper: "RCLONE_" + upper)
     ];
 
-  toEnvVal = v: if lib.isBool v then lib.boolToString v else v;
+  toEnvVal = v: if lib.isBool v then lib.boolToString v else toString v;
+
   attrsToEnvs =
     attrs:
     lib.pipe attrs [
@@ -127,6 +128,7 @@ in
                   attrsOf (oneOf [
                     str
                     bool
+                    int
                   ]);
                 default = { };
                 apply = lib.mapAttrs' (opt: v: lib.nameValuePair (fmtRcloneOpt opt) v);

--- a/tests/modules/services/restic/backup-configs.nix
+++ b/tests/modules/services/restic/backup-configs.nix
@@ -91,6 +91,11 @@ in
       ;
     initialize = true;
     repository = "rclone:local:/root/restic-rclone-backup";
+    rcloneOptions = {
+      checksum = true;
+      color = "ALWAYS";
+      list-cutoff = 5;
+    };
   };
 
   prune = {

--- a/tests/modules/services/restic/unit-files.nix
+++ b/tests/modules/services/restic/unit-files.nix
@@ -106,6 +106,9 @@ in
     serviceFile=$serviceFiles/restic-backups-"$backup".service
     assertFileRegex $serviceFile "Environment=RESTIC_REPOSITORY=rclone:local:/root/restic-rclone-backup"
     assertFileRegex $serviceFile "Environment=RESTIC_PASSWORD_FILE"
+    assertFileRegex $serviceFile "Environment=RCLONE_CHECKSUM=true"
+    assertFileRegex $serviceFile "Environment=RCLONE_COLOR=ALWAYS"
+    assertFileRegex $serviceFile "Environment=RCLONE_LIST_CUTOFF=5"
     assertFileRegex $serviceFile "ExecStart=.*$defaultPruneOpts"
     for part in ''${defaultPruneOpts[@]}; do
       assertFileRegex $serviceFile "ExecStart=.*$part"


### PR DESCRIPTION
Resolves #8595


### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
