### PR TITLE
claude-code: add support for output styles

### DIFF
--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -293,6 +293,29 @@ in
       example = lib.literalExpression "./hooks";
     };
 
+    outputStyles = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.either lib.types.lines lib.types.path);
+      default = { };
+      description = ''
+        Custom output styles for Claude Code.
+        The attribute name becomes the base of the output style filename.
+        The value is either:
+          - Inline content as a string
+          - A path to a file
+        In both cases, the contents will be written to .claude/output-styles/<name>.md
+      '';
+      example = lib.literalExpression ''
+        {
+          concise = ./output-styles/concise.md;
+          detailed = '''
+            # Detailed Output Style
+
+            Contents will be used verbatim for the detailed output format.
+          ''';
+        }
+      '';
+    };
+
     skills = lib.mkOption {
       type = lib.types.attrsOf (lib.types.either lib.types.lines lib.types.path);
       default = { };
@@ -520,7 +543,13 @@ in
           lib.nameValuePair ".claude/skills/${name}/SKILL.md" (
             if lib.isPath content then { source = content; } else { text = content; }
           )
-      ) cfg.skills;
+      ) cfg.skills
+      // lib.mapAttrs' (
+        name: content:
+        lib.nameValuePair ".claude/output-styles/${name}.md" (
+          if lib.isPath content then { source = content; } else { text = content; }
+        )
+      ) cfg.outputStyles;
     };
   };
 }

--- a/tests/modules/programs/claude-code/default.nix
+++ b/tests/modules/programs/claude-code/default.nix
@@ -17,4 +17,6 @@
   claude-code-commands-path = ./commands-path.nix;
   claude-code-skills-path = ./skills-path.nix;
   claude-code-mixed-content = ./mixed-content.nix;
+  claude-code-output-styles = ./output-styles.nix;
+  claude-code-output-styles-not-set = ./output-styles-not-set.nix;
 }

--- a/tests/modules/programs/claude-code/output-styles-not-set.nix
+++ b/tests/modules/programs/claude-code/output-styles-not-set.nix
@@ -1,0 +1,12 @@
+{
+  programs.claude-code = {
+    enable = true;
+    settings = {
+      theme = "dark";
+    };
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.claude/output-styles
+  '';
+}

--- a/tests/modules/programs/claude-code/output-styles.nix
+++ b/tests/modules/programs/claude-code/output-styles.nix
@@ -1,0 +1,25 @@
+{
+  programs.claude-code = {
+    enable = true;
+    outputStyles = {
+      inline-style = ''
+        # Inline Output Style
+
+        This is an inline output style for testing.
+        It should be written to .claude/output-styles/inline-style.md
+      '';
+      path-style = ./test-output-style.md;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.claude/output-styles/inline-style.md
+    assertFileExists home-files/.claude/output-styles/path-style.md
+
+    assertFileContent home-files/.claude/output-styles/path-style.md \
+      ${./test-output-style.md}
+
+    assertFileRegex home-files/.claude/output-styles/inline-style.md \
+      'This is an inline output style for testing'
+  '';
+}

--- a/tests/modules/programs/claude-code/test-output-style.md
+++ b/tests/modules/programs/claude-code/test-output-style.md
@@ -1,0 +1,4 @@
+# Test Output Style
+
+This is a test output style loaded from a file path.
+Used to verify path support functionality for output styles.


### PR DESCRIPTION
### Description

Adds a single option plus tests to configure and populate the `.claude/output-styles` directory used by Claude Code to store [custom output styles](https://code.claude.com/docs/en/output-styles#create-a-custom-output-style). The module accepts either inline text or paths which will be used as the content of the custom style verbatim.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
