### PR TITLE
xonsh: add module

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -627,6 +627,7 @@ in
     programs.zsh.shellAliases = cfg.shellAliases;
     programs.fish.shellAliases = cfg.shellAliases;
     programs.nushell.shellAliases = cfg.shellAliases;
+    programs.xonsh.shellAliases = cfg.shellAliases;
 
     home.sessionVariables =
       let

--- a/modules/misc/news/2026/02/2026-02-28_18-03-02.nix
+++ b/modules/misc/news/2026/02/2026-02-28_18-03-02.nix
@@ -1,0 +1,14 @@
+{
+  time = "2026-02-28T23:03:02+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.xonsh'.
+
+    Xonsh is a Python-powered shell. Full-featured, 
+    cross-platform and AI-friendly. The language is 
+    a superset of Python 3 with seamless integration 
+    of shell functionality and commands. The name Xonsh 
+    should be pronounced like "consh" — a softer form of the word 
+    "conch", referring to the world of command shells.
+  '';
+}

--- a/modules/programs/xonsh.nix
+++ b/modules/programs/xonsh.nix
@@ -1,0 +1,277 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    literalExpression
+    mkIf
+    mkOption
+    mkEnableOption
+    types
+    ;
+
+  cfg = config.programs.xonsh;
+
+  package =
+    if cfg.extraPackages == null then
+      cfg.package
+    else
+      cfg.package.override { inherit (cfg) extraPackages; };
+
+  aliasesStr = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (
+      k: v: "aliases[${lib.strings.escapeNixString k}] = ${builtins.toJSON v}"
+    ) cfg.shellAliases
+  );
+
+  envVarsStr = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (k: v: "${"$"}${k} = ${builtins.toJSON v}") cfg.sessionVariables
+  );
+
+  xontribsStr =
+    if cfg.xontribs == [ ] then "" else "xontrib load ${lib.concatStringsSep " " cfg.xontribs}";
+
+  optionalBlock =
+    comment: text:
+    if lib.strings.stringLength (lib.strings.trim text) == 0 then "" else "# ${comment}\n${text}\n";
+
+  rcText =
+    let
+      dollar = "$";
+    in
+    ''
+      # ~/.config/xonsh/rc.xsh: DO NOT EDIT -- this file has been generated
+      # automatically by home-manager.
+
+      ${optionalBlock "Session variables" envVarsStr}
+      ${optionalBlock "Xontribs" xontribsStr}
+      ${optionalBlock "Aliases" aliasesStr}
+      ${optionalBlock "Shell init" cfg.shellInit}
+      ${lib.optionalString (lib.strings.trim cfg.loginShellInit != "") ''
+        if ${dollar}XONSH_LOGIN:
+            # Login shell initialisation
+            ${lib.concatStringsSep "\n    " (lib.strings.splitString "\n" cfg.loginShellInit)}
+      ''}
+      ${lib.optionalString (lib.strings.trim cfg.interactiveShellInit != "") ''
+        if ${dollar}XONSH_INTERACTIVE:
+            # Interactive shell initialisation
+            ${lib.concatStringsSep "\n    " (lib.strings.splitString "\n" cfg.interactiveShellInit)}
+      ''}
+      ${optionalBlock "Shell init last" cfg.shellInitLast}
+      ${optionalBlock "Extra config" cfg.xonshrcExtra}
+    '';
+
+in
+{
+  meta.maintainers = with lib.maintainers; [ ZZBaron ];
+
+  options.programs.xonsh = {
+    enable = mkEnableOption "xonsh, a Python-powered shell";
+
+    package = lib.mkPackageOption pkgs "xonsh" {
+      extraDescription = ''
+        When {option}`programs.xonsh.extraPackages` is set, this package will
+        be overridden via its `extraPackages` argument, mirroring the NixOS
+        `programs.xonsh` module behaviour.
+      '';
+    };
+
+    extraPackages = mkOption {
+      type = types.nullOr (
+        types.coercedTo (types.listOf types.package) (v: (_: v)) (
+          types.functionTo (types.listOf types.package)
+        )
+      );
+      default = null;
+      defaultText = literalExpression "null";
+      example = literalExpression ''
+        ps: with ps; [ numpy xonsh.xontribs.xontrib-vox ]
+      '';
+      description = ''
+        Extra Python packages and xontrib packages to make available inside
+        xonsh. When non-null, the xonsh derivation is overridden with these
+        packages via its `extraPackages` argument.
+
+        Leave as `null` (the default) to use the package unmodified.
+      '';
+    };
+
+    shellAliases = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = literalExpression ''
+        {
+          g    = "git";
+          ll   = "ls -l";
+          ".." = "cd ..";
+        }
+      '';
+      description = ''
+        An attribute set of shell aliases. Each entry is emitted as
+        `aliases["key"] = "value"` in the xonsh run control file.
+      '';
+    };
+
+    sessionVariables = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = literalExpression ''
+        {
+          EDITOR = "nvim";
+          PAGER  = "less";
+        }
+      '';
+      description = ''
+        Environment variables to set via xonsh's `$VAR = "value"` syntax.
+        These are set unconditionally at every shell startup.
+      '';
+    };
+
+    xontribs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = literalExpression ''[ "vox" "mpl" "coreutils" ]'';
+      description = ''
+        List of xontrib names to load via `xontrib load` at startup. The
+        corresponding Python packages must be available, either through
+        {option}`programs.xonsh.extraPackages` or {option}`home.packages`.
+      '';
+    };
+
+    plugins = mkOption {
+      type = types.listOf (
+        types.submodule {
+          options = {
+            name = mkOption {
+              type = types.str;
+              description = ''
+                A unique name for this plugin, used as the file stem in
+                {file}`~/.config/xonsh/rc.d/` (e.g. `"my-init"` →
+                {file}`rc.d/my-init.xsh`).
+              '';
+            };
+            src = mkOption {
+              type = types.path;
+              description = ''
+                Path to a `.xsh` or `.py` file to install into
+                {file}`~/.config/xonsh/rc.d/`. Xonsh executes all files
+                in this directory at startup in alphabetical order.
+              '';
+            };
+          };
+        }
+      );
+      default = [ ];
+      example = literalExpression ''
+        [
+          {
+            name = "my-init";
+            src  = ./my-xonsh-init.xsh;
+          }
+        ]
+      '';
+      description = ''
+        A list of xonsh script files (`.xsh` or `.py`) to install into
+        {file}`~/.config/xonsh/rc.d/`. Files are executed in alphabetical
+        order at startup.
+      '';
+    };
+
+    shellInit = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Xonsh code executed at shell startup in both interactive and
+        non-interactive sessions. Runs before the login and interactive
+        blocks.
+      '';
+    };
+
+    loginShellInit = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Xonsh code executed only in login shells (`$XONSH_LOGIN` is `True`).
+      '';
+    };
+
+    interactiveShellInit = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Xonsh code executed only in interactive shells
+        (`$XONSH_INTERACTIVE` is `True`).
+      '';
+    };
+
+    shellInitLast = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Xonsh code executed at the very end of the run control file, after
+        all other init blocks. Useful for settings or overrides that must
+        come last.
+      '';
+    };
+
+    xonshrcExtra = mkOption {
+      type = types.lines;
+      default = "";
+      example = literalExpression ''
+        $XONSH_HISTORY_MATCH_ANYWHERE = True
+        $XONSH_AUTOPAIR = True
+      '';
+      description = ''
+        Extra xonsh code appended verbatim to the end of
+        {file}`~/.config/xonsh/rc.xsh`. This is the escape hatch for
+        settings not covered by the other options.
+      '';
+    };
+
+    bashCompletion = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to configure xonsh to use bash completions by pointing
+          `$BASH_COMPLETIONS` at the bash-completion package. This enables
+          completion for programs that ship bash completion scripts.
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs "bash-completion" { };
+    };
+  };
+
+  config = mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        home.packages = [ package ];
+
+        xdg.configFile."xonsh/rc.xsh".text = rcText;
+      }
+
+      (mkIf (cfg.plugins != [ ]) {
+        xdg.configFile = lib.listToAttrs (
+          map (plugin: {
+            name = "xonsh/rc.d/${plugin.name}.xsh";
+            value = {
+              source = plugin.src;
+            };
+          }) cfg.plugins
+        );
+      })
+
+      (mkIf cfg.bashCompletion.enable {
+        home.packages = [ cfg.bashCompletion.package ];
+
+        programs.xonsh.interactiveShellInit = lib.mkAfter ''
+          $BASH_COMPLETIONS = '${cfg.bashCompletion.package}/share/bash-completion/bash_completion'
+        '';
+      })
+    ]
+  );
+}

