### PR TITLE
lutris: fix proton packages not showing up

### DIFF
--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -24,6 +24,7 @@ let
     recursiveUpdate
     listToAttrs
     getExe
+    versionOlder
     ;
   cfg = config.programs.lutris;
   settingsFormat = pkgs.formats.yaml { };
@@ -238,8 +239,10 @@ in
               source = package;
             })
           ) packages;
-        steamcompattools = map (proton: proton.steamcompattool) cfg.protonPackages;
+        differentiatesProton = versionOlder cfg.package.version "0.5.20";
+        protonPackages = map (proton: proton.steamcompattool) cfg.protonPackages;
+        protonDirectory = if differentiatesProton then "proton" else "wine";
       in
-      listToAttrs (buildWineLink "wine" cfg.winePackages ++ buildWineLink "proton" steamcompattools);
+      listToAttrs (buildWineLink "wine" cfg.winePackages ++ buildWineLink protonDirectory protonPackages);
   };
 }

--- a/tests/modules/programs/lutris/wine-configuration.nix
+++ b/tests/modules/programs/lutris/wine-configuration.nix
@@ -9,9 +9,11 @@
   nmt.script =
     let
       runnersDir = "home-files/.local/share/lutris/runners";
+      differentiatesProton = lib.versionOlder pkgs.lutris.version "0.5.20";
+      protonDirectory = if differentiatesProton then "proton" else "wine";
     in
     ''
-      assertFileExists ${runnersDir}/proton/${lib.toLower pkgs.proton-ge-bin.steamcompattool.name}/proton
+      assertFileExists ${runnersDir}/${protonDirectory}/${lib.toLower pkgs.proton-ge-bin.steamcompattool.name}/proton
       assertFileExists ${runnersDir}/wine/${lib.toLower pkgs.wineWow64Packages.name}/bin/wine
     '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Fix proton packages no longer showing up on lutris 0.5.20+, essentially they used to check for proton packages under `$XDG_DATA_HOME/lutris/runners/proton`, they're now under the `wine` folder just like regular wine packages.

Should close #8844 

I've updated the tests for wine runners, but I still can't get them to work as the testing environment still seem to complain about packages not being absolute paths, but it should work.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
