### PR TITLE
cargo: add package option

### DIFF
--- a/modules/programs/cargo.nix
+++ b/modules/programs/cargo.nix
@@ -5,10 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkEnableOption;
-
   tomlFormat = pkgs.formats.toml { };
-
   cfg = config.programs.cargo;
 in
 {
@@ -17,7 +14,9 @@ in
   options = {
     programs = {
       cargo = {
-        enable = mkEnableOption "management of cargo config";
+        enable = lib.mkEnableOption "management of cargo config";
+
+        package = lib.mkPackageOption pkgs "cargo" { nullable = true; };
 
         settings = lib.mkOption {
           inherit (tomlFormat) type;
@@ -33,6 +32,8 @@ in
 
   config = lib.mkIf cfg.enable {
     home = {
+      packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
       file = {
         ".cargo/config.toml" = {
           source = tomlFormat.generate "config.toml" cfg.settings;


### PR DESCRIPTION
### Description

add missing cargo package option

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
