### PR TITLE
bash: support defining aliases beginning with a dash or plus

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -204,7 +204,7 @@ in
   config =
     let
       aliasesStr = lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (k: v: "alias ${k}=${lib.escapeShellArg v}") cfg.shellAliases
+        lib.mapAttrsToList (k: v: "alias -- ${k}=${lib.escapeShellArg v}") cfg.shellAliases
       );
 
       shoptsStr =

--- a/tests/modules/programs/eza/bash.nix
+++ b/tests/modules/programs/eza/bash.nix
@@ -18,21 +18,21 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
-      "alias eza='eza --icons auto --git --group-directories-first --header'"
+      "alias -- eza='eza --icons auto --git --group-directories-first --header'"
     assertFileContains \
       home-files/.bashrc \
-      "alias ls=eza"
+      "alias -- ls=eza"
     assertFileContains \
       home-files/.bashrc \
-      "alias ll='eza -l'"
+      "alias -- ll='eza -l'"
     assertFileContains \
       home-files/.bashrc \
-      "alias la='eza -a'"
+      "alias -- la='eza -a'"
     assertFileContains \
       home-files/.bashrc \
-      "alias lt='eza --tree'"
+      "alias -- lt='eza --tree'"
     assertFileContains \
       home-files/.bashrc \
-      "alias lla='eza -la'"
+      "alias -- lla='eza -la'"
   '';
 }

--- a/tests/modules/programs/pls/bash.nix
+++ b/tests/modules/programs/pls/bash.nix
@@ -12,9 +12,9 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
-      "alias ls=@pls@/bin/pls"
+      "alias -- ls=@pls@/bin/pls"
     assertFileContains \
       home-files/.bashrc \
-      "alias ll='@pls@/bin/pls -d perm -d user -d group -d size -d mtime -d git'"
+      "alias -- ll='@pls@/bin/pls -d perm -d user -d group -d size -d mtime -d git'"
   '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
This allows defining aliases like this:

```bash
alias -- -='cd -'
alias -- +x='chmod +x'
```

(see https://github.com/NixOS/nixpkgs/pull/198217 for reference)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
