### PR TITLE
i3-sway: allow inverse_outer on smart_gaps

### DIFF
--- a/modules/misc/news/2026/02/2026-02-24_19-17-29.nix
+++ b/modules/misc/news/2026/02/2026-02-24_19-17-29.nix
@@ -1,0 +1,9 @@
+{
+  time = "2026-02-24T18:17:29+00:00";
+  condition = true;
+  message = ''
+    The options 'xsession.windowManager.i3.config.gaps.smartGaps' and
+    'wayland.windowManager.sway.config.gaps.smartGaps' now expects either "on",
+    "off" (default) or "inverse_outer".
+  '';
+}

--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -189,7 +189,7 @@ rec {
           (optionalString (bottom != null) "gaps bottom ${toString bottom}")
           (optionalString (left != null) "gaps left ${toString left}")
           (optionalString (right != null) "gaps right ${toString right}")
-          (optionalString smartGaps "smart_gaps on")
+          (optionalString (smartGaps != "off") "smart_gaps ${smartGaps}")
           (optionalString (smartBorders != "off") "smart_borders ${smartBorders}")
         ]
     );

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -932,13 +932,27 @@ in
           };
 
           smartGaps = mkOption {
-            type = types.bool;
-            default = false;
+            type = types.either types.bool (
+              types.enum [
+                "on"
+                "off"
+                "inverse_outer"
+              ]
+            );
+            apply =
+              value:
+              if value == true then
+                "on"
+              else if value == false then
+                "off"
+              else
+                value;
+            default = "off";
             description = ''
               This option controls whether to disable all gaps (outer and inner)
               on workspace with a single container.
             '';
-            example = true;
+            example = "on";
           };
 
           smartBorders = mkOption {


### PR DESCRIPTION
### Description

Change the boolean `smartGaps` option to an `enum` that expects common values of i3 and sway ("on" "off" "inverse_outer").

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] ~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).~
  - [x] ~Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)~
  - [x] ~Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)~

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
