### PR TITLE
zsh/syntaxHighlighting: Set highlighters instead of ammending

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -44,7 +44,7 @@ in
 
           highlighters = mkOption {
             type = types.listOf types.str;
-            default = [ ];
+            default = [ "main" ];
             example = [ "brackets" ];
             description = ''
               Highlighters to enable
@@ -562,7 +562,7 @@ in
                 # https://github.com/zsh-users/zsh-syntax-highlighting#faq
                 ''
                   source ${cfg.syntaxHighlighting.package}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-                  ZSH_HIGHLIGHT_HIGHLIGHTERS+=(${lib.concatStringsSep " " (map lib.escapeShellArg cfg.syntaxHighlighting.highlighters)})
+                  ZSH_HIGHLIGHT_HIGHLIGHTERS=(${lib.concatStringsSep " " (map lib.escapeShellArg cfg.syntaxHighlighting.highlighters)})
                   ${lib.concatStringsSep "\n" (
                     lib.mapAttrsToList (
                       name: value: "ZSH_HIGHLIGHT_STYLES[${lib.escapeShellArg name}]=${lib.escapeShellArg value}"

--- a/tests/modules/programs/zsh/syntax-highlighting.nix
+++ b/tests/modules/programs/zsh/syntax-highlighting.nix
@@ -7,6 +7,7 @@
       enable = true;
       package = pkgs.hello;
       highlighters = [
+        "main"
         "brackets"
         "pattern"
         "cursor"
@@ -18,7 +19,7 @@
 
   nmt.script = ''
     assertFileContains home-files/.zshrc "source ${pkgs.hello}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-    assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_HIGHLIGHTERS+=(brackets pattern cursor)"
+    assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_HIGHLIGHTERS=(main brackets pattern cursor)"
     assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_STYLES[comment]='fg=#6c6c6c'"
   '';
 }


### PR DESCRIPTION
### Description
This allows users to drop the `main` highlighter (or highlighters set by plugins sourced before eg: catppucin's zsh highlighting settings) 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
