### PR TITLE
mako: remove extraConfig in favour of settings.include

### DIFF
--- a/modules/misc/news/2026/01/2026-01-30_14-43-31.nix
+++ b/modules/misc/news/2026/01/2026-01-30_14-43-31.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+{
+  time = "2026-01-30T14:43:31+00:00";
+  condition = config.services.mako ? extraConfig;
+  message = ''
+    The option 'services.mako.extraConfig' has been removed, please use
+    'services.mako.settings.include' instead.
+
+    The 'services.mako.settings.include' option expects either a single file
+    path, or a list of file paths.
+  '';
+}

--- a/tests/modules/services/mako/config
+++ b/tests/modules/services/mako/config
@@ -19,36 +19,15 @@ anchor=top-left
 [app-name=Google\ Chrome]
 max-visible=5
 
-[field1=value field2=value]
-text-alignment=left
-
-[urgency=low]
-border-color=#CCCCCC
-
-[urgency=normal]
-border-color=#FFF700
-
-[urgency=high]
-border-color=#FF0000
-default-timeout=0
-
 [app-name=system-notify]
 border-color=#FF0000
 default-timeout=0
-
-[summary~="Update"]
-border-color=#0000FF
-default-timeout=20000
 
 [body~="Update"]
 border-color=#0000FF
 default-timeout=20000
 
-[summary~=failed]
-border-color=#FF0000
-default-timeout=0
-
-[summary~=error]
+[body~=error]
 border-color=#FF0000
 default-timeout=0
 
@@ -56,6 +35,27 @@ default-timeout=0
 border-color=#FF0000
 default-timeout=0
 
-[body~=error]
+[field1=value field2=value]
+text-alignment=left
+
+[summary~="Update"]
+border-color=#0000FF
+default-timeout=20000
+
+[summary~=error]
 border-color=#FF0000
 default-timeout=0
+
+[summary~=failed]
+border-color=#FF0000
+default-timeout=0
+
+[urgency=high]
+border-color=#FF0000
+default-timeout=0
+
+[urgency=low]
+border-color=#CCCCCC
+
+[urgency=normal]
+border-color=#FFF700

--- a/tests/modules/services/mako/example-config.nix
+++ b/tests/modules/services/mako/example-config.nix
@@ -26,47 +26,45 @@
       "field1=value field2=value" = {
         text-alignment = "left";
       };
+      "urgency=low" = {
+        border-color = "#CCCCCC";
+      };
+      "urgency=normal" = {
+        border-color = "#FFF700";
+      };
+      "urgency=high" = {
+        border-color = "#FF0000";
+        default-timeout = 0;
+      };
+      "app-name=system-notify" = {
+        border-color = "#FF0000";
+        default-timeout = 0;
+      };
+      "summary~=\"Update\"" = {
+        border-color = "#0000FF";
+        default-timeout = 20000;
+      };
+      "body~=\"Update\"" = {
+        border-color = "#0000FF";
+        default-timeout = 20000;
+      };
+      "summary~=failed" = {
+        border-color = "#FF0000";
+        default-timeout = 0;
+      };
+      "summary~=error" = {
+        border-color = "#FF0000";
+        default-timeout = 0;
+      };
+      "body~=failed" = {
+        border-color = "#FF0000";
+        default-timeout = 0;
+      };
+      "body~=error" = {
+        border-color = "#FF0000";
+        default-timeout = 0;
+      };
     };
-
-    extraConfig = ''
-      [urgency=low]
-      border-color=#CCCCCC
-
-      [urgency=normal]
-      border-color=#FFF700
-
-      [urgency=high]
-      border-color=#FF0000
-      default-timeout=0
-
-      [app-name=system-notify]
-      border-color=#FF0000
-      default-timeout=0
-
-      [summary~="Update"]
-      border-color=#0000FF
-      default-timeout=20000
-
-      [body~="Update"]
-      border-color=#0000FF
-      default-timeout=20000
-
-      [summary~=failed]
-      border-color=#FF0000
-      default-timeout=0
-
-      [summary~=error]
-      border-color=#FF0000
-      default-timeout=0
-
-      [body~=failed]
-      border-color=#FF0000
-      default-timeout=0
-
-      [body~=error]
-      border-color=#FF0000
-      default-timeout=0
-    '';
   };
 
   nmt.script = ''

--- a/tests/modules/services/mako/renamed-options-config
+++ b/tests/modules/services/mako/renamed-options-config
@@ -25,3 +25,4 @@ progress-color=#4C7899
 sort=-time
 text-color=#FFFFFF
 width=300
+


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
removes `services.mako.extraConfig`
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
