### PR TITLE
neovim: rename extraLuaConfig to initLua

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -35,6 +35,13 @@ in
 {
   meta.maintainers = with lib.maintainers; [ khaneliman ];
 
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "programs" "neovim" "extraLuaConfig" ]
+      [ "programs" "neovim" "initLua" ]
+    )
+  ];
+
   options = {
     programs.neovim = {
       enable = mkEnableOption "Neovim";
@@ -211,7 +218,7 @@ in
         '';
       };
 
-      extraLuaConfig = mkOption {
+      initLua = mkOption {
         type = types.lines;
         default = "";
         example = lib.literalExpression ''
@@ -488,7 +495,7 @@ in
       programs.neovim.extraConfig = lib.concatStringsSep "\n" vimPackageInfo.userPluginViml;
       programs.neovim.extraPackages = mkIf cfg.autowrapRuntimeDeps vimPackageInfo.runtimeDeps;
 
-      programs.neovim.extraLuaConfig =
+      programs.neovim.initLua =
         let
           # using default 'foldmarker', to be used with foldmethod=marker
           foldedLuaBlock =
@@ -543,8 +550,8 @@ in
         (map (x: x.runtime) pluginsNormalized)
         ++ [
           {
-            "nvim/init.lua" = mkIf (cfg.extraLuaConfig != "") {
-              text = cfg.extraLuaConfig;
+            "nvim/init.lua" = mkIf (cfg.initLua != "") {
+              text = cfg.initLua;
             };
 
             "nvim/coc-settings.json" = mkIf cfg.coc.enable {

--- a/tests/modules/programs/neovim/extra-lua-init.nix
+++ b/tests/modules/programs/neovim/extra-lua-init.nix
@@ -4,15 +4,15 @@
   programs.neovim = {
     enable = true;
 
-    extraLuaConfig = ''
-      -- extraLuaConfig
+    initLua = ''
+      -- initLua
     '';
   };
 
   nmt.script = ''
     nvimFolder="home-files/.config/nvim"
     assertFileContent "$nvimFolder/init.lua" ${builtins.toFile "init.lua-expected" ''
-      -- extraLuaConfig
+      -- initLua
     ''}
   '';
 }


### PR DESCRIPTION
Now that the whole lua config is exposed via the extraLuaConfig option, it's not "extra" anymore but the whole content. Renaming it to "initLua" is more adequate and it makes the option more understandable I hope.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
