### PR TITLE
cargo: add cargoHome option

### DIFF
--- a/modules/programs/cargo.nix
+++ b/modules/programs/cargo.nix
@@ -18,11 +18,19 @@ in
 
         package = lib.mkPackageOption pkgs "cargo" { nullable = true; };
 
+        cargoHome = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          apply = p: if p != null then lib.removePrefix "${config.home.homeDirectory}/" p else p;
+          default = null;
+          example = lib.literalExpression "\${config.xdg.dataHome}/cargo";
+          description = "Directory to store cargo configuration & state. Setting this also sets $CARGO_HOME.";
+        };
+
         settings = lib.mkOption {
           inherit (tomlFormat) type;
           default = { };
           description = ''
-            Available configuration options for the .cargo/config see:
+            Available configuration options for the $CARGO_HOME/config see:
             https://doc.rust-lang.org/cargo/reference/config.html
           '';
         };
@@ -30,15 +38,23 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    home = {
-      packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+  config =
+    let
+      cargoHome = if cfg.cargoHome != null then cfg.cargoHome else ".cargo";
+    in
+    lib.mkIf cfg.enable {
+      home = {
+        packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-      file = {
-        ".cargo/config.toml" = {
-          source = tomlFormat.generate "config.toml" cfg.settings;
+        sessionVariables = lib.mkIf (cfg.cargoHome != null) {
+          CARGO_HOME = "${config.home.homeDirectory}/${cfg.cargoHome}";
+        };
+
+        file = {
+          "${cargoHome}/config.toml" = {
+            source = tomlFormat.generate "config.toml" cfg.settings;
+          };
         };
       };
     };
-  };
 }

--- a/tests/modules/programs/cargo/cargo-home.nix
+++ b/tests/modules/programs/cargo/cargo-home.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  programs.cargo = {
+    enable = true;
+
+    cargoHome = "${config.xdg.dataHome}/cargo";
+
+    settings = {
+      net = {
+        git-fetch-with-cli = true;
+      };
+    };
+  };
+
+  nmt.script =
+    let
+      cargoTestPath = "home-files/.local/share/cargo";
+      configTestPath = "${cargoTestPath}/config.toml";
+    in
+    ''
+      assertPathNotExists home-files/.cargo/config
+      assertDirectoryExists ${cargoTestPath}
+      assertFileExists ${configTestPath}
+      assertFileContent ${configTestPath} \
+        ${./example-config.toml}
+    '';
+}

--- a/tests/modules/programs/cargo/default.nix
+++ b/tests/modules/programs/cargo/default.nix
@@ -1,4 +1,5 @@
 {
   cargo = ./example-config.nix;
   cargo-empty-config = ./empty-config.nix;
+  cargo-home = ./cargo-home.nix;
 }


### PR DESCRIPTION
### Description

Add option to change & use $CARGO_HOME.
Closes #8398.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
