### PR TITLE
gemini-cli: make config file mutable

### DIFF
--- a/tests/modules/programs/gemini-cli/commands.nix
+++ b/tests/modules/programs/gemini-cli/commands.nix
@@ -2,12 +2,6 @@
   programs.gemini-cli = {
     enable = true;
     defaultModel = "gemini-2.5-flash";
-    settings = {
-      theme = "Default";
-      vimMode = true;
-      preferredEditor = "nvim";
-      autoAccept = true;
-    };
     commands = {
       changelog = {
         prompt = ''
@@ -22,9 +16,6 @@
     };
   };
   nmt.script = ''
-    assertFileExists home-files/.gemini/settings.json
-    assertFileContent home-files/.gemini/settings.json \
-      ${./settings.json}
     assertFileContent home-files/.gemini/commands/changelog.toml \
       ${./changelog.toml}
     assertFileContent home-files/.gemini/commands/git/fix.toml \

--- a/tests/modules/programs/gemini-cli/default.nix
+++ b/tests/modules/programs/gemini-cli/default.nix
@@ -1,4 +1,4 @@
 {
-  gemini-cli-settings = ./settings.nix;
+  gemini-cli-commands = ./commands.nix;
   gemini-cli-context = ./context.nix;
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR changes the way we deploy the config file for `gemini-cli` since it must be mutable in order to allow subtle changes in the config file such as auth. I re-implemented it adding a new entry to the activation script, instead of symlinking `~/.gemini/settings.json` to a file in `/nix/store`. This way the settings defined in the Home-Manager configuration will be option that will be forced to that defined value, while also allowing the program to change the file as it needs. Should close #8654.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
