### PR TITLE
starship: skip one program invocation on each shell init

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -120,14 +120,14 @@ in
 
     programs.fish.${initFish} = mkIf cfg.enableFishIntegration ''
       if test "$TERM" != "dumb"
-        ${lib.getExe cfg.package} init fish | source
+        ${lib.getExe cfg.package} init fish --print-full-init | source
         ${lib.optionalString cfg.enableTransience "enable_transience"}
       end
     '';
 
     programs.ion.initExtra = mkIf cfg.enableIonIntegration ''
       if test $TERM != "dumb"
-        eval $(${lib.getExe cfg.package} init ion)
+        eval $(${lib.getExe cfg.package} init ion --print-full-init)
       end
     '';
 


### PR DESCRIPTION
### Description

Same simplification as #2862, but for fish and ion.

Both of the shell's indirect init functions do identical or equivalent as what we do in the module already.

#### Fish
```bash
❯ starship init ion
eval $(starship init ion --print-full-init)
❯ starship init fish
source (starship init fish --print-full-init | psub)
```

I'm not sure why the fish code using psub instead of just `starship init fish --print-full-init | source`, but the latter works perfectly fine when I try piping the full init to `source`.

See also https://github.com/starship/starship/issues/2637 for discussion about this. The indirection for fish was removed and the reverted because it was incompatible with `eval (starship init fish)`, but that isn't relevant for us.

I haven't actually tried the ion simplification, but since the output is identical to the code in this module, I can't imagine that it could possibly break anything

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
