### PR TITLE
waybar: Avoid reload onChange when systemd integration is enabled

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -318,7 +318,7 @@ in
 
         xdg.configFile."waybar/config" = mkIf (settings != [ ]) {
           source = configSource;
-          onChange = ''
+          onChange = mkIf (!cfg.systemd.enable) ''
             ${pkgs.procps}/bin/pkill -u $USER -USR2 waybar || true
           '';
         };
@@ -329,7 +329,7 @@ in
               cfg.style
             else
               pkgs.writeText "waybar/style.css" cfg.style;
-          onChange = ''
+          onChange = mkIf (!cfg.systemd.enable) ''
             ${pkgs.procps}/bin/pkill -u $USER -USR2 waybar || true
           '';
         };


### PR DESCRIPTION
When systemd integration is enabled, systemd will handle the issuing of `SIGUSR2` through `X-Reload-Triggers`.

All this would do is trigger multiple `SIGUSR2` signals, which can exacerbate this upstream issue:
https://github.com/Alexays/Waybar/issues/3344#issuecomment-2390661508

### Description

Modifies the waybar module to only reload the waybar process onChange to configuration when the systemd integration is not enabled, as that already handles this.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
