### PR TITLE
colima: fix KeepAlive to prevent process accumulation on macOS

### DIFF
--- a/modules/services/colima.nix
+++ b/modules/services/colima.nix
@@ -202,7 +202,9 @@ in
             "--activate=${if profile.isActive then "true" else "false"}"
             "--save-config=false"
           ];
-          KeepAlive = true;
+          KeepAlive = {
+            SuccessfulExit = true;
+          };
           RunAtLoad = true;
           EnvironmentVariables.PATH = lib.makeBinPath [
             cfg.package

--- a/tests/modules/services/colima/darwin/expected-agent.plist
+++ b/tests/modules/services/colima/darwin/expected-agent.plist
@@ -8,7 +8,10 @@
 		<string>@colima@/bin:@perl@/bin:@docker@/bin:@openssh@/bin:@coreutils@/bin:@curl@/bin:@bashNonInteractive@/bin:@DarwinTools@/bin</string>
 	</dict>
 	<key>KeepAlive</key>
-	<true/>
+	<dict>
+		<key>SuccessfulExit</key>
+		<true/>
+	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.colima-default</string>
 	<key>ProgramArguments</key>


### PR DESCRIPTION
### Description

Change KeepAlive from boolean true to SuccessfulExit dictionary in the LaunchAgent configuration.
When colima fails to start (e.g., disk already attached), the boolean true setting causes
launchd to immediately restart it, spawning orphaned limactl usernet processes with each
restart.

Using SuccessfulExit = true ensures the service only restarts on clean exits (exit code 0),
preventing the aggressive restart loop that accumulates orphaned processes.

Fixes #8719.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
