### PR TITLE
feat: introduce nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+let
+  nixpkgs = (
+    import (
+      let
+        lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+        n = lock.nodes.nixpkgs.locked;
+      in
+      fetchTarball {
+        url = "https://github.com/${n.owner}/${n.repo}/archive/${n.rev}.tar.gz";
+        sha256 = n.narHash;
+      }
+    ) { }
+  );
+in
+nixpkgs.callPackage ./home-manager { }


### PR DESCRIPTION
flakes are not stable yet, community is divided but maintaining both flake and a set of dependencies in our scripts is hard. So instead have all home-manager dependencies set in the flake and rely on https://github.com/NixOS/flake-compat to share a shell.nix while keeping a single source of truth.

Endgame is to remove `nix-shell` calls with sometimes unpinned nixpkgs (or pinned to a different nixpkgs than the flake) from our scripts like:
- modules/misc/news/create-news-entry.sh 
- lib/python/generate-all-maintainers.py
- lib/python/check-duplicate-maintainers.py
- 2 nix-shell calls from Makefile

Instead one would either:
- enter a nix-shell / nix develop and run the command
- nix-shell --run or nix develop --command

Advantages are using a single nixpkgs/source of truth. Fewer evals if you enter a nix(-)shell.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
