### PR TITLE
opencode: allow derivations in skills option

### DIFF
--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -457,6 +457,7 @@ in
       name: content:
       if
         (lib.isPath content && lib.pathIsDirectory content)
+        || (lib.isDerivation content)
         || (builtins.isString content && lib.hasPrefix builtins.storeDir content)
 
       then

--- a/tests/modules/programs/opencode/default.nix
+++ b/tests/modules/programs/opencode/default.nix
@@ -19,6 +19,7 @@
   opencode-skills-store-path = ./skills-store-path.nix;
   opencode-skills-directory = ./skills-directory.nix;
   opencode-skills-bulk-directory = ./skills-bulk-directory.nix;
+  opencode-skills-from-derivation = ./skills-from-derivation.nix;
   opencode-themes-inline = ./themes-inline.nix;
   opencode-themes-path = ./themes-path.nix;
   opencode-themes-bulk-directory = ./themes-bulk-directory.nix;

--- a/tests/modules/programs/opencode/skills-from-derivation.nix
+++ b/tests/modules/programs/opencode/skills-from-derivation.nix
@@ -1,0 +1,41 @@
+{ config, ... }:
+
+let
+  skill = config.lib.test.mkStubPackage {
+    name = "mock-skill";
+
+    buildScript = ''
+      mkdir -p $out/supporting-files
+
+      echo "# Mock skill" > $out/SKILL.md
+      echo "This skill was built as a derivation." >> $out/SKILL.md
+
+      echo "# Some supporting file" > $out/supporting-files/another-file.md
+    '';
+  };
+in
+{
+  programs.opencode = {
+    enable = true;
+    skills = {
+      skill-from-derivation = skill;
+      skill-from-string = "${skill}";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/opencode/skill/skill-from-derivation/SKILL.md
+    assertFileExists home-files/.config/opencode/skill/skill-from-derivation/supporting-files/another-file.md
+    assertFileContent home-files/.config/opencode/skill/skill-from-derivation/SKILL.md \
+      "${skill}/SKILL.md"
+    assertFileContent home-files/.config/opencode/skill/skill-from-derivation/supporting-files/another-file.md \
+      "${skill}/supporting-files/another-file.md"
+
+    assertFileExists home-files/.config/opencode/skill/skill-from-string/SKILL.md
+    assertFileExists home-files/.config/opencode/skill/skill-from-string/supporting-files/another-file.md
+    assertFileContent home-files/.config/opencode/skill/skill-from-string/SKILL.md \
+      "${skill}/SKILL.md"
+    assertFileContent home-files/.config/opencode/skill/skill-from-string/supporting-files/another-file.md \
+      "${skill}/supporting-files/another-file.md"
+  '';
+}


### PR DESCRIPTION
### Description

I needed to pass a derivation to `programs.opencode.skills`, but the config logic only checked lib.isPath, which returns false for derivations. This caused derivations to fall through and be treated as SKILL.md content instead of directory symlinks.

Added `lib.isDerivation` to handle derivation inputs correctly.

Note: The same bug likely exists in other opencode options (`commands`, `agents`, `tools`, `themes`, `rules`). Happy to fix those in follow-up PRs if this approach is accepted.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
