### PR TITLE
man: add 'cache.generateAtRuntime'

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -666,7 +666,7 @@ in
         in
         {
           # Support completion for `man` by building a cache for `apropos`.
-          programs.man.generateCaches = lib.mkDefault true;
+          programs.man.cache.enable = lib.mkDefault true;
 
           xdg.dataFile."fish/home-manager/generated_completions".source =
             let

--- a/modules/programs/man.nix
+++ b/modules/programs/man.nix
@@ -9,6 +9,13 @@ let
   cfg = config.programs.man;
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "programs" "man" "generateCaches" ]
+      [ "programs" "man" "cache" "enable" ]
+    )
+  ];
+
   options = {
     programs.man = {
       enable = mkOption {
@@ -44,33 +51,35 @@ in
         '';
       };
 
-      generateCaches = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to generate the manual page index caches using
-          {manpage}`mandb(8)`. This allows searching for a page or
-          keyword using utilities like {manpage}`apropos(1)`.
+      cache = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to generate the manual page index caches using
+            {manpage}`mandb(8)`. This allows searching for a page or
+            keyword using utilities like {manpage}`apropos(1)`.
 
-          This feature is disabled by default because it slows down
-          building. If you don't mind waiting a few more seconds when
-          Home Manager builds a new generation, you may safely enable
-          this option.
-        '';
+            This feature is disabled by default because it slows down
+            building. If you don't mind waiting a few more seconds when
+            Home Manager builds a new generation, you may safely enable
+            this option.
+          '';
+        };
       };
     };
   };
 
   config = lib.mkIf cfg.enable {
     warnings = lib.optional (
-      cfg.generateCaches && cfg.package == null
-    ) "programs.man.generateCaches has no effect when programs.man.package is null";
+      cfg.cache.enable && cfg.package == null
+    ) "programs.man.cache.enable has no effect when programs.man.package is null";
 
     home.packages = lib.optional (cfg.package != null) cfg.package;
     home.extraOutputsToInstall = [ "man" ];
 
     # This is mostly copy/pasted/adapted from NixOS' documentation.nix.
-    home.file = lib.mkIf (cfg.generateCaches && cfg.package != null) {
+    home.file = lib.mkIf (cfg.cache.enable && cfg.package != null) {
       ".manpath".text =
         let
           # Generate a directory containing installed packages' manpages.

--- a/modules/programs/man.nix
+++ b/modules/programs/man.nix
@@ -70,47 +70,51 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    warnings = lib.optional (
-      cfg.cache.enable && cfg.package == null
-    ) "programs.man.cache.enable has no effect when programs.man.package is null";
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        warnings = lib.optional (
+          cfg.cache.enable && cfg.package == null
+        ) "programs.man.cache.enable has no effect when programs.man.package is null";
+      }
+      {
+        home.packages = lib.optional (cfg.package != null) cfg.package;
+        home.extraOutputsToInstall = [ "man" ];
+      }
+      (lib.mkIf (cfg.cache.enable && cfg.package != null) {
+        # This is mostly copy/pasted/adapted from NixOS' documentation.nix.
+        home.file.".manpath".text =
+          let
+            # Generate a directory containing installed packages' manpages.
+            manualPages = pkgs.buildEnv {
+              name = "man-paths";
+              paths = config.home.packages;
+              pathsToLink = [ "/share/man" ];
+              extraOutputsToInstall = [ "man" ];
+              ignoreCollisions = true;
+            };
 
-    home.packages = lib.optional (cfg.package != null) cfg.package;
-    home.extraOutputsToInstall = [ "man" ];
+            # Generate a database of all manpages in ${manualPages}.
+            manualCache =
+              pkgs.runCommandLocal "man-cache"
+                {
+                  nativeBuildInputs = [ cfg.package ];
+                }
+                ''
+                  # Generate a temporary man.conf so mandb knows where to
+                  # write cache files.
+                  echo "MANDB_MAP ${manualPages}/share/man $out" > man.conf
 
-    # This is mostly copy/pasted/adapted from NixOS' documentation.nix.
-    home.file = lib.mkIf (cfg.cache.enable && cfg.package != null) {
-      ".manpath".text =
-        let
-          # Generate a directory containing installed packages' manpages.
-          manualPages = pkgs.buildEnv {
-            name = "man-paths";
-            paths = config.home.packages;
-            pathsToLink = [ "/share/man" ];
-            extraOutputsToInstall = [ "man" ];
-            ignoreCollisions = true;
-          };
-
-          # Generate a database of all manpages in ${manualPages}.
-          manualCache =
-            pkgs.runCommandLocal "man-cache"
-              {
-                nativeBuildInputs = [ cfg.package ];
-              }
-              ''
-                # Generate a temporary man.conf so mandb knows where to
-                # write cache files.
-                echo "MANDB_MAP ${manualPages}/share/man $out" > man.conf
-
-                # Run mandb to generate cache files:
-                mandb -C man.conf --no-straycats --create \
-                  ${manualPages}/share/man
-              '';
-        in
-        ''
-          MANDB_MAP ${config.home.profileDirectory}/share/man ${manualCache}
-        ''
-        + lib.optionalString (cfg.extraConfig != "") "\n${cfg.extraConfig}";
-    };
-  };
+                  # Run mandb to generate cache files:
+                  mandb -C man.conf --no-straycats --create \
+                    ${manualPages}/share/man
+                '';
+          in
+          ''
+            MANDB_MAP ${config.home.profileDirectory}/share/man ${manualCache}
+          ''
+          + lib.optionalString (cfg.extraConfig != "") "\n${cfg.extraConfig}";
+      })
+    ]
+  );
 }

