### PR TITLE
peon-ping: add module

### DIFF
--- a/modules/misc/news/2026/02/2026-02-15_12-00-00.nix
+++ b/modules/misc/news/2026/02/2026-02-15_12-00-00.nix
@@ -1,0 +1,12 @@
+{
+  time = "2026-02-15T12:00:00+00:00";
+  condition = true;
+  message = ''
+
+    A new module is available: 'programs.peon-ping'.
+
+    Peon-ping is a notification sound player for AI coding agents
+    (Claude Code, Cursor, Codex, etc.) that plays sound effects when
+    tasks complete, permissions are needed, or other events occur.
+  '';
+}

--- a/modules/programs/peon-ping.nix
+++ b/modules/programs/peon-ping.nix
@@ -1,0 +1,196 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.peon-ping;
+  jsonFormat = pkgs.formats.json { };
+
+  defaultOgPacksSource = pkgs.fetchFromGitHub {
+    owner = "PeonPing";
+    repo = "og-packs";
+    rev = "v1.1.0";
+    hash = "sha256-spao/GTIhH4c5HOmVc0umMvrwOaMRa4s5Pem1AWyUOw=";
+  };
+
+  hookCommand = "${cfg.package}/bin/peon";
+
+  hookEntry = event: {
+    matcher = "";
+    hooks = [
+      (
+        {
+          type = "command";
+          command = hookCommand;
+          timeout = 10;
+        }
+        // lib.optionalAttrs (event != "SessionStart") { async = true; }
+      )
+    ];
+  };
+
+  skillNames = [
+    "peon-ping-config"
+    "peon-ping-toggle"
+    "peon-ping-use"
+  ];
+
+  packFiles = lib.listToAttrs (
+    map (
+      name:
+      lib.nameValuePair ".claude/hooks/peon-ping/packs/${name}" {
+        source = "${cfg.ogPacksSource}/${name}";
+        recursive = true;
+      }
+    ) cfg.packs
+  );
+
+  skillFiles = lib.listToAttrs (
+    map (
+      name:
+      lib.nameValuePair ".claude/skills/${name}" {
+        source = "${cfg.package.src}/skills/${name}";
+        recursive = true;
+      }
+    ) skillNames
+  );
+
+  claudeCodeHooks = lib.listToAttrs (
+    map (event: lib.nameValuePair event [ (hookEntry event) ]) cfg.claudeCodeHookEvents
+  );
+in
+{
+  meta.maintainers = [ lib.maintainers.workflow ];
+
+  options.programs.peon-ping = {
+    enable = lib.mkEnableOption "peon-ping, a notification sound player for AI coding agents";
+
+    package = lib.mkPackageOption pkgs "peon-ping" { };
+
+    settings = lib.mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = {
+        active_pack = "peon";
+        volume = 0.5;
+        enabled = true;
+        desktop_notifications = true;
+        categories = {
+          "session.start" = true;
+          "task.complete" = true;
+          "input.required" = true;
+        };
+      };
+      description = ''
+        Declarative peon-ping configuration written to
+        {file}`~/.claude/hooks/peon-ping/config.json`.
+
+        When non-empty, the config file is managed by Home Manager as an
+        immutable symlink. When left empty (the default), a mutable default
+        config is seeded on first activation so that the `peon` CLI and
+        Claude Code skills can modify it at runtime.
+      '';
+    };
+
+    packs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "peon" ];
+      example = [
+        "peon"
+        "peon_de"
+        "aoe2"
+      ];
+      description = ''
+        Sound pack names to install from {option}`ogPacksSource`.
+        Each name corresponds to a subdirectory in the og-packs repository.
+      '';
+    };
+
+    ogPacksSource = lib.mkOption {
+      type = lib.types.package;
+      default = defaultOgPacksSource;
+      defaultText = lib.literalExpression ''
+        pkgs.fetchFromGitHub {
+          owner = "PeonPing";
+          repo = "og-packs";
+          rev = "v1.1.0";
+          hash = "sha256-spao/GTIhH4c5HOmVc0umMvrwOaMRa4s5Pem1AWyUOw=";
+        }
+      '';
+      description = ''
+        Source derivation containing sound packs. Pack names in
+        {option}`packs` are resolved as subdirectories of this source.
+      '';
+    };
+
+    enableClaudeCodeIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to automatically configure Claude Code hooks and skills
+        for peon-ping integration.
+
+        Requires {option}`programs.claude-code.enable` to be set.
+      '';
+    };
+
+    claudeCodeHookEvents = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "SessionStart"
+        "SessionEnd"
+        "UserPromptSubmit"
+        "Stop"
+        "Notification"
+        "PermissionRequest"
+      ];
+      description = ''
+        Claude Code hook events to register peon-ping for.
+        Each event fires the `peon` command which reads the event
+        from stdin and plays the appropriate sound.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !cfg.enableClaudeCodeIntegration || config.programs.claude-code.enable;
+        message = ''
+          `programs.peon-ping.enableClaudeCodeIntegration` requires
+          `programs.claude-code.enable` to be set.
+        '';
+      }
+    ];
+
+    home.packages = [ cfg.package ];
+
+    home.file =
+      packFiles
+      // lib.optionalAttrs cfg.enableClaudeCodeIntegration skillFiles
+      // {
+        ".claude/hooks/peon-ping/config.json" = lib.mkIf (cfg.settings != { }) {
+          source = jsonFormat.generate "peon-ping-config.json" cfg.settings;
+        };
+      };
+
+    home.activation.seedPeonPingConfig = lib.mkIf (cfg.settings == { }) (
+      lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+        peonConfigDir="''${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"
+        peonConfigFile="$peonConfigDir/config.json"
+        if [ ! -f "$peonConfigFile" ]; then
+          run mkdir -p "$peonConfigDir"
+          run cp "${cfg.package}/lib/peon-ping/config.json" "$peonConfigFile"
+          run chmod u+w "$peonConfigFile"
+          verboseEcho "Seeded peon-ping default config at $peonConfigFile"
+        fi
+      ''
+    );
+
+    programs.claude-code.settings = lib.mkIf cfg.enableClaudeCodeIntegration {
+      hooks = claudeCodeHooks;
+    };
+  };
+}

