### PR TITLE
colima: only pass `--save-config=false` if `settings` were set

### DIFF
--- a/modules/services/colima.nix
+++ b/modules/services/colima.nix
@@ -271,8 +271,8 @@ in
               "start"
               name
               "-f"
-              "--activate=${if profile.isActive then "true" else "false"}"
-              "--save-config=false"
+              "--activate=${lib.boolToString profile.isActive}"
+              "--save-config=${lib.boolToString (profile.settings == { })}"
             ];
             KeepAlive = {
               SuccessfulExit = true;
@@ -319,8 +319,8 @@ in
             ExecStart = ''
               ${lib.getExe cfg.package} start ${name} \
                 -f \
-                --activate=${if profile.isActive then "true" else "false"} \
-                --save-config=false
+                --activate=${lib.boolToString profile.isActive} \
+                --save-config=${lib.boolToString (profile.settings == { })}
             '';
             Restart = "always";
             RestartSec = 2;

--- a/tests/modules/services/colima/darwin/colima-docker-cli-expected.plist
+++ b/tests/modules/services/colima/darwin/colima-docker-cli-expected.plist
@@ -26,7 +26,7 @@
 	<array>
 		<string>/bin/sh</string>
 		<string>-c</string>
-		<string>/bin/wait4path /nix/store &amp;&amp; exec @colima@/bin/colima start default -f &apos;--activate=true&apos; &apos;--save-config=false&apos;</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec @colima@/bin/colima start default -f &apos;--activate=true&apos; &apos;--save-config=true&apos;</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/tests/modules/services/colima/darwin/expected-agent.plist
+++ b/tests/modules/services/colima/darwin/expected-agent.plist
@@ -22,7 +22,7 @@
 	<array>
 		<string>/bin/sh</string>
 		<string>-c</string>
-		<string>/bin/wait4path /nix/store &amp;&amp; exec @colima@/bin/colima start default -f &apos;--activate=true&apos; &apos;--save-config=false&apos;</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec @colima@/bin/colima start default -f &apos;--activate=true&apos; &apos;--save-config=true&apos;</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/tests/modules/services/colima/linux/colima-docker-cli-expected.service
+++ b/tests/modules/services/colima/linux/colima-docker-cli-expected.service
@@ -9,7 +9,7 @@ Environment=DOCKER_CONFIG=/home/hm-user/.config/docker
 ExecStart=@colima@/bin/colima start default \
   -f \
   --activate=true \
-  --save-config=false
+  --save-config=true
 
 Restart=always
 RestartSec=2

--- a/tests/modules/services/colima/linux/expected-service.service
+++ b/tests/modules/services/colima/linux/expected-service.service
@@ -7,7 +7,7 @@ Environment=PATH=@colima@/bin:@perl@/bin:@docker@/bin:@openssh@/bin:@coreutils@/
 ExecStart=@colima@/bin/colima start default \
   -f \
   --activate=true \
-  --save-config=false
+  --save-config=true
 
 Restart=always
 RestartSec=2


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

colima's service module was unconditionally passing `--save-config=false`, which is only correct if the user is configuring colima through home-manager.

Truth is that colima has a very weird configuration system. It seems to me that you're actually supposed to modify `_template/default.yaml` instead of `{profile}/colima.yaml`, because colima treats a profile's configuration as mutable state (e.g: it will delete the config on `colima delete`, modify it by default on `colima start`).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
