### PR TITLE
syncthing: rewrite credential management

### DIFF
--- a/modules/misc/news/2026/04/2026-04-12_23-36-53.nix
+++ b/modules/misc/news/2026/04/2026-04-12_23-36-53.nix
@@ -1,0 +1,20 @@
+{ config, ... }:
+{
+  time = "2026-04-12T21:36:53+00:00";
+  condition = config.services.syncthing.enable;
+  message = ''
+    The `services.syncthing.passwordFile` option has been removed, as
+    configuring it would not add any authentication requirements to the
+    Syncthing GUI, but in most circumstances would suppress the warnings about
+    the GUI not being secured.
+
+    Instead, configure `services.syncthing.guiCredentials.passwordFile` and
+    `services.syncthing.guiCredentials.username`.
+
+    As a benefit, using `services.syncthing.guiCredentials` will only change
+    the Syncthing login configuration if credentials have actually changed,
+    rather than configuring them unconditionally.  This prevents the Syncthing
+    API key from changing unnecessarily, so other tools such as Syncthing Tray
+    do not need to reconfigure the API key as often.
+  '';
+}

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -68,6 +68,7 @@ let
   install = lib.getExe' pkgs.coreutils "install";
   mktemp = lib.getExe' pkgs.coreutils "mktemp";
   syncthing = lib.getExe cfg.package;
+  mkpasswd = lib.getExe pkgs.mkpasswd;
 
   copyKeys = pkgs.writers.writeBash "syncthing-copy-keys" ''
     ${install} -dm700 "${syncthing_dir}"
@@ -108,6 +109,27 @@ let
 
       ${curlShellFunction}
     ''
+    + lib.optionalString (cfg.guiCredentials != null) ''
+      ${lib.toShellVars { inherit (cfg.guiCredentials) username passwordFile; }}
+      password="$(<"$passwordFile")"
+
+      credential_eval="$(curl -X GET ${curlAddressArgs "/rest/config/gui"} | ${jq} -r '@sh "current_username=\(.user) current_password=\(.password)"')"
+      eval "$credential_eval"
+
+      if [[ "$current_username" != "$username" ]]; then
+          ${jq} -n --arg username "$username" '{user: $username}' | curl --json @- -X PATCH ${curlAddressArgs "/rest/config/gui"}
+      fi
+
+      # The REST API will return the password hashed in bcrypt format.  The
+      # user might have provided a hashed password, or might have provided a
+      # cleartext one.  Only change the password if the password from the
+      # user's configuration neither matches the hashed password from the API,
+      # nor hashes to that password.
+      if [[ -z "$current_password" ]] || { [[ "$current_password" != "$password" ]] && ! printf '%s' "$password" | ${mkpasswd} --stdin --salt "$current_password" &>/dev/null; }; then
+          ${jq} -n --arg password "$password" '{password: $password}' | curl --json @- -X PATCH ${curlAddressArgs "/rest/config/gui"}
+      fi
+
+    ''
     +
 
       /*
@@ -115,137 +137,138 @@ let
         Hence we iterate them using lib.pipe and generate shell commands for both at
         the same time.
       */
