### PR TITLE
syncthing: improvements

### DIFF
--- a/modules/misc/news/2026/02/2026-02-08_17-47-15.nix
+++ b/modules/misc/news/2026/02/2026-02-08_17-47-15.nix
@@ -1,0 +1,8 @@
+{
+  time = "2026-02-08T16:47:15+00:00";
+  condition = true;
+  message = ''
+
+    A new assertion prevents specifying the `services.syncthing.passwordFile` option without an accompanying `services.syncthing.settings.gui.user`.
+  '';
+}

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -770,6 +770,13 @@ in
 
   config = lib.mkMerge [
     (lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = (cfg.passwordFile) == null || (cfg.settings ? gui.user);
+          message = "Missing username for the provided password to connect to the GUI.";
+        }
+      ];
+
       home.packages = [ (lib.getOutput "man" cfg.package) ];
 
       systemd.user.services = {

--- a/tests/modules/services/syncthing/default.nix
+++ b/tests/modules/services/syncthing/default.nix
@@ -1,5 +1,6 @@
 { lib, pkgs, ... }:
 {
   syncthing-extra-options = ./extra-options.nix;
+  syncthing-password-without-user = ./password-without-user.nix;
 }
 // (lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (import ./linux/default.nix))

--- a/tests/modules/services/syncthing/fake-password-file
+++ b/tests/modules/services/syncthing/fake-password-file
@@ -1,0 +1,1 @@
+unused dummy value

--- a/tests/modules/services/syncthing/password-without-user.nix
+++ b/tests/modules/services/syncthing/password-without-user.nix
@@ -1,0 +1,10 @@
+{
+  services.syncthing = {
+    enable = true;
+    passwordFile = ./fake-password-file;
+  };
+
+  test.asserts.assertions.expected = [
+    "Missing username for the provided password to connect to the GUI."
+  ];
+}


### PR DESCRIPTION
### Description

* Slightly more extensive example for the `settings` options; 
* Assertion to prevent a confusing issue about ineffective configuration: GUI is not password protected when setting a password using the `settings.passwordFile` option while no user is specified.

### Checklist

- [ ] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.
- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like
  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
