### PR TITLE
difftastic: fix example: s/sort-path/sort-paths/

### DIFF
--- a/modules/programs/difftastic.nix
+++ b/modules/programs/difftastic.nix
@@ -75,7 +75,7 @@ in
       default = { };
       example = {
         color = "dark";
-        sort-path = true;
+        sort-paths = true;
         tab-width = 8;
       };
       description = "Configuration options for {command}`difftastic`. See {command}`difft --help`";


### PR DESCRIPTION
### Description

Fixed the example, I realized it was wrong since I copied it and got an error:

```
$ difft --sort-path
error: unexpected argument '--sort-path' found

  tip: a similar argument exists: '--sort-paths'
```

The option is documented in `difft --help` and implemented in `difftastic/src/options.rs`.

https://github.com/Wilfred/difftastic/blob/7d8175dccfdde3a9046acd389980f7240ca58d96/src/options.rs#L375

It's used correctly in the jujutsu submodule at the end of this file.

### Checklist

- [x] Change is backwards compatible.

- [] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
