### PR TITLE
qt: add kvantum config options

### DIFF
--- a/modules/misc/qt/kvantum.nix
+++ b/modules/misc/qt/kvantum.nix
@@ -1,0 +1,132 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    concatMapStringsSep
+    generators
+    literalExpression
+    mkIf
+    mkOption
+    types
+    ;
+
+  kvconfigFormat = pkgs.formats.ini {
+    listToValue = concatMapStringsSep ", " (generators.mkValueStringDefault { });
+  };
+
+  kvconfigAtom = kvconfigFormat.lib.types.atom;
+
+  kvconfigSection = (types.attrsOf kvconfigAtom) // {
+    description = "section of a kvconfig file (attrs of ${kvconfigAtom.description})";
+  };
+
+  cfg = config.qt.kvantum;
+in
+
+{
+  options.qt.kvantum = {
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = types.attrsOf kvconfigSection;
+
+        options = {
+          General = mkOption {
+            type = types.submodule {
+              freeformType = kvconfigSection;
+
+              options = {
+                theme = mkOption {
+                  type = with types; nullOr str;
+                  default = null;
+                  example = "KvAdapta";
+                  description = ''
+                    The default Kvantum theme to use.
+                  '';
+                };
+              };
+            };
+            default = { };
+            example = {
+              theme = "KvAdapta";
+            };
+            description = ''
+              General configuration settings for Kvantum.
+            '';
+          };
+
+          Applications = mkOption {
+            type = with types; attrsOf (listOf str);
+            default = { };
+            example = {
+              KvArc = [
+                "app1"
+                "app2"
+              ];
+              KvFlat = [ "app3" ];
+            };
+            description = ''
+              Application configuration settings for Kvantum.
+
+              Themes set here will override {option}`qt.kvantum.settings.General.theme`
+              for their specific applications.
+            '';
+          };
+        };
+      };
+      default = { };
+      example = {
+        General = {
+          theme = "KvAdapta";
+        };
+        Applications = {
+          KvArc = [
+            "app1"
+            "app2"
+          ];
+          KvFlat = [ "app3" ];
+        };
+        SomethingElse = {
+          foo = "bar";
+        };
+      };
+      description = ''
+        Global configuration settings written to {file}`$XDG_CONFIG_HOME/Kvantum/kvantum.kvconfig`.
+      '';
+    };
+
+    themes = mkOption {
+      type = with types; listOf package;
+      default = [ ];
+      example = literalExpression ''
+        with pkgs; [
+          gruvbox-kvantum
+          catppuccin-kvantum
+        ]'';
+      description = ''
+        Theme packages to install to {file}`$XDG_CONFIG_HOME/Kvantum/`.
+      '';
+    };
+  };
+
+  config = {
+    xdg.configFile = {
+      "Kvantum" = mkIf (cfg.themes != [ ]) {
+        recursive = true;
+        source = pkgs.symlinkJoin {
+          name = "kvantum-themes";
+          paths = cfg.themes;
+          stripPrefix = "/share/Kvantum";
+        };
+      };
+
+      "Kvantum/kvantum.kvconfig" = mkIf (cfg.settings != { }) {
+        source = kvconfigFormat.generate "kvantum-config" cfg.settings;
+      };
+    };
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -45,6 +45,7 @@ let
       ./misc/pam.nix
       ./misc/qt.nix
       ./misc/qt/kconfig.nix
+      ./misc/qt/kvantum.nix
       ./misc/shell.nix
       ./misc/specialisation.nix
       ./misc/submodule-support.nix

--- a/tests/modules/misc/qt/default.nix
+++ b/tests/modules/misc/qt/default.nix
@@ -1,5 +1,7 @@
 {
   qt-basic = ./qt-basic.nix;
+  qt-kvantum-settings = ./qt-kvantum-settings.nix;
+  qt-kvantum-themes = ./qt-kvantum-themes.nix;
   qt-platform-theme-gtk = ./qt-platform-theme-gtk.nix;
   qt-platform-theme-gtk3 = ./qt-platform-theme-gtk3.nix;
   qt-platform-theme-gnome = ./qt-platform-theme-gnome.nix;

--- a/tests/modules/misc/qt/qt-kvantum-settings.nix
+++ b/tests/modules/misc/qt/qt-kvantum-settings.nix
@@ -1,0 +1,54 @@
+{ pkgs, ... }:
+
+{
+  qt = {
+    enable = true;
+    kvantum = {
+      settings = {
+        General = {
+          theme = "KvAdapta";
+          hello = "world";
+        };
+        Applications = {
+          KvArc = [
+            "app1"
+            "app2"
+          ];
+          KvFlat = [ "app3" ];
+        };
+        SomethingElse = {
+          foo = "bar";
+          baz = [
+            "qux"
+            123
+            true
+            null
+          ];
+        };
+      };
+    };
+  };
+
+  nmt.script =
+    let
+      configPath = "home-files/.config/Kvantum/kvantum.kvconfig";
+
+      expectedContent = pkgs.writeText "expected.kvconfig" ''
+        [Applications]
+        KvArc=app1, app2
+        KvFlat=app3
+
+        [General]
+        hello=world
+        theme=KvAdapta
+
+        [SomethingElse]
+        baz=qux, 123, true, null
+        foo=bar
+      '';
+    in
+    ''
+      assertFileExists "${configPath}"
+      assertFileContent "${configPath}" "${expectedContent}"
+    '';
+}

--- a/tests/modules/misc/qt/qt-kvantum-themes.nix
+++ b/tests/modules/misc/qt/qt-kvantum-themes.nix
@@ -1,0 +1,29 @@
+{ pkgs, ... }:
+
+{
+  qt = {
+    enable = true;
+    kvantum = {
+      settings = {
+        general = {
+          theme = "KvAdapta";
+        };
+      };
+      themes = [
+        (pkgs.runCommand "kvantum-test-theme" { } ''
+          mkdir -p $out/share/Kvantum/TestTheme
+          touch $out/share/Kvantum/TestTheme/TestTheme.kvconfig
+        '')
+      ];
+    };
+  };
+
+  nmt.script =
+    let
+      configDir = "home-files/.config/Kvantum";
+    in
+    ''
+      assertFileExists "${configDir}/kvantum.kvconfig"
+      assertFileExists "${configDir}/TestTheme/TestTheme.kvconfig"
+    '';
+}


### PR DESCRIPTION
### Description

adds `qt.kvantum.{settings,themes}` options, closes #3641

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
