### PR TITLE
colima: add `kubectl` to the service's `$PATH`

### DIFF
--- a/modules/services/colima.nix
+++ b/modules/services/colima.nix
@@ -62,6 +62,9 @@ in
     bashPackage = lib.mkPackageOption pkgs "bashNonInteractive" {
       extraDescription = "Used by colima's internal scripts.";
     };
+    kubectlPackage = lib.mkPackageOption pkgs "kubectl" {
+      extraDescription = "Used by colima when kubernetes is enabled in the profile.";
+    };
 
     profiles = lib.mkOption {
       default = {
@@ -285,6 +288,7 @@ in
                 cfg.coreutilsPackage
                 cfg.curlPackage
                 cfg.bashPackage
+                cfg.kubectlPackage
                 pkgs.darwin.DarwinTools
               ];
             }
@@ -331,6 +335,7 @@ in
                   cfg.coreutilsPackage
                   cfg.curlPackage
                   cfg.bashPackage
+                  cfg.kubectlPackage
                 ]
               }"
             ]

--- a/tests/modules/services/colima/darwin/colima-default-config.nix
+++ b/tests/modules/services/colima/darwin/colima-default-config.nix
@@ -47,6 +47,10 @@
       name = "bashNonInteractive";
       outPath = "@bashNonInteractive@";
     };
+    kubectlPackage = config.lib.test.mkStubPackage {
+      name = "kubectl";
+      outPath = "@kubectl@";
+    };
   };
 
   nmt.script = ''

--- a/tests/modules/services/colima/darwin/colima-docker-cli-expected.plist
+++ b/tests/modules/services/colima/darwin/colima-docker-cli-expected.plist
@@ -11,7 +11,7 @@
 		<key>LIMA_HOME</key>
 		<string>/home/hm-user/.local/share/lima</string>
 		<key>PATH</key>
-		<string>@colima@/bin:@perl@/bin:@docker@/bin:@openssh@/bin:@coreutils@/bin:@curl@/bin:@bashNonInteractive@/bin:@DarwinTools@/bin</string>
+		<string>@colima@/bin:@perl@/bin:@docker@/bin:@openssh@/bin:@coreutils@/bin:@curl@/bin:@bashNonInteractive@/bin:@kubectl@/bin:@DarwinTools@/bin</string>
 		<key>XDG_CACHE_HOME</key>
 		<string>/home/hm-user/.cache</string>
 	</dict>

--- a/tests/modules/services/colima/darwin/colima-docker-cli.nix
+++ b/tests/modules/services/colima/darwin/colima-docker-cli.nix
@@ -54,6 +54,10 @@
       name = "bashNonInteractive";
       outPath = "@bashNonInteractive@";
     };
+    kubectlPackage = config.lib.test.mkStubPackage {
+      name = "kubectl";
+      outPath = "@kubectl@";
+    };
   };
 
   nmt.script =

--- a/tests/modules/services/colima/darwin/expected-agent.plist
+++ b/tests/modules/services/colima/darwin/expected-agent.plist
@@ -7,7 +7,7 @@
 		<key>COLIMA_HOME</key>
 		<string>/home/hm-user/.colima</string>
 		<key>PATH</key>
-		<string>@colima@/bin:@perl@/bin:@docker@/bin:@openssh@/bin:@coreutils@/bin:@curl@/bin:@bashNonInteractive@/bin:@DarwinTools@/bin</string>
+		<string>@colima@/bin:@perl@/bin:@docker@/bin:@openssh@/bin:@coreutils@/bin:@curl@/bin:@bashNonInteractive@/bin:@kubectl@/bin:@DarwinTools@/bin</string>
 		<key>XDG_CACHE_HOME</key>
 		<string>/home/hm-user/.cache</string>
 	</dict>

--- a/tests/modules/services/colima/linux/colima-docker-cli-expected.service
+++ b/tests/modules/services/colima/linux/colima-docker-cli-expected.service
@@ -3,7 +3,7 @@ WantedBy=default.target
 
 [Service]
 Environment=COLIMA_HOME=/home/hm-user/.config/colima
-Environment=PATH=@colima@/bin:@perl@/bin:@docker@/bin:@openssh@/bin:@coreutils@/bin:@curl@/bin:@bashNonInteractive@/bin
+Environment=PATH=@colima@/bin:@perl@/bin:@docker@/bin:@openssh@/bin:@coreutils@/bin:@curl@/bin:@bashNonInteractive@/bin:@kubectl@/bin
 Environment=LIMA_HOME=/home/hm-user/.local/share/lima
 Environment=DOCKER_CONFIG=/home/hm-user/.config/docker
 ExecStart=@colima@/bin/colima start default \

--- a/tests/modules/services/colima/linux/expected-service.service
+++ b/tests/modules/services/colima/linux/expected-service.service
@@ -3,7 +3,7 @@ WantedBy=default.target
 
 [Service]
 Environment=COLIMA_HOME=/home/hm-user/.colima
-Environment=PATH=@colima@/bin:@perl@/bin:@docker@/bin:@openssh@/bin:@coreutils@/bin:@curl@/bin:@bashNonInteractive@/bin
+Environment=PATH=@colima@/bin:@perl@/bin:@docker@/bin:@openssh@/bin:@coreutils@/bin:@curl@/bin:@bashNonInteractive@/bin:@kubectl@/bin
 ExecStart=@colima@/bin/colima start default \
   -f \
   --activate=true \


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

`kubernetes.enabled` requires `kubectl` to be available in `$PATH` when starting the profile, otherwise we fail with:
```
time="2026-02-20T16:33:46-03:00" level=info msg="starting colima"
time="2026-02-20T16:33:46-03:00" level=info msg="runtime: docker+k3s"
time="2026-02-20T16:33:46-03:00" level=fatal msg="dependency check failed for kubernetes: kubectl not found, run 'brew install kubectl' to install"
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
