### PR TITLE
cursor-agent: init module

### DIFF
--- a/modules/programs/cursor-agent.nix
+++ b/modules/programs/cursor-agent.nix
@@ -1,0 +1,346 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.cursor-agent;
+  jsonFormat = pkgs.formats.json { };
+  transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
+    lib.mapAttrs (
+      name: server:
+      (removeAttrs server [ "disabled" ])
+      // (lib.optionalAttrs (server ? url) { type = "http"; })
+      // (lib.optionalAttrs (server ? command) { type = "stdio"; })
+      // {
+        enabled = !(server.disabled or false);
+      }
+    ) config.programs.mcp.servers
+  );
+
+  mergedMcpServers = transformedMcpServers // cfg.mcpServers;
+in
+{
+  options.programs.cursor-agent = {
+    enable = lib.mkEnableOption "Cursor Agent, Cursor's agentic coding CLI";
+
+    package = lib.mkPackageOption pkgs "cursor-cli" { nullable = true; };
+
+    enableMcpIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to integrate the MCP servers config from
+        {option}`programs.mcp.servers` into
+        the Cursor Agent MCP configuration.
+
+        Note: Settings defined in {option}`programs.mcp.servers` are merged
+        with {option}`programs.cursor-agent.mcpServers`, with Cursor Agent servers
+        taking precedence.
+      '';
+    };
+
+    settings = lib.mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = {
+        editor.vimMode = false;
+        permissions = {
+          allow = [
+            "Shell(git diff:*)"
+            "Shell(git log:*)"
+          ];
+          deny = [
+            "Shell(rm:*)"
+            "Read(.env*)"
+          ];
+        };
+        network.useHttp1ForAgent = false;
+        attribution = {
+          attributeCommitsToAgent = false;
+          attributePRsToAgent = false;
+        };
+      };
+      description = ''
+        JSON configuration for Cursor Agent CLI.
+
+        The `version` field is always set to `1` and does not need to be specified.
+
+        See <https://cursor.com/docs/cli/reference/configuration> for available options.
+      '';
+    };
+
+    mcpServers = lib.mkOption {
+      type = lib.types.attrsOf jsonFormat.type;
+      default = { };
+      description = "MCP (Model Context Protocol) servers configuration";
+      example = {
+        context7 = {
+          type = "http";
+          url = "https://mcp.context7.com/mcp";
+        };
+        playwright = {
+          type = "stdio";
+          command = "npx";
+          args = [
+            "-y"
+            "@playwright/mcp@latest"
+          ];
+        };
+      };
+    };
+
+    rules = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.either lib.types.lines lib.types.path);
+      default = { };
+      description = ''
+        Rule files for Cursor Agent.
+        The attribute name becomes the rule filename, and the value is either:
+        - Inline content as a string (with optional MDC frontmatter)
+        - A path to a file containing the rule content
+        Rules are stored in {file}`~/.cursor/rules/` directory.
+      '';
+      example = lib.literalExpression ''
+        {
+          code-style = '''
+            ---
+            description: "Code style guidelines"
+            alwaysApply: true
+            ---
+            - Use consistent formatting
+            - Follow language conventions
+          ''';
+          security = ./rules/security.mdc;
+        }
+      '';
+    };
+
+    rulesDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a directory containing rule files for Cursor Agent.
+        Rule files from this directory will be symlinked to {file}`~/.cursor/rules/`.
+      '';
+      example = lib.literalExpression "./rules";
+    };
+
+    agents = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.either lib.types.lines lib.types.path);
+      default = { };
+      description = ''
+        Custom agents for Cursor Agent.
+        The attribute name becomes the agent filename, and the value is either:
+        - Inline content as a string with frontmatter
+        - A path to a file containing the agent content with frontmatter
+        Agents are stored in {file}`~/.cursor/agents/` directory.
+      '';
+      example = lib.literalExpression ''
+        {
+          code-reviewer = '''
+            ---
+            name: code-reviewer
+            description: Specialized code review agent
+            tools: Read, Edit, Grep
+            ---
+
+            You are a senior software engineer specializing in code reviews.
+            Focus on code quality, security, and maintainability.
+          ''';
+          documentation = ./agents/documentation.md;
+        }
+      '';
+    };
+
+    agentsDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a directory containing agent files for Cursor Agent.
+        Agent files from this directory will be symlinked to {file}`~/.cursor/agents/`.
+      '';
+      example = lib.literalExpression "./agents";
+    };
+
+    commands = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.either lib.types.lines lib.types.path);
+      default = { };
+      description = ''
+        Custom commands for Cursor Agent.
+        The attribute name becomes the command filename, and the value is either:
+        - Inline content as a string
+        - A path to a file containing the command content
+        Commands are stored in {file}`~/.cursor/commands/` directory.
+      '';
+      example = lib.literalExpression ''
+        {
+          commit = '''
+            Based on the current changes, create a single atomic git commit
+            with a descriptive message following conventional commits.
+          ''';
+          fix-issue = ./commands/fix-issue.md;
+        }
+      '';
+    };
+
+    commandsDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a directory containing command files for Cursor Agent.
+        Command files from this directory will be symlinked to {file}`~/.cursor/commands/`.
+      '';
+      example = lib.literalExpression "./commands";
+    };
+
+    skills = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.either lib.types.lines lib.types.path);
+      default = { };
+      description = ''
+        Custom skills for Cursor Agent.
+        The attribute name becomes the skill directory name, and the value is either:
+        - Inline content as a string with frontmatter (creates {file}`~/.cursor/skills/<name>/SKILL.md`)
+        - A path to a file (creates {file}`~/.cursor/skills/<name>/SKILL.md`)
+        - A path to a directory (creates {file}`~/.cursor/skills/<name>/` with all files including SKILL.md)
+      '';
+      example = lib.literalExpression ''
+        {
+          pdf-processing = '''
+            ---
+            name: pdf-processing
+            description: Extract text and tables from PDF files
+            ---
+
+            # PDF Processing
+
+            Use pdfplumber to extract text from PDFs.
+          ''';
+          xlsx = ./skills/xlsx.md;
+          data-analysis = ./skills/data-analysis;
+        }
+      '';
+    };
+
+    skillsDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a directory containing skill files for Cursor Agent.
+        Skill files from this directory will be symlinked to {file}`~/.cursor/skills/`.
+      '';
+      example = lib.literalExpression "./skills";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.rules != { } && cfg.rulesDir != null);
+        message = "Cannot specify both `programs.cursor-agent.rules` and `programs.cursor-agent.rulesDir`";
+      }
+      {
+        assertion = !(cfg.agents != { } && cfg.agentsDir != null);
+        message = "Cannot specify both `programs.cursor-agent.agents` and `programs.cursor-agent.agentsDir`";
+      }
+      {
+        assertion = !(cfg.commands != { } && cfg.commandsDir != null);
+        message = "Cannot specify both `programs.cursor-agent.commands` and `programs.cursor-agent.commandsDir`";
+      }
+      {
+        assertion = !(cfg.skills != { } && cfg.skillsDir != null);
+        message = "Cannot specify both `programs.cursor-agent.skills` and `programs.cursor-agent.skillsDir`";
+      }
+    ];
+
+    home = {
+      packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+      file = {
+        ".cursor/rules" = lib.mkIf (cfg.rulesDir != null) {
+          source = cfg.rulesDir;
+          recursive = true;
+        };
+
+        ".cursor/agents" = lib.mkIf (cfg.agentsDir != null) {
+          source = cfg.agentsDir;
+          recursive = true;
+        };
+
+        ".cursor/commands" = lib.mkIf (cfg.commandsDir != null) {
+          source = cfg.commandsDir;
+          recursive = true;
+        };
+
+        ".cursor/skills" = lib.mkIf (cfg.skillsDir != null) {
+          source = cfg.skillsDir;
+          recursive = true;
+        };
+
+        ".cursor/mcp.json" = lib.mkIf (mergedMcpServers != { }) {
+          source = jsonFormat.generate "cursor-mcp.json" {
+            mcpServers = mergedMcpServers;
+          };
+        };
+
+      }
+      // lib.mapAttrs' (
+        name: content:
+        lib.nameValuePair ".cursor/rules/${name}.md" (
+          if lib.isPath content then { source = content; } else { text = content; }
+        )
+      ) cfg.rules
+      // lib.mapAttrs' (
+        name: content:
+        lib.nameValuePair ".cursor/agents/${name}.md" (
+          if lib.isPath content then { source = content; } else { text = content; }
+        )
+      ) cfg.agents
+      // lib.mapAttrs' (
+        name: content:
+        lib.nameValuePair ".cursor/commands/${name}.md" (
+          if lib.isPath content then { source = content; } else { text = content; }
+        )
+      ) cfg.commands
+      // lib.mapAttrs' (
+        name: content:
+        if lib.isPath content && lib.pathIsDirectory content then
+          lib.nameValuePair ".cursor/skills/${name}" {
+            source = content;
+            recursive = true;
+          }
+        else
+          lib.nameValuePair ".cursor/skills/${name}/SKILL.md" (
+            if lib.isPath content then { source = content; } else { text = content; }
+          )
+      ) cfg.skills;
+
+      activation = lib.mkIf (cfg.settings != { }) {
+        cursorAgentCliConfig =
+          let
+            staticSettings = jsonFormat.generate "cursor-cli-config.json" (
+              {
+                version = 1;
+              }
+              // cfg.settings
+            );
+            jq = lib.getExe pkgs.jq;
+          in
+          lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+            config_path="${config.home.homeDirectory}/.cursor/cli-config.json"
+            mkdir -p "$(dirname "$config_path")"
+            if [ ! -e "$config_path" ]; then
+              echo '{}' > "$config_path"
+            fi
+            if ! ${jq} -S '. * $static[0]' \
+                --slurpfile static ${staticSettings} \
+                "$config_path" > "$config_path.tmp" 2>/dev/null; then
+              ${jq} -S '.' ${staticSettings} > "$config_path.tmp"
+            fi
+            mv "$config_path.tmp" "$config_path"
+          '';
+      };
+    };
+
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -36,6 +36,7 @@ let
     "codex"
     "comodoro"
     "cudatext"
