### PR TITLE
rizin: add settings option

### DIFF
--- a/tests/modules/programs/rizin/default.nix
+++ b/tests/modules/programs/rizin/default.nix
@@ -2,4 +2,5 @@
   rizin-basic-configuration = ./basic-configuration.nix;
   rizin-disabled-configuration = ./disabled-configuration.nix;
   rizin-prefer-xdg = ./prefer-xdg.nix;
+  rizin-settings-configuration = ./settings-configuration.nix;
 }

--- a/tests/modules/programs/rizin/settings-configuration.nix
+++ b/tests/modules/programs/rizin/settings-configuration.nix
@@ -1,0 +1,13 @@
+{
+  programs.rizin = {
+    enable = true;
+    settings = {
+      "asm.bytes" = true;
+      "asm.bytes.space" = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/.rizinrc"
+  '';
+}


### PR DESCRIPTION
### Description

This adds a `settings` option to the rizin module,
which allows configuring rizin with the `e` command.
All other configuration currently still requires `extraConfig`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
