### PR TITLE
fresh-editor: add extraPackages and defaultEditor options

### DIFF
--- a/modules/programs/fresh-editor.nix
+++ b/modules/programs/fresh-editor.nix
@@ -28,6 +28,15 @@ in
       example = literalExpression "[ pkgs.rust-analyzer ]";
       description = "Extra package to add to fresh";
     };
+    defaultEditor = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to configure {command}`fresh` as the default
+        editor using the {env}`EDITOR` and {env}`VISUAL`
+        environment variables.
+      '';
+    };
     settings = mkOption {
       inherit (jsonFormat) type;
       default = { };
@@ -63,6 +72,12 @@ in
         ]
       else
         [ cfg.package ];
+
+    home.sessionVariables = mkIf cfg.defaultEditor {
+      EDITOR = "fresh";
+      VISUAL = "fresh";
+    };
+
     xdg.configFile."fresh/config.json" = mkIf (cfg.settings != { }) {
       source = jsonFormat.generate "config.json" cfg.settings;
     };


### PR DESCRIPTION
### Description

This PR adds the extraPackages and defaultEditor options to fresh-editor to ensure parity with the helix module.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