+    "cursor-cli"
     "darcs"
     "delta"
     "difftastic"

--- a/tests/modules/programs/cursor-agent/agents-dir.nix
+++ b/tests/modules/programs/cursor-agent/agents-dir.nix
@@ -1,0 +1,14 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+
+    agentsDir = ./agents;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/agents/test-agent.md
+    assertFileContent home-files/.cursor/agents/test-agent.md \
+      ${./agents/test-agent.md}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/agents-inline.nix
+++ b/tests/modules/programs/cursor-agent/agents-inline.nix
@@ -1,0 +1,24 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+
+    agents = {
+      code-reviewer = ''
+        ---
+        name: code-reviewer
+        description: Specialized code review agent
+        ---
+
+        You are a senior software engineer specializing in code reviews.
+        Focus on code quality, security, and maintainability.
+      '';
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/agents/code-reviewer.md
+    assertFileContent home-files/.cursor/agents/code-reviewer.md \
+      ${./expected-code-reviewer-agent.md}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/agents-path.nix
+++ b/tests/modules/programs/cursor-agent/agents-path.nix
@@ -1,0 +1,16 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+
+    agents = {
+      test-agent = ./agents/test-agent.md;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/agents/test-agent.md
+    assertFileContent home-files/.cursor/agents/test-agent.md \
+      ${./agents/test-agent.md}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/agents/test-agent.md
+++ b/tests/modules/programs/cursor-agent/agents/test-agent.md
@@ -1,0 +1,7 @@
+---
+name: test-agent
+description: A test agent for code review
+---
+
+You are a senior software engineer specializing in code reviews.
+Focus on code quality, security, and maintainability.

--- a/tests/modules/programs/cursor-agent/assertion.nix
+++ b/tests/modules/programs/cursor-agent/assertion.nix
@@ -1,0 +1,29 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+    rules = {
+      code-style = "test";
+    };
+    rulesDir = ./rules;
+    agents = {
+      test-agent = "test";
+    };
+    agentsDir = ./agents;
+    commands = {
+      test-command = "test";
+    };
+    commandsDir = ./commands;
+    skills = {
+      test-skill = "test";
+    };
+    skillsDir = ./skills;
+  };
+
+  test.asserts.assertions.expected = [
+    "Cannot specify both `programs.cursor-agent.rules` and `programs.cursor-agent.rulesDir`"
+    "Cannot specify both `programs.cursor-agent.agents` and `programs.cursor-agent.agentsDir`"
+    "Cannot specify both `programs.cursor-agent.commands` and `programs.cursor-agent.commandsDir`"
+    "Cannot specify both `programs.cursor-agent.skills` and `programs.cursor-agent.skillsDir`"
+  ];
+}

