### PR TITLE
vscode: fix extension path for Antigravity

### DIFF
--- a/modules/programs/vscode/default.nix
+++ b/modules/programs/vscode/default.nix
@@ -27,7 +27,6 @@ let
       "${cfg.package}/lib/antigravity"
     else
       "${cfg.package}/lib/vscode";
-  sharePrefix = if vscodePname == "antigravity" then "/share/antigravity" else "/share/vscode";
 
   productInfoPath =
     if
@@ -111,7 +110,7 @@ let
     pkgs.writeTextFile {
       inherit text;
       name = "extensions-json-${name}";
-      destination = "${sharePrefix}/extensions/extensions.json";
+      destination = "/share/vscode/extensions/extensions.json";
     };
 
   mergedUserSettings =
@@ -590,7 +589,7 @@ in
         lib.mapAttrs' (
           n: v:
           lib.nameValuePair "${userDir}/profiles/${n}/extensions.json" {
-            source = "${extensionJsonFile n (extensionJson v.extensions)}${sharePrefix}/extensions/extensions.json";
+            source = "${extensionJsonFile n (extensionJson v.extensions)}/share/vscode/extensions/extensions.json";
           }
         ) allProfilesExceptDefault
       ))
@@ -598,7 +597,7 @@ in
       (mkIf (cfg.profiles != { }) (
         let
           # Adapted from https://discourse.nixos.org/t/vscode-extensions-setup/1801/2
-          subDir = "${sharePrefix}/extensions";
+          subDir = "share/vscode/extensions";
           toPaths =
             ext:
             map (k: { "${extensionPath}/${k}".source = "${ext}/${subDir}/${k}"; }) (
@@ -654,6 +653,7 @@ in
                         || builtins.elem vscodePname [
                           "cursor"
                           "windsurf"
+                          "antigravity"
                         ]
                       )
                       && defaultProfile != { }


### PR DESCRIPTION
Standardize the extension installation path to `/share/vscode/extensions` regardless of the package name.

Previously, setting the package name to 'antigravity' would change the internal path to `/share/antigravity`, which caused a mismatch because most upstream Nixpkgs extensions are hardcoded to install into `/share/vscode/extensions`. This resulted in an empty or incomplete extensions directory in the nix store.

Also added 'antigravity' to the list of packages requiring an immutable extensions.json file.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
