### PR TITLE
cargo: add home option

### DIFF
--- a/modules/programs/cargo.nix
+++ b/modules/programs/cargo.nix
@@ -18,11 +18,20 @@ in
 
         package = lib.mkPackageOption pkgs "cargo" { nullable = true; };
 
+        home = lib.mkOption {
+          type = lib.types.str;
+          default = ".cargo";
+          description = ''
+            The home directory of cargo. This is where the configuration,
+            the registry and the git dependencies are stored by cargo.
+          '';
+        };
+
         settings = lib.mkOption {
           inherit (tomlFormat) type;
           default = { };
           description = ''
-            Available configuration options for the .cargo/config see:
+            Available configuration options for the $CARGO_HOME/config see:
             https://doc.rust-lang.org/cargo/reference/config.html
           '';
         };
@@ -34,8 +43,12 @@ in
     home = {
       packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
+      sessionVariables = lib.mkIf (cfg.home != ".cargo") {
+        CARGO_HOME = "${config.home.homeDirectory}/${cfg.home}";
+      };
+
       file = {
-        ".cargo/config.toml" = {
+        "${cfg.home}/config.toml" = {
           source = tomlFormat.generate "config.toml" cfg.settings;
         };
       };

--- a/tests/modules/programs/cargo/default.nix
+++ b/tests/modules/programs/cargo/default.nix
@@ -1,4 +1,5 @@
 {
   cargo = ./example-config.nix;
   cargo-empty-config = ./empty-config.nix;
+  cargo-moved-home = ./moved-home.nix;
 }

--- a/tests/modules/programs/cargo/moved-home.nix
+++ b/tests/modules/programs/cargo/moved-home.nix
@@ -1,0 +1,25 @@
+let
+  cargo_home = ".cargo_home";
+in
+{
+  programs.cargo = {
+    enable = true;
+
+    home = cargo_home;
+
+    settings = {
+      net = {
+        git-fetch-with-cli = true;
+      };
+    };
+  };
+
+  nmt.script =
+    let
+      configTestPath = "home-files/${cargo_home}/config.toml";
+    in
+    ''
+      assertPathNotExists home-files/${cargo_home}/config
+      assertFileExists ${configTestPath}
+    '';
+}


### PR DESCRIPTION

### Description

The CARGO_HOME environment variable sets the data home for cargo and can now be set with config.programs.cargo.home.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
