### PR TITLE
anki: fix autoSyncMediaMinutes and networkTimeout not being applied

### DIFF
--- a/modules/programs/anki/helper.nix
+++ b/modules/programs/anki/helper.nix
@@ -134,11 +134,11 @@ let
 
     media_sync_minutes_str: str = "${toString cfg.sync.autoSyncMediaMinutes}"
     if media_sync_minutes_str:
-      profile_manager.set_periodic_sync_media_minutes = int(media_sync_minutes_str)
+      profile_manager.set_periodic_sync_media_minutes(int(media_sync_minutes_str))
 
     network_timeout_str: str = "${toString cfg.sync.networkTimeout}"
     if network_timeout_str:
-      profile_manager.set_network_timeout = int(network_timeout_str)
+      profile_manager.set_network_timeout(int(network_timeout_str))
 
     profile_manager.save()
   '';


### PR DESCRIPTION
### Description
The Anki Python SDK uses functions to set values for `autoSyncMediaMinutes` and `networkTimeout`, but the generated script assigned the values instead (overwriting the functions). This resulted in the two values not being applied.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