--- a/tests/modules/programs/peon-ping/basic.nix
+++ b/tests/modules/programs/peon-ping/basic.nix
@@ -1,0 +1,13 @@
+{
+  programs.peon-ping = {
+    enable = true;
+    packs = [ ];
+  };
+
+  test.stubs.peon-ping = { };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.claude/hooks/peon-ping/config.json
+    assertPathNotExists home-files/.claude/settings.json
+  '';
+}

--- a/tests/modules/programs/peon-ping/claude-code-integration.nix
+++ b/tests/modules/programs/peon-ping/claude-code-integration.nix
@@ -1,0 +1,34 @@
+{ config, ... }:
+{
+  programs.claude-code.enable = true;
+
+  programs.peon-ping = {
+    enable = true;
+    enableClaudeCodeIntegration = true;
+    packs = [ ];
+  };
+
+  test.stubs.peon-ping = {
+    extraAttrs.src = config.lib.test.mkStubPackage {
+      name = "peon-ping-src";
+      buildScript = ''
+        mkdir -p $out/skills/peon-ping-config
+        mkdir -p $out/skills/peon-ping-toggle
+        mkdir -p $out/skills/peon-ping-use
+        echo "# Config skill" > $out/skills/peon-ping-config/SKILL.md
+        echo "# Toggle skill" > $out/skills/peon-ping-toggle/SKILL.md
+        echo "# Use skill" > $out/skills/peon-ping-use/SKILL.md
+      '';
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.claude/settings.json
+    assertFileContent home-files/.claude/settings.json \
+      ${./expected-settings.json}
+
+    assertFileExists home-files/.claude/skills/peon-ping-config/SKILL.md
+    assertFileExists home-files/.claude/skills/peon-ping-toggle/SKILL.md
+    assertFileExists home-files/.claude/skills/peon-ping-use/SKILL.md
+  '';
+}

--- a/tests/modules/programs/peon-ping/default.nix
+++ b/tests/modules/programs/peon-ping/default.nix
@@ -1,0 +1,6 @@
+{
+  peon-ping-basic = ./basic.nix;
+  peon-ping-settings = ./settings.nix;
+  peon-ping-packs = ./packs.nix;
+  peon-ping-claude-code-integration = ./claude-code-integration.nix;
+}

--- a/tests/modules/programs/peon-ping/expected-config.json
+++ b/tests/modules/programs/peon-ping/expected-config.json
@@ -1,0 +1,11 @@
+{
+  "active_pack": "glados",
+  "categories": {
+    "input.required": false,
+    "session.start": true,
+    "task.complete": true
+  },
+  "desktop_notifications": false,
+  "enabled": true,
+  "volume": 0.8
+}

--- a/tests/modules/programs/peon-ping/expected-settings.json
+++ b/tests/modules/programs/peon-ping/expected-settings.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "@peon-ping@/bin/peon",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "@peon-ping@/bin/peon",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "@peon-ping@/bin/peon",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "@peon-ping@/bin/peon",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "@peon-ping@/bin/peon",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "@peon-ping@/bin/peon",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
+  }
+}

