### PR TITLE
starship: move init at the end of `.bashrc`

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -105,7 +105,7 @@ in
     };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (
-      lib.mkOrder 1999 ''
+      lib.mkOrder 1900 ''
         if [[ $TERM != "dumb" ]]; then
           eval "$(${lib.getExe cfg.package} init bash --print-full-init)"
         fi


### PR DESCRIPTION
### Description

Move Starship's Bash init at the end of `.bashrc` using `mkOrder 1999`.

Starship [uses `$PROMPT_COMMAND` to generate timing information](https://github.com/starship/starship/blob/674b916c45545a9e5033389d8507c5f1e2fe1ac1/src/init/starship.bash#L1-L4). To do so, it copies the original content of `$PROMPT_COMMAND` into `$STARSHIP_PROMPT_COMMAND`. Therefore it should be [loaded last](https://starship.rs/#bash) to prevent other program to append to `$PROMPT_COMMAND`.

Only Zoxide, which is initialized with `mkOrder 2000`, should be loaded after, see: https://github.com/ajeetdsouza/zoxide/pull/1136

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
