### PR TITLE
man: make `package` nullable and default to `null` on darwin

### DIFF
--- a/docs/release-notes/rl-2605.md
+++ b/docs/release-notes/rl-2605.md
@@ -36,3 +36,9 @@ changes are only active if the `home.stateVersion` option is set to
   you had the key `XDG_DESKTOP_DIR` before, you should now use the key
   `DESKTOP`. Home Manager 26.05 introduced a warning when the `XDG_<name>_DIR`
   form is used.
+
+- The [](#opt-programs.man.package) option now defaults to `null` on
+  Darwin because the GNU `man` from nixpkgs ships `apropos`/`man -k`
+  and `whatis`/`man -f` binaries that don't work on Darwin. Nix-installed
+  manual pages still work with macOS's built-in `man` via
+  [](#opt-home.extraOutputsToInstall).

--- a/tests/modules/programs/man/default.nix
+++ b/tests/modules/programs/man/default.nix
@@ -1,4 +1,10 @@
+{ lib, pkgs, ... }:
+
 {
   man-apropos = ./apropos.nix;
   man-no-manpath = ./no-manpath.nix;
+  man-no-caches-without-package = ./no-caches-without-package.nix;
+}
+// lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+  man-no-package-on-darwin = ./no-package-on-darwin.nix;
 }

--- a/tests/modules/programs/man/no-caches-without-package.nix
+++ b/tests/modules/programs/man/no-caches-without-package.nix
@@ -1,0 +1,19 @@
+{
+  config = {
+    home.stateVersion = "26.05";
+
+    programs.man = {
+      enable = true;
+      package = null;
+      generateCaches = true;
+    };
+
+    test.asserts.warnings.expected = [
+      "programs.man.generateCaches has no effect when programs.man.package is null"
+    ];
+
+    nmt.script = ''
+      assertPathNotExists home-files/.manpath
+    '';
+  };
+}

--- a/tests/modules/programs/man/no-package-on-darwin.nix
+++ b/tests/modules/programs/man/no-package-on-darwin.nix
@@ -1,0 +1,12 @@
+{
+  config = {
+    home.stateVersion = "26.05";
+
+    programs.man.enable = true;
+
+    nmt.script = ''
+      assertPathNotExists home-path/bin/man
+      assertPathNotExists home-files/.manpath
+    '';
+  };
+}


### PR DESCRIPTION
### Description

On macOS, the system ships its own `man`. The GNU version of `man` present in nixpkgs ships `apropos`/`man -k` and `whatis`/`man -f` binaries that don't work on darwin (likely related to https://github.com/NixOS/nixpkgs/issues/456879), so installing it effectively replaces a working man with one that only works for some things.

Note that Nix-installed manual pages still work fine with macOS's built-in man — they are
discovered through `home.extraOutputsToInstall`, which this module continues to set regardless of the package option. The only thing lost by not installing GNU man is the generateCaches/mandb functionality, and a warning is now emitted if that option is enabled with a null package.

Since this changes the default behavior for Darwin users who currently have
`programs.man.enable = true` (which is the default), it is gated behind `stateVersion >= 26.05`. Users on older state versions are unaffected.

Before this change, darwin users had to set `programs.man.enable = false` and modify `home.extraOutputsToInstall` manually, which I did myself in my config: https://github.com/iniw/system/blob/e2a202b613d7a6d41667f905f884a4c6688e3e04/modules/tools.nix#L69-L73

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
