### PR TITLE
chromium: add plasmaSupport option for google-chrome

### DIFF
--- a/modules/misc/news/2026/01/2026-01-19_05-36-20.nix
+++ b/modules/misc/news/2026/01/2026-01-19_05-36-20.nix
@@ -1,0 +1,19 @@
+{
+  time = "2026-01-19T05:36:20+00:00";
+  condition = true;
+  message = ''
+    Chrome now has a `plasmaSupport` flag.
+
+    If you use KDE Plasma, set:
+
+    ```
+    programs.google-chrome.plasmaSupport = true`
+    home.sessionVariables = [
+      QT_QPA_PLATFORMTHEME = "kde";
+    ];
+    ```
+
+    This enables the "Use QT" theme in **Settings > Appearance**, which makes
+    Chrome match your Plasma theme.
+  '';
+}


### PR DESCRIPTION
### Description

This exposes a [new option on Chrome](https://github.com/NixOS/nixpkgs/pull/483541) to introspect your Plasma theme and make Chrome match when the "Use QT" appearance is enabled.

Note, you may still need to add this entry to your home-manager config:
```
home.sessionVariables = [
  QT_QPA_PLATFORMTHEME = "kde";
];
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
   > My main editing device is a Mac.  I tried running the tests on it and got `clang`/`swift` errors that are unrelated to this change.  Since it's a simple flag addition, I think this is not relevant, but I can runs tests on my Linux device next time I get a chance it that's helpful.
   >
  > FWIW, I have been using this flag in my personal Home Manager config for more than a week and it's worked great.
   
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
   > n/a: the Chrome module doesn't currently have tests

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