-      (lib.pipe
-        {
-          # The attributes below are the only ones that are different for devices /
-          # folders.
-          devs = {
-            new_conf_IDs = map (v: v.id) devices;
-            GET_IdAttrName = "deviceID";
-            override = cfg.overrideDevices;
-            conf = devices;
-            baseAddress = curlAddressArgs "/rest/config/devices";
-          };
-          dirs = {
-            new_conf_IDs = map (v: v.id) folders;
-            GET_IdAttrName = "id";
-            override = cfg.overrideFolders;
-            conf = folders;
-            baseAddress = curlAddressArgs "/rest/config/folders";
-          };
-        }
-        [
-          # Now for each of these attributes, write the curl commands that are
-          # identical to both folders and devices.
-          (lib.mapAttrs (
-            conf_type: s:
-            # We iterate the `conf` list now, and run a curl -X POST command for each, that
-            # should update that device/folder only.
-            lib.pipe s.conf [
-              # Quoting https://docs.syncthing.net/rest/config.html:
-              #
-              # > PUT takes an array and POST a single object. In both cases if a
-              # given folder/device already exists, it’s replaced, otherwise a new
-              # one is added.
-              #
-              # What's not documented, is that using PUT will remove objects that
-              # don't exist in the array given. That's why we use here `POST`, and
-              # only if s.override == true then we DELETE the relevant folders
-              # afterwards.
-              (map (
-                new_cfg:
-                let
-                  jsonPreSecretsFile = pkgs.writeTextFile {
-                    name = "${conf_type}-${new_cfg.id}-conf-pre-secrets.json";
-                    text = builtins.toJSON new_cfg;
-                  };
-                  injectSecretsJqCmd =
-                    {
-                      # There are no secrets in `devs`, so no massaging needed.
-                      "devs" = "${jq} .";
-                      "dirs" =
-                        let
-                          folder = new_cfg;
-                          devicesWithSecrets = lib.pipe folder.devices [
-                            (lib.filter (device: (builtins.isAttrs device) && device ? encryptionPasswordFile))
-                            (map (device: {
-                              inherit (device) deviceId;
-                              variableName = "secret_${builtins.hashString "sha256" device.encryptionPasswordFile}";
-                              secretPath = device.encryptionPasswordFile;
-                            }))
-                          ];
-                          # At this point, `jsonPreSecretsFile` looks something like this:
-                          #
-                          #   {
-                          #     ...,
-                          #     "devices": [
-                          #       {
-                          #         "deviceId": "id1",
-                          #         "encryptionPasswordFile": "/etc/bar-encryption-password",
-                          #         "name": "..."
-                          #       }
-                          #     ],
-                          #   }
-                          #
-                          # We now generate a `jq` command that can replace those
-                          # `encryptionPasswordFile`s with `encryptionPassword`.
-                          # The `jq` command ends up looking like this:
-                          #
-                          #   jq --rawfile secret_DEADBEEF /etc/bar-encryption-password '
-                          #     .devices[] |= (
-                          #       if .deviceId == "id1" then
-                          #         del(.encryptionPasswordFile) |
-                          #         .encryptionPassword = $secret_DEADBEEF
-                          #       else
-                          #         .
-                          #       end
-                          #     )
-                          #   '
-                          jqUpdates = map (device: ''
-                            .devices[] |= (
-                              if .deviceId == "${device.deviceId}" then
-                                del(.encryptionPasswordFile) |
-                                .encryptionPassword = ''$${device.variableName}
-                              else
-                                .
-                              end
-                            )
-                          '') devicesWithSecrets;
-                          jqRawFiles = map (
-                            device: "--rawfile ${device.variableName} ${lib.escapeShellArg device.secretPath}"
-                          ) devicesWithSecrets;
-                        in
-                        "${jq} ${lib.concatStringsSep " " jqRawFiles} ${
-                          lib.escapeShellArg (lib.concatStringsSep "|" ([ "." ] ++ jqUpdates))
-                        }";
-                    }
-                    .${conf_type};
-                in
-                ''
-                  ${injectSecretsJqCmd} ${jsonPreSecretsFile} | curl --json @- -X POST ${s.baseAddress}
-                ''
-              ))
-              (lib.concatStringsSep "\n")
-            ]
-            /*
-              If we need to override devices/folders, we iterate all currently configured
-              IDs, via another `curl -X GET`, and we delete all IDs that are not part of
-              the Nix configured list of IDs
-            */
-            + lib.optionalString s.override ''
-              stale_${conf_type}_ids="$(curl -X GET ${s.baseAddress} | ${jq} \
-                --argjson new_ids ${lib.escapeShellArg (builtins.toJSON s.new_conf_IDs)} \
-                --raw-output \
-                '[.[].${s.GET_IdAttrName}] - $new_ids | .[]'
-              )"
-              for id in ''${stale_${conf_type}_ids}; do
-                curl -X DELETE ${s.baseAddress}/$id
-              done
-            ''
-          ))
-          builtins.attrValues
-          (lib.concatStringsSep "\n")
-        ]
+      lib.optionalString (cleanedConfig != { }) (
+        lib.pipe
+          {
+            # The attributes below are the only ones that are different for devices /
+            # folders.
+            devs = {
+              new_conf_IDs = map (v: v.id) devices;
+              GET_IdAttrName = "deviceID";
+              override = cfg.overrideDevices;
+              conf = devices;
+              baseAddress = curlAddressArgs "/rest/config/devices";
+            };
+            dirs = {
+              new_conf_IDs = map (v: v.id) folders;
+              GET_IdAttrName = "id";
+              override = cfg.overrideFolders;
+              conf = folders;
+              baseAddress = curlAddressArgs "/rest/config/folders";
+            };
+          }
+          [
+            # Now for each of these attributes, write the curl commands that are
+            # identical to both folders and devices.
+            (lib.mapAttrs (
+              conf_type: s:
+              # We iterate the `conf` list now, and run a curl -X POST command for each, that
+              # should update that device/folder only.
+              lib.pipe s.conf [
+                # Quoting https://docs.syncthing.net/rest/config.html:
+                #
+                # > PUT takes an array and POST a single object. In both cases if a
+                # given folder/device already exists, it’s replaced, otherwise a new
+                # one is added.
+                #
+                # What's not documented, is that using PUT will remove objects that
+                # don't exist in the array given. That's why we use here `POST`, and
+                # only if s.override == true then we DELETE the relevant folders
+                # afterwards.
+                (map (
+                  new_cfg:
+                  let
+                    jsonPreSecretsFile = pkgs.writeTextFile {
+                      name = "${conf_type}-${new_cfg.id}-conf-pre-secrets.json";
+                      text = builtins.toJSON new_cfg;
+                    };
+                    injectSecretsJqCmd =
+                      {
+                        # There are no secrets in `devs`, so no massaging needed.
+                        "devs" = "${jq} .";
+                        "dirs" =
+                          let
+                            folder = new_cfg;
+                            devicesWithSecrets = lib.pipe folder.devices [
+                              (lib.filter (device: (builtins.isAttrs device) && device ? encryptionPasswordFile))
+                              (map (device: {
+                                inherit (device) deviceId;
+                                variableName = "secret_${builtins.hashString "sha256" device.encryptionPasswordFile}";
+                                secretPath = device.encryptionPasswordFile;
+                              }))
+                            ];
+                            # At this point, `jsonPreSecretsFile` looks something like this:
+                            #
+                            #   {
+                            #     ...,
+                            #     "devices": [
+                            #       {
+                            #         "deviceId": "id1",
+                            #         "encryptionPasswordFile": "/etc/bar-encryption-password",
+                            #         "name": "..."
+                            #       }
+                            #     ],
+                            #   }
+                            #
+                            # We now generate a `jq` command that can replace those
+                            # `encryptionPasswordFile`s with `encryptionPassword`.
+                            # The `jq` command ends up looking like this:
+                            #
+                            #   jq --rawfile secret_DEADBEEF /etc/bar-encryption-password '
+                            #     .devices[] |= (
+                            #       if .deviceId == "id1" then
+                            #         del(.encryptionPasswordFile) |
+                            #         .encryptionPassword = $secret_DEADBEEF
+                            #       else
+                            #         .
+                            #       end
+                            #     )
+                            #   '
+                            jqUpdates = map (device: ''
+                              .devices[] |= (
+                                if .deviceId == "${device.deviceId}" then
+                                  del(.encryptionPasswordFile) |
+                                  .encryptionPassword = ''$${device.variableName}
+                                else
+                                  .
+                                end
+                              )
+                            '') devicesWithSecrets;
+                            jqRawFiles = map (
+                              device: "--rawfile ${device.variableName} ${lib.escapeShellArg device.secretPath}"
+                            ) devicesWithSecrets;
+                          in
+                          "${jq} ${lib.concatStringsSep " " jqRawFiles} ${
+                            lib.escapeShellArg (lib.concatStringsSep "|" ([ "." ] ++ jqUpdates))
+                          }";
+                      }
+                      .${conf_type};
+                  in
+                  ''
+                    ${injectSecretsJqCmd} ${jsonPreSecretsFile} | curl --json @- -X POST ${s.baseAddress}
+                  ''
+                ))
+                (lib.concatStringsSep "\n")
+              ]
+              /*
+                If we need to override devices/folders, we iterate all currently configured
+                IDs, via another `curl -X GET`, and we delete all IDs that are not part of
+                the Nix configured list of IDs
+              */
+              + lib.optionalString s.override ''
+                stale_${conf_type}_ids="$(curl -X GET ${s.baseAddress} | ${jq} \
+                  --argjson new_ids ${lib.escapeShellArg (builtins.toJSON s.new_conf_IDs)} \
+                  --raw-output \
+                  '[.[].${s.GET_IdAttrName}] - $new_ids | .[]'
+                )"
+                for id in ''${stale_${conf_type}_ids}; do
+                  curl -X DELETE ${s.baseAddress}/$id
+                done
+              ''
+            ))
+            builtins.attrValues
+            (lib.concatStringsSep "\n")
+          ]
       )
     +
       /*
@@ -265,10 +288,6 @@ let
         ''))
         (lib.concatStringsSep "\n")
       ])
-    + lib.optionalString (cfg.passwordFile != null) ''
-      syncthing_password=$(${cat} ${cfg.passwordFile})
-      curl -X PATCH -d '{"password": "'$syncthing_password'"}' ${curlAddressArgs "/rest/config/gui"}
-    ''
     + lib.optionalString (cfg.guiAddress != null) ''
       curl -X PATCH -d '{"address": "'${cfg.guiAddress}'"}' ${curlAddressArgs "/rest/config/gui"}
     ''
@@ -280,6 +299,8 @@ let
       fi
     ''
   );
+
+  doUpdateConfig = cleanedConfig != { } || cfg.guiCredentials != null || cfg.guiAddress != null;
 
   defaultSyncthingArgs = [
     "${syncthing}"
@@ -296,6 +317,14 @@ in
   meta.maintainers = [
     lib.maintainers.rycee
     lib.maintainers.aionescu
+  ];
+
+  imports = [
+    (lib.mkRemovedOptionModule [
+      "services"
+      "syncthing"
+      "passwordFile"
+    ] "Instead, configure services.syncthing.guiCredentials.")
   ];
 
   options = {
@@ -322,12 +351,42 @@ in
         '';
       };
 
-      passwordFile = mkOption {
-        type = with types; nullOr path;
+      guiCredentials = mkOption {
         default = null;
         description = ''
-          Path to the gui password file.
+          Credentials to use for access to the Syncthing GUI.  Configuring
+          these is recommended, as otherwise any user with access to the GUI
+          web address -- which would typically include all local accounts on
+          your system -- will effectively have read/write access to the
+          filesystem with your permissions.
         '';
+        type = types.nullOr (
+          types.submodule {
+            options = {
+              username = mkOption {
+                description = "Username to use to log into the Syncthing GUI.";
+                type = types.nonEmptyStr;
+                example = literalExpression "config.home.username";
+              };
+
+              passwordFile = lib.mkOption {
+                description = ''
+                  The full path to a file that contains the password, or a hash of
+                  the password, to set for GUI access.
+
+                  The password file is read each time Syncthing is started.
+
+                  If the password file contains a bcrypt hash, Syncthing will use
+                  that hash as-is.  Otherwise, Syncthing will hash the password
+                  provided before storing it.
+                '';
+                type = lib.types.str;
+                example = literalExpression "config.sops.secrets.syncthing.path";
+                default = null;
+              };
+            };
+          }
+        );
       };
 
       overrideDevices = mkOption {
@@ -807,7 +866,7 @@ in
           };
         };
 
-        syncthing-init = lib.mkIf (cleanedConfig != { }) {
+        syncthing-init = lib.mkIf doUpdateConfig {
           Unit = {
             Description = "Syncthing configuration updater";
             Requires = [ "syncthing.service" ];
@@ -848,7 +907,7 @@ in
         };
 
         syncthing-init = {
-          enable = cleanedConfig != { };
+          enable = doUpdateConfig;
           config = {
             ProgramArguments = [ "${updateConfig}" ];
             ProcessType = "Background";


### PR DESCRIPTION
Syncthing's web GUI will only require login credentials if both a username and password are configured.  Expose both of these through a new services.syncthing.guiCredentials submodule, and require migration to the new configuration to catch anyone who has only configured a password using the old services.syncthing.passwordFile option.

Additionally, make sure that the syncthing-init script to set configuration using the API is enabled if there is any such configuration that needs setting.  Without this fix, configuration that was set using the API, notably guiCredentials/passwordFile and guiAddress, would not be set at all if there wasn't also something to configure under services.syncthing.settings.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.
- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.  _Currently blocked by #8643_
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
