### PR TITLE
mergiraf: add jujutsu integration

### DIFF
--- a/modules/programs/mergiraf.nix
+++ b/modules/programs/mergiraf.nix
@@ -27,17 +27,21 @@ in
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    programs.git = {
-      attributes = [ "* merge=mergiraf" ];
-      settings = {
-        merge = {
-          mergiraf = {
-            name = "mergiraf";
-            driver = "${mergiraf} merge --git %O %A %B -s %S -x %X -y %Y -p %P -l %L";
+    programs = {
+      git = {
+        attributes = [ "* merge=mergiraf" ];
+        settings = {
+          merge = {
+            mergiraf = {
+              name = "mergiraf";
+              driver = "${mergiraf} merge --git %O %A %B -s %S -x %X -y %Y -p %P -l %L";
+            };
+            conflictStyle = "diff3";
           };
-          conflictStyle = "diff3";
         };
       };
+
+      jujutsu.settings.ui.merge-editor = "mergiraf";
     };
   };
 }

--- a/tests/modules/programs/mergiraf/default.nix
+++ b/tests/modules/programs/mergiraf/default.nix
@@ -1,1 +1,4 @@
-{ mergiraf-basic-configuration = ./basic-configuration.nix; }
+{
+  mergiraf-basic-configuration = ./basic-configuration.nix;
+  mergiraf-jujutsu-integration = ./jujutsu-integration.nix;
+}

--- a/tests/modules/programs/mergiraf/jujutsu-integration.nix
+++ b/tests/modules/programs/mergiraf/jujutsu-integration.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.jujutsu;
+  packageVersion = lib.getVersion cfg.package;
+
+  # jj v0.29+ deprecated support for "~/Library/Application Support" on Darwin.
+  configDir =
+    if pkgs.stdenv.isDarwin && !(lib.versionAtLeast packageVersion "0.29.0") then
+      "Library/Application Support"
+    else
+      ".config";
+in
+{
+  programs.jujutsu = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+  };
+  programs.mergiraf.enable = true;
+
+  nmt.script = ''
+    assertFileExists 'home-files/${configDir}/jj/config.toml'
+    assertFileContent 'home-files/${configDir}/jj/config.toml' \
+      ${builtins.toFile "expected.toml" ''
+        [ui]
+        merge-editor = "mergiraf"
+      ''}
+  '';
+}


### PR DESCRIPTION
### Description

Simply sets `"mergiraf"` as jujutsu's [`merge-editor`](https://docs.jj-vcs.dev/latest/config/#3-way-merge-tools-for-conflict-resolution).

The diff is a bit big but it's mostly just because I un-flattened the existing `programs.git` setting.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
