### PR TITLE
treewide: remove thiagokokada from maintainers

### DIFF
--- a/modules/misc/nixpkgs-disabled.nix
+++ b/modules/misc/nixpkgs-disabled.nix
@@ -59,7 +59,7 @@ let
 
 in
 {
-  meta.maintainers = with lib.maintainers; [ thiagokokada ];
+  meta.maintainers = [ ];
 
   options.nixpkgs = {
     config = lib.mkOption {

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -92,7 +92,6 @@ in
 {
   meta.maintainers = with lib.maintainers; [
     rycee
-    thiagokokada
   ];
 
   imports = [

--- a/modules/programs/hexchat.nix
+++ b/modules/programs/hexchat.nix
@@ -239,7 +239,7 @@ let
 
 in
 {
-  meta.maintainers = with lib.maintainers; [ thiagokokada ];
+  meta.maintainers = [ ];
 
   options.programs.hexchat = {
     enable = lib.mkEnableOption "HexChat, a graphical IRC client";

--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -14,7 +14,6 @@ let
 in
 {
   meta.maintainers = with lib.maintainers; [
-    thiagokokada
     workflow
   ];
 

--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -67,7 +67,6 @@ let
 in
 {
   meta.maintainers = with lib.maintainers; [
-    thiagokokada
     chuangzhu
   ];
 

--- a/modules/programs/nnn.nix
+++ b/modules/programs/nnn.nix
@@ -49,7 +49,7 @@ let
   };
 in
 {
-  meta.maintainers = with lib.maintainers; [ thiagokokada ];
+  meta.maintainers = [ ];
 
   options = {
     programs.nnn = {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Removing myself from modules that I am not using anymore.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
