### PR TITLE
feat(firefox): Use XDG config home for configPath

### DIFF
--- a/modules/programs/firefox/default.nix
+++ b/modules/programs/firefox/default.nix
@@ -12,6 +12,9 @@ let
   moduleName = lib.concatStringsSep "." modulePath;
 
   mkFirefoxModule = import ./mkFirefoxModule.nix;
+
+  xdgConfigHome = lib.removePrefix config.home.homeDirectory config.xdg.configHome;
+
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -29,7 +32,11 @@ in
       visible = true;
 
       platforms.linux = {
-        configPath = ".mozilla/firefox";
+        configPath =
+          if ((lib.versionAtLeast config.home.stateVersion "26.05") && config.home.preferXdgDirectories) then
+            "${xdgConfigHome}/mozilla/firefox"
+          else
+            ".mozilla/firefox";
       };
       platforms.darwin = {
         configPath = "Library/Application Support/Firefox";

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -278,7 +278,7 @@ in
       type = types.nullOr types.str;
       default = if platforms.darwin ? "defaultsId" then platforms.darwin.defaultsId else null;
       example = if default != null then default else "com.developer.app";
-      description = ''The id for the darwin defaults in order to set policies'';
+      description = "The id for the darwin defaults in order to set policies";
     };
 
     darwinAppName = mkOption {
@@ -987,7 +987,28 @@ in
         ++ optional (cfg.vendorPath != null) ''
           Using '${moduleName}.vendorPath' has been deprecated and
           will be removed in the future. Native messaging hosts will function normally without specifying this path.
-        '';
+        ''
+        ++ (
+          let
+            nonXdgPath = ".mozilla/firefox";
+          in
+          optional
+            (
+              config.home.preferXdgDirectories
+              && pkgs.stdenv.hostPlatform.isLinux
+              && (builtins.pathExists (config.home.homeDirectory + "/${nonXdgPath}"))
+            )
+            ''
+              Found existing Firefox profile at '${nonXdgPath}'. Since
+              'home.preferXdgDirectories' is true, the profile path is now
+              '${cfg.configPath}'.
+
+              Unfortunately, there is no automatic way to migrate your
+              profile. You must manually move the contents of '${nonXdgPath}' to
+              '${cfg.configPath}' and remove the old directory.
+            ''
+        );
+
       targets.darwin.defaults = (
         mkIf (cfg.darwinDefaultsId != null && isDarwin) {
 


### PR DESCRIPTION
### Description

Uses XDG config home for Firefox, as now supported by firefox 147 https://bugzilla.mozilla.org/show_bug.cgi?id=259356

Closes #8200 

seems to work fine.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
