### PR TITLE
tray: split sni/xembed targets

### DIFF
--- a/docs/release-notes/rl-2605.md
+++ b/docs/release-notes/rl-2605.md
@@ -10,6 +10,12 @@ This release has the following notable changes:
 - The [](#opt-programs.anki.uiScale) option now expects a value in the
   range 1.0–2.0, previously it erroneously expected values in the
   range `0.0–1.0`.
+- Tray units are now split into `tray-sni.target` and `tray-xembed.target`,
+  with `tray.target` acting as an umbrella. A new
+  [](#opt-services.tray.waitForWatcher) option controls whether SNI services
+  wait for a watcher (default: `prefer`). Watcher readiness is detected via
+  the D-Bus name configured by [](#opt-services.tray.watcherBusName), with
+  an optional timeout via [](#opt-services.tray.watcherTimeoutSec).
 
 ## State Version Changes {#sec-release-26.05-state-version-changes}
 

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -65,6 +65,7 @@ let
       ./systemd.nix
       ./targets/darwin
       ./targets/generic-linux.nix
+      ./tray.nix
       ./wayland.nix
       ./xresources.nix
       ./xsession.nix

--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -342,9 +342,15 @@ in
             Documentation = "https://github.com/Alexays/Waybar/wiki";
             PartOf = [
               cfg.systemd.target
-              "tray.target"
+              "tray-sni.target"
             ];
-            After = [ cfg.systemd.target ];
+            After = [
+              cfg.systemd.target
+              "tray-sni.target"
+            ]
+            ++ config.lib.tray.sniWatcherAfter;
+            Wants = config.lib.tray.sniWatcherWants;
+            Requires = config.lib.tray.sniWatcherRequires;
             ConditionEnvironment = "WAYLAND_DISPLAY";
             X-Reload-Triggers =
               optional (settings != [ ]) "${config.xdg.configFile."waybar/config".source}"
@@ -361,7 +367,7 @@ in
 
           Install.WantedBy = [
             cfg.systemd.target
-            "tray.target"
+            "tray-sni.target"
           ];
         };
       })

--- a/modules/services/blueman-applet.nix
+++ b/modules/services/blueman-applet.nix
@@ -48,8 +48,8 @@ in
     systemd.user.services.blueman-applet = {
       Unit = {
         Description = "Blueman applet";
-        Requires = [ "tray.target" ];
-        After = cfg.systemdTargets ++ [ "tray.target" ];
+        Requires = [ "tray-xembed.target" ];
+        After = cfg.systemdTargets ++ [ "tray-xembed.target" ];
         PartOf = cfg.systemdTargets;
       };
 

--- a/modules/services/cbatticon.nix
+++ b/modules/services/cbatticon.nix
@@ -138,10 +138,10 @@ in
     systemd.user.services.cbatticon = {
       Unit = {
         Description = "cbatticon system tray battery icon";
-        Requires = [ "tray.target" ];
+        Requires = [ "tray-xembed.target" ];
         After = [
           "graphical-session.target"
-          "tray.target"
+          "tray-xembed.target"
         ];
         PartOf = [ "graphical-session.target" ];
       };

--- a/modules/services/flameshot.nix
+++ b/modules/services/flameshot.nix
@@ -52,11 +52,13 @@ in
     systemd.user.services.flameshot = {
       Unit = {
         Description = "Flameshot screenshot tool";
-        Requires = [ "tray.target" ];
+        Requires = [ "tray-sni.target" ] ++ config.lib.tray.sniWatcherRequires;
         After = [
           "graphical-session.target"
-          "tray.target"
-        ];
+          "tray-sni.target"
+        ]
+        ++ config.lib.tray.sniWatcherAfter;
+        Wants = config.lib.tray.sniWatcherWants;
         PartOf = [ "graphical-session.target" ];
         X-Restart-Triggers = lib.mkIf (cfg.settings != { }) [ "${iniFile}" ];
       };

--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -69,10 +69,12 @@ in
           Description = "kdeconnect-indicator";
           After = [
             "graphical-session.target"
-            "tray.target"
-          ];
+            "tray-sni.target"
+          ]
+          ++ config.lib.tray.sniWatcherAfter;
           PartOf = [ "graphical-session.target" ];
-          Requires = [ "tray.target" ];
+          Requires = [ "tray-sni.target" ] ++ config.lib.tray.sniWatcherRequires;
+          Wants = config.lib.tray.sniWatcherWants;
         };
 
         Install = {

--- a/modules/services/network-manager-applet.nix
+++ b/modules/services/network-manager-applet.nix
@@ -7,6 +7,8 @@
 let
 
   cfg = config.services.network-manager-applet;
+  trayTarget = config.lib.tray.preferredTarget;
+  useSni = config.xsession.preferStatusNotifierItems;
 
 in
 {
@@ -34,11 +36,13 @@ in
     systemd.user.services.network-manager-applet = {
       Unit = {
         Description = "Network Manager applet";
-        Requires = [ "tray.target" ];
+        Requires = [ trayTarget ] ++ lib.optionals useSni config.lib.tray.sniWatcherRequires;
         After = [
           "graphical-session.target"
-          "tray.target"
-        ];
+          trayTarget
+        ]
+        ++ lib.optionals useSni config.lib.tray.sniWatcherAfter;
+        Wants = lib.optionals useSni config.lib.tray.sniWatcherWants;
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/parcellite.nix
+++ b/modules/services/parcellite.nix
@@ -39,10 +39,10 @@ in
     systemd.user.services.parcellite = {
       Unit = {
         Description = "Lightweight GTK+ clipboard manager";
-        Requires = [ "tray.target" ];
+        Requires = [ "tray-xembed.target" ];
         After = [
           "graphical-session.target"
-          "tray.target"
+          "tray-xembed.target"
         ];
         PartOf = [ "graphical-session.target" ];
       };

--- a/modules/services/pasystray.nix
+++ b/modules/services/pasystray.nix
@@ -35,10 +35,10 @@ in
     systemd.user.services.pasystray = {
       Unit = {
         Description = "PulseAudio system tray";
-        Requires = [ "tray.target" ];
+        Requires = [ "tray-xembed.target" ];
         After = [
           "graphical-session.target"
-          "tray.target"
+          "tray-xembed.target"
         ];
         PartOf = [ "graphical-session.target" ];
       };

--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -236,7 +236,7 @@ in
     systemd.user.services.polybar = {
       Unit = {
         Description = "Polybar status bar";
-        PartOf = [ "tray.target" ];
+        PartOf = [ "tray-xembed.target" ];
         X-Restart-Triggers = mkIf (configFile != null) [ "${configFile}" ];
       };
 
@@ -252,7 +252,7 @@ in
       };
 
       Install = {
-        WantedBy = [ "tray.target" ];
+        WantedBy = [ "tray-xembed.target" ];
       };
     };
   };

--- a/modules/services/redshift-gammastep/lib/options.nix
+++ b/modules/services/redshift-gammastep/lib/options.nix
@@ -221,10 +221,10 @@ in
           After = [
             "graphical-session.target"
           ]
-          ++ (lib.optional cfg.tray "tray.target")
+          ++ (lib.optional cfg.tray "tray-xembed.target")
           ++ geoclueAgentService;
           Wants = geoclueAgentService;
-          Requires = lib.mkIf cfg.tray "tray.target";
+          Requires = lib.mkIf cfg.tray "tray-xembed.target";
           PartOf = [ "graphical-session.target" ];
         };
 

--- a/modules/services/stalonetray.nix
+++ b/modules/services/stalonetray.nix
@@ -64,11 +64,11 @@ in
         systemd.user.services.stalonetray = {
           Unit = {
             Description = "Stalonetray system tray";
-            PartOf = [ "tray.target" ];
+            PartOf = [ "tray-xembed.target" ];
           };
 
           Install = {
-            WantedBy = [ "tray.target" ];
+            WantedBy = [ "tray-xembed.target" ];
           };
 
           Service = {

--- a/modules/services/status-notifier-watcher.nix
+++ b/modules/services/status-notifier-watcher.nix
@@ -29,7 +29,7 @@ in
     systemd.user.services.status-notifier-watcher = {
       Unit = {
         Description = "SNI watcher";
-        PartOf = [ "tray.target" ];
+        PartOf = [ "tray-sni.target" ];
         Before = [ "taffybar.service" ];
       };
 
@@ -41,7 +41,7 @@ in
 
       Install = {
         WantedBy = [
-          "tray.target"
+          "tray-sni.target"
           "taffybar.service"
         ];
       };

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -872,11 +872,13 @@ in
         ${cfg.tray.package.pname} = {
           Unit = {
             Description = cfg.tray.package.pname;
-            Requires = [ "tray.target" ];
+            Requires = [ "tray-sni.target" ] ++ config.lib.tray.sniWatcherRequires;
             After = [
               "graphical-session.target"
-              "tray.target"
-            ];
+              "tray-sni.target"
+            ]
+            ++ config.lib.tray.sniWatcherAfter;
+            Wants = config.lib.tray.sniWatcherWants;
             PartOf = [ "graphical-session.target" ];
           };
 

--- a/modules/services/taffybar.nix
+++ b/modules/services/taffybar.nix
@@ -29,7 +29,10 @@ in
     systemd.user.services.taffybar = {
       Unit = {
         Description = "Taffybar desktop bar";
-        PartOf = [ "tray.target" ];
+        PartOf = [ "tray-sni.target" ];
+        After = config.lib.tray.sniWatcherAfter;
+        Wants = config.lib.tray.sniWatcherWants;
+        Requires = config.lib.tray.sniWatcherRequires;
         StartLimitBurst = 5;
         StartLimitIntervalSec = 10;
       };
@@ -43,7 +46,7 @@ in
       };
 
       Install = {
-        WantedBy = [ "tray.target" ];
+        WantedBy = [ "tray-sni.target" ];
       };
     };
 

--- a/modules/services/tailscale-systray.nix
+++ b/modules/services/tailscale-systray.nix
@@ -31,11 +31,13 @@ in
     systemd.user.services.tailscale-systray = {
       Unit = {
         Description = "Official Tailscale systray application for Linux";
-        Requires = [ "tray.target" ];
+        Requires = [ "tray-sni.target" ] ++ config.lib.tray.sniWatcherRequires;
         After = [
           "graphical-session.target"
-          "tray.target"
-        ];
+          "tray-sni.target"
+        ]
+        ++ config.lib.tray.sniWatcherAfter;
+        Wants = config.lib.tray.sniWatcherWants;
         PartOf = [ "graphical-session.target" ];
       };
       Install = {

--- a/modules/services/trayer.nix
+++ b/modules/services/trayer.nix
@@ -164,10 +164,10 @@ in
       {
         Unit = {
           Description = "trayer -- lightweight GTK2+ systray for UNIX desktops";
-          PartOf = [ "tray.target" ];
+          PartOf = [ "tray-xembed.target" ];
         };
 
-        Install.WantedBy = [ "tray.target" ];
+        Install.WantedBy = [ "tray-xembed.target" ];
 
         Service = {
           ExecStart = "${cfg.package}/bin/trayer ${parameters}";

--- a/modules/services/trayscale.nix
+++ b/modules/services/trayscale.nix
@@ -31,10 +31,10 @@ in
     systemd.user.services.trayscale = {
       Unit = {
         Description = "An unofficial GUI wrapper around the Tailscale CLI client";
-        Requires = [ "tray.target" ];
+        Requires = [ "tray-xembed.target" ];
         After = [
           "graphical-session.target"
-          "tray.target"
+          "tray-xembed.target"
         ];
         PartOf = [ "graphical-session.target" ];
       };

--- a/modules/tray.nix
+++ b/modules/tray.nix
@@ -1,0 +1,149 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.tray;
+
+  watcherService = "tray-watcher.service";
+
+  watcherDeps = lib.optional (
+    cfg.waitForWatcher != "none" && cfg.watcherBusName != null
+  ) watcherService;
+
+  sniWatcherAfter = watcherDeps;
+  sniWatcherWants = if cfg.waitForWatcher == "prefer" then watcherDeps else [ ];
+  sniWatcherRequires = if cfg.waitForWatcher == "require" then watcherDeps else [ ];
+in
+{
+  options.services.tray = {
+    waitForWatcher = lib.mkOption {
+      type = lib.types.enum [
+        "none"
+        "prefer"
+        "require"
+      ];
+      default = "prefer";
+      description = ''
+        Controls whether StatusNotifierItem (SNI) tray services should wait for a
+        watcher to be available on D-Bus.
+
+        - `none`: do not add any watcher dependency.
+        - `prefer`: add `Wants=` and `After=` on `tray-watcher.service` so
+          services wait for the watcher if it starts, but continue if it fails.
+        - `require`: add `Requires=` and `After=` on `tray-watcher.service` so
+          services only start when the watcher is available.
+
+        The watcher readiness is determined by D-Bus ownership of
+        `org.kde.StatusNotifierWatcher` (e.g. a `Type=dbus` service).
+      '';
+    };
+
+    watcherBusName = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = "org.kde.StatusNotifierWatcher";
+      description = ''
+        The D-Bus name used to detect watcher readiness when
+        `waitForWatcher` is enabled.
+
+        Set to `null` to disable watcher readiness checks entirely.
+      '';
+    };
+
+    watcherTimeoutSec = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      example = 15;
+      description = ''
+        Timeout in seconds for waiting on the watcher D-Bus name. When `null`,
+        systemd's default `TimeoutStartSec` applies.
+      '';
+    };
+  };
+
+  config = {
+    lib.tray = {
+      targets = {
+        main = "tray.target";
+        sni = "tray-sni.target";
+        xembed = "tray-xembed.target";
+      };
+      preferSni = config.xsession.preferStatusNotifierItems;
+      preferredTarget =
+        if config.xsession.preferStatusNotifierItems then "tray-sni.target" else "tray-xembed.target";
+      watcherService = watcherService;
+      sniWatcherAfter = sniWatcherAfter;
+      sniWatcherWants = sniWatcherWants;
+      sniWatcherRequires = sniWatcherRequires;
+    };
+
+    systemd.user = lib.mkIf config.systemd.user.enable {
+      services.tray-watcher = lib.mkIf (cfg.waitForWatcher != "none" && cfg.watcherBusName != null) (
+        let
+          script = pkgs.writeShellScript "hm-wait-sni-watcher" ''
+            set -eu
+
+            busctl=${lib.getExe' pkgs.systemd "busctl"}
+            name=${lib.escapeShellArg cfg.watcherBusName}
+
+            while true; do
+              out="$($busctl --user call org.freedesktop.DBus /org/freedesktop/DBus \
+                org.freedesktop.DBus NameHasOwner s "$name" 2>/dev/null || true)"
+              set -- $out
+              if [ "''${2:-}" = "true" ]; then
+                exit 0
+              fi
+              sleep 0.2
+            done
+          '';
+        in
+        {
+          Unit = {
+            Description = "Wait for SNI watcher on D-Bus";
+          };
+
+          Service = {
+            Type = "oneshot";
+            ExecStart = "${script}";
+            RemainAfterExit = true;
+          }
+          // lib.optionalAttrs (cfg.watcherTimeoutSec != null) {
+            TimeoutStartSec = cfg.watcherTimeoutSec;
+          };
+        }
+      );
+
+      targets = {
+        tray = {
+          Unit = {
+            Description = "Home Manager System Tray";
+            Requires = [ "graphical-session-pre.target" ];
+            Wants = [
+              "tray-sni.target"
+              "tray-xembed.target"
+            ];
+          };
+        };
+
+        tray-sni = {
+          Unit = {
+            Description = "Home Manager SNI Tray";
+            Requires = [ "graphical-session-pre.target" ];
+            PartOf = [ "tray.target" ];
+          };
+        };
+
+        tray-xembed = {
+          Unit = {
+            Description = "Home Manager XEmbed Tray";
+            Requires = [ "graphical-session-pre.target" ];
+            PartOf = [ "tray.target" ];
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/wayland.nix
+++ b/modules/wayland.nix
@@ -22,7 +22,5 @@
     };
   };
 
-  config = lib.mkIf (!config.xsession.enable) {
-    systemd.user.targets.tray = config.xsession.trayTarget;
-  };
+  config = { };
 }

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -18,20 +18,6 @@ in
     xsession = {
       enable = lib.mkEnableOption "X Session";
 
-      trayTarget = mkOption {
-        readOnly = true;
-        internal = true;
-        visible = false;
-        description = "Common tray.target for both xsession and wayland";
-        type = types.attrs;
-        default = {
-          Unit = {
-            Description = "Home Manager System Tray";
-            Requires = [ "graphical-session-pre.target" ];
-          };
-        };
-      };
-
       scriptPath = mkOption {
         type = types.str;
         default = ".xsession";
@@ -202,7 +188,6 @@ in
           };
         };
 
-        tray = cfg.trayTarget;
       };
     };
 

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
@@ -1,6 +1,6 @@
 [Install]
 WantedBy=sway-session.target
-WantedBy=tray.target
+WantedBy=tray-sni.target
 
 [Service]
 ExecReload=/nix/store/00000000000000000000000000000000-coreutils/bin/kill -SIGUSR2 $MAINPID
@@ -10,8 +10,11 @@ Restart=on-failure
 
 [Unit]
 After=sway-session.target
+After=tray-sni.target
+After=tray-watcher.service
 ConditionEnvironment=WAYLAND_DISPLAY
 Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
 Documentation=https://github.com/Alexays/Waybar/wiki
 PartOf=sway-session.target
-PartOf=tray.target
+PartOf=tray-sni.target
+Wants=tray-watcher.service

--- a/tests/modules/services/parcellite/parcellite-expected.service
+++ b/tests/modules/services/parcellite/parcellite-expected.service
@@ -7,7 +7,7 @@ Restart=on-abort
 
 [Unit]
 After=graphical-session.target
-After=tray.target
+After=tray-xembed.target
 Description=Lightweight GTK+ clipboard manager
 PartOf=graphical-session.target
-Requires=tray.target
+Requires=tray-xembed.target

--- a/tests/modules/services/pasystray/expected.service
+++ b/tests/modules/services/pasystray/expected.service
@@ -7,7 +7,7 @@ ExecStart=@pasystray@/bin/pasystray -g
 
 [Unit]
 After=graphical-session.target
-After=tray.target
+After=tray-xembed.target
 Description=PulseAudio system tray
 PartOf=graphical-session.target
-Requires=tray.target
+Requires=tray-xembed.target

--- a/tests/modules/services/redshift-gammastep/gammastep-tray-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/gammastep-tray-configuration-expected.service
@@ -8,8 +8,8 @@ RestartSec=3
 
 [Unit]
 After=graphical-session.target
-After=tray.target
+After=tray-xembed.target
 Description=Gammastep colour temperature adjuster
 Documentation=https://gitlab.com/chinstrap/gammastep/
 PartOf=graphical-session.target
-Requires=tray.target
+Requires=tray-xembed.target

--- a/tests/modules/services/redshift-gammastep/redshift-tray-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/redshift-tray-configuration-expected.service
@@ -8,8 +8,8 @@ RestartSec=3
 
 [Unit]
 After=graphical-session.target
-After=tray.target
+After=tray-xembed.target
 Description=Redshift colour temperature adjuster
 Documentation=http://jonls.dk/redshift/
 PartOf=graphical-session.target
-Requires=tray.target
+Requires=tray-xembed.target

--- a/tests/modules/services/syncthing/linux/tray.nix
+++ b/tests/modules/services/syncthing/linux/tray.nix
@@ -14,10 +14,12 @@
 
         [Unit]
         After=graphical-session.target
-        After=tray.target
+        After=tray-sni.target
+        After=tray-watcher.service
         Description=syncthingtray
         PartOf=graphical-session.target
-        Requires=tray.target
+        Requires=tray-sni.target
+        Wants=tray-watcher.service
       ''}
   '';
 }

--- a/tests/modules/services/udiskie/basic.nix
+++ b/tests/modules/services/udiskie/basic.nix
@@ -3,8 +3,8 @@
 
   nmt.script = ''
     serviceFile="home-files/.config/systemd/user/udiskie.service"
-    assertFileRegex "$serviceFile" 'After=tray\.target'
-    assertFileRegex "$serviceFile" 'Requires=tray\.target'
+    assertFileRegex "$serviceFile" 'After=tray-xembed\.target'
+    assertFileRegex "$serviceFile" 'Requires=tray-xembed\.target'
     assertFileContent "home-files/.config/udiskie/config.yml" \
         ${./basic.yml}
   '';

--- a/tests/modules/services/udiskie/no-tray.nix
+++ b/tests/modules/services/udiskie/no-tray.nix
@@ -6,8 +6,8 @@
 
   nmt.script = ''
     serviceFile="home-files/.config/systemd/user/udiskie.service"
-    assertFileNotRegex "$serviceFile" 'After=tray\.target'
-    assertFileNotRegex "$serviceFile" 'Requires=tray\.target'
+    assertFileNotRegex "$serviceFile" 'After=tray-(sni|xembed)\.target'
+    assertFileNotRegex "$serviceFile" 'Requires=tray-(sni|xembed)\.target'
     assertFileContent "home-files/.config/udiskie/config.yml" \
         ${./no-tray.yml}
   '';


### PR DESCRIPTION
## Summary
- split tray targets into `tray-sni.target` and `tray-xembed.target` with `tray.target` as an umbrella
- add a D-Bus watcher wait service and global tray watcher options
- rewire tray services/tests/docs to the new targets

## Testing
- `nix run .#tests -- parcellite pasystray redshift-gammastep udiskie syncthing waybar`