--- a/tests/modules/programs/cursor-agent/basic.nix
+++ b/tests/modules/programs/cursor-agent/basic.nix
@@ -1,0 +1,10 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.cursor
+  '';
+}

--- a/tests/modules/programs/cursor-agent/commands-dir.nix
+++ b/tests/modules/programs/cursor-agent/commands-dir.nix
@@ -1,0 +1,14 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+
+    commandsDir = ./commands;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/commands/test-command.md
+    assertFileContent home-files/.cursor/commands/test-command.md \
+      ${./commands/test-command.md}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/commands-inline.nix
+++ b/tests/modules/programs/cursor-agent/commands-inline.nix
@@ -1,0 +1,19 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+
+    commands = {
+      commit = ''
+        Based on the current changes, create a single atomic git commit
+        with a descriptive message following conventional commits.
+      '';
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/commands/commit.md
+    assertFileContent home-files/.cursor/commands/commit.md \
+      ${./expected-commit-command.md}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/commands-path.nix
+++ b/tests/modules/programs/cursor-agent/commands-path.nix
@@ -1,0 +1,16 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+
+    commands = {
+      test-command = ./commands/test-command.md;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/commands/test-command.md
+    assertFileContent home-files/.cursor/commands/test-command.md \
+      ${./commands/test-command.md}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/commands/test-command.md
+++ b/tests/modules/programs/cursor-agent/commands/test-command.md
@@ -1,0 +1,2 @@
+Based on the current changes, create a single atomic git commit
+with a descriptive message following conventional commits.

--- a/tests/modules/programs/cursor-agent/default.nix
+++ b/tests/modules/programs/cursor-agent/default.nix
@@ -1,0 +1,18 @@
+{
+  cursor-agent-basic = ./basic.nix;
+  cursor-agent-full-config = ./full-config.nix;
+  cursor-agent-mcp = ./mcp.nix;
+  cursor-agent-mcp-integration = ./mcp-integration.nix;
+  cursor-agent-assertion = ./assertion.nix;
+  cursor-agent-rules-dir = ./rules-dir.nix;
+  cursor-agent-rules-path = ./rules-path.nix;
+  cursor-agent-agents-inline = ./agents-inline.nix;
+  cursor-agent-agents-path = ./agents-path.nix;
+  cursor-agent-agents-dir = ./agents-dir.nix;
+  cursor-agent-commands-inline = ./commands-inline.nix;
+  cursor-agent-commands-path = ./commands-path.nix;
+  cursor-agent-commands-dir = ./commands-dir.nix;
+  cursor-agent-skills-inline = ./skills-inline.nix;
+  cursor-agent-skills-path = ./skills-path.nix;
+  cursor-agent-skills-dir = ./skills-dir.nix;
+}

--- a/tests/modules/programs/cursor-agent/expected-code-reviewer-agent.md
+++ b/tests/modules/programs/cursor-agent/expected-code-reviewer-agent.md
@@ -1,0 +1,7 @@
+---
+name: code-reviewer
+description: Specialized code review agent
+---
+
+You are a senior software engineer specializing in code reviews.
+Focus on code quality, security, and maintainability.

--- a/tests/modules/programs/cursor-agent/expected-code-style.md
+++ b/tests/modules/programs/cursor-agent/expected-code-style.md
@@ -1,0 +1,6 @@
+---
+description: "Code style guidelines"
+alwaysApply: true
+---
+- Use consistent formatting
+- Follow language conventions

--- a/tests/modules/programs/cursor-agent/expected-commit-command.md
+++ b/tests/modules/programs/cursor-agent/expected-commit-command.md
@@ -1,0 +1,2 @@
+Based on the current changes, create a single atomic git commit
+with a descriptive message following conventional commits.

--- a/tests/modules/programs/cursor-agent/expected-mcp-integration.json
+++ b/tests/modules/programs/cursor-agent/expected-mcp-integration.json
@@ -1,0 +1,31 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "database": {
+      "args": [
+        "-y",
+        "@bytebase/dbhub",
+        "--dsn",
+        "postgresql://user:pass@localhost:5432/db"
+      ],
+      "command": "npx",
+      "enabled": true,
+      "env": {
+        "DATABASE_URL": "postgresql://user:pass@localhost:5432/db"
+      },
+      "type": "stdio"
+    },
+    "filesystem": {
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/tmp"
+      ],
+      "command": "npx",
+      "type": "stdio"
+    }
+  }
+}

