### PR TITLE
firefox: prepare xdg compliant configuration

### DIFF
--- a/modules/programs/firefox/default.nix
+++ b/modules/programs/firefox/default.nix
@@ -1,8 +1,20 @@
-{ lib, config, ... }:
+{
+  lib,
+  config,
+  options,
+  pkgs,
+  ...
+}:
 let
   inherit (lib) mkRemovedOptionModule;
 
   cfg = config.programs.firefox;
+
+  linuxConfigPath =
+    if lib.versionAtLeast config.home.stateVersion "26.11" then
+      "${config.xdg.configHome}/mozilla/firefox"
+    else
+      ".mozilla/firefox";
 
   modulePath = [
     "programs"
@@ -29,7 +41,7 @@ in
       visible = true;
 
       platforms.linux = {
-        configPath = ".mozilla/firefox";
+        configPath = linuxConfigPath;
       };
       platforms.darwin = {
         configPath = "Library/Application Support/Firefox";
@@ -57,6 +69,29 @@ in
   ];
 
   config = lib.mkIf cfg.enable {
+    warnings =
+      lib.optionals
+        (
+          pkgs.stdenv.hostPlatform.isLinux
+          && !lib.versionAtLeast config.home.stateVersion "26.11"
+          && options.programs.firefox.configPath.highestPrio >= 1500
+        )
+        [
+          ''
+            The default value of `programs.firefox.configPath` will change in a future release.
+            You are currently using the legacy default (`.mozilla/firefox`) because `home.stateVersion` is less than "26.11".
+
+            Please set `programs.firefox.configPath` explicitly to lock in your choice:
+              programs.firefox.configPath = ".mozilla/firefox";
+              # New default in 26.11+
+              programs.firefox.configPath = "''${config.xdg.configHome}/mozilla/firefox";
+
+            To migrate to the XDG path, move `~/.mozilla/firefox` to `~/.config/mozilla/firefox`.
+            Firefox keeps using the legacy path if `~/.mozilla/firefox` still exists.
+            Migrating profiles can break existing setups, so make a backup before moving.
+          ''
+        ];
+
     mozilla.firefoxNativeMessagingHosts =
       cfg.nativeMessagingHosts
       # package configured native messaging hosts (entire browser actually)

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -136,6 +136,13 @@ let
             lib.mkDefault "/home/hm-user"
           );
 
+          # NOTE: Added 2026-02-09
+          # Avoid option change warning for Firefox configPath
+          # Remove after deprecation period
+          programs.firefox.configPath = lib.mkIf (config.home.stateVersion == "18.09") (
+            lib.mkDefault ".mozilla/firefox"
+          );
+
           # Avoid including documentation since this will cause
           # unnecessary rebuilds of the tests.
           manual.manpages.enable = lib.mkDefault false;


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Supersedes #8672
Closes #8200

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
