### PR TITLE
window-managers/wayfire: fix configuration

### DIFF
--- a/modules/services/window-managers/wayfire.nix
+++ b/modules/services/window-managers/wayfire.nix
@@ -157,7 +157,7 @@
 
       finalPackage = pkgs.wayfire-with-plugins.override {
         wayfire = cfg.package;
-        plugins = cfg.plugins;
+        plugins = cfg.plugins ++ (lib.optional cfg.wf-shell.enable cfg.wf-shell.package);
       };
     in
     lib.mkIf cfg.enable {
@@ -172,8 +172,9 @@
         ]
       );
 
-      wayland.windowManager.wayfire = {
-        settings = {
+      xdg.configFile."wayfire.ini".text = lib.generators.toINI { } (
+        cfg.settings
+        // {
           autostart = lib.mkIf cfg.systemd.enable { inherit systemdActivation; };
           core = {
             plugins = lib.concatStringsSep " " (
@@ -184,12 +185,8 @@
             );
             xwayland = cfg.xwayland.enable;
           };
-        };
-
-        plugins = lib.optional cfg.wf-shell.enable cfg.wf-shell.package;
-      };
-
-      xdg.configFile."wayfire.ini".text = lib.generators.toINI { } cfg.settings;
+        }
+      );
 
       xdg.configFile."wf-shell.ini" = lib.mkIf cfg.wf-shell.enable {
         text = lib.generators.toINI { } cfg.wf-shell.settings;


### PR DESCRIPTION
For some reason nobody took notice of the fact that configuration gets overwritten by the module itself to an empty config.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