--- a/modules/programs/man.nix
+++ b/modules/programs/man.nix
@@ -7,6 +7,16 @@
 let
   inherit (lib) mkOption types;
   cfg = config.programs.man;
+
+  # Generate a directory containing installed packages' manpages.
+  manualPages = pkgs.buildEnv {
+    name = "man-paths";
+    paths = config.home.packages;
+    pathsToLink = [ "/share/man" ];
+    extraOutputsToInstall = [ "man" ];
+    ignoreCollisions = true;
+  };
+
 in
 {
   imports = [
@@ -66,6 +76,19 @@ in
             this option.
           '';
         };
+
+        generateAtRuntime = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to generate the manual page index caches at runtime using
+            a systemd service.
+
+            ::: {.note}
+            This is currently only supported on Linux.
+            :::
+          '';
+        };
       };
     };
   };
@@ -73,6 +96,20 @@ in
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
+        assertions = [
+          {
+            assertion =
+              let
+                runtimeCache = (cfg.cache.enable && cfg.cache.generateAtRuntime);
+                isLinux = lib.elem pkgs.stdenv.hostPlatform.system lib.platforms.linux;
+              in
+              runtimeCache -> isLinux;
+            message = ''
+              `programs.man.cache.generateAtRuntime` is only supported on Linux.
+            '';
+          }
+        ];
+
         warnings = lib.optional (
           cfg.cache.enable && cfg.package == null
         ) "programs.man.cache.enable has no effect when programs.man.package is null";
@@ -85,17 +122,8 @@ in
         # This is mostly copy/pasted/adapted from NixOS' documentation.nix.
         home.file.".manpath".text =
           let
-            # Generate a directory containing installed packages' manpages.
-            manualPages = pkgs.buildEnv {
-              name = "man-paths";
-              paths = config.home.packages;
-              pathsToLink = [ "/share/man" ];
-              extraOutputsToInstall = [ "man" ];
-              ignoreCollisions = true;
-            };
-
             # Generate a database of all manpages in ${manualPages}.
-            manualCache =
+            manualCache' =
               pkgs.runCommandLocal "man-cache"
                 {
                   nativeBuildInputs = [ cfg.package ];
@@ -109,11 +137,54 @@ in
                   mandb -C man.conf --no-straycats --create \
                     ${manualPages}/share/man
                 '';
+            manualCache =
+              if (!cfg.cache.generateAtRuntime) then
+                manualCache'
+              else
+                # FIXME: relies on this path being correct
+                "${config.xdg.cacheHome}/man/hm-mandb";
+
           in
           ''
             MANDB_MAP ${config.home.profileDirectory}/share/man ${manualCache}
           ''
           + lib.optionalString (cfg.extraConfig != "") "\n${cfg.extraConfig}";
+      })
+      (lib.mkIf (cfg.cache.enable && cfg.cache.generateAtRuntime && cfg.package != null) {
+        systemd.user.services.mandb = {
+          Unit = {
+            Description = ""; # FIXME
+            Documentation = "man:mandb(8)";
+            X-Restart-Triggers = [
+              manualPages
+            ];
+          };
+          Service = {
+            ExecStart =
+              pkgs.writeShellApplication
+                {
+                  runtimeInputs = [
+                    cfg.package
+                    pkgs.rsync
+                  ];
+                }
+                ''
+                  rsync \
+                    --checksum --recursive --copy-links --delete --no-times --no-perms --chmod=+w \
+                    ${manualPages}/share/man/ "$CACHE_DIRECTORY/hm-manpages"
+
+                  echo "MANDB_MAP $CACHE_DIRECTORY/hm-manpages $CACHE_DIRECTORY/hm-mandb" \
+                    > "$RUNTIME_DIRECTORY/man.conf"
+
+                  mandb -C "$RUNTIME_DIRECTORY/man.conf" -q
+                '';
+            CacheDirectory = "man";
+            RuntimeDirectory = "mandb";
+            BindReadOnlyPaths = [ "/dev/null:/etc/man_db.conf" ]; # mandb will still read /etc/man_db.conf if it exists, even when setting -C path/to/config.conf
+            ProtectSystem = "strict";
+          };
+          Install.WantedBy = [ "default.target" ];
+        };
       })
     ]
   );

--- a/tests/modules/programs/man/apropos.nix
+++ b/tests/modules/programs/man/apropos.nix
@@ -2,7 +2,7 @@
   config = {
     programs.man = {
       enable = true;
-      generateCaches = true;
+      cache.enable = true;
     };
 
     nmt.script = ''

--- a/tests/modules/programs/man/no-caches-without-package.nix
+++ b/tests/modules/programs/man/no-caches-without-package.nix
@@ -5,11 +5,11 @@
     programs.man = {
       enable = true;
       package = null;
-      generateCaches = true;
+      cache.enable = true;
     };
 
     test.asserts.warnings.expected = [
-      "programs.man.generateCaches has no effect when programs.man.package is null"
+      "programs.man.cache.enable has no effect when programs.man.package is null"
     ];
 
     nmt.script = ''


### PR DESCRIPTION
### Description

Closes #8860.

NOTE: currently untested, hence opening a draft.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
