### PR TITLE
docs: add section about idiomatic options

### DIFF
--- a/docs/manual/writing-modules.md
+++ b/docs/manual/writing-modules.md
@@ -11,3 +11,7 @@ chapter of the NixOS manual.
 ```{=include=} sections
 writing-modules/types.md
 ```
+
+```{=include=} sections
+writing-modules/idiomatic-options.md
+```

--- a/docs/manual/writing-modules/idiomatic-options.md
+++ b/docs/manual/writing-modules/idiomatic-options.md
@@ -1,0 +1,24 @@
+# Idiomatic options {#sec-idiomatic-options}
+
+With time, a few patterns have emerged in the "shape" of some modules, with
+common patterns and a shared vocabulary of options in use for Home Manager.
+
+We've documented a few of them as do's and don'ts here.
+
+## Shell integrations {#sec-shell-integrations}
+
+XXX.
+
+### Shell completion {#sec-shell-completion}
+
+Shell completion is _not_ the duty of Home-Manager, and should instead be
+packaged upstream in Nixpkgs, usually through the use of
+[`installShellCompletion`](https://nixos.org/manual/nixpkgs/unstable/#installshellfiles-installshellcompletion).
+
+To be more explicit: a module's shell integration should _not_ be to source its
+completion at runtime, this is better done by generating them at build time
+during packaging and placing them in their expected location.
+
+## VCS integrations {#sec-vcs-integrations}
+
+Similar to [shell integrations](#sec-vcs-integrations). XXX.


### PR DESCRIPTION
### Description

Draft to work towards (finally) closing #6441.

I think this would belong into a larger section about common patterns in Home Manager, like the shell and VCS integration options. Feel free to suggest more patterns that should belong in this section.

Still a draft, as it needs to be _actually_ written.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