--- a/tests/modules/programs/xonsh/aliases.nix
+++ b/tests/modules/programs/xonsh/aliases.nix
@@ -1,0 +1,26 @@
+{ ... }:
+{
+  config = {
+    programs.xonsh = {
+      enable = true;
+
+      shellAliases = {
+        g = "git";
+        ll = "ls -l";
+        ".." = "cd ..";
+      };
+    };
+
+    nmt = {
+      description = "if xonsh.shellAliases is set, rc.xsh should contain aliases dict assignments";
+      script = ''
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          'aliases["g"] = "git"'
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          'aliases["ll"] = "ls -l"'
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          'aliases[".."] = "cd .."'
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/xonsh/bash-completion.nix
+++ b/tests/modules/programs/xonsh/bash-completion.nix
@@ -1,0 +1,20 @@
+{ ... }:
+{
+  config = {
+    programs.xonsh = {
+      enable = true;
+
+      bashCompletion.enable = true;
+    };
+
+    nmt = {
+      description = "if xonsh.bashCompletion.enable is true, rc.xsh should set BASH_COMPLETIONS in the interactive block";
+      script = ''
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          '$BASH_COMPLETIONS'
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          '$XONSH_INTERACTIVE'
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/xonsh/basic.nix
+++ b/tests/modules/programs/xonsh/basic.nix
@@ -1,0 +1,15 @@
+{ ... }:
+{
+  config = {
+    programs.xonsh.enable = true;
+
+    nmt = {
+      description = "if xonsh is enabled, rc.xsh should exist and contain the header";
+      script = ''
+        assertFileExists home-files/.config/xonsh/rc.xsh
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          "DO NOT EDIT"
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/xonsh/default.nix
+++ b/tests/modules/programs/xonsh/default.nix
@@ -1,0 +1,12 @@
+{
+  xonsh-basic = ./basic.nix;
+  xonsh-aliases = ./aliases.nix;
+  xonsh-session-variables = ./session-variables.nix;
+  xonsh-xontribs = ./xontribs.nix;
+  xonsh-plugins = ./plugins.nix;
+  xonsh-shell-init = ./shell-init.nix;
+  xonsh-extra-packages = ./extra-packages.nix;
+  xonsh-bash-completion = ./bash-completion.nix;
+  xonsh-no-plugins = ./no-plugins.nix;
+  xonsh-extra-config = ./extra-config.nix;
+}

--- a/tests/modules/programs/xonsh/extra-config.nix
+++ b/tests/modules/programs/xonsh/extra-config.nix
@@ -1,0 +1,20 @@
+{ ... }:
+{
+  config = {
+    programs.xonsh = {
+      enable = true;
+
+      xonshrcExtra = ''
+        $XONSH_HISTORY_MATCH_ANYWHERE = True
+      '';
+    };
+
+    nmt = {
+      description = "if xonsh.xonshrcExtra is set, rc.xsh should contain the extra config verbatim";
+      script = ''
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          '$XONSH_HISTORY_MATCH_ANYWHERE = True'
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/xonsh/extra-packages.nix
+++ b/tests/modules/programs/xonsh/extra-packages.nix
@@ -1,0 +1,20 @@
+{ pkgs, ... }:
+{
+  config = {
+    programs.xonsh = {
+      enable = true;
+
+      extraPackages = _ps: [ pkgs.git ];
+    };
+
+    nmt = {
+      description = "if xonsh.extraPackages is set, xonsh should still be installed and rc.xsh should exist";
+      script = ''
+        assertFileExists home-path/bin/xonsh
+        assertFileExists home-files/.config/xonsh/rc.xsh
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          "DO NOT EDIT"
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/xonsh/no-plugins.nix
+++ b/tests/modules/programs/xonsh/no-plugins.nix
@@ -1,0 +1,17 @@
+{ ... }:
+{
+  config = {
+    programs.xonsh = {
+      enable = true;
+
+      plugins = [ ];
+    };
+
+    nmt = {
+      description = "if xonsh.plugins is empty, the rc.d directory should not exist";
+      script = ''
+        assertPathNotExists home-files/.config/xonsh/rc.d
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/xonsh/plugins.nix
+++ b/tests/modules/programs/xonsh/plugins.nix
@@ -1,0 +1,29 @@
+{ pkgs, ... }:
+let
+  myPluginSrc = pkgs.writeText "my-plugin.xsh" ''
+    # my custom plugin
+    aliases['hello'] = 'echo hello'
+  '';
+in
+{
+  config = {
+    programs.xonsh = {
+      enable = true;
+
+      plugins = [
+        {
+          name = "my-plugin";
+          src = myPluginSrc;
+        }
+      ];
+    };
+
+    nmt = {
+      description = "if xonsh.plugins is set, rc.d file should exist with correct content";
+      script = ''
+        assertFileExists home-files/.config/xonsh/rc.d/my-plugin.xsh
+        assertFileContent home-files/.config/xonsh/rc.d/my-plugin.xsh ${myPluginSrc}
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/xonsh/session-variables.nix
+++ b/tests/modules/programs/xonsh/session-variables.nix
@@ -1,0 +1,23 @@
+{ ... }:
+{
+  config = {
+    programs.xonsh = {
+      enable = true;
+
+      sessionVariables = {
+        EDITOR = "nvim";
+        PAGER = "less";
+      };
+    };
+
+    nmt = {
+      description = "if xonsh.sessionVariables is set, rc.xsh should contain xonsh env var assignments";
+      script = ''
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          '$EDITOR = "nvim"'
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          '$PAGER = "less"'
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/xonsh/shell-init.nix
+++ b/tests/modules/programs/xonsh/shell-init.nix
@@ -1,0 +1,42 @@
+{ ... }:
+{
+  config = {
+    programs.xonsh = {
+      enable = true;
+
+      shellInit = ''
+        $XONSH_SHOW_TRACEBACK = True
+      '';
+
+      loginShellInit = ''
+        $XONSH_STORE_STDOUT = True
+      '';
+
+      interactiveShellInit = ''
+        $COMPLETIONS_CONFIRM = True
+      '';
+
+      shellInitLast = ''
+        $XONSH_AUTOPAIR = True
+      '';
+    };
+
+    nmt = {
+      description = "xonsh shell init phases should appear in rc.xsh in the correct blocks";
+      script = ''
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          '$XONSH_SHOW_TRACEBACK = True'
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          '$XONSH_LOGIN'
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          '$XONSH_STORE_STDOUT = True'
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          '$XONSH_INTERACTIVE'
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          '$COMPLETIONS_CONFIRM = True'
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          '$XONSH_AUTOPAIR = True'
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/xonsh/xontribs.nix
+++ b/tests/modules/programs/xonsh/xontribs.nix
@@ -1,0 +1,22 @@
+{ ... }:
+{
+  config = {
+    programs.xonsh = {
+      enable = true;
+
+      xontribs = [
+        "vox"
+        "coreutils"
+        "mpl"
+      ];
+    };
+
+    nmt = {
+      description = "if xonsh.xontribs is set, rc.xsh should contain a xontrib load line with all names";
+      script = ''
+        assertFileContains home-files/.config/xonsh/rc.xsh \
+          "xontrib load vox coreutils mpl"
+      '';
+    };
+  };
+}


### PR DESCRIPTION
### Description

Added a home-manager module for [xonsh](https://github.com/xonsh/xonsh) shell.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
