### PR TITLE
nnn: add cd on quit option

### DIFF
--- a/modules/programs/nnn.nix
+++ b/modules/programs/nnn.nix
@@ -100,6 +100,14 @@ in
         '';
         default = { };
       };
+
+      enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
+
+      enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
+
+      enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+
+      quitcd = lib.mkEnableOption "cd on quit";
     };
   };
 
@@ -116,10 +124,25 @@ in
             --prefix NNN_PLUG : "${renderSettings cfg.plugins.mappings}"
         '';
       });
+
+      quitcd = {
+        bash_sh_zsh = "source ${nnnPackage}/share/quitcd/quitcd.bash_sh_zsh";
+        fish = "source ${nnnPackage}/share/quitcd/quitcd.fish";
+      };
     in
     lib.mkIf cfg.enable {
       programs.nnn.finalPackage = nnnPackage;
       home.packages = [ nnnPackage ];
       xdg.configFile."nnn/plugins" = lib.mkIf (cfg.plugins.src != null) { source = cfg.plugins.src; };
+
+      programs.bash.initExtra = lib.mkIf (cfg.enableBashIntegration && cfg.quitcd) (
+        lib.mkAfter quitcd.bash_sh_zsh
+      );
+      programs.fish.interactiveShellInit = lib.mkIf (cfg.enableFishIntegration && cfg.quitcd) (
+        lib.mkAfter quitcd.fish
+      );
+      programs.zsh.initContent = lib.mkIf (cfg.enableZshIntegration && cfg.quitcd) (
+        lib.mkAfter quitcd.bash_sh_zsh
+      );
     };
 }


### PR DESCRIPTION
### Description

Basically a clone of #5639 which seems to be stale now

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
