### PR TITLE
waybar: reuse upstream service

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -336,6 +336,10 @@ in
       }
 
       (mkIf cfg.systemd.enable {
+
+        systemd.user.packages = [
+          cfg.package
+        ];
         systemd.user.services.waybar = {
           Unit = {
             Description = "Highly customizable Wayland bar for Sway and Wlroots based compositors.";
@@ -345,7 +349,6 @@ in
               "tray.target"
             ];
             After = [ cfg.systemd.target ];
-            ConditionEnvironment = "WAYLAND_DISPLAY";
             X-Reload-Triggers =
               optional (settings != [ ]) "${config.xdg.configFile."waybar/config".source}"
               ++ optional (cfg.style != null) "${config.xdg.configFile."waybar/style.css".source}";


### PR DESCRIPTION
### Description

Putting as draft to spark some discussion 

The `ConditionEnvironment = "WAYLAND_DISPLAY";` was introduced in https://github.com/nix-community/home-manager/pull/6253 and at the time I thought it was a good idea but in practice, this broke my setup and others too (todo reference issue).

I am happy to fix my setup and/or home-manager setup, I tried to start sway as a systemd service in hope of fixing this to no avail. I probably need to fix startup order such that waybar starts when `WAYLAND_DISPLAY`is ready. 
I might try later again

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
