### PR TITLE
vscode: fix extension loading by directly merging extensions.json

### DIFF
--- a/modules/programs/vscode/default.nix
+++ b/modules/programs/vscode/default.nix
@@ -627,14 +627,42 @@ in
                   && defaultProfile != { }
                 )
                 {
-                  # Whenever our immutable extensions.json changes, force VSCode to regenerate
-                  # extensions.json with both mutable and immutable extensions.
+                  # Whenever our immutable extensions.json changes, merge it with
+                  # extensions.json to preserve manually-installed extensions.
                   "${extensionPath}/.extensions-immutable.json" = {
                     text = extensionJson defaultProfile.extensions;
                     onChange = ''
-                      run rm $VERBOSE_ARG -f ${extensionPath}/{extensions.json,.init-default-profile-extensions}
-                      verboseEcho "Regenerating VSCode extensions.json"
-                      run ${lib.getExe cfg.package} --list-extensions > /dev/null
+                      extensions_file="${extensionPath}/extensions.json"
+                      immutable_file="${extensionPath}/.extensions-immutable.json"
+                      obsolete_file="${extensionPath}/.obsolete"
+
+                      verboseEcho "Merging Nix-managed extensions into extensions.json"
+
+                      if [ -f "$extensions_file" ]; then
+                        # Merge: Nix extensions take precedence, keep manual extensions
+                        run ${pkgs.jq}/bin/jq -s '
+                          (.[0] | map({key: .identifier.id | ascii_downcase, value: .}) | from_entries) as $existing |
+                          (.[1] | map({key: .identifier.id | ascii_downcase, value: .}) | from_entries) as $immutable |
+                          ($immutable + $existing) | to_entries | map(.value)
+                        ' "$immutable_file" "$extensions_file" > "$extensions_file.tmp"
+                        run mv "$extensions_file.tmp" "$extensions_file"
+                      else
+                        # No existing extensions.json, use immutable as base
+                        run cp "$immutable_file" "$extensions_file"
+                      fi
+
+                      # Remove Nix-managed extensions from .obsolete file
+                      if [ -f "$obsolete_file" ]; then
+                        nix_ext_patterns=$(${pkgs.jq}/bin/jq -r '.[].relativeLocation | ascii_downcase' "$immutable_file" | paste -sd'|' -)
+                        if [ -n "$nix_ext_patterns" ]; then
+                          run ${pkgs.jq}/bin/jq --arg patterns "$nix_ext_patterns" '
+                            to_entries | map(select(.key | ascii_downcase | test($patterns) | not)) | from_entries
+                          ' "$obsolete_file" > "$obsolete_file.tmp"
+                          run mv "$obsolete_file.tmp" "$obsolete_file"
+                        fi
+                      fi
+
+                      run rm $VERBOSE_ARG -f ${extensionPath}/.init-default-profile-extensions
                     '';
                   };
                 }


### PR DESCRIPTION
## Description

Fixes #8793
Related: #7880, #7719, #3507

Instead of relying on `code --list-extensions` to regenerate `extensions.json` (which fails when VS Code isn't running or marks symlinks as obsolete first), directly merge Nix-managed extensions into `extensions.json` using jq.

## Root Cause Analysis

The previous approach:
1. Deleted `extensions.json`
2. Ran `code --list-extensions` hoping VS Code would regenerate it

This failed because:
- VS Code may not be running during home-manager activation
- VS Code marks symlinked extensions as `.obsolete` before the `onChange` hook runs
- `code --list-extensions` doesn't reliably regenerate `extensions.json` in headless mode
- Race conditions cause intermittent extension loading (#7719)

## Solution

The new approach:
1. If `extensions.json` exists, merge Nix extensions into it (Nix takes precedence, manual extensions preserved)
2. If no `extensions.json`, use `.extensions-immutable.json` as base
3. Remove Nix-managed extensions from `.obsolete` file (so VS Code doesn't skip them)

This works reliably regardless of VS Code state and should fix the long-standing extension loading issues on Darwin and with `profiles.default.extensions`.

## Testing

- [x] Nix syntax check passes
- [x] Manual testing with `mutableExtensionsDir = true`
- [x] Verify extensions load correctly after rebuild
- [x] Test on Darwin with `profiles.default.extensions`

### Test Results (macOS darwin-aarch64)
- All 11 Nix-managed extensions load correctly
- 2 manually-installed extensions preserved
- No deprecation warning about renamed option

---
*Investigation and fix assisted by Claude Opus 4.5*