### PR TITLE
mpdscribble: fix journal file location

### DIFF
--- a/modules/services/mpdscribble.nix
+++ b/modules/services/mpdscribble.nix
@@ -5,7 +5,6 @@
   pkgs,
   ...
 }:
-
 let
   cfg = config.services.mpdscribble;
   mpdCfg = config.services.mpd;
@@ -22,7 +21,6 @@ in
   meta.maintainers = [ lib.hm.maintainers.msyds ];
 
   options.services.mpdscribble = {
-
     enable = lib.mkEnableOption ''
       mpdscribble, an MPD client which submits info about tracks being played to
       Last.fm (formerly AudioScrobbler)
@@ -125,7 +123,6 @@ in
         If the endpoint is one of "${lib.concatStringsSep ''", "'' (builtins.attrNames endpointUrls)}" the url is set automatically.
       '';
     };
-
   };
 
   config = lib.mkIf cfg.enable {
@@ -134,14 +131,14 @@ in
     ];
     systemd.user.services.mpdscribble =
       let
-        localMpd = (cfg.host == "localhost" || cfg.host == "127.0.0.1");
+        localMpd = cfg.host == "localhost" || cfg.host == "127.0.0.1";
 
         mkSection = secname: secCfg: ''
           [${secname}]
           url      = ${secCfg.url}
           username = ${secCfg.username}
           password = {{${secname}_PASSWORD}}
-          journal  = /var/lib/mpdscribble/${secname}.journal
+          journal  = ${config.xdg.dataHome}/mpdscribble/${secname}.journal
         '';
 
         endpoints = lib.concatStringsSep "\n" (lib.mapAttrsToList mkSection cfg.endpoints);
@@ -209,7 +206,6 @@ in
           configFile="${configFile}"
           exec "${lib.getExe cfg.package}" --no-daemon --conf "$configFile"
         '';
-
       in
       {
         Unit = {


### PR DESCRIPTION
### Description
The existing module seems to have just been copied straight from the NixOS module. This changes the location from /var/lib to the user's data home directory.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
