### PR TITLE
radicle: enable default.target for non-lazy node service

### DIFF
--- a/modules/services/radicle.nix
+++ b/modules/services/radicle.nix
@@ -2,7 +2,6 @@
   config,
   lib,
   pkgs,
-  options,
   ...
 }:
 let
@@ -183,6 +182,7 @@ in
                 ];
               }
             ];
+            Install.WantedBy = mkIf (!cfg.node.lazy.enable) [ "default.target" ];
           };
         "radicle-node-proxy" = mkIf cfg.node.lazy.enable {
           Unit = {


### PR DESCRIPTION
### Description

When `services.radicle.node.lazy.enable` is false, it wouldn't start on boot for me. Setting `Install.WantedBy` fixes this for me. I can't find other people having this issue though. 

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```