### PR TITLE
programs.prek: init module

### DIFF
--- a/modules/misc/news/2026/02/2026-02-28_16-47-14.nix
+++ b/modules/misc/news/2026/02/2026-02-28_16-47-14.nix
@@ -1,0 +1,7 @@
+{
+  time = "2026-02-28T13:47:14+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.prek`
+  '';
+}

--- a/modules/programs/prek.nix
+++ b/modules/programs/prek.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.prek;
+  exe = lib.getExe cfg.package;
+in
+{
+  meta.maintainers = with lib.maintainers; [ ilkecan ];
+
+  options.programs.prek = {
+    enable = lib.mkEnableOption "prek, a pre-commit alternative re-engineered in Rust";
+
+    package = lib.mkPackageOption pkgs "prek" { };
+
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
+
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs.bash.initExtra = lib.mkIf cfg.enableBashIntegration ''
+      eval "$(COMPLETE=bash ${exe})"
+    '';
+
+    programs.zsh.initContent = lib.mkIf cfg.enableZshIntegration ''
+      eval "$(COMPLETE=zsh ${exe})"
+    '';
+
+    programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+      COMPLETE=fish ${exe} | source
+    '';
+  };
+}


### PR DESCRIPTION
### Description
Add a module for [prek](https://github.com/j178/prek), a `pre-commit` alternative.

Since there is no global (`$XDG_CONFIG_HOME/prek/*`) configuration file, the module currently only enables shell completions, on top of installing the tool.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
