### PR TITLE
zed-editor: don't generate empty keymap files

### DIFF
--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -304,7 +304,7 @@ in
       (mkIf (!cfg.mutableUserSettings && mergedSettings != { }) {
         "zed/settings.json".source = jsonFormat.generate "zed-user-settings" mergedSettings;
       })
-      (mkIf (!cfg.mutableUserKeymaps && cfg.userKeymaps != { }) {
+      (mkIf (!cfg.mutableUserKeymaps && cfg.userKeymaps != [ ]) {
         "zed/keymap.json".source = jsonFormat.generate "zed-user-keymaps" cfg.userKeymaps;
       })
       (mkIf (!cfg.mutableUserTasks && cfg.userTasks != [ ]) {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

default value for user keymaps is an empty list, but the check was made against an empty set, generating the file when no value was given

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
