### PR TITLE
kitty: add autoThemeFiles option

### DIFF
--- a/tests/integration/standalone/kitty-auto-theme-bad-home.nix
+++ b/tests/integration/standalone/kitty-auto-theme-bad-home.nix
@@ -1,0 +1,17 @@
+{
+  home.username = "alice";
+  home.homeDirectory = "/home/alice";
+  home.stateVersion = "24.11";
+
+  # Let Home Manager install and manage itself.
+  programs.home-manager.enable = true;
+
+  programs.kitty = {
+    enable = true;
+    autoThemeFiles = {
+      light = "GitHub";
+      dark = "No Such Theme";
+      noPreference = "OneDark";
+    };
+  };
+}

--- a/tests/integration/standalone/kitty.nix
+++ b/tests/integration/standalone/kitty.nix
@@ -59,6 +59,14 @@
       assert expected in actual, \
         f"expected home-manager switch to contain {expected}, but got {actual}"
 
+    with subtest("Switch to Bad Kitty Auto Theme"):
+      succeed_as_alice("cp ${./kitty-auto-theme-bad-home.nix} /home/alice/.config/home-manager/home.nix")
+
+      actual = fail_as_alice("home-manager switch")
+      expected = "kitty-themes does not contain the theme file"
+      assert expected in actual, \
+        f"expected home-manager switch to contain {expected}, but got {actual}"
+
     with subtest("Switch to Good Kitty"):
       succeed_as_alice("cp ${./kitty-theme-good-home.nix} /home/alice/.config/home-manager/home.nix")
 

--- a/tests/modules/programs/kitty/auto-theme-files.nix
+++ b/tests/modules/programs/kitty/auto-theme-files.nix
@@ -1,0 +1,27 @@
+{ config, pkgs, ... }:
+{
+  programs.kitty = {
+    enable = true;
+    autoThemeFiles = {
+      light = "GitHub";
+      dark = "TokyoNight";
+      noPreference = "OneDark";
+    };
+  };
+
+  test = {
+    assertFileExists = [
+      "home-files/.config/kitty/light-theme.auto.conf"
+      "home-files/.config/kitty/dark-theme.auto.conf"
+      "home-files/.config/kitty/no-preference-theme.auto.conf"
+    ];
+    assertFileRegex = [
+      "home-files/.config/kitty/light-theme.auto.conf"
+      "^include .*themes/GitHub\\.conf$"
+      "home-files/.config/kitty/dark-theme.auto.conf"
+      "^include .*themes/TokyoNight\\.conf$"
+      "home-files/.config/kitty/no-preference-theme.auto.conf"
+      "^include .*themes/OneDark\\.conf$"
+    ];
+  };
+}

--- a/tests/modules/programs/kitty/default.nix
+++ b/tests/modules/programs/kitty/default.nix
@@ -4,4 +4,5 @@
   kitty-null-shellIntegration = ./null-shellIntegration.nix;
   kitty-example-mkOrder = ./example-mkOrder.nix;
   kitty-example-quickAccessTerminalConfig = ./example-quickAccessTerminalConfig.nix;
+  kitty-auto-theme-files = ./auto-theme-files.nix;
 }


### PR DESCRIPTION
## Summary

Add support for kitty's automatic theme switching based on OS color scheme.
This creates the required auto theme config files:
- `light-theme.auto.conf`
- `dark-theme.auto.conf`
- `no-preference-theme.auto.conf`

Closes #6869

## Checklist

- [x] Change is backwards compatible
- [x] Code formatted (`nix fmt`)
- [x] Code tested (`nix run .#tests -- kitty-*`)
- [x] Test cases added (`tests/modules/programs/kitty/auto-theme-files.nix`)
- [x] Commit message formatted as `{component}: {description}`

### New features
- [ ] News entry generated (optional for existing module enhancement)