### PR TITLE
zsh: add multiple new options

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -364,6 +364,24 @@ in
           '';
         };
 
+        zstyle = mkOption {
+          type = types.attrsOf (types.attrsOf types.anything);
+          default = { };
+          example = {
+            auto-description = "'+%d'";
+            file-sort = "name";
+            use-cache = true;
+            ignore-parents = [
+              "parent"
+              "pwd"
+            ];
+          };
+          description = ''
+            Configure zstyle options. See {manpage}`zshmodules(1)`.
+            These are used to configure the completion System See {manpage}`zshcompsys(1).
+          '';
+        };
+
         bindkey = mkOption {
           type = types.attrsOf types.str;
           default = { };
@@ -638,6 +656,21 @@ in
                     ) cfg.shellGlobalAliases
                   ))
                 ))
+              )
+            ))
+
+            (lib.mkIf (cfg.zstyle != { }) (
+              mkOrder 1120 (
+                concatStringsSep "\n" (
+                  lib.flatten (
+                    lib.mapAttrsToList (
+                      pattern: set:
+                      map (opts: "zstyle '${pattern}' ${opts}") (
+                        lib.mapAttrsToList (name: val: "${name} ${(toString val)}") set
+                      )
+                    ) cfg.zstyle
+                  )
+                )
               )
             ))
 

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -337,6 +337,17 @@ in
           '';
         };
 
+        functions = mkOption {
+          type = types.attrsOf types.lines;
+          default = { };
+          example = {
+            pargs = "print $0: $*";
+          };
+          description = ''
+            Functions added to .zshrc
+          '';
+        };
+
         setOptions = mkOption {
           type = types.listOf types.str;
           default = [ ];
@@ -529,6 +540,18 @@ in
             ))
 
             (lib.mkIf (localVarsStr != "") (mkOrder 540 localVarsStr))
+
+            (lib.mkIf (cfg.functions != { }) (
+              mkOrder 550 (
+                concatStringsSep "\n" (
+                  lib.mapAttrsToList (name: def: ''
+                    function ${name} {
+                      ${def}
+                    }
+                  '') cfg.functions
+                )
+              )
+            ))
 
             # NOTE: Oh-My-Zsh/Prezto calls compinit during initialization,
             # calling it twice causes slight start up slowdown

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -156,6 +156,17 @@ in
           type = types.attrsOf types.str;
         };
 
+        shellSuffixAliases = mkOption {
+          default = { };
+          example = {
+            ps = "gv --";
+          };
+          description = ''
+            Suffix Aliases used when a file with a matching suffix is called
+            without any other commands.
+          '';
+        };
+
         dirHashes = mkOption {
           default = { };
           example = literalExpression ''
@@ -645,7 +656,7 @@ in
               ''
             ))
 
-            (lib.mkIf (aliasesStr != "" || cfg.shellGlobalAliases != { }) (
+            (lib.mkIf (aliasesStr != "" || cfg.shellGlobalAliases != { } || cfg.shellSuffixAliases != { }) (
               mkOrder 1100 (
                 (optionalString (aliasesStr != "") aliasesStr)
                 + (optionalString (cfg.shellGlobalAliases != { }) (
@@ -654,6 +665,14 @@ in
                     lib.mapAttrsToList (
                       k: v: "alias -g -- ${lib.escapeShellArg k}=${lib.escapeShellArg v}"
                     ) cfg.shellGlobalAliases
+                  ))
+                ))
+                + (optionalString (cfg.shellSuffixAliases != { }) (
+                  optionalString (cfg.shellGlobalAliases != { } || cfg.shellAliases != { }) "\n"
+                  + (concatStringsSep "\n" (
+                    lib.mapAttrsToList (
+                      k: v: "alias -s -- ${lib.escapeShellArg k}=${lib.escapeShellArg v}"
+                    ) cfg.shellSuffixAliases
                   ))
                 ))
               )

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -364,6 +364,18 @@ in
           '';
         };
 
+        bindkey = mkOption {
+          type = types.attrsOf types.str;
+          default = { };
+          description = ''
+            Keybinds set in Zsh via bindkey. The name is the keybind and value
+            is the command.
+          '';
+          example = {
+            "^A" = "beginning-of-line";
+          };
+        };
+
         zleFunctions = mkOption {
           type = types.attrsOf types.lines;
           default = { };
@@ -581,6 +593,12 @@ in
             # as all $fpath entries will be traversed again.
             (lib.mkIf (cfg.enableCompletion && !cfg.oh-my-zsh.enable && !cfg.prezto.enable) (
               mkOrder 570 cfg.completionInit
+            ))
+
+            (lib.mkIf (cfg.bindkey != { }) (
+              mkOrder 580 (
+                concatStringsSep "\n" (lib.mapAttrsToList (name: def: "bindkey '${name}' ${def}") cfg.bindkey)
+              )
             ))
 
             (lib.mkIf cfg.autosuggestion.enable (

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -364,6 +364,21 @@ in
           '';
         };
 
+        zleFunctions = mkOption {
+          type = types.attrsOf types.lines;
+          default = { };
+          description = ''
+            Functions that are added to the Zsh environment and are added to the
+            zsh command line editor via `zle -N`. The key is the name
+            and the value is the body of the function to be added
+          '';
+          example = {
+            mkcd = ''
+              mkdir --parents "$1" && cd "$1"
+            '';
+          };
+        };
+
         siteFunctions = mkOption {
           type = types.attrsOf types.lines;
           default = { };
@@ -490,6 +505,8 @@ in
           );
         })
 
+        (lib.mkIf (cfg.zleFunctions != { }) { programs.zsh.functions = cfg.zleFunctions; })
+
         {
           home.file."${dotDirRel}/.zshenv".text = ''
             # Environment variables
@@ -550,6 +567,12 @@ in
                     }
                   '') cfg.functions
                 )
+              )
+            ))
+
+            (lib.mkIf (cfg.zleFunctions != { }) (
+              mkOrder 560 (
+                concatStringsSep "\n" (lib.mapAttrsToList (name: _def: "zle -N ${name}") cfg.zleFunctions)
               )
             ))
 


### PR DESCRIPTION
### Description
Adds the options:

- `functions`: for shell functions
- `bindkey`: to set keybinds
- `zleFunctions`: to add line editing widgets
- `zstyle`: to configure various plugins eg: zshcompsys
- `shellSuffixAliases`: to set suffix aliases called by directly invoking the name of a file

I'm not sure what the appropriate numbers for `mkOrder` are so I've used values that just function.
The code for zstyle is weird as the second argument to it needs to be quoted to allow wildcards (eg: `':completion:*'`)

Also fixes #6315
<!--

Please provide a brief description of your change.

-->

### Checklist
<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
