### PR TITLE
neovim: load the wrapper generated lua

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,18 +2,14 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773389992,
-        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
-        "type": "github"
+        "lastModified": 1773744634,
+        "narHash": "sha256-g9xKSLMB0FQeCmygDVfiM0pGpTPdWq2OvFcnYkEUoAg=",
+        "path": "/home/teto/nixpkgs3",
+        "type": "path"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "path": "/home/teto/nixpkgs3",
+        "type": "path"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,8 @@
 {
   description = "Home Manager for Nix";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  # inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "path:/home/teto/nixpkgs3";
 
   outputs =
     {

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -460,6 +460,13 @@ in
         wrapperArgs = cfg.extraWrapperArgs ++ extraMakeWrapperArgs;
         wrapRc = false;
       };
+
+      # This is a hack to avoid breaking config for users that dont want an init.lua to get generated
+      # See https://github.com/nix-community/home-manager/pull/8734
+      # we basically check if the generated wrapper lua config has any user-set config
+      # if not HM avoids creating an init.lua
+      # this makes the logic harder to understand and maintain so hopefully we can find a way out
+      wrapperHasUserConfig = wrappedNeovim'.luaRcContent != wrappedNeovim'.providerLuaRc;
     in
     {
       programs.neovim = {
@@ -488,6 +495,11 @@ in
 
       programs.neovim.extraConfig = lib.concatStringsSep "\n" vimPackageInfo.userPluginViml;
       programs.neovim.extraPackages = mkIf cfg.autowrapRuntimeDeps vimPackageInfo.runtimeDeps;
+
+      programs.neovim.extraWrapperArgs = mkIf (!wrapperHasUserConfig) [
+        "--add-flags"
+        ''--cmd 'lua dofile("${pkgs.writeText "wrapper-init-lua" wrappedNeovim'.luaRcContent}")' ''
+      ];
 
       programs.neovim.initLua =
         let
@@ -519,8 +531,9 @@ in
             ''
           ))
           (lib.mkIf (advisedLua != null) (lib.mkOrder 510 advisedLua))
-          (lib.mkIf (wrappedNeovim'.initRc != "") (
-            lib.mkBefore "vim.cmd [[source ${pkgs.writeText "nvim-init-home-manager.vim" wrappedNeovim'.initRc}]]"
+          (lib.mkIf wrapperHasUserConfig (
+            # we want it to appear rather early
+            lib.mkOrder 200 wrappedNeovim'.luaRcContent
           ))
           (lib.mkIf (lib.hasAttr "lua" cfg.generatedConfigs && cfg.generatedConfigs.lua != "") (
             lib.mkAfter (foldedLuaBlock "user-associated plugin config" cfg.generatedConfigs.lua)

--- a/tests/modules/programs/neovim/default.nix
+++ b/tests/modules/programs/neovim/default.nix
@@ -5,7 +5,7 @@
   neovim-wrapper-args = ./wrapper-args.nix;
 
   # waiting for a nixpkgs patch
-  neovim-no-init = ./no-init.nix;
+  neovim-no-init-vim = ./no-init.nix;
   neovim-extra-lua-init = ./extra-lua-init.nix;
   neovim-extra-lua-default = ./extra-lua-default.nix;
   neovim-extra-lua-empty-plugin = ./extra-lua-empty-plugin.nix;

--- a/tests/modules/programs/neovim/extra-lua-init.nix
+++ b/tests/modules/programs/neovim/extra-lua-init.nix
@@ -10,8 +10,10 @@
   };
 
   nmt.script = ''
-    nvimFolder="home-files/.config/nvim"
-    assertFileContent "$nvimFolder/init.lua" ${builtins.toFile "init.lua-expected" ''
+    initLua="home-files/.config/nvim/init.lua"
+    initLuaNormalized="$(normalizeStorePaths "$initLua")"
+
+    assertFileContent "$initLuaNormalized" ${builtins.toFile "init.lua-expected" ''
       -- initLua
     ''}
   '';

--- a/tests/modules/programs/neovim/no-init.nix
+++ b/tests/modules/programs/neovim/no-init.nix
@@ -26,6 +26,5 @@
   nmt.script = ''
     nvimFolder="home-files/.config/nvim"
     assertPathNotExists "$nvimFolder/init.vim"
-    assertPathNotExists "$nvimFolder/init.lua"
   '';
 }

--- a/tests/modules/programs/neovim/plugin-config.expected
+++ b/tests/modules/programs/neovim/plugin-config.expected
@@ -1,7 +1,9 @@
 package.path = "/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/share/lua/5.1/?.lua;/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/share/lua/5.1/?/init.lua".. ";" .. package.path
 package.cpath = "/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/lib/lua/5.1/?.so".. ";" .. package.cpath
 
-vim.cmd [[source /nix/store/00000000000000000000000000000000-nvim-init-home-manager.vim]]
+vim.g.loaded_node_provider=0;vim.g.loaded_perl_provider=0;vim.g.loaded_ruby_provider=0;vim.g.python3_host_prog='/nix/store/00000000000000000000000000000000-nvim-host-python3/bin/nvim-python3'
+vim.cmd.source "/nix/store/00000000000000000000000000000000-init.vim"
+
 -- user-associated plugin config {{{
 function HM_PLUGIN_LUA_CONFIG ()
 end


### PR DESCRIPTION
### Description

Logical follow up once https://github.com/NixOS/nixpkgs/pull/487390 is merged.

This means an init.lua is now always generated which will probably break a lot more configs than the recent neovim-related changes. I would like to avoid adding yet a new option just to keep the old behavior as we would get 2 different ways to launch neovim, making the behavior and testing different in an obscure way for the user. 

The manual user solution to update their config would be the same as for previous PR:
https://github.com/nix-community/home-manager/commit/5786e425304ea2788a1cdc2533dd4c53583591bd

At the same time, I fear it breaks too many configs for us to ignore to here is what I came up with:

To avoid creating a new option while keeping current behavior:
1. check if the HM generated init lua is empty and if yes load the provider config via the wrapper,  thus keeping current behavior.
2. If the user has already configured some lua, then we just add some more to an already existing initLua. This makes config simpler and if the user doesn't set any extraPackages, we could actually get rid of the wrapped nvim executable and just use neovim-unwrapped (hourra \o/)

Ideally I would like to get rid of 1 (to avoid special casing HM, compared to nixpkgs neovim wrapper), maybe by displaying some warning to user on how to update their config. 
In the short term, if I could get 2 running on my machine, it would be great. Would make neovim work as on other distrib, and let me hack on neovim C code without further nix hacks. 


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
