### PR TITLE
home-manager: defer module check when evaluating activationPackage

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -55,21 +55,21 @@ let
   withExtraAttrs =
     rawModule:
     let
-      module = moduleChecks rawModule;
+      checkedModule = moduleChecks rawModule;
     in
-    module
+    rawModule
     // {
-      activationPackage = module.config.home.activationPackage;
+      activationPackage = checkedModule.config.home.activationPackage;
 
       # For backwards compatibility. Please use activationPackage instead.
-      activation-script = module.config.home.activationPackage;
+      activation-script = checkedModule.config.home.activationPackage;
 
       newsDisplay = rawModule.config.news.display;
       newsEntries = lib.sort (a: b: a.time > b.time) (
         lib.filter (a: a.condition) rawModule.config.news.entries
       );
 
-      inherit (module._module.args) pkgs;
+      inherit (checkedModule._module.args) pkgs;
 
       extendModules = args: withExtraAttrs (rawModule.extendModules args);
     };


### PR DESCRIPTION
### Description

Fixes #8689

This change defers the checking of module validity at the moment when `config.activationPackage` is evaluated. This allows better composability by allowing the original modules to be incomplete.


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
