### PR TITLE
tmux: fix double press prefix passthrough

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -92,7 +92,7 @@ let
         # rebind main key: ${prefix}
         unbind ${defaultPrefix}
         set -g prefix ${prefix}
-        bind -n -N "Send the prefix key through to the application" \
+        bind -N "Send the prefix key through to the application" \
           ${prefix} send-prefix
       ''
     }

--- a/tests/modules/programs/tmux/prefix.conf
+++ b/tests/modules/programs/tmux/prefix.conf
@@ -15,7 +15,7 @@ set -g mode-keys   emacs
 # rebind main key: C-a
 unbind C-b
 set -g prefix C-a
-bind -n -N "Send the prefix key through to the application" \
+bind -N "Send the prefix key through to the application" \
   C-a send-prefix
 
 

--- a/tests/modules/programs/tmux/shortcut-without-prefix.conf
+++ b/tests/modules/programs/tmux/shortcut-without-prefix.conf
@@ -15,7 +15,7 @@ set -g mode-keys   emacs
 # rebind main key: C-a
 unbind C-b
 set -g prefix C-a
-bind -n -N "Send the prefix key through to the application" \
+bind -N "Send the prefix key through to the application" \
   C-a send-prefix
 
 


### PR DESCRIPTION
### Description

After #7549 double hitting the prefix key would no longer be passed through to the application within tmux. I have applied the fix suggested in #7771.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
