### PR TITLE
crush: add module

### DIFF
--- a/all-maintainers.nix
+++ b/all-maintainers.nix
@@ -951,6 +951,14 @@
     name = "Robin Stumm";
     source = "nixpkgs";
   };
+  rane = {
+    name = "Rane";
+    email = "rane+git@junkyard.systems";
+    matrix = "@rane:junkyard.systems";
+    github = "digitalrane";
+    githubId = 1829286;
+    keys = [ { fingerprint = "EBB6 0EE1 488F D04C D922  C039 AE96 1AF5 9D40 10B5"; } ];
+  };
   diniamo = {
     email = "diniamo53@gmail.com";
     github = "diniamo";

--- a/flake.nix
+++ b/flake.nix
@@ -54,10 +54,18 @@
           "x86_64-linux"
         ];
 
+        # Helper to get pkgs with unfree allowed for tests
+        pkgsWithUnfree =
+          system:
+          import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+          };
+
         testChunks =
           system:
           let
-            pkgs = nixpkgs.legacyPackages.${system};
+            pkgs = pkgsWithUnfree system;
             inherit (pkgs) lib;
 
             # Create chunked test packages for better CI parallelization
@@ -99,7 +107,7 @@
         integrationTests =
           system:
           let
-            pkgs = nixpkgs.legacyPackages.${system};
+            pkgs = pkgsWithUnfree system;
             inherit (pkgs) lib;
           in
           lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (
@@ -113,7 +121,7 @@
         buildTests =
           system:
           let
-            pkgs = nixpkgs.legacyPackages.${system};
+            pkgs = pkgsWithUnfree system;
             tests = import ./tests { inherit pkgs; };
             renameTestPkg = n: nixpkgs.lib.nameValuePair "test-${n}";
           in
@@ -122,7 +130,7 @@
         buildTestsNoBig =
           system:
           let
-            pkgs = nixpkgs.legacyPackages.${system};
+            pkgs = pkgsWithUnfree system;
             tests = import ./tests {
               inherit pkgs;
               enableBig = false;
@@ -135,7 +143,7 @@
         buildTestsNoBigIfd =
           system:
           let
-            pkgs = nixpkgs.legacyPackages.${system};
+            pkgs = pkgsWithUnfree system;
             tests = import ./tests {
               inherit pkgs;
               enableBig = false;
@@ -149,7 +157,7 @@
         integrationTestPackages =
           system:
           let
-            pkgs = nixpkgs.legacyPackages.${system};
+            pkgs = pkgsWithUnfree system;
             inherit (pkgs) lib;
             tests = import ./tests/integration { inherit pkgs lib; };
             renameTestPkg = n: lib.nameValuePair "integration-test-${n}";

--- a/modules/misc/news/2026/02/2026-02-07_20-00-00.nix
+++ b/modules/misc/news/2026/02/2026-02-07_20-00-00.nix
@@ -1,0 +1,11 @@
+{
+  time = "2026-02-07T20:00:00+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.crush'
+
+    Crush is an agentic coding CLI from Charmbracelet that supports multiple
+    AI providers, Language Server Protocol (LSP) integration, Model Context
+    Protocol (MCP), and the Agent Skills open standard.
+  '';
+}

--- a/modules/programs/crush.nix
+++ b/modules/programs/crush.nix
@@ -1,0 +1,321 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.crush;
+  jsonFormat = pkgs.formats.json { };
+
+  # Recursively filter nulls (keep all non-null values including false)
+  filterNulls =
+    value:
+    if lib.isAttrs value then
+      let
+        filtered = lib.mapAttrs (n: v: filterNulls v) value;
+      in
+      lib.filterAttrs (n: v: v != null && v != { } && v != [ ]) filtered
+    else if lib.isList value then
+      map filterNulls value
+    else
+      value;
+
+  # Remove transport-specific fields from MCP configs to prevent invalid combinations
+  # (stdio servers can't have url/headers; http servers can't have command/args)
+  filterMcpServer =
+    server:
+    let
+      filtered = filterNulls server;
+      withoutDisabled =
+        if filtered ? disabled && filtered.disabled == false then
+          removeAttrs filtered [ "disabled" ]
+        else
+          filtered;
+      withType = withoutDisabled // lib.optionalAttrs (!withoutDisabled ? type) { type = "stdio"; };
+    in
+    if withType.type == "stdio" then
+      removeAttrs withType [
+        "url"
+        "headers"
+      ]
+    else
+      removeAttrs withType [
+        "command"
+        "args"
+        "env"
+      ];
+
+  # Transform MCP servers from programs.mcp if integration is enabled
+  # Defaults type to "stdio" if command is present (and not explicitly set),
+  # or "http" if url is present (and not explicitly set)
+  transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
+    lib.mapAttrs (
+      name: server:
+      let
+        typeFromTransport = if server ? url then "http" else "stdio";
+        withoutDisabled = removeAttrs server [ "disabled" ];
+      in
+      withoutDisabled // lib.optionalAttrs (!server ? type) { type = typeFromTransport; }
+    ) config.programs.mcp.servers
+  );
+
+  # Loads secrets from files into env vars at runtime (keeps them out of the Nix store)
+  makeSecretLoaderCode =
+    secretEnvVars:
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (name: path: ''
+        if [ -f "${path}" ]; then
+          export ${name}="$(cat ${lib.escapeShellArg path})"
+        fi
+      '') secretEnvVars
+    );
+in
+{
+  meta.maintainers = with lib.maintainers; [ rane ];
+
+  options.programs.crush = {
+    enable = lib.mkEnableOption "Crush, an agentic coding CLI from Charmbracelet";
+
+    package = lib.mkPackageOption pkgs "crush" { };
+
+    finalPackage = lib.mkOption {
+      type = lib.types.package;
+      readOnly = true;
+      internal = true;
+      description = ''
+        Wraps the crush package to inject secret environment variables at runtime.
+        This is the actual package installed to {env}`$PATH`.
+        If {option}`secretEnvVars` is empty, this equals {option}`package`.
+      '';
+    };
+
+    enableMcpIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        When enabled, merges MCP servers from {option}`programs.mcp.servers` into {option}`programs.crush.settings.mcp`.
+
+        Transforms MCP servers from {option}`programs.mcp.servers` to Crush format:
+        - If `url` is set, `type` defaults to `"http"`
+        - If `command` is set, `type` defaults to `"stdio"`
+
+        Servers explicitly configured in {option}`programs.crush.settings.mcp` take precedence over imported servers.
+      '';
+    };
+
+    settings = lib.mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = {
+        options = {
+          disabled_tools = [
+            "bash"
+            "sourcegraph"
+          ];
+          skills_paths = [
+            "~/.config/crush/skills"
+            "./project-skills"
+          ];
+          initialize_as = "AGENTS.md";
+          attribution = {
+            trailer_style = "co-authored-by";
+            generated_with = true;
+          };
+        };
+        permissions = {
+          allowed_tools = [
+            "view"
+            "ls"
+            "grep"
+            "edit"
+          ];
+        };
+        lsp = {
+          go.command = "gopls";
+          typescript = {
+            command = "typescript-language-server";
+            args = [ "--stdio" ];
+          };
+        };
+        mcp = {
+          filesystem = {
+            command = "npx";
+            args = [
+              "-y"
+              "@modelcontextprotocol/server-filesystem"
+              "/tmp"
+            ];
+          };
+          github = {
+            type = "http";
+            url = "https://api.githubcopilot.com/mcp/";
+            headers.Authorization = "Bearer $(echo $GH_PAT)";
+          };
+        };
+        providers = {
+          deepseek = {
+            type = "openai-compat";
+            base_url = "https://api.deepseek.com/v1";
+            api_key = "$DEEPSEEK_API_KEY";
+            models = [
+              {
+                id = "deepseek-chat";
+                name = "Deepseek V3";
+                cost_per_1m_in = 0.27;
+                cost_per_1m_out = 1.1;
+                context_window = 64000;
+              }
+            ];
+          };
+        };
+      };
+      description = ''
+        Main JSON configuration for Crush.
+        Writes to {file}`$HOME/.config/crush/crush.json`.
+
+        Configure LSP servers ({option}`settings.lsp`), MCP servers ({option}`settings.mcp`),
+        AI providers ({option}`settings.providers`), and general options ({option}`settings.options`).
+
+        For sensitive values like API keys, use {option}`secretEnvVars`
+        to inject them from files at runtime.
+
+        See <https://github.com/charmbracelet/crush> for full configuration options.
+      '';
+    };
+
+    skills = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.either lib.types.lines lib.types.path);
+      default = { };
+      description = ''
+        Agent Skills configuration.
+        The attribute name becomes the skill filename. Values can be:
+        - Inline content as a string (creates a .md file)
+        - A path to a file containing the skill content
+        - A path to a directory (symlinked recursively)
+        - Empty to create a placeholder
+      '';
+      example = lib.literalExpression ''
+        {
+          pdf-processing = '''
+            ---
+            name: pdf-processing
+            description: Extract text and tables from PDF files
+            ---
+
+            # PDF Processing
+
+            Use pdfplumber to extract text from PDFs.
+          ''';
+          xlsx = ./skills/xlsx.md;
+          data-analysis = ./skills/data-analysis;
+        }
+      '';
+    };
+
+    skillsDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a directory containing skill files for Crush.
+        Symlinks skill files from this directory to ~/.config/crush/skills/.
+      '';
+      example = lib.literalExpression "./skills";
+    };
+
+    secretEnvVars = lib.mkOption {
+      type = lib.types.attrsOf lib.types.path;
+      default = { };
+      description = ''
+        Environment variables to inject from files at runtime.
+        Use this for secure secret management with tools like sops-nix and agenix.
+
+        The attribute name is the environment variable name, and the value
+        is the path to a file containing the secret.
+      '';
+      example = lib.literalExpression ''
+        {
+          ANTHROPIC_API_KEY = config.sops.secrets.anthropic-api-key.path;
+          OPENAI_API_KEY = config.sops.secrets.openai-api-key.path;
+          DEEPSEEK_API_KEY = config.age.secrets.deepseek-api-key.path;
+        }
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.skills != { } && cfg.skillsDir != null);
+        message = "Cannot specify both `programs.crush.skills` and `programs.crush.skillsDir`";
+      }
+    ];
+
+    programs.crush.finalPackage =
+      if cfg.secretEnvVars != { } then
+        pkgs.writeShellScriptBin "crush" ''
+          ${makeSecretLoaderCode cfg.secretEnvVars}
+          exec ${lib.getExe cfg.package} "$@"
+        ''
+      else
+        cfg.package;
+
+    home = {
+      packages = [ cfg.finalPackage ];
+
+      file =
+        let
+          # Filter and process settings sections
+          filteredSettings =
+            let
+              # Filter LSP section
+              withLsp =
+                if cfg.settings ? lsp then
+                  cfg.settings // { lsp = lib.mapAttrs (n: v: filterNulls v) cfg.settings.lsp; }
+                else
+                  cfg.settings;
+
+              # Filter and merge MCP section
+              withMcp =
+                let
+                  settingsMcp = cfg.settings.mcp or { };
+                  combined = transformedMcpServers // settingsMcp;
+                  filteredMcp = lib.mapAttrs (n: v: filterMcpServer v) combined;
+                in
+                if filteredMcp != { } then withLsp // { mcp = filteredMcp; } else withLsp;
+
+              # Filter providers section
+              withProviders =
+                if cfg.settings ? providers then
+                  withMcp // { providers = lib.mapAttrs (n: v: filterNulls v) cfg.settings.providers; }
+                else
+                  withMcp;
+            in
+            filterNulls withProviders;
+
+          finalConfig = filteredSettings;
+        in
+        {
+          ".config/crush/crush.json" = lib.mkIf (finalConfig != { }) {
+            source = jsonFormat.generate "crush-config.json" finalConfig;
+          };
+
+          ".config/crush/skills" = lib.mkIf (cfg.skillsDir != null) { source = cfg.skillsDir; };
+        }
+        // lib.optionalAttrs (cfg.skills != { } && cfg.skillsDir == null) (
+          lib.mapAttrs' (
+            name: content:
+            if lib.isPath content && lib.pathIsDirectory content then
+              lib.nameValuePair ".config/crush/skills/${name}" {
+                source = content;
+                recursive = true;
+              }
+            else
+              lib.nameValuePair ".config/crush/skills/${name}.md" (
+                if lib.isPath content then { source = content; } else { text = content; }
+              )
+          ) cfg.skills
+        );
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,5 +1,7 @@
 {
-  pkgs ? import <nixpkgs> { },
+  pkgs ? import <nixpkgs> {
+    config.allowUnfree = true;
+  },
   enableBig ? true,
   enableLegacyIfd ? false,
 }:

