### PR TITLE
home-environment: revert use nix profile add instead of install

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -712,11 +712,11 @@ in
 
             nixProfileRemove 'home-manager-path'
 
-            run $oldNix profile add $1
+            run $oldNix profile install $1
           }
 
           if [[ -e ${cfg.profileDirectory}/manifest.json ]] ; then
-            INSTALL_CMD="nix profile add"
+            INSTALL_CMD="nix profile install"
             INSTALL_CMD_ACTUAL="nixReplaceProfile"
             LIST_CMD="nix profile list"
             REMOVE_CMD_SYNTAX='nix profile remove {number | store path}'

--- a/tests/integration/standalone/flake-basics.nix
+++ b/tests/integration/standalone/flake-basics.nix
@@ -54,7 +54,7 @@
 
     # Make sure that Alice has a "nix profile" compatible profile.
     if True:
-      succeed_as_alice("nix profile add nixpkgs#cowsay")
+      succeed_as_alice("nix profile install nixpkgs#cowsay")
       result = succeed_as_alice("cowsay Hello")
       machine.log(f"\n{result}")
 


### PR DESCRIPTION
This reverts commit e8d5fc77c212eea1f0b18648ce48e84df2eb5c4c from #8756

### Description

`nix profile add` does not exist for lix. This means that activation fails, after removing the profile, leaving the user's home in a broken state. Reverting for now until a more compatible change is implemented. See #8786 for discussion.

While the deprecation warning is not ideal, it's also not currently fatal.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
