### PR TITLE
password-store: add shell integrations

### DIFF
--- a/modules/programs/password-store.nix
+++ b/modules/programs/password-store.nix
@@ -51,11 +51,29 @@ in
         available keys.
       '';
     };
+
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
+
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
+
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = lib.mkIf cfg.enable {
     home.packages = [ cfg.package ];
     home.sessionVariables = cfg.settings;
+
+    programs.bash.initExtra = lib.mkIf cfg.enableBashIntegration ''
+      source ${cfg.package}/share/bash-completion/completions/pass
+    '';
+
+    programs.fish.shellInit = lib.mkIf cfg.enableFishIntegration ''
+      source ${cfg.package}/share/fish/vendor_completions.d/pass.fish
+    '';
+
+    programs.zsh.initContent = lib.mkIf cfg.enableZshIntegration ''
+      source ${cfg.package}/share/zsh/site-functions/_pass
+    '';
 
     services.pass-secret-service = lib.mkIf (builtins.hasAttr "PASSWORD_STORE_DIR" cfg.settings) {
       storePath = cfg.settings.PASSWORD_STORE_DIR;

--- a/tests/modules/programs/password-store/bash-integration.nix
+++ b/tests/modules/programs/password-store/bash-integration.nix
@@ -1,0 +1,19 @@
+{ config, ... }:
+{
+  programs = {
+    bash.enable = true;
+    password-store = {
+      enable = true;
+      package = config.lib.test.mkStubPackage {
+        outPath = "@pass@";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileContains \
+      home-files/.bashrc \
+      "source @pass@/share/bash-completion/completions/pass"
+  '';
+}

--- a/tests/modules/programs/password-store/default.nix
+++ b/tests/modules/programs/password-store/default.nix
@@ -2,4 +2,7 @@
   password-store-default-path = ./default-path.nix;
   password-store-old-default-path = ./old-default-path.nix;
   password-store-nondefault-path = ./nondefault-path.nix;
+  password-store-bash-integration = ./bash-integration.nix;
+  password-store-fish-integration = ./fish-integration.nix;
+  password-store-zsh-integration = ./zsh-integration.nix;
 }

--- a/tests/modules/programs/password-store/fish-integration.nix
+++ b/tests/modules/programs/password-store/fish-integration.nix
@@ -1,0 +1,19 @@
+{ config, ... }:
+{
+  programs = {
+    fish.enable = true;
+    password-store = {
+      enable = true;
+      package = config.lib.test.mkStubPackage {
+        outPath = "@pass@";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      "source @pass@/share/fish/vendor_completions.d/pass.fish"
+  '';
+}

--- a/tests/modules/programs/password-store/zsh-integration.nix
+++ b/tests/modules/programs/password-store/zsh-integration.nix
@@ -1,0 +1,19 @@
+{ config, ... }:
+{
+  programs = {
+    zsh.enable = true;
+    password-store = {
+      enable = true;
+      package = config.lib.test.mkStubPackage {
+        outPath = "@pass@";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+    assertFileContains \
+      home-files/.zshrc \
+      "source @pass@/share/zsh/site-functions/_pass"
+  '';
+}


### PR DESCRIPTION
### Description

Add shell integrations in bash, zsh, and fish for password-store, just sourcing the shell completions already available in the package.

I think the zsh and bash completions aren't strictly necessary as they get auto-loaded currently, but I copied the pattern in `watson.nix` to add all 3.

Fixes #2898

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
