### PR TITLE
nixpkgs: add setting nixpkgs.config.allowUnfreePackages = ["list" "of" "packages"]

### DIFF
--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -20,8 +20,10 @@ let
       lhs = optCall lhs_ { inherit pkgs; };
       rhs = optCall rhs_ { inherit pkgs; };
     in
-    lhs
-    // rhs
+    lib.recursiveUpdate lhs rhs
+    // lib.optionalAttrs (lhs ? allowUnfreePackages) {
+      allowUnfreePackages = lhs.allowUnfreePackages ++ (lib.attrByPath [ "allowUnfreePackages" ] [ ] rhs);
+    }
     // lib.optionalAttrs (lhs ? packageOverrides) {
       packageOverrides =
         pkgs:


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Includes the allowUnfreeOptions option added to nixpkgs via [918178a](https://github.com/NixOS/nixpkgs/commit/918178a9c9760091e6f71a31151bf15602898305).

Changes taken 1:1 from linked upstream nixpkgs change, redistribution as permitted by the MIT license.

Closes #8775 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] ~~Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~~

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] ~~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).~~
  - [x] ~~Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)~~
  - [x] ~~Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)~~

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] ~~Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)~~
