### PR TITLE
mkFirefoxModule: remove visible option

### DIFF
--- a/modules/programs/firefox/default.nix
+++ b/modules/programs/firefox/default.nix
@@ -26,7 +26,6 @@ in
       name = "Firefox";
       wrappedPackageName = "firefox";
       unwrappedPackageName = "firefox-unwrapped";
-      visible = true;
 
       platforms.linux = {
         configPath = ".mozilla/firefox";

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -5,7 +5,6 @@
   wrappedPackageName ? null,
   unwrappedPackageName ? null,
   platforms,
-  visible ? false,
   enableBookmarks ? true,
 }:
 {
@@ -209,12 +208,10 @@ in
       example = true;
       description = ''
         Whether to enable ${appName}.${optionalString (description != null) " ${description}"}
-        ${optionalString (!visible) "See `${moduleName}` for more configuration options."}
       '';
     };
 
     package = mkOption {
-      inherit visible;
       type = with types; nullOr package;
       default = pkgs.${defaultPackageName};
       defaultText = literalExpression "pkgs.${packageName}";
@@ -317,7 +314,6 @@ in
     };
 
     nativeMessagingHosts = mkOption {
-      inherit visible;
       type = types.listOf types.package;
       default = [ ];
       description = ''
@@ -327,14 +323,12 @@ in
     };
 
     finalPackage = mkOption {
-      inherit visible;
       type = with types; nullOr package;
       readOnly = true;
       description = "Resulting ${appName} package.";
     };
 
     policies = lib.optionalAttrs (wrappedPackageName != null) (mkOption {
-      inherit visible;
       type = types.attrsOf jsonFormat.type;
       default = { };
       description = "[See list of policies](https://mozilla.github.io/policy-templates/).";
@@ -360,7 +354,6 @@ in
     };
 
     profiles = mkOption {
-      inherit visible;
       type = types.attrsOf (
         types.submodule (
           { config, name, ... }:
@@ -913,7 +906,6 @@ in
     };
 
     enableGnomeExtensions = mkOption {
-      inherit visible;
       type = types.bool;
       default = false;
       description = ''

--- a/modules/programs/floorp.nix
+++ b/modules/programs/floorp.nix
@@ -18,7 +18,6 @@ in
       name = "Floorp";
       wrappedPackageName = "floorp-bin";
       unwrappedPackageName = "floorp-bin-unwrapped";
-      visible = true;
 
       platforms.linux = {
         configPath = ".floorp";

--- a/modules/programs/librewolf.nix
+++ b/modules/programs/librewolf.nix
@@ -34,7 +34,6 @@ in
       description = "LibreWolf is a privacy enhanced Firefox fork.";
       wrappedPackageName = "librewolf";
       unwrappedPackageName = "librewolf-unwrapped";
-      visible = true;
 
       platforms.linux = {
         configPath = ".librewolf";


### PR DESCRIPTION
Just default everything to show options to remove confusion / chance of disabling documentation. We already set visible = true so it wasn't even being used really.

### Description
Closes https://github.com/nix-community/home-manager/issues/6349
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
