### PR TITLE
tomat: modify `After`, `PartOf`, `Environment` in service

### DIFF
--- a/modules/services/tomat.nix
+++ b/modules/services/tomat.nix
@@ -57,17 +57,19 @@ in
     systemd.user.services.tomat = {
       Unit = {
         Description = "Tomat Pomodoro server";
-        After = [ "graphical.target" ];
+        After = [ "graphical-session.target" ];
+        PartOf = [ "graphical-session.target" ];
       };
 
       Service = {
         ExecStart = "${lib.getExe cfg.package} daemon run";
         Restart = "always";
         RestartSec = 5;
+        Environment = [ "PATH=${config.home.profileDirectory}/bin" ];
       };
 
       Install = {
-        WantedBy = [ "default.target" ];
+        WantedBy = [ "graphical-session.target" ];
       };
     };
   };

--- a/tests/modules/services/tomat/expected.service
+++ b/tests/modules/services/tomat/expected.service
@@ -1,11 +1,13 @@
 [Install]
-WantedBy=default.target
+WantedBy=graphical-session.target
 
 [Service]
+Environment=PATH=/home/hm-user/.nix-profile/bin
 ExecStart=@tomat@/bin/tomat daemon run
 Restart=always
 RestartSec=5
 
 [Unit]
-After=graphical.target
+After=graphical-session.target
 Description=Tomat Pomodoro server
+PartOf=graphical-session.target


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

tomat now support executing hooks on state changes, but this only works if the service is loaded as part of graphical-session and if the PATH is modified.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
