### PR TITLE
zed-editor: fix remote server executable name

### DIFF
--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -246,8 +246,8 @@ in
 
     home.file = mkIf (cfg.installRemoteServer && (cfg.package ? remote_server)) (
       let
-        inherit (cfg.package) version remote_server;
-        binaryName = "zed-remote-server-stable-${version}";
+        inherit (cfg.package) remote_server;
+        binaryName = cfg.package.remoteServerExecutableName;
       in
       {
         ".zed_server/${binaryName}".source = lib.getExe' remote_server binaryName;

--- a/tests/modules/programs/zed-editor/install-remote-server.nix
+++ b/tests/modules/programs/zed-editor/install-remote-server.nix
@@ -1,5 +1,8 @@
 { config, ... }:
 
+let
+  executableName = "zed-remote-server-stable-57+stable";
+in
 {
   programs.zed-editor = {
     enable = true;
@@ -7,14 +10,15 @@
       remote_server = config.lib.test.mkStubPackage {
         buildScript = ''
           mkdir -p $out/bin
-          touch $out/bin/zed-remote-server-stable-57
+          touch $out/bin/${executableName}
         '';
       };
+      remoteServerExecutableName = executableName;
     };
     installRemoteServer = true;
   };
 
   nmt.script = ''
-    assertFileExists "home-files/.zed_server/zed-remote-server-stable-57"
+    assertFileExists "home-files/.zed_server/${executableName}"
   '';
 }


### PR DESCRIPTION
The remote server executable in the zed-editor package has a '+stable' appended at the end now. This uses the remoteServerExecutableName attribute from the zed-editor package instead of guessing.

### Description

Fix for #8777.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
