### PR TITLE
ec: init module

### DIFF
--- a/modules/programs/ec.nix
+++ b/modules/programs/ec.nix
@@ -1,0 +1,41 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.ec;
+  ec = lib.getExe cfg.package;
+in
+{
+  meta.maintainers = [ lib.maintainers.kpbaks ];
+
+  options = {
+    programs.ec = {
+      enable = lib.mkEnableOption "ec, 3-way terminal native Git merge conflict resolver";
+      package = lib.mkPackageOption pkgs "ec" { };
+
+      enableGitIntegration = lib.mkOption {
+        type = lib.types.bool;
+        description = ''
+          Whether to enable git integration for ec.
+
+          When enabled, ec will be configured as git's merge tool.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs.git.settings = lib.mkIf cfg.enableGitIntegration {
+      merge.tool = "ec";
+      mergetool.ec = {
+        cmd = ''${ec} "$BASE" "$LOCAL" "$REMOTE" "$MERGED"'';
+        trustExitCode = true;
+      };
+    };
+  };
+}

--- a/modules/programs/ec.nix
+++ b/modules/programs/ec.nix
@@ -18,6 +18,7 @@ in
 
       enableGitIntegration = lib.mkOption {
         type = lib.types.bool;
+        default = false;
         description = ''
           Whether to enable git integration for ec.
 

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -44,6 +44,7 @@ let
     "discord"
     "discoss"
     "earthly"
+    "ec"
     "element-desktop"
     "emacs"
     "espanso"

--- a/tests/modules/programs/ec/basic-configuration.nix
+++ b/tests/modules/programs/ec/basic-configuration.nix
@@ -1,0 +1,9 @@
+{
+  programs.git.enable = true;
+  programs.ec.enable = true;
+  programs.ec.enableGitIntegration = true;
+
+  nmt.script = ''
+    assertFileContent "home-files/.config/git/config" ${./ec-git.conf}
+  '';
+}

--- a/tests/modules/programs/ec/default.nix
+++ b/tests/modules/programs/ec/default.nix
@@ -1,0 +1,3 @@
+{
+  ec-basic-configuration = ./basic-configuration.nix;
+}

--- a/tests/modules/programs/ec/ec-git.conf
+++ b/tests/modules/programs/ec/ec-git.conf
@@ -1,0 +1,12 @@
+[gpg]
+	format = "openpgp"
+
+[gpg "openpgp"]
+	program = "@gnupg@/bin/gpg"
+
+[merge]
+	tool = "ec"
+
+[mergetool "ec"]
+	cmd = "@ec@/bin/ec \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\""
+	trustExitCode = true


### PR DESCRIPTION
### Description

Adds Home Manager module for ec, a 3-way terminal native Git merge conflict resolver.

The module supports:
- Git integration by configuring ec as a mergetool.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