--- a/tests/modules/programs/cursor-agent/expected-mcp.json
+++ b/tests/modules/programs/cursor-agent/expected-mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "filesystem": {
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/tmp"
+      ],
+      "command": "npx",
+      "type": "stdio"
+    }
+  }
+}

--- a/tests/modules/programs/cursor-agent/expected-pdf-processing-skill.md
+++ b/tests/modules/programs/cursor-agent/expected-pdf-processing-skill.md
@@ -1,0 +1,8 @@
+---
+name: pdf-processing
+description: Extract text and tables from PDF files
+---
+
+# PDF Processing
+
+Use pdfplumber to extract text from PDFs.

--- a/tests/modules/programs/cursor-agent/expected-settings.json
+++ b/tests/modules/programs/cursor-agent/expected-settings.json
@@ -1,0 +1,23 @@
+{
+  "attribution": {
+    "attributeCommitsToAgent": false,
+    "attributePRsToAgent": false
+  },
+  "editor": {
+    "vimMode": false
+  },
+  "network": {
+    "useHttp1ForAgent": false
+  },
+  "permissions": {
+    "allow": [
+      "Shell(git diff:*)",
+      "Shell(git log:*)"
+    ],
+    "deny": [
+      "Shell(rm:*)",
+      "Read(.env*)"
+    ]
+  },
+  "version": 1
+}

