### PR TITLE
walker: fix path and remove theme.layout

### DIFF
--- a/modules/services/walker.nix
+++ b/modules/services/walker.nix
@@ -41,7 +41,7 @@ in
       };
       description = ''
         Configuration settings for walker. All the available options can be found here:
-        <https://github.com/abenz1267/walker/wiki/Basic-Configuration>
+        <https://github.com/abenz1267/walker/blob/master/resources/config.toml>
       '';
     };
 
@@ -56,20 +56,20 @@ in
               description = "The theme name.";
             };
 
-            layout = mkOption {
-              inherit (tomlFormat) type;
-              default = { };
-              description = ''
-                The layout of the theme.
-
-                See <https://github.com/abenz1267/walker/wiki/Theming> for the full list of options.
-              '';
-            };
-
             style = mkOption {
               type = lines;
               default = "";
               description = "The styling of the theme, written in GTK CSS.";
+            };
+
+            layout = mkOption {
+              type = with types; attrsOf (either path lines);
+              default = { };
+              description = ''
+                The GTK XML layout used.
+                See the default layout for the correct structure: <https://github.com/abenz1267/walker/tree/master/resources/themes/default>
+              '';
+              example = lib.literalExpression ''{ "item" = ./myfile.xml; };'';
             };
           };
         });
@@ -111,10 +111,18 @@ in
     (mkIf (cfg.theme != null) {
       services.walker.settings.theme = cfg.theme.name;
       xdg.configFile = {
-        "walker/themes/${cfg.theme.name}.toml".source =
-          tomlFormat.generate "walker-theme-${cfg.theme.name}.toml" cfg.theme.layout;
-        "walker/themes/${cfg.theme.name}.css".text = cfg.theme.style;
-      };
+        "walker/themes/${cfg.theme.name}/style.css".text = cfg.theme.style;
+      }
+      // lib.mapAttrs' (
+        n: v:
+        lib.nameValuePair "walker/themes/${cfg.theme.name}/${n}.xml" {
+          source =
+            if builtins.isPath v || lib.isStorePath v then
+              v
+            else
+              pkgs.writeText "walker-theme-${cfg.theme.name}-${n}.xml" v;
+        }
+      ) cfg.theme.layout;
     })
   ]);
 }

--- a/tests/modules/services/walker/example-config.nix
+++ b/tests/modules/services/walker/example-config.nix
@@ -1,3 +1,7 @@
+{ pkgs, ... }:
+let
+  layout_xml = builtins.readFile ./item_dmenu.xml;
+in
 {
   services.walker = {
     enable = true;
@@ -17,41 +21,33 @@
 
     theme = {
       name = "mytheme";
-      layout = {
-        ui = {
-          anchors = {
-            bottom = true;
-            left = true;
-            right = true;
-            top = true;
-          };
-
-          window = {
-            h_align = "fill";
-            v_align = "fill";
-          };
-        };
-      };
       style = ''
         * {
           color: #dcd7ba;
         }
       '';
+      # create 2 identical files, one points into the store the other is a direct text
+      layout.item_dmenu_two = pkgs.writeText "item_dmenu.xml" layout_xml;
+      layout.item_dmenu_one = layout_xml;
     };
   };
 
   nmt.script = ''
     assertFileExists home-files/.config/walker/config.toml
-    assertFileExists home-files/.config/walker/themes/mytheme.toml
-    assertFileExists home-files/.config/walker/themes/mytheme.css
+    assertFileExists home-files/.config/walker/themes/mytheme/style.css
+    assertFileExists home-files/.config/walker/themes/mytheme/item_dmenu_one.xml
+    assertFileExists home-files/.config/walker/themes/mytheme/item_dmenu_two.xml
+
+    assertFileContent home-files/.config/walker/themes/mytheme/item_dmenu_one.xml \
+    ${./item_dmenu.xml}
+
+    assertFileContent home-files/.config/walker/themes/mytheme/item_dmenu_two.xml \
+    ${./item_dmenu.xml}
 
     assertFileContent home-files/.config/walker/config.toml \
     ${./config.toml}
 
-    assertFileContent home-files/.config/walker/themes/mytheme.toml \
-    ${./mytheme.toml}
-
-    assertFileContent home-files/.config/walker/themes/mytheme.css \
+    assertFileContent home-files/.config/walker/themes/mytheme/style.css \
     ${./mytheme.css}
   '';
 }

--- a/tests/modules/services/walker/item_dmenu.xml
+++ b/tests/modules/services/walker/item_dmenu.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"></requires>
+  <object class="GtkBox" id="ItemBox">
+    <style>
+      <class name="item-box"></class>
+    </style>
+    <property name="orientation">horizontal</property>
+    <property name="spacing">10</property>
+    <child>
+      <object class="GtkBox" id="ItemTextBox">
+        <style>
+          <class name="item-text-box"></class>
+        </style>
+        <property name="orientation">vertical</property>
+        <property name="hexpand">true</property>
+        <property name="vexpand">true</property>
+        <property name="vexpand-set">true</property>
+        <property name="spacing">0</property>
+        <child>
+          <object class="GtkLabel" id="ItemText">
+            <style>
+              <class name="item-text"></class>
+            </style>
+            <property name="vexpand">true</property>
+            <property name="xalign">0</property>
+            <property name="lines">1</property>
+            <property name="ellipsize">3</property>
+            <property name="single-line-mode">true</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel" id="QuickActivation">
+        <style>
+          <class name="item-quick-activation"></class>
+        </style>
+        <property name="wrap">false</property>
+        <property name="valign">center</property>
+        <property name="xalign">0</property>
+        <property name="yalign">0.5</property>
+      </object>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
### Description

- this removes theme.layout as upstream changed it
- fixes path change of css walker/themes/$name.css -> themes/$name/style.css

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

