### PR TITLE
hyprland: allow closing submaps on dispatch

### DIFF
--- a/tests/modules/services/hyprland/default.nix
+++ b/tests/modules/services/hyprland/default.nix
@@ -9,4 +9,5 @@ lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   hyprland-sourceFirst-false-config = ./sourceFirst-false-config.nix;
   hyprland-inconsistent-config = ./inconsistent-config.nix;
   hyprland-submaps-config = ./submaps-config.nix;
+  hyprland-submaps-on-dispatch = ./submaps-on-dispatch.nix;
 }

--- a/tests/modules/services/hyprland/inconsistent-config.nix
+++ b/tests/modules/services/hyprland/inconsistent-config.nix
@@ -9,7 +9,7 @@
   };
 
   test.asserts.warnings.expected = [
-    "You have enabled hyprland.systemd.enable or listed plugins in hyprland.plugins but do not have any configuration in hyprland.settings or hyprland.extraConfig. This is almost certainly a mistake."
+    "You have enabled hyprland.systemd.enable or listed plugins in hyprland.plugins but do not have any configuration in hyprland.settings, hyprland.extraConfig or hyprland.submaps. This is almost certainly a mistake."
   ];
   test.asserts.warnings.enable = true;
 

--- a/tests/modules/services/hyprland/submaps-on-dispatch.nix
+++ b/tests/modules/services/hyprland/submaps-on-dispatch.nix
@@ -1,0 +1,31 @@
+{ config, ... }:
+
+{
+  wayland.windowManager.hyprland = {
+    enable = true;
+    submaps = {
+      resize = {
+        onDispatch = "reset";
+        settings = {
+          binde = [
+            ", right, resizeactive, 10 0"
+            ", left, resizeactive, -10 0"
+          ];
+        };
+      };
+      other = {
+        onDispatch = "resize";
+        settings = {
+          bind = [ ", a, exec, true" ];
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    config=home-files/.config/hypr/hyprland.conf
+    assertFileExists "$config"
+    assertFileContains "$config" "submap = resize, reset"
+    assertFileContains "$config" "submap = other, resize"
+  '';
+}


### PR DESCRIPTION
### Description

This adds an 'onDispatch' option to the 'submaps' attribute set,
enabling the 'submap = name, ondispatch' syntax which allows submaps to
be closed automatically after a dispatch.

fixes #8005

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module
  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