--- a/tests/modules/programs/cursor-agent/full-config.nix
+++ b/tests/modules/programs/cursor-agent/full-config.nix
@@ -1,0 +1,114 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+
+    settings = {
+      editor.vimMode = false;
+      permissions = {
+        allow = [
+          "Shell(git diff:*)"
+          "Shell(git log:*)"
+        ];
+        deny = [
+          "Shell(rm:*)"
+          "Read(.env*)"
+        ];
+      };
+      network.useHttp1ForAgent = false;
+      attribution = {
+        attributeCommitsToAgent = false;
+        attributePRsToAgent = false;
+      };
+    };
+
+    rules = {
+      code-style = ''
+        ---
+        description: "Code style guidelines"
+        alwaysApply: true
+        ---
+        - Use consistent formatting
+        - Follow language conventions
+      '';
+    };
+  };
+
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+  nmt.script =
+    let
+      preexistingSettings = builtins.toFile "preexisting.json" (
+        builtins.toJSON {
+          version = 1;
+          editor.vimMode = true;
+          custom.agentSetting = "keep-me";
+        }
+      );
+
+      expectedContent = builtins.toFile "expected.json" ''
+        {
+          "attribution": {
+            "attributeCommitsToAgent": false,
+            "attributePRsToAgent": false
+          },
+          "custom": {
+            "agentSetting": "keep-me"
+          },
+          "editor": {
+            "vimMode": false
+          },
+          "network": {
+            "useHttp1ForAgent": false
+          },
+          "permissions": {
+            "allow": [
+              "Shell(git diff:*)",
+              "Shell(git log:*)"
+            ],
+            "deny": [
+              "Shell(rm:*)",
+              "Read(.env*)"
+            ]
+          },
+          "version": 1
+        }
+      '';
+
+      configPath = ".cursor/cli-config.json";
+      activationScript = pkgs.writeScript "activation" config.home.activation.cursorAgentCliConfig.data;
+    in
+    ''
+      export HOME=$TMPDIR/hm-user
+
+      # Simulate preexisting settings written by cursor agent
+      mkdir -p $HOME/.cursor
+      cat ${preexistingSettings} > $HOME/${configPath}
+
+      # Run the activation script
+      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+      chmod +x $TMPDIR/activate
+      $TMPDIR/activate
+
+      # Validate the merged settings (nix settings override, agent additions preserved)
+      assertFileExists "$HOME/${configPath}"
+      assertFileContent "$HOME/${configPath}" "${expectedContent}"
+
+      # Test idempotency
+      $TMPDIR/activate
+      assertFileExists "$HOME/${configPath}"
+      assertFileContent "$HOME/${configPath}" "${expectedContent}"
+
+      # Validate rules still work via home.file
+      assertFileExists home-files/.cursor/rules/code-style.md
+      assertFileContent home-files/.cursor/rules/code-style.md \
+        ${./expected-code-style.md}
+    '';
+}

