### PR TITLE
neovim: move LUA_(C)PATH setup from wrapping to init.lua

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -505,9 +505,18 @@ in
           advisedLua = foldedLuaBlock "home-manager generated: plugin config advised in nixpkgs" (
             lib.concatStringsSep "\n" vimPackageInfo.pluginAdvisedLua
           );
+
+          generatedLuaPath = lib.concatMapStringsSep ";" luaPackages.getLuaPath resolvedExtraLuaPackages;
+          generatedLuaCPath = lib.concatMapStringsSep ";" luaPackages.getLuaCPath resolvedExtraLuaPackages;
         in
 
         lib.mkMerge [
+          (lib.mkIf (
+            resolvedExtraLuaPackages != [ ]
+          ) ''package.path = "${generatedLuaPath}".. ";" .. package.path'')
+          (lib.mkIf (
+            resolvedExtraLuaPackages != [ ]
+          ) ''package.cpath = "${generatedLuaCPath}".. ";" .. package.cpath'')
           (lib.mkIf (advisedLua != null) (lib.mkOrder 510 advisedLua))
           (lib.mkIf (wrappedNeovim'.initRc != "") (
             lib.mkBefore "vim.cmd [[source ${pkgs.writeText "nvim-init-home-manager.vim" wrappedNeovim'.initRc}]]"
@@ -515,6 +524,7 @@ in
           (lib.mkIf (lib.hasAttr "lua" cfg.generatedConfigs) (
             lib.mkAfter (foldedLuaBlock "user-associated plugin config" cfg.generatedConfigs.lua)
           ))
+
         ];
 
       # link the packpath in expected folder so that even unwrapped neovim can pick

--- a/tests/modules/programs/neovim/plugin-config.expected
+++ b/tests/modules/programs/neovim/plugin-config.expected
@@ -1,4 +1,6 @@
 vim.cmd [[source /nix/store/00000000000000000000000000000000-nvim-init-home-manager.vim]]
+package.path = "/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/share/lua/5.1/?.lua;/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/share/lua/5.1/?/init.lua".. ";" .. package.path
+package.cpath = "/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/lib/lua/5.1/?.so".. ";" .. package.cpath
 -- user-associated plugin config {{{
 function HM_PLUGIN_LUA_CONFIG ()
 end


### PR DESCRIPTION
Motivation is similar to https://github.com/nix-community/home-manager/pull/8586: not relying on wrapped arguments make the neovim install more "natural", or what users are used to. Alternative GUIs can find lua dependencies that are not plugins (for instance nio) without wrapping. 
Some plugins depend on lua packages that are not vim plugins and thus become "invisible" to nixpkgs as it stands.
For now they need to be specified manually via `extraLuaPackages` but hopefully we can autodiscover those in nixpkgs.


I will wait for a bit before merging, to see if https://github.com/nix-community/home-manager/pull/8586 triggered any issue.

TODO:
- ~~enrich the path only if extraLuaPackages is set~~

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
