### PR TITLE
home-environment: use nix profile add instead of install

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -712,11 +712,11 @@ in
 
             nixProfileRemove 'home-manager-path'
 
-            run $oldNix profile install $1
+            run $oldNix profile add $1
           }
 
           if [[ -e ${cfg.profileDirectory}/manifest.json ]] ; then
-            INSTALL_CMD="nix profile install"
+            INSTALL_CMD="nix profile add"
             INSTALL_CMD_ACTUAL="nixReplaceProfile"
             LIST_CMD="nix profile list"
             REMOVE_CMD_SYNTAX='nix profile remove {number | store path}'

--- a/tests/integration/standalone/flake-basics.nix
+++ b/tests/integration/standalone/flake-basics.nix
@@ -54,7 +54,7 @@
 
     # Make sure that Alice has a "nix profile" compatible profile.
     if True:
-      succeed_as_alice("nix profile install nixpkgs#cowsay")
+      succeed_as_alice("nix profile add nixpkgs#cowsay")
       result = succeed_as_alice("cowsay Hello")
       machine.log(f"\n{result}")
 


### PR DESCRIPTION
### Description

`nix profile install` was renamed to `nix profile add` in Nix 2.28. The old subcommand still works via a deprecated alias, but emits a warning on every `home-manager switch`:

```
warning: 'install' is a deprecated alias for 'add'
```

This replaces all three occurrences: the actual invocation and the `INSTALL_CMD` string in `nixReplaceProfile`, and the test setup in the standalone integration test.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.
- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

  > `test-all` fails identically on unmodified master (Firefox wrapper/nixpkgs issue, unrelated to this change). The other two variants pass on both master and this branch.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```