### PR TITLE
gitignore: hide noisy Mac `.DS_Store` files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /result*
 /tests/flake.lock
+.DS_Store


### PR DESCRIPTION
Macs litter the filesystem with hidden metadata `.DS_Store`.  This keeps them from being suggested for inclusion in the git repo.