### PR TITLE
treewide: remove xorg package set

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -224,7 +224,7 @@ in
 
         (mkIf cfg.x11.enable {
           xsession.profileExtra = ''
-            ${pkgs.xorg.xsetroot}/bin/xsetroot -xcf ${cursorPath} ${toString cfg.size}
+            ${lib.getExe pkgs.xsetroot} -xcf ${cursorPath} ${toString cfg.size}
           '';
 
           xresources.properties = {

--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -371,7 +371,7 @@ in
                     exit 1
                 esac
 
-                echo "Xft.dpi: $DPI" | ''${pkgs.xorg.xrdb}/bin/xrdb -merge
+                echo "Xft.dpi: $DPI" | ''${lib.getExe pkgs.xrdb} -merge
               '''
             };
           }

--- a/modules/services/fusuma.nix
+++ b/modules/services/fusuma.nix
@@ -100,11 +100,11 @@ in
       default = with pkgs; [
         xdotool
         coreutils
-        xorg.xprop
+        xprop
       ];
-      defaultText = literalExpression "pkgs.xdotool pkgs.coreutils pkgs.xorg.xprop";
+      defaultText = literalExpression "pkgs.xdotool pkgs.coreutils pkgs.xprop";
       example = literalExpression ''
-        with pkgs; [ xdotool coreutils xorg.xprop ];
+        with pkgs; [ xdotool coreutils xprop ];
       '';
       description = ''
         Extra packages needs to bring to the scope of fusuma service.

--- a/modules/services/grobi.nix
+++ b/modules/services/grobi.nix
@@ -45,7 +45,7 @@ in
               primary = true;
               atomic = true;
               execute_after = [
-                "''${pkgs.xorg.xrandr}/bin/xrandr --dpi 96"
+                "''${lib.getExe pkgs.xrandr} --dpi 96"
                 "''${pkgs.xmonad-with-packages}/bin/xmonad --restart";
               ];
             }
@@ -56,7 +56,7 @@ in
               primary = true;
               atomic = true;
               execute_after = [
-                "''${pkgs.xorg.xrandr}/bin/xrandr --dpi 120"
+                "''${lib.getExe pkgs.xrandr} --dpi 120"
                 "''${pkgs.xmonad-with-packages}/bin/xmonad --restart";
               ];
             }
@@ -92,7 +92,7 @@ in
         ExecStart = "${lib.getExe cfg.package} watch -v";
         Restart = "always";
         RestartSec = "2s";
-        Environment = [ "PATH=${pkgs.xorg.xrandr}/bin:${pkgs.bash}/bin" ];
+        Environment = [ "PATH=${pkgs.xrandr}/bin:${pkgs.bash}/bin" ];
       };
 
       Install = {

--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -161,7 +161,7 @@ in
         };
       }
       (mkIf (!cfg.xautolock.enable) {
-        systemd.user.services.xss-lock.Service.ExecStartPre = "${pkgs.xorg.xset}/bin/xset s ${
+        systemd.user.services.xss-lock.Service.ExecStartPre = "${lib.getExe pkgs.xset} s ${
           toString (cfg.inactiveInterval * 60)
         } ${toString cfg.xss-lock.screensaverCycle}";
       })

--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -31,7 +31,7 @@ let
     in
     "${n}: ${formatValue v}";
 
-  xrdbMerge = "${pkgs.xorg.xrdb}/bin/xrdb -merge ${cfg.path}";
+  xrdbMerge = "${lib.getExe pkgs.xrdb} -merge ${cfg.path}";
 
 in
 {

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -150,7 +150,7 @@ in
                   ++ [ "-option ''" ]
                   ++ map (v: "-option '${v}'") options;
               in
-              "${pkgs.xorg.setxkbmap}/bin/setxkbmap ${toString args}";
+              "${lib.getExe pkgs.setxkbmap} ${toString args}";
           };
         };
 

--- a/tests/modules/misc/xsession/basic.nix
+++ b/tests/modules/misc/xsession/basic.nix
@@ -8,16 +8,6 @@
       profileExtra = "profile extra commands";
     };
 
-    nixpkgs.overlays = [
-      (self: super: {
-        xorg = super.xorg // {
-          setxkbmap = super.xorg.setxkbmap // {
-            outPath = "@setxkbmap@";
-          };
-        };
-      })
-    ];
-
     nmt.script = ''
       assertFileExists home-files/.xprofile
       assertFileContent \

--- a/tests/modules/misc/xsession/keyboard-without-layout.nix
+++ b/tests/modules/misc/xsession/keyboard-without-layout.nix
@@ -17,16 +17,6 @@
       profileExtra = "profile extra commands";
     };
 
-    nixpkgs.overlays = [
-      (self: super: {
-        xorg = super.xorg // {
-          setxkbmap = super.xorg.setxkbmap // {
-            outPath = "@setxkbmap@";
-          };
-        };
-      })
-    ];
-
     nmt.script = ''
       assertFileExists home-files/.config/systemd/user/setxkbmap.service
       assertFileContent \

--- a/tests/modules/services/fusuma/expected-service.service
+++ b/tests/modules/services/fusuma/expected-service.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-Environment=PATH=@coreutils@/bin:@xdotool@/bin:@xorg.xprop@/bin
+Environment=PATH=@coreutils@/bin:@xdotool@/bin:@xprop@/bin
 ExecStart=@fusuma@/bin/fusuma
 
 [Unit]

--- a/tests/modules/services/fusuma/service.nix
+++ b/tests/modules/services/fusuma/service.nix
@@ -8,7 +8,7 @@
     extraPackages = [
       (config.lib.test.mkStubPackage { outPath = "@coreutils@"; })
       (config.lib.test.mkStubPackage { outPath = "@xdotool@"; })
-      (config.lib.test.mkStubPackage { outPath = "@xorg.xprop@"; })
+      (config.lib.test.mkStubPackage { outPath = "@xprop@"; })
     ];
     settings = { };
   };


### PR DESCRIPTION
Xorg package set removed, now aliases.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
