### PR TITLE
git: respect programs.msmtp.package

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -402,7 +402,7 @@ in
               lib.nameValuePair "sendemail.${name}" (
                 if account.msmtp.enable then
                   {
-                    sendmailCmd = "${pkgs.msmtp}/bin/msmtp";
+                    sendmailCmd = lib.getExe config.programs.msmtp.package;
                     envelopeSender = "auto";
                     from = "${realName} <${address}>";
                   }

--- a/modules/programs/notmuch/default.nix
+++ b/modules/programs/notmuch/default.nix
@@ -72,6 +72,8 @@ in
     programs.notmuch = {
       enable = lib.mkEnableOption "Notmuch mail indexer";
 
+      package = lib.mkPackageOption pkgs "notmuch" { };
+
       new = mkOption {
         type = types.submodule {
           options = {
@@ -197,7 +199,7 @@ in
       }
     ];
 
-    home.packages = [ pkgs.notmuch ];
+    home.packages = [ cfg.package ];
 
     home.sessionVariables = {
       NOTMUCH_CONFIG = "${config.xdg.configHome}/notmuch/default/config";
@@ -208,7 +210,7 @@ in
       let
         hook = name: cmds: {
           "notmuch/default/hooks/${name}".source = pkgs.writeShellScript name ''
-            export PATH="${pkgs.notmuch}/bin''${PATH:+:}$PATH"
+            export PATH="${cfg.package}/bin''${PATH:+:}$PATH"
             export NOTMUCH_CONFIG="${config.xdg.configHome}/notmuch/default/config"
             export NMBGIT="${config.xdg.dataHome}/notmuch/nmbug"
 


### PR DESCRIPTION
### Description

This PR contains two patches submitted by email:

#### git: respect programs.msmtp.package

Since the user may override `programs.msmtp.package` using `pkgs.msmtp` as the sendmail binary might result in the wrong package being used.

#### notmuch: add programs.notmuch.package option

Allow users to specify which notmuch package should be used.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.