--- a/tests/modules/programs/crush/config.nix
+++ b/tests/modules/programs/crush/config.nix
@@ -1,0 +1,143 @@
+{
+  programs.crush = {
+    enable = true;
+
+    skillsDir = ./skills;
+
+    settings = {
+      options = {
+        disabled_tools = [
+          "bash"
+          "sourcegraph"
+        ];
+        skills_paths = [
+          "~/.config/crush/skills"
+          "./project-skills"
+        ];
+        initialize_as = "AGENTS.md";
+        attribution = {
+          trailer_style = "co-authored-by";
+          generated_with = true;
+        };
+        disable_provider_auto_update = true;
+        disable_metrics = true;
+      };
+
+      permissions = {
+        allowed_tools = [
+          "view"
+          "ls"
+          "grep"
+          "edit"
+        ];
+      };
+
+      lsp = {
+        go = {
+          command = "gopls";
+          env = {
+            GOTOOLCHAIN = "go1.24.5";
+          };
+        };
+        typescript = {
+          command = "typescript-language-server";
+          args = [ "--stdio" ];
+        };
+        nix = {
+          command = "nil";
+        };
+      };
+
+      mcp = {
+        filesystem = {
+          type = "stdio";
+          command = "npx";
+          args = [
+            "-y"
+            "@modelcontextprotocol/server-filesystem"
+            "/tmp"
+          ];
+          timeout = 120;
+        };
+        github = {
+          type = "http";
+          url = "https://api.githubcopilot.com/mcp/";
+          headers = {
+            Authorization = "Bearer $(echo $GH_PAT)";
+          };
+        };
+        streaming = {
+          type = "sse";
+          url = "https://example.com/mcp/sse";
+          headers = {
+            "API-Key" = "$(echo $API_KEY)";
+          };
+          disabled_tools = [ "some-tool" ];
+        };
+      };
+
+      providers = {
+        deepseek = {
+          type = "openai-compat";
+          base_url = "https://api.deepseek.com/v1";
+          api_key = "$DEEPSEEK_API_KEY";
+          models = [
+            {
+              id = "deepseek-chat";
+              name = "Deepseek V3";
+              cost_per_1m_in = 0.27;
+              cost_per_1m_out = 1.1;
+              cost_per_1m_in_cached = 0.07;
+              cost_per_1m_out_cached = 1.1;
+              context_window = 64000;
+              default_max_tokens = 5000;
+            }
+          ];
+        };
+        custom-anthropic = {
+          type = "anthropic";
+          base_url = "https://api.anthropic.com/v1";
+          api_key = "$ANTHROPIC_API_KEY";
+          extra_headers = {
+            "anthropic-version" = "2023-06-01";
+          };
+          models = [
+            {
+              id = "claude-sonnet-4-20250514";
+              name = "Claude Sonnet 4";
+              cost_per_1m_in = 3.0;
+              cost_per_1m_out = 15.0;
+              context_window = 200000;
+              default_max_tokens = 50000;
+              can_reason = true;
+              supports_attachments = true;
+            }
+          ];
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/crush/crush.json
+    assertFileContent home-files/.config/crush/crush.json ${./expected-config.json}
+
+    # Verify skills directory is linked
+    assertDirectoryExists home-files/.config/crush/skills
+    assertLinkExists home-files/.config/crush/skills
+
+    # Verify standalone skill file (test-skill.md)
+    assertFileExists home-files/.config/crush/skills/test-skill.md
+    assertFileRegex home-files/.config/crush/skills/test-skill.md "Test Skill"
+
+    # Verify standalone skill file (standalone-skill.md)
+    assertFileExists home-files/.config/crush/skills/standalone-skill.md
+    assertFileRegex home-files/.config/crush/skills/standalone-skill.md "Standalone Skill"
+
+    # Verify directory-based skill (directory-skill/)
+    assertDirectoryExists home-files/.config/crush/skills/directory-skill
+    assertFileExists home-files/.config/crush/skills/directory-skill/SKILL.md
+    assertFileRegex home-files/.config/crush/skills/directory-skill/SKILL.md "Directory Skill"
+    assertFileExists home-files/.config/crush/skills/directory-skill/README.md
+  '';
+}

--- a/tests/modules/programs/crush/default.nix
+++ b/tests/modules/programs/crush/default.nix
@@ -1,0 +1,6 @@
+{
+  crush-skill-assertion = ./skill-assertion.nix;
+  crush-config = ./config.nix;
+  crush-inline-skills = ./inline-skills.nix;
+  crush-empty-config = ./empty-config.nix;
+}

--- a/tests/modules/programs/crush/empty-config.nix
+++ b/tests/modules/programs/crush/empty-config.nix
@@ -1,0 +1,10 @@
+{
+  programs.crush = {
+    enable = true;
+    settings = { };
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/crush/crush.json
+  '';
+}

--- a/tests/modules/programs/crush/expected-config.json
+++ b/tests/modules/programs/crush/expected-config.json
@@ -1,0 +1,112 @@
+{
+  "lsp": {
+    "go": {
+      "command": "gopls",
+      "env": {
+        "GOTOOLCHAIN": "go1.24.5"
+      }
+    },
+    "nix": {
+      "command": "nil"
+    },
+    "typescript": {
+      "args": [
+        "--stdio"
+      ],
+      "command": "typescript-language-server"
+    }
+  },
+  "mcp": {
+    "filesystem": {
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/tmp"
+      ],
+      "command": "npx",
+      "timeout": 120,
+      "type": "stdio"
+    },
+    "github": {
+      "headers": {
+        "Authorization": "Bearer $(echo $GH_PAT)"
+      },
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    },
+    "streaming": {
+      "disabled_tools": [
+        "some-tool"
+      ],
+      "headers": {
+        "API-Key": "$(echo $API_KEY)"
+      },
+      "type": "sse",
+      "url": "https://example.com/mcp/sse"
+    }
+  },
+  "options": {
+    "attribution": {
+      "generated_with": true,
+      "trailer_style": "co-authored-by"
+    },
+    "disable_metrics": true,
+    "disable_provider_auto_update": true,
+    "disabled_tools": [
+      "bash",
+      "sourcegraph"
+    ],
+    "initialize_as": "AGENTS.md",
+    "skills_paths": [
+      "~/.config/crush/skills",
+      "./project-skills"
+    ]
+  },
+  "permissions": {
+    "allowed_tools": [
+      "view",
+      "ls",
+      "grep",
+      "edit"
+    ]
+  },
+  "providers": {
+    "custom-anthropic": {
+      "api_key": "$ANTHROPIC_API_KEY",
+      "base_url": "https://api.anthropic.com/v1",
+      "extra_headers": {
+        "anthropic-version": "2023-06-01"
+      },
+      "models": [
+        {
+          "can_reason": true,
+          "context_window": 200000,
+          "cost_per_1m_in": 3.0,
+          "cost_per_1m_out": 15.0,
+          "default_max_tokens": 50000,
+          "id": "claude-sonnet-4-20250514",
+          "name": "Claude Sonnet 4",
+          "supports_attachments": true
+        }
+      ],
+      "type": "anthropic"
+    },
+    "deepseek": {
+      "api_key": "$DEEPSEEK_API_KEY",
+      "base_url": "https://api.deepseek.com/v1",
+      "models": [
+        {
+          "context_window": 64000,
+          "cost_per_1m_in": 0.27,
+          "cost_per_1m_in_cached": 0.07,
+          "cost_per_1m_out": 1.1,
+          "cost_per_1m_out_cached": 1.1,
+          "default_max_tokens": 5000,
+          "id": "deepseek-chat",
+          "name": "Deepseek V3"
+        }
+      ],
+      "type": "openai-compat"
+    }
+  }
+}

--- a/tests/modules/programs/crush/inline-skills.nix
+++ b/tests/modules/programs/crush/inline-skills.nix
@@ -1,0 +1,54 @@
+{
+  programs.crush = {
+    enable = true;
+
+    settings = {
+      options = {
+        skills_paths = [ "~/.config/crush/skills" ];
+      };
+    };
+
+    skills = {
+      # Inline string skill
+      pdf-processing = ''
+        ---
+        name: pdf-processing
+        description: Extract text and tables from PDF files
+        ---
+
+        # PDF Processing
+
+        Use pdfplumber to extract text from PDFs.
+      '';
+
+      # Skills from file paths
+      test-skill = ./skills/test-skill.md;
+      standalone-skill = ./skills/standalone-skill.md;
+
+      # Directory-based skill
+      directory-skill = ./skills/directory-skill;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/crush/crush.json
+
+    # Verify inline string skill
+    assertFileExists home-files/.config/crush/skills/pdf-processing.md
+    assertFileRegex home-files/.config/crush/skills/pdf-processing.md "PDF Processing"
+    assertFileRegex home-files/.config/crush/skills/pdf-processing.md "pdfplumber"
+
+    # Verify file-based skills
+    assertFileExists home-files/.config/crush/skills/test-skill.md
+    assertFileRegex home-files/.config/crush/skills/test-skill.md "Test Skill"
+
+    assertFileExists home-files/.config/crush/skills/standalone-skill.md
+    assertFileRegex home-files/.config/crush/skills/standalone-skill.md "Standalone Skill"
+
+    # Verify directory-based skill
+    assertDirectoryExists home-files/.config/crush/skills/directory-skill
+    assertFileExists home-files/.config/crush/skills/directory-skill/SKILL.md
+    assertFileRegex home-files/.config/crush/skills/directory-skill/SKILL.md "Directory Skill"
+    assertFileExists home-files/.config/crush/skills/directory-skill/README.md
+  '';
+}

--- a/tests/modules/programs/crush/skill-assertion.nix
+++ b/tests/modules/programs/crush/skill-assertion.nix
@@ -1,0 +1,15 @@
+{
+  programs.crush = {
+    enable = true;
+
+    skills = {
+      test = "test skill content";
+    };
+
+    skillsDir = ./skills;
+  };
+
+  test.asserts.assertions.expected = [
+    "Cannot specify both `programs.crush.skills` and `programs.crush.skillsDir`"
+  ];
+}

--- a/tests/modules/programs/crush/skills/directory-skill/README.md
+++ b/tests/modules/programs/crush/skills/directory-skill/README.md
@@ -1,0 +1,3 @@
+# Directory Skill Resources
+
+This directory contains supporting files for the directory-skill.

--- a/tests/modules/programs/crush/skills/directory-skill/SKILL.md
+++ b/tests/modules/programs/crush/skills/directory-skill/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: directory-skill
+description: A skill in a directory structure for testing
+---
+
+# Directory Skill
+
+This is a skill that lives in a subdirectory with additional resources.

--- a/tests/modules/programs/crush/skills/standalone-skill.md
+++ b/tests/modules/programs/crush/skills/standalone-skill.md
@@ -1,0 +1,8 @@
+---
+name: standalone-skill
+description: A standalone skill file for testing
+---
+
+# Standalone Skill
+
+This is a standalone skill file (not in a subdirectory).

--- a/tests/modules/programs/crush/skills/test-skill.md
+++ b/tests/modules/programs/crush/skills/test-skill.md
@@ -1,0 +1,8 @@
+---
+name: test-skill
+description: A test skill for testing
+---
+
+# Test Skill
+
+This is a test skill for the skills directory test.


### PR DESCRIPTION
### Description

This adds a module for Charmbracelet Crush, an agentic coding tool.

The module supports:
- Setting main Crush configuration
- Configuring LSP servers
- Configuring MCP servers
- Configuring AI providers
- Configuring skills directory, or by setting a skills directory
- Including MCP server configuration via `programs.mcp`
- Secrets handling for sensitive values

This also enables non-free package installation in tests, which is required for some of the Nix build tests to pass in CI. Whilst not required for the unit tests included in this PR, other generic tests fail on this PR without the ability to install non-free software.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [X] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
