### PR TITLE
neovim: fix breakage from nixpkgs bd66006

### DIFF
--- a/tests/modules/programs/neovim/extra-lua-default.nix
+++ b/tests/modules/programs/neovim/extra-lua-default.nix
@@ -5,6 +5,9 @@
 
   nmt.script = ''
     nvimFolder="home-files/.config/nvim"
-    assertPathNotExists "$nvimFolder/init.lua"
+    assertFileExists "$nvimFolder/init.lua"
+    assertFileContains "$nvimFolder/init.lua" "python3_host_prog="
+    assertFileContains "$nvimFolder/init.lua" "ruby_host_prog="
+    assertFileContains "$nvimFolder/init.lua" "loaded_node_provider=0"
   '';
 }

--- a/tests/modules/programs/neovim/extra-lua-empty-plugin.nix
+++ b/tests/modules/programs/neovim/extra-lua-empty-plugin.nix
@@ -14,6 +14,8 @@
 
   nmt.script = ''
     initLua="home-files/.config/nvim/init.lua"
-    assertPathNotExists "$initLua"
+    assertFileExists "$initLua"
+    assertFileContains "$initLua" "python3_host_prog="
+    assertFileContains "$initLua" "loaded_node_provider=0"
   '';
 }

--- a/tests/modules/programs/neovim/extra-lua-init.nix
+++ b/tests/modules/programs/neovim/extra-lua-init.nix
@@ -11,8 +11,9 @@
 
   nmt.script = ''
     nvimFolder="home-files/.config/nvim"
-    assertFileContent "$nvimFolder/init.lua" ${builtins.toFile "init.lua-expected" ''
-      -- initLua
-    ''}
+    assertFileExists "$nvimFolder/init.lua"
+    assertFileContains "$nvimFolder/init.lua" "python3_host_prog="
+    assertFileContains "$nvimFolder/init.lua" "loaded_node_provider=0"
+    assertFileContains "$nvimFolder/init.lua" "initLua"
   '';
 }

--- a/tests/modules/programs/neovim/no-init.nix
+++ b/tests/modules/programs/neovim/no-init.nix
@@ -26,6 +26,8 @@
   nmt.script = ''
     nvimFolder="home-files/.config/nvim"
     assertPathNotExists "$nvimFolder/init.vim"
-    assertPathNotExists "$nvimFolder/init.lua"
+    assertFileExists "$nvimFolder/init.lua"
+    assertFileContains "$nvimFolder/init.lua" "python3_host_prog="
+    assertFileContains "$nvimFolder/init.lua" "loaded_node_provider=0"
   '';
 }

--- a/tests/modules/programs/neovim/plugin-config.expected
+++ b/tests/modules/programs/neovim/plugin-config.expected
@@ -1,8 +1,0 @@
-vim.cmd [[source /nix/store/00000000000000000000000000000000-nvim-init-home-manager.vim]]
-package.path = "/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/share/lua/5.1/?.lua;/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/share/lua/5.1/?/init.lua".. ";" .. package.path
-package.cpath = "/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/lib/lua/5.1/?.so".. ";" .. package.cpath
--- user-associated plugin config {{{
-function HM_PLUGIN_LUA_CONFIG ()
-end
-
--- }}}

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -49,7 +49,18 @@ lib.mkIf config.test.enableBig {
       assertFileContains "$vimout" "HM_PLUGINS_CONFIG"
 
       initLua="$TESTED/home-files/.config/nvim/init.lua"
-      assertFileContent $(normalizeStorePaths "$initLua") ${./plugin-config.expected}
+
+      # Provider configuration must be present
+      assertFileContains "$initLua" "python3_host_prog="
+      assertFileContains "$initLua" "ruby_host_prog="
+      assertFileContains "$initLua" "loaded_node_provider=0"
+      assertFileContains "$initLua" "loaded_perl_provider=0"
+      assertFileContains "$initLua" "loaded_python_provider=0"
+
+      # Lua package path, VimScript source, and plugin config must be present
+      assertFileContains "$initLua" "package.path"
+      assertFileContains "$initLua" "nvim-init-home-manager.vim"
+      assertFileContains "$initLua" "HM_PLUGIN_LUA_CONFIG"
 
       # Verify generatedConfigs evaluated properly (issue #8371)
       echo "Lua config length: ${toString (builtins.stringLength luaConfig)}"

--- a/tests/modules/programs/neovim/wrapper-args.nix
+++ b/tests/modules/programs/neovim/wrapper-args.nix
@@ -38,6 +38,7 @@ in
 
   nmt.script = ''
     nvimBin="home-path/bin/nvim"
+    initLua="home-files/.config/nvim/init.lua"
 
     assertBinaryContains() {
         local file="$TESTED/$1"
@@ -54,22 +55,22 @@ in
     # 1. extraName: Check if the suffix is in the rplugin manifest path within the wrapper
     assertBinaryContains "$nvimBin" "-my-suffix/rplugin.vim"
 
-    # 2. withPerl: Check if nvim-perl binary exists and host prog is set
+    # 2. withPerl: Check if nvim-perl binary exists and host prog is set in init.lua
     assertFileExists "home-path/bin/nvim-perl"
-    assertBinaryContains "$nvimBin" "perl_host_prog="
+    assertFileContains "$initLua" "perl_host_prog="
 
-    # 3. withPython3: Check if nvim-python3 binary exists and host prog is set
+    # 3. withPython3: Check if nvim-python3 binary exists and host prog is set in init.lua
     assertFileExists "home-path/bin/nvim-python3"
-    assertBinaryContains "$nvimBin" "python3_host_prog="
+    assertFileContains "$initLua" "python3_host_prog="
 
-    # 4. withRuby: Check if nvim-ruby binary exists, GEM_HOME and host prog are set
+    # 4. withRuby: Check if nvim-ruby binary exists, GEM_HOME is in wrapper, host prog in init.lua
     assertFileExists "home-path/bin/nvim-ruby"
     assertBinaryContains "$nvimBin" "GEM_HOME="
-    assertBinaryContains "$nvimBin" "ruby_host_prog="
+    assertFileContains "$initLua" "ruby_host_prog="
 
-    # 5. withNodeJs: Check if nvim-node binary exists and host prog is set
+    # 5. withNodeJs: Check if nvim-node binary exists and host prog is set in init.lua
     assertFileExists "home-path/bin/nvim-node"
-    assertBinaryContains "$nvimBin" "node_host_prog="
+    assertFileContains "$initLua" "node_host_prog="
 
     # 6. waylandSupport: Check for wl-clipboard path in wrapper's PATH modification
     # We check for the store path of wl-clipboard in the current pkgs


### PR DESCRIPTION
### Description

Nixpkgs commit `bd66006` moved `providerLuaRc` from a `--cmd` CLI flag into `rcContent`, which is only loaded when `wrapRc=true`.

Since home-manager sets `wrapRc=false` (it manages `init.lua` itself), provider globals like `python3_host_prog` are never set, breaking plugins that depend on `:python3` (e.g. `cmp-nvim-ultisnips`).

Generate the provider table directly in `initLua` at `mkOrder 50`, using the neovim wrapper store path via Nix string interpolation (avoiding the placeholder "out" issue in `providerLuaRc`).

Each provider is either pointed at its `nvim-<prog>` binary or disabled via `loaded_<prog>_provider=0`.

Update tests to assert provider lines appear in `init.lua` rather than in the wrapper binary or via exact file content matching.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>
Co-authored-by: Claude Opus 4.6

### Checklist

- [x] Change is backwards compatible.
  - NOTE: that new content is added to `init.lua` but no existing config should break

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or `nix-shell --pure tests -A run.all`.
  - NOTE: unrelated test failures:
    ```
    $ nix run .#tests -- test-all
    ℹ️ Discovering tests...
    ℹ️ Running 3 test(s)...
    
    --- Running test 1/3: test-all ---
    ❌ Test failed: test-all
    path '/Users/sirio/repos/foss/home-manager/tests' does not contain a 'flake.nix', searching up
    building '/nix/store/k6n27672zflnhdy818jr1y8m782j504p-calibre-plugins.drv'...
    error:
           … while calling the 'derivationStrict' builtin
             at <nix/derivation-internal.nix>:37:12:
               36|
               37|   strict = derivationStrict drvAttrs;
                 |            ^
               38|
    
           … while evaluating derivation 'nmt-all-tests'
             whose name attribute is located at /nix/store/0hxg06dwld1rqiyn16hg01vpk8hbqvc8-source/pkgs/stdenv/generic/make-derivation.nix:536:13
    
           … while evaluating attribute 'buildCommand' of derivation 'nmt-all-tests'
             at /nix/store/0hxg06dwld1rqiyn16hg01vpk8hbqvc8-source/pkgs/build-support/trivial-builders/default.nix:80:17:
               79|         enableParallelBuilding = true;
               80|         inherit buildCommand name;
                 |                 ^
               81|         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);
    
           … while evaluating the option `home.activation.checkFilesChanged.data':
    
           … while evaluating definitions from `/nix/store/aas9ahl3cyq62q8xfcgkidh34753rcxf-source/modules/files.nix':
    
           … while evaluating the option `home.file':
    
           … while evaluating definitions from `/nix/store/aas9ahl3cyq62q8xfcgkidh34753rcxf-source/modules/misc/mozilla-messaging-hosts.nix':
    
           … while evaluating the option `mozilla.firefoxNativeMessagingHosts':
    
           … while evaluating definitions from `/nix/store/aas9ahl3cyq62q8xfcgkidh34753rcxf-source/modules/programs/firefox':
    
           … while evaluating the option `programs.firefox.finalPackage':
    
           … while evaluating definitions from `/nix/store/aas9ahl3cyq62q8xfcgkidh34753rcxf-source/modules/programs/firefox':
    
           (stack trace truncated; use '--show-trace' to show the full, detailed trace)
    
           error: attribute 'description' missing
           at /nix/store/0hxg06dwld1rqiyn16hg01vpk8hbqvc8-source/pkgs/applications/networking/browsers/firefox/wrapper.nix:581:32:
              580|       meta = browser.meta // {
              581|         inherit (browser.meta) description;
                 |                                ^
              582|         mainProgram = launcherName;
    
    
    --- Running test 2/3: test-all-enableBig-false-enableLegacyIfd-false ---
    ✅ Test passed: test-all-enableBig-false-enableLegacyIfd-false
    ℹ️ Test directory available at: /nix/store/77zyjiy6nrihykifnzp6v83j7k2q37ng-nmt-all-tests/tested/
    
    --- Running test 3/3: test-all-enableBig-false-enableLegacyIfd-true ---
    ✅ Test passed: test-all-enableBig-false-enableLegacyIfd-true
    ℹ️ Test directory available at: /nix/store/3h3kdxnlc986yx7da8agvyxs51hfhcrv-nmt-all-tests/tested/
    
    --- Summary ---
    ❌ 1 of 3 test(s) failed:
      - test-all
    ```

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
