### PR TITLE
neovim: adapt provider tests

### DIFF
--- a/tests/modules/programs/neovim/wrapper-args.nix
+++ b/tests/modules/programs/neovim/wrapper-args.nix
@@ -1,6 +1,7 @@
 {
   lib,
   pkgs,
+  realPkgs,
   ...
 }:
 
@@ -21,11 +22,11 @@ let
   };
 in
 {
-  imports = [ ./stubs.nix ];
   tests.stubs.wl-clipboard = { };
 
   programs.neovim = {
     enable = true;
+    package = realPkgs.neovim-unwrapped;
     extraName = "-my-suffix";
     withPerl = true;
     withPython3 = true;
@@ -38,6 +39,8 @@ in
 
   nmt.script = ''
     nvimBin="home-path/bin/nvim"
+    export PATH="$TESTED/home-path/bin:$PATH"
+    export HOME="$TMPDIR/hm-user"
 
     assertBinaryContains() {
         local file="$TESTED/$1"
@@ -45,6 +48,15 @@ in
 
         if ! grep -a -qF -- "$2" "$file"; then
             fail "Expected binary file '$1' to contain '$2' but it did not."
+        fi
+    }
+
+    # Helper function to check host_prog provider configuration
+    assertNeovimExpr() {
+        local var_name="$1"
+        local expected_pattern="$2"
+        if ! nvim -i NONE --headless --cmd "echo $var_name" +q! 2>&1 | grep "$expected_pattern" ; then
+          fail "Provider $var_name doesn't match expected pattern '$expected_pattern'"
         fi
     }
 
@@ -56,20 +68,20 @@ in
 
     # 2. withPerl: Check if nvim-perl binary exists and host prog is set
     assertFileExists "home-path/bin/nvim-perl"
-    assertBinaryContains "$nvimBin" "perl_host_prog="
+    assertNeovimExpr "g:perl_host_prog" "nvim-perl"
 
     # 3. withPython3: Check if nvim-python3 binary exists and host prog is set
     assertFileExists "home-path/bin/nvim-python3"
-    assertBinaryContains "$nvimBin" "python3_host_prog="
+    assertNeovimExpr "g:python3_host_prog" "python3"
 
     # 4. withRuby: Check if nvim-ruby binary exists, GEM_HOME and host prog are set
     assertFileExists "home-path/bin/nvim-ruby"
     assertBinaryContains "$nvimBin" "GEM_HOME="
-    assertBinaryContains "$nvimBin" "ruby_host_prog="
+    assertNeovimExpr "g:ruby_host_prog" "ruby"
 
     # 5. withNodeJs: Check if nvim-node binary exists and host prog is set
     assertFileExists "home-path/bin/nvim-node"
-    assertBinaryContains "$nvimBin" "node_host_prog="
+    assertNeovimExpr "g:node_host_prog" "node"
 
     # 6. waylandSupport: Check for wl-clipboard path in wrapper's PATH modification
     # We check for the store path of wl-clipboard in the current pkgs


### PR DESCRIPTION
### Description

trying to make some changes ahead of some nixpkgs changes (and reduce need for https://github.com/nix-community/home-manager/pull/8683). 

This is an end to end test, checking the value seen by neovim, rather than testing the implementation for provider.
I had to remove the stub for neovim. 


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
