### PR TITLE
home-manager: Prevent pipe failure when reading news

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -998,9 +998,11 @@ function doShowNews() {
             return 1
     esac
 
+    local formattedNewsFile="$WORK_DIR/news.txt"
     nix-instantiate --quiet --eval --json --expr "(import ${newsNixFile}).news.$newsAttr" \
         | jq -r . \
-        | ${PAGER:-less}
+        > "$formattedNewsFile"
+    ${PAGER:-less} "$formattedNewsFile"
 
     local allIds
     allIds="$(nix-instantiate --quiet --eval --expr "(import ${newsNixFile}).meta.ids")"


### PR DESCRIPTION
### Description

On my system (Fedora 43 with Nix 2.31.3) `home-manager news` exits from `SIGPIPE` and never writes `~/.local/share/home-manager/news-read-ids`, resulting in news items to never be marked read.  This is caused by piping `(import ./news.nix).news.all` through `jq` and `less` failing with an error as soon as `less` exits, which triggers `set -o pipefail` to exit the shell running `home-manager` itself.

Avoiding the pipe into `$PAGER`	avoids the problem.

Closes: https://github.com/nix-community/home-manager/issues/8690
References: https://github.com/jqlang/jq/issues/1017
References: https://www.greenend.org.uk/rjk/tech/shellmistakes.html#pipeerrors

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
