### PR TITLE
neovim: add missing bit for extraLuaPackages

### DIFF
--- a/modules/misc/news/2026/01/2026-01-25_19-00-28.nix
+++ b/modules/misc/news/2026/01/2026-01-25_19-00-28.nix
@@ -1,0 +1,21 @@
+{ config, ... }:
+{
+  time = "2026-01-25T18:00:28+00:00";
+  condition = config.programs.neovim.enable;
+  message = ''
+    The neovim module now exposes programs.neovim.extraLuaPackages via init.lua instead of wrapper arguments.
+    This makes for a better out of the box experience, closer to what users can expect on other distributions, i.e., you
+    can now run any neovim derivatives (neovide, neovim-qt etc) without wrapping.
+
+    If you used home-manager only to install plugins, the newly generated init.lua might conflict with yours.
+    You can ignore the generated init.lua with
+    `xdg.configFile."nvim/init.lua".enable = false` but `extraLuaPackages` will become ineffective.
+    You can still refer to its generated content via:
+        xdg.configFile."nvim/lua/hm-generated.lua".text = config.programs.neovim.initLua;
+      and in your manual init.lua `require'hm-generated'`
+
+    For more details, see:
+    - https://github.com/nix-community/home-manager/pull/8586
+    - https://github.com/nix-community/home-manager/pull/8606 and its linked comments for more details/solutions.
+  '';
+}

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -7,7 +7,6 @@
 
 let
   inherit (lib)
-    concatMapStringsSep
     literalExpression
     mkEnableOption
     mkIf
@@ -428,20 +427,6 @@ in
         (lib.makeBinPath cfg.extraPackages)
       ];
 
-      extraMakeWrapperLuaCArgs = optionals (resolvedExtraLuaPackages != [ ]) [
-        "--suffix"
-        "LUA_CPATH"
-        ";"
-        (concatMapStringsSep ";" luaPackages.getLuaCPath resolvedExtraLuaPackages)
-      ];
-
-      extraMakeWrapperLuaArgs = optionals (resolvedExtraLuaPackages != [ ]) [
-        "--suffix"
-        "LUA_PATH"
-        ";"
-        (concatMapStringsSep ";" luaPackages.getLuaPath resolvedExtraLuaPackages)
-      ];
-
       vimPackageInfo = neovimUtils.makeVimPackageInfo (map suppressNotVimlConfig pluginsNormalized);
 
       wrappedNeovim' = pkgs.wrapNeovimUnstable cfg.package {
@@ -462,8 +447,7 @@ in
         extraPython3Packages =
           ps: (cfg.extraPython3Packages ps) ++ (lib.concatMap (f: f ps) vimPackageInfo.pluginPython3Packages);
         neovimRcContent = cfg.extraConfig;
-        wrapperArgs =
-          cfg.extraWrapperArgs ++ extraMakeWrapperArgs ++ extraMakeWrapperLuaCArgs ++ extraMakeWrapperLuaArgs;
+        wrapperArgs = cfg.extraWrapperArgs ++ extraMakeWrapperArgs;
         wrapRc = false;
       };
     in


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->


    turns out I forgot to remove the now unnecessary wrapper arguments in
    https://github.com/nix-community/home-manager/pull/8606.
    This meant that `xdg.configFile."nvim/init.lua".enable = false` was
    enough to fix the user issues but this should not be the case anymore.

see https://github.com/BerkeleyTrue/dotfiles/commit/728c9b3bdbe4d31e66193b76cfd04f783695e076 for an example of a fix.



### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
