### PR TITLE
syncthing: run darwin config updater at load

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -853,6 +853,7 @@ in
             enable = cleanedConfig != { };
             config = {
               ProgramArguments = [ "${updateConfig}" ];
+              RunAtLoad = true;
               WatchPaths = [
                 "${config.home.homeDirectory}/Library/Application Support/Syncthing/${watch_file}"
               ];

--- a/tests/modules/services/syncthing/darwin-init-run-at-load.nix
+++ b/tests/modules/services/syncthing/darwin-init-run-at-load.nix
@@ -1,0 +1,13 @@
+{
+  services.syncthing = {
+    enable = true;
+    settings.options.relaysEnabled = false;
+  };
+
+  nmt.script = ''
+    serviceFile=LaunchAgents/org.nix-community.home.syncthing-init.plist
+    assertFileExists "$serviceFile"
+    assertFileContains "$serviceFile" "<key>RunAtLoad</key>"
+    assertFileContains "$serviceFile" "<true/>"
+  '';
+}

--- a/tests/modules/services/syncthing/default.nix
+++ b/tests/modules/services/syncthing/default.nix
@@ -2,4 +2,7 @@
 {
   syncthing-extra-options = ./extra-options.nix;
 }
+// (lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+  syncthing-darwin-init-run-at-load = ./darwin-init-run-at-load.nix;
+})
 // (lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (import ./linux/default.nix))


### PR DESCRIPTION
## Summary
- run the `syncthing-init` launchd agent at load time on Darwin by setting `RunAtLoad = true`
- close a gap where settings-only changes (for example device introducer flags) could stay unapplied until `syncthing` restarted and touched the watch file
- add a Darwin regression test (`test-syncthing-darwin-init-run-at-load`) to assert the generated `syncthing-init` plist includes `RunAtLoad`

## Context
I hit this while moving a multi-device Syncthing setup to an introducer-based topology on macOS.

I changed `services.syncthing.settings.devices.<hub>.introducer = true` in Home Manager and ran `home-manager switch`. The generation switched successfully, but the running Syncthing config still showed `introducer = false` (`syncthing cli ... introducer get`).

The change only applied after manually restarting the launch agent with:

```bash
launchctl kickstart -k gui/$(id -u)/org.nix-community.home.syncthing
```

That restart caused the watch file to be touched and `syncthing-init` to run, which then reconciled config correctly.

## Why this change
On Darwin, `syncthing-init` was configured with `WatchPaths` only. For settings-only changes, the updated `syncthing-init` plist can be reloaded without the watch event firing immediately, so reconciliation may not happen until a later Syncthing restart.

Setting `RunAtLoad = true` ensures `syncthing-init` runs as soon as launchd loads/reloads the agent during activation, so declarative settings are applied without requiring a manual kickstart.

## Testing
- `nix run .#tests -- syncthing`