### PR TITLE
vesktop: add QuickCSS support

### DIFF
--- a/modules/programs/vesktop.nix
+++ b/modules/programs/vesktop.nix
@@ -89,6 +89,17 @@ in
           }
         '';
       };
+      extraQuickCss = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = ''
+          Additional CSS rules.
+        '';
+        example = ''
+          /* disable webcam preview mirroring */
+          .media-engine-video { transform: none; }
+        '';
+      };
     };
   };
 
@@ -105,6 +116,9 @@ in
             };
             "vesktop/settings/settings.json" = lib.mkIf (cfg.vencord.settings != { }) {
               source = jsonFormat.generate "vencord-settings" cfg.vencord.settings;
+            };
+            "vesktop/settings/quickCss.css" = lib.mkIf (cfg.vencord.extraQuickCss != "") {
+              text = cfg.vencord.extraQuickCss;
             };
           }
           (


### PR DESCRIPTION
### Description

vencord quickcss support with `extraQuickCss`

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.
- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like
  ```
  {component}: {description}

  {long description}
  ```
  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.