### PR TITLE
mistral-vibe: init

### DIFF
--- a/modules/misc/news/2026/02/2026-02-17_15-42-25.nix
+++ b/modules/misc/news/2026/02/2026-02-17_15-42-25.nix
@@ -1,0 +1,10 @@
+{
+  time = "2026-02-17T14:42:25+00:00";
+  condition = true;
+  message = ''
+
+    A new module is available: 'programs.mistral-vibe'.
+
+    mistral-vibe is Mistral's open-source CLI coding assistant.
+  '';
+}

--- a/modules/programs/mistral-vibe.nix
+++ b/modules/programs/mistral-vibe.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+
+  cfg = config.programs.mistral-vibe;
+
+  settingsFormat = pkgs.formats.toml { };
+
+in
+{
+  meta.maintainers = [ lib.maintainers.GaetanLepage ];
+
+  options.programs.mistral-vibe = {
+    enable = lib.mkEnableOption "Mistral Vibe, Mistral's open-source CLI coding assistant";
+
+    package = lib.mkPackageOption pkgs "mistral-vibe" { nullable = true; };
+
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      example = lib.literalExpression ''
+        {
+          active_model = "devstral-latest";
+          vim_keybindings = false;
+          tool_paths = [];
+
+          providers = [
+            {
+              name = "mistral";
+              backend = "mistral";
+              api_base = "https://api.mistral.ai/v1";
+              api_key_env_var = "MISTRAL_API_KEY";
+              api_style = "openai";
+            }
+          ];
+
+          models = [
+            {
+              name = "devstral-latest";
+              provider = "mistral";
+              alias = "devstral-latest";
+              temperature = 0.1;
+              input_price = 0.4;
+              output_price = 2.0;
+            }
+          ];
+        }
+      '';
+      description = ''
+        Mistral Vibe configuration.
+        For available settings see <https://github.com/mistralai/mistral-vibe>.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    home.file.".vibe/config.toml".source = settingsFormat.generate "config.toml" cfg.settings;
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -104,6 +104,7 @@ let
     "mergiraf"
     "micro"
     "mise"
+    "mistral-vibe"
     "mpv"
     "msmtp"
     "mu"

--- a/tests/modules/programs/mistral-vibe/default.nix
+++ b/tests/modules/programs/mistral-vibe/default.nix
@@ -1,0 +1,1 @@
+{ mistral-vibe-program = ./mistral-vibe.nix; }

--- a/tests/modules/programs/mistral-vibe/expected.toml
+++ b/tests/modules/programs/mistral-vibe/expected.toml
@@ -1,0 +1,16 @@
+active_model = "tracer-vibe"
+
+[[models]]
+alias = "tracer-vibe"
+input_price = 0.0
+name = "mistralai/devstral-2512:free"
+output_price = 0.0
+provider = "tracer-proxy"
+temperature = 0.1
+
+[[providers]]
+api_base = "http://tracer:8081/proxy"
+api_key_env_var = "OPENROUTER_API_KEY"
+api_style = "openai"
+backend = "generic"
+name = "tracer-proxy"

--- a/tests/modules/programs/mistral-vibe/mistral-vibe.nix
+++ b/tests/modules/programs/mistral-vibe/mistral-vibe.nix
@@ -1,0 +1,34 @@
+{
+  programs.mistral-vibe = {
+    enable = true;
+
+    settings = {
+      active_model = "tracer-vibe";
+
+      providers = [
+        {
+          name = "tracer-proxy";
+          api_base = "http://tracer:8081/proxy";
+          api_key_env_var = "OPENROUTER_API_KEY";
+          api_style = "openai";
+          backend = "generic";
+        }
+      ];
+      models = [
+        {
+          name = "mistralai/devstral-2512:free";
+          provider = "tracer-proxy";
+          alias = "tracer-vibe";
+          temperature = 0.1;
+          input_price = 0.0;
+          output_price = 0.0;
+        }
+      ];
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.vibe/config.toml
+    assertFileContent home-files/.vibe/config.toml ${./expected.toml}
+  '';
+}


### PR DESCRIPTION
### Description

Add the `programs.mistral-vibe` module for [mistral-vibe](https://github.com/mistralai/mistral-vibe), Mistral AI's CLI coding agent.

cc @mana-byte

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