--- a/tests/modules/programs/peon-ping/packs.nix
+++ b/tests/modules/programs/peon-ping/packs.nix
@@ -1,0 +1,25 @@
+{ config, ... }:
+{
+  programs.peon-ping = {
+    enable = true;
+    packs = [
+      "peon"
+      "glados"
+    ];
+    ogPacksSource = config.lib.test.mkStubPackage {
+      name = "test-og-packs";
+      buildScript = ''
+        mkdir -p $out/peon/sounds $out/glados/sounds
+        echo '{}' > $out/peon/openpeon.json
+        echo '{}' > $out/glados/openpeon.json
+      '';
+    };
+  };
+
+  test.stubs.peon-ping = { };
+
+  nmt.script = ''
+    assertDirectoryExists home-files/.claude/hooks/peon-ping/packs/peon
+    assertDirectoryExists home-files/.claude/hooks/peon-ping/packs/glados
+  '';
+}

--- a/tests/modules/programs/peon-ping/settings.nix
+++ b/tests/modules/programs/peon-ping/settings.nix
@@ -1,0 +1,25 @@
+{
+  programs.peon-ping = {
+    enable = true;
+    packs = [ ];
+    settings = {
+      active_pack = "glados";
+      volume = 0.8;
+      enabled = true;
+      desktop_notifications = false;
+      categories = {
+        "session.start" = true;
+        "task.complete" = true;
+        "input.required" = false;
+      };
+    };
+  };
+
+  test.stubs.peon-ping = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.claude/hooks/peon-ping/config.json
+    assertFileContent home-files/.claude/hooks/peon-ping/config.json \
+      ${./expected-config.json}
+  '';
+}


### PR DESCRIPTION
### Description

Adds a `programs.peon-ping` home-manager module for [peon-ping](https://github.com/PeonPing/peon-ping), a notification sound player for AI coding agents (Claude Code, Cursor, Codex, etc.).

**Features:**

- `programs.peon-ping.enable` — installs peon-ping
- `programs.peon-ping.settings` — declarative config (immutable nix store symlink) or mutable seeded config when left empty
- `programs.peon-ping.packs` — sound packs from [og-packs](https://github.com/PeonPing/og-packs) (defaults to `["peon"]`)
- `programs.peon-ping.enableClaudeCodeIntegration` — auto-configures Claude Code hooks and skills

**Design note — sound packs via `fetchFromGitHub`:**

The `ogPacksSource` option defaults to a `fetchFromGitHub` of [PeonPing/og-packs](https://github.com/PeonPing/og-packs) v1.1.0, which contains ~40 sound packs (~35 MB) including localized variants (German, Czech, Spanish, French, Polish, Russian). The `packs` option selects which subdirectories to install, defaulting to `["peon"]`.

This keeps sound packs out of nixpkgs (they're audio assets, not software) while still being declaratively managed. The tradeoff is a `fetchFromGitHub` at eval time pinned to a specific tag. Users can override `ogPacksSource` to point at their own source. Open to feedback on whether this approach is appropriate or if there's a preferred pattern for managing non-software assets.

**Dependency:** This module depends on the `peon-ping` package being available in nixpkgs. Pending PR: NixOS/nixpkgs#490742. Tests use stubs in the meantime.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)