### PR TITLE
opencode: add web service configuration

### DIFF
--- a/tests/modules/programs/opencode/default.nix
+++ b/tests/modules/programs/opencode/default.nix
@@ -23,4 +23,5 @@
   opencode-themes-bulk-directory = ./themes-bulk-directory.nix;
   opencode-mcp-integration = ./mcp-integration.nix;
   opencode-mcp-integration-with-override = ./mcp-integration-with-override.nix;
+  opencode-web-service = ./web-service.nix;
 }

--- a/tests/modules/programs/opencode/web-service.nix
+++ b/tests/modules/programs/opencode/web-service.nix
@@ -1,0 +1,41 @@
+{
+  pkgs,
+  ...
+}:
+{
+  programs.opencode = {
+    enable = true;
+
+    web = {
+      enable = true;
+      extraArgs = [
+        "--hostname"
+        "0.0.0.0"
+        "--port"
+        "4096"
+        "--mdns"
+        "--cors"
+        "https://example.com"
+        "--cors"
+        "http://localhost:3000"
+        "--print-logs"
+        "--log-level"
+        "DEBUG"
+      ];
+    };
+  };
+
+  nmt.script =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      ''
+        serviceFile=LaunchAgents/org.nix-community.home.opencode-web.plist
+        assertFileExists "$serviceFile"
+        assertFileContent "$serviceFile" ${./web-service.plist}
+      ''
+    else
+      ''
+        serviceFile=home-files/.config/systemd/user/opencode-web.service
+        assertFileExists "$serviceFile"
+        assertFileContent "$serviceFile" ${./web-service.service}
+      '';
+}

--- a/tests/modules/programs/opencode/web-service.plist
+++ b/tests/modules/programs/opencode/web-service.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>KeepAlive</key>
+	<dict>
+		<key>Crashed</key>
+		<true/>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+	<key>Label</key>
+	<string>org.nix-community.home.opencode-web</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>@opencode@/bin/opencode</string>
+		<string>web</string>
+		<string>--hostname</string>
+		<string>0.0.0.0</string>
+		<string>--port</string>
+		<string>4096</string>
+		<string>--mdns</string>
+		<string>--cors</string>
+		<string>https://example.com</string>
+		<string>--cors</string>
+		<string>http://localhost:3000</string>
+		<string>--print-logs</string>
+		<string>--log-level</string>
+		<string>DEBUG</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/modules/programs/opencode/web-service.service
+++ b/tests/modules/programs/opencode/web-service.service
@@ -1,0 +1,11 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecStart=@opencode@/bin/opencode web --hostname 0.0.0.0 --port 4096 --mdns --cors https://example.com --cors http://localhost:3000 --print-logs --log-level DEBUG
+Restart=always
+RestartSec=5
+
+[Unit]
+After=network.target
+Description=OpenCode Web Service


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add configuration options for the opencode web service including host, port, mDNS, logging, and CORS settings. Implement systemd user service to run the web server with configurable parameters.

I have been using this for a few weeks now, and had no issues so far. I am unsure regarding the security aspect of the systemd module, some tips would be helpful!

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
