### PR TITLE
mpdris2-rs: add module

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,6 +19,7 @@
           - modules/services/mpd-mpris.nix
           - modules/services/mpd.nix
           - modules/services/mpdris2.nix
+          - modules/services/mpdris2-rs.nix
           - modules/services/mpdscribble.nix
           - modules/services/mpris-proxy.nix
           - modules/services/pasystray.nix

--- a/modules/misc/news/2026/02/2026-02-06_21-46-14.nix
+++ b/modules/misc/news/2026/02/2026-02-06_21-46-14.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+{
+  time = "2026-02-06T21:46:14+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: `services.mpdris2-rs`
+
+    Adds a module for mpdris2-rs, a lightweight implementation of the MPD to D-Bus bridge.
+  '';
+}

--- a/modules/services/mpdris2-rs.nix
+++ b/modules/services/mpdris2-rs.nix
@@ -1,0 +1,129 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.mpdris2-rs;
+in
+{
+  meta.maintainers = [ lib.maintainers.Kladki ];
+
+  options.services.mpdris2-rs = {
+    enable = lib.mkEnableOption "mpdris2-rs, A lightweight implementation of MPD to D-Bus bridge";
+
+    host = lib.mkOption {
+      type = with lib.types; nullOr str;
+      default = null;
+      example = "192.168.1.1";
+      description = ''
+        hostname + port, or UNIX socket path of MPD server, similar to what `mpc` takes
+
+        - if not configured, `MPD_HOST` will be used
+        - if `MPD_HOST` is not set either, `localhost:6600` is the default
+        - UNIX socket path has to be absolute
+        - Abstract sockets are supported on Linux (socket path that starts with `@`, e.g., `@mpd_socket`)
+      '';
+    };
+
+    notifications = {
+      enable = lib.mkEnableOption "song change notifications";
+
+      timeout = lib.mkOption {
+        type = with lib.types; nullOr float;
+        default = null;
+        example = 10.0;
+        description = "notification timeout (default 5 secs)";
+      };
+
+      summary = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        example = "%artist% - %album%";
+        description = ''
+          Templating for the notification summary.
+
+          See <https://github.com/szclsya/mpdris2-rs?tab=readme-ov-file#configuration> for available variables.
+        '';
+      };
+
+      summaryPaused = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        example = "%artist% - %album%";
+        description = ''
+          Templating for the notification summary (when paused).
+
+          See <https://github.com/szclsya/mpdris2-rs?tab=readme-ov-file#configuration> for available variables.
+        '';
+      };
+
+      body = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        example = "%title% (%elapsed%/%duration%)";
+        description = ''
+          Templating for the notification body.
+
+          See <https://github.com/szclsya/mpdris2-rs?tab=readme-ov-file#configuration> for available variables.
+        '';
+      };
+
+      bodyPaused = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        example = "%title% (%elapsed%/%duration%)";
+        description = ''
+          Templating for the notification body (when paused).
+
+          See <https://github.com/szclsya/mpdris2-rs?tab=readme-ov-file#configuration> for available variables.
+        '';
+      };
+    };
+
+    package = lib.mkPackageOption pkgs "mpdris2-rs" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.mpdris2-rs" pkgs lib.platforms.linux)
+    ];
+
+    systemd.user.services.mpdris2-rs = {
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+
+      Unit = {
+        Description = "Music Player Daemon D-Bus Bridge";
+        After = [ "mpd.service" ];
+      };
+
+      Service = {
+        Type = "dbus";
+        Restart = "on-failure";
+        ExecStart =
+          let
+            optionFormat = optionName: {
+              option = "--${optionName}";
+              sep = null;
+              explicitBool = false;
+            };
+            args = lib.cli.toCommandLineShell optionFormat {
+              host = cfg.host;
+              no-notification = !cfg.notifications.enable;
+              notification-timeout = cfg.notifications.timeout;
+              notification-summary = cfg.notifications.summary;
+              notification-summary-paused = cfg.notifications.summaryPaused;
+              notification-body = cfg.notifications.body;
+              notification-body-paused = cfg.notifications.bodyPaused;
+            };
+          in
+          "${lib.getExe cfg.package} ${args}";
+
+        BusName = "org.mpris.MediaPlayer2.mpd";
+      };
+    };
+  };
+}

--- a/tests/modules/services/mpdris2-rs/basic-configuration.nix
+++ b/tests/modules/services/mpdris2-rs/basic-configuration.nix
@@ -1,0 +1,10 @@
+{
+  services.mpdris2-rs = {
+    enable = true;
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/mpdris2-rs.service
+    assertFileContent "$serviceFile" ${./basic-configuration.service}
+  '';
+}

--- a/tests/modules/services/mpdris2-rs/basic-configuration.service
+++ b/tests/modules/services/mpdris2-rs/basic-configuration.service
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+BusName=org.mpris.MediaPlayer2.mpd
+ExecStart=@mpdris2-rs@/bin/mpdris2-rs --no-notification
+Restart=on-failure
+Type=dbus
+
+[Unit]
+After=mpd.service
+Description=Music Player Daemon D-Bus Bridge

--- a/tests/modules/services/mpdris2-rs/custom-notifications.nix
+++ b/tests/modules/services/mpdris2-rs/custom-notifications.nix
@@ -1,0 +1,17 @@
+{
+  services.mpdris2-rs = {
+    enable = true;
+    notifications = {
+      enable = true;
+      summary = "%artist% - %album%";
+      summaryPaused = "%artist% - %album% (paused)";
+      body = "%title% (%elapsed%/%duration%)";
+      bodyPaused = "%title% (%elapsed%/%duration%) (paused)";
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/mpdris2-rs.service
+    assertFileContent "$serviceFile" ${./custom-notifications.service}
+  '';
+}

--- a/tests/modules/services/mpdris2-rs/custom-notifications.service
+++ b/tests/modules/services/mpdris2-rs/custom-notifications.service
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+BusName=org.mpris.MediaPlayer2.mpd
+ExecStart=@mpdris2-rs@/bin/mpdris2-rs --notification-body '%title% (%elapsed%/%duration%)' --notification-body-paused '%title% (%elapsed%/%duration%) (paused)' --notification-summary '%artist% - %album%' --notification-summary-paused '%artist% - %album% (paused)'
+Restart=on-failure
+Type=dbus
+
+[Unit]
+After=mpd.service
+Description=Music Player Daemon D-Bus Bridge

--- a/tests/modules/services/mpdris2-rs/default.nix
+++ b/tests/modules/services/mpdris2-rs/default.nix
@@ -1,0 +1,6 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  mpdris2-rs-basic-configuration = ./basic-configuration.nix;
+  mpdris2-rs-custom-notifications = ./custom-notifications.nix;
+}


### PR DESCRIPTION
### Description

Adds module for [mpdris2-rs](https://github.com/szclsya/mpdris2-rs), a lightweight implementation of MPD to D-Bus bridge.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
