### PR TITLE
tirith: add module

### DIFF
--- a/modules/misc/news/2026/02/2026-02-13_12-21-10.nix
+++ b/modules/misc/news/2026/02/2026-02-13_12-21-10.nix
@@ -1,0 +1,11 @@
+{
+  time = "2026-02-13T11:21:10+00:00";
+  condition = true;
+  message = ''
+
+    A new module is available: 'programs.tirith'.
+
+    Tirith is a shell security monitor that helps protect against
+    malicious commands by analyzing shell inputs before execution.
+  '';
+}

--- a/modules/programs/tirith.nix
+++ b/modules/programs/tirith.nix
@@ -1,0 +1,84 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.tirith;
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = with lib.maintainers; [ malik ];
+
+  options.programs.tirith = {
+    enable = lib.mkEnableOption "Tirith, a shell security monitor";
+
+    package = lib.mkPackageOption pkgs "tirith" { };
+
+    allowlist = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      apply = builtins.filter (s: s != "");
+      example = [
+        "localhost"
+      ];
+      description = ''
+        List of allowed domains that bypass Tirith analysis.
+        Written to `$XDG_CONFIG_HOME/tirith/allowlist`.
+      '';
+    };
+
+    policy = lib.mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          version = 1;
+          fail_mode = "open";
+          allow_bypass = true;
+          severity_overrides = {
+            docker_untrusted_registry = "critical";
+          };
+        }
+      '';
+      description = ''
+        Tirith policy configuration.
+        Written to `$XDG_CONFIG_HOME/tirith/policy.yaml`.
+
+        See <https://github.com/sheeki03/tirith/blob/main/docs/cookbook.md>
+        for policy examples.
+      '';
+    };
+
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = {
+      "tirith/allowlist" = lib.mkIf (cfg.allowlist != [ ]) {
+        text = (lib.concatStringsSep "\n" cfg.allowlist) + "\n";
+      };
+
+      "tirith/policy.yaml" = lib.mkIf (cfg.policy != { }) {
+        source = yamlFormat.generate "tirith-policy.yaml" cfg.policy;
+      };
+    };
+
+    programs.bash.initExtra = lib.mkIf cfg.enableBashIntegration ''
+      eval "$(${lib.getExe cfg.package} init --shell bash)"
+    '';
+
+    programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+      ${lib.getExe cfg.package} init --shell fish | source
+    '';
+
+    programs.zsh.initExtra = lib.mkIf cfg.enableZshIntegration ''
+      eval "$(${lib.getExe cfg.package} init --shell zsh)"
+    '';
+  };
+}

--- a/tests/modules/programs/tirith/basic.nix
+++ b/tests/modules/programs/tirith/basic.nix
@@ -1,0 +1,27 @@
+{ ... }:
+
+{
+  programs.tirith = {
+    enable = true;
+    allowlist = [
+      "localhost"
+      "example.com"
+    ];
+    policy = {
+      version = 1;
+      fail_mode = "open";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/tirith/allowlist
+    assertFileContent \
+      home-files/.config/tirith/allowlist \
+      ${builtins.toFile "expected" ''
+        localhost
+        example.com
+      ''}
+
+    assertFileExists home-files/.config/tirith/policy.yaml
+  '';
+}

--- a/tests/modules/programs/tirith/default.nix
+++ b/tests/modules/programs/tirith/default.nix
@@ -1,0 +1,3 @@
+{
+  tirith-basic = ./basic.nix;
+}


### PR DESCRIPTION
### Description

Adds Home Manager module for Tirith, a shell security monitor.

The module supports:
- Shell integration for Bash, Fish, and Zsh
- Allowlist configuration for bypassing Tirith analysis
- Policy configuration for customizing security behavior

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [X] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