--- a/tests/modules/programs/cursor-agent/mcp-integration.nix
+++ b/tests/modules/programs/cursor-agent/mcp-integration.nix
@@ -1,0 +1,57 @@
+{
+  programs = {
+    cursor-agent = {
+      enable = true;
+      package = null;
+
+      enableMcpIntegration = true;
+
+      mcpServers = {
+        context7 = {
+          type = "http";
+          url = "https://mcp.context7.com/mcp";
+        };
+        filesystem = {
+          type = "stdio";
+          command = "npx";
+          args = [
+            "-y"
+            "@modelcontextprotocol/server-filesystem"
+            "/tmp"
+          ];
+        };
+      };
+    };
+    mcp = {
+      enable = true;
+      servers = {
+        filesystem = {
+          command = "npx";
+          args = [
+            "-y"
+            "@modelcontextprotocol/server-filesystem"
+            "/other-tmp"
+          ];
+        };
+        database = {
+          command = "npx";
+          args = [
+            "-y"
+            "@bytebase/dbhub"
+            "--dsn"
+            "postgresql://user:pass@localhost:5432/db"
+          ];
+          env = {
+            DATABASE_URL = "postgresql://user:pass@localhost:5432/db";
+          };
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/mcp.json
+    assertFileContent home-files/.cursor/mcp.json \
+      ${./expected-mcp-integration.json}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/mcp.nix
+++ b/tests/modules/programs/cursor-agent/mcp.nix
@@ -1,0 +1,28 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+
+    mcpServers = {
+      context7 = {
+        type = "http";
+        url = "https://mcp.context7.com/mcp";
+      };
+      filesystem = {
+        type = "stdio";
+        command = "npx";
+        args = [
+          "-y"
+          "@modelcontextprotocol/server-filesystem"
+          "/tmp"
+        ];
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/mcp.json
+    assertFileContent home-files/.cursor/mcp.json \
+      ${./expected-mcp.json}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/rules-dir.nix
+++ b/tests/modules/programs/cursor-agent/rules-dir.nix
@@ -1,0 +1,13 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+    rulesDir = ./rules;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/rules/test-rule.md
+    assertFileContent home-files/.cursor/rules/test-rule.md \
+      ${./rules/test-rule.md}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/rules-path.nix
+++ b/tests/modules/programs/cursor-agent/rules-path.nix
@@ -1,0 +1,15 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+    rules = {
+      test-rule = ./rules/test-rule.md;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/rules/test-rule.md
+    assertFileContent home-files/.cursor/rules/test-rule.md \
+      ${./rules/test-rule.md}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/rules/test-rule.md
+++ b/tests/modules/programs/cursor-agent/rules/test-rule.md
@@ -1,0 +1,5 @@
+---
+description: "Test rule"
+alwaysApply: true
+---
+This is a test rule.

--- a/tests/modules/programs/cursor-agent/skills-dir.nix
+++ b/tests/modules/programs/cursor-agent/skills-dir.nix
@@ -1,0 +1,14 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+
+    skillsDir = ./skills;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/skills/deploy-app/SKILL.md
+    assertFileContent home-files/.cursor/skills/deploy-app/SKILL.md \
+      ${./skills/deploy-app/SKILL.md}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/skills-inline.nix
+++ b/tests/modules/programs/cursor-agent/skills-inline.nix
@@ -1,0 +1,25 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+
+    skills = {
+      pdf-processing = ''
+        ---
+        name: pdf-processing
+        description: Extract text and tables from PDF files
+        ---
+
+        # PDF Processing
+
+        Use pdfplumber to extract text from PDFs.
+      '';
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/skills/pdf-processing/SKILL.md
+    assertFileContent home-files/.cursor/skills/pdf-processing/SKILL.md \
+      ${./expected-pdf-processing-skill.md}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/skills-path.nix
+++ b/tests/modules/programs/cursor-agent/skills-path.nix
@@ -1,0 +1,16 @@
+{
+  programs.cursor-agent = {
+    enable = true;
+    package = null;
+
+    skills = {
+      deploy-app = ./skills/deploy-app/SKILL.md;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.cursor/skills/deploy-app/SKILL.md
+    assertFileContent home-files/.cursor/skills/deploy-app/SKILL.md \
+      ${./skills/deploy-app/SKILL.md}
+  '';
+}

--- a/tests/modules/programs/cursor-agent/skills/deploy-app/SKILL.md
+++ b/tests/modules/programs/cursor-agent/skills/deploy-app/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: deploy-app
+description: Deploy the application to staging or production
+---
+
+# Deploy App
+
+Run the deployment script for the target environment.


### PR DESCRIPTION
### Description

Add a new `programs.cursor-agent` module for managing [Cursor Agent CLI](https://cursor.com/docs/cli) configuration through Home Manager.

The module supports:
- Configuration through `programs.cursor-agent.settings`
- Custom rules via `programs.cursor-agent.rules` / `rulesDir`
- Custom agents (subagents) via `programs.cursor-agent.agents` / `agentsDir`
- Custom commands via `programs.cursor-agent.commands` / `commandsDir`
- Custom skills via `programs.cursor-agent.skills` / `skillsDir`
- MCP (Model Context Protocol) servers via `programs.cursor-agent.mcpServers`
- MCP integration with `programs.mcp` via `programs.cursor-agent.enableMcpIntegration`
- Package installation control via `programs.cursor-agent.package`

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or
  `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.
- [x] Code tested through `nix run .#tests -- test-all` or
  `nix-shell --pure tests -A run.all`.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like
  ```
  {component}: {description}

  {long description}
  ```
  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
- If this PR adds a new module
  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)