### PR TITLE
lazygit: fix incorrect bash integration

### DIFF
--- a/modules/programs/lazygit.nix
+++ b/modules/programs/lazygit.nix
@@ -88,7 +88,7 @@ in
             "~/.lazygit/newdir";
 
         bashIntegration = ''
-          ${cfg.shellWrapperName}() {
+          function ${cfg.shellWrapperName}() {
               export LAZYGIT_NEW_DIR_FILE=${lazygitNewDirFilePath}
               command lazygit "$@"
               if [ -f $LAZYGIT_NEW_DIR_FILE ]; then


### PR DESCRIPTION
### Description

Fix bash integration for lazygit https://github.com/nix-community/home-manager/issues/8669

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

