### PR TITLE
opencode: handle string store paths in skill sources

### DIFF
--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -200,7 +200,13 @@ in
     };
 
     skills = lib.mkOption {
-      type = lib.types.either (lib.types.attrsOf (lib.types.either lib.types.lines lib.types.path)) lib.types.path;
+      type = lib.types.either (lib.types.attrsOf (
+        lib.types.oneOf [
+          lib.types.lines
+          lib.types.path
+          lib.types.str
+        ]
+      )) lib.types.path;
       default = { };
       description = ''
         Custom agent skills for opencode.
@@ -214,6 +220,9 @@ in
         - Inline content as a string (creates `opencode/skill/<name>/SKILL.md`)
         - A path to a file (creates `opencode/skill/<name>/SKILL.md`)
         - A path to a directory (creates `opencode/skill/<name>/` with all files)
+
+        This also accepts Nix store paths (e.g., source from a package), allowing you to
+        reference subdirectories within a package source.
 
         If a path is used, it is expected to contain one folder per skill name, each
         containing a {file}`SKILL.md`. The directory is symlinked to
@@ -238,6 +247,9 @@ in
 
           # A skill can also be a directory containing SKILL.md and other files.
           data-analysis = ./skills/data-analysis;
+
+          # A skill can also be a subdirectory within a package source (store path)
+          beads = "''${pkgs.beads.src}/claude-plugin/skills/beads";
         }
       '';
     };
@@ -413,7 +425,11 @@ in
     )
     // lib.mapAttrs' (
       name: content:
-      if lib.isPath content && lib.pathIsDirectory content then
+      if
+        (lib.isPath content && lib.pathIsDirectory content)
+        || (builtins.isString content && lib.hasPrefix builtins.storeDir content)
+
+      then
         lib.nameValuePair "opencode/skill/${name}" {
           source = content;
           recursive = true;

--- a/tests/modules/programs/opencode/default.nix
+++ b/tests/modules/programs/opencode/default.nix
@@ -16,6 +16,7 @@
   opencode-mixed-content = ./mixed-content.nix;
   opencode-skills-inline = ./skills-inline.nix;
   opencode-skills-path = ./skills-path.nix;
+  opencode-skills-store-path = ./skills-store-path.nix;
   opencode-skills-directory = ./skills-directory.nix;
   opencode-skills-bulk-directory = ./skills-bulk-directory.nix;
   opencode-themes-inline = ./themes-inline.nix;

--- a/tests/modules/programs/opencode/skills-store-path.nix
+++ b/tests/modules/programs/opencode/skills-store-path.nix
@@ -1,0 +1,24 @@
+{ pkgs, ... }:
+
+let
+  src = pkgs.writeTextDir "skills/external-skill/SKILL.md" ''
+    # Mock Skill
+    This content simulates a skill living inside a package source.
+  '';
+in
+{
+  programs.opencode = {
+    enable = true;
+    skills = {
+      # We reference the specific subfolder inside the store path
+      internal-skill = "${src}/skills/external-skill";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/opencode/skill/internal-skill/SKILL.md
+
+    assertFileContent home-files/.config/opencode/skill/internal-skill/SKILL.md \
+      "${src}/skills/external-skill/SKILL.md"
+  '';
+}


### PR DESCRIPTION
Add support for store directory paths provided as strings, in addition to the existing path type check for directories.
Context: certain project will include a `SKILL.md` file, and instead of managing them via some 3rd party manager or manually, why not include them from the source itself! I implemented this in my setup, since I wanted to include the `SKILL.md` file from the [beads](https://github.com/steveyegge/beads) project.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
