### PR TITLE
sioyek: add `startupCommands` option

### DIFF
--- a/tests/modules/programs/sioyek/sioyek-basic-configuration.nix
+++ b/tests/modules/programs/sioyek/sioyek-basic-configuration.nix
@@ -19,6 +19,10 @@
       "dark_mode_background_color" = "0.0 0.0 0.0";
       "dark_mode_contrast" = "0.8";
     };
+    startupCommands = [
+      "toggle_visual_scroll"
+      "toggle_dark_mode"
+    ];
   };
 
   nmt = {

--- a/tests/modules/programs/sioyek/test_prefs_user.config
+++ b/tests/modules/programs/sioyek/test_prefs_user.config
@@ -1,2 +1,3 @@
 dark_mode_background_color 0.0 0.0 0.0
 dark_mode_contrast 0.8
+startup_commands toggle_visual_scroll;toggle_dark_mode


### PR DESCRIPTION
### Description

Add a `programs.sioyek.startupCommands` option. Since the `startup_commands` option for Sioyek is a semicolon-separated list of strings, it makes more sense to add this as a separate option. Also, this is needed for https://github.com/nix-community/stylix/pull/2199 (see [this comment](https://github.com/nix-community/stylix/pull/2199#discussion_r2816786099)).

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
