### PR TITLE
claude-code: add lsp servers support

### DIFF
--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -364,6 +364,33 @@ in
       example = lib.literalExpression "./skills";
     };
 
+    lspServers = lib.mkOption {
+      type = lib.types.attrsOf jsonFormat.type;
+      default = { };
+      description = ''
+        LSP (Language Server Protocol) servers configuration.
+      '';
+      example = {
+        go = {
+          command = "gopls";
+          args = [ "serve" ];
+          extensionToLanguage = {
+            ".go" = "go";
+          };
+        };
+        typescript = {
+          command = "typescript-language-server";
+          args = [ "--stdio" ];
+          extensionToLanguage = {
+            ".ts" = "typescript";
+            ".tsx" = "typescriptreact";
+            ".js" = "javascript";
+            ".jsx" = "javascriptreact";
+          };
+        };
+      };
+    };
+
     mcpServers = lib.mkOption {
       type = lib.types.attrsOf jsonFormat.type;
       default = { };
@@ -408,8 +435,10 @@ in
   config = lib.mkIf cfg.enable {
     assertions = [
       {
-        assertion = (cfg.mcpServers == { } && !cfg.enableMcpIntegration) || cfg.package != null;
-        message = "`programs.claude-code.package` cannot be null when `mcpServers` or `enableMcpIntegration` is configured";
+        assertion =
+          (cfg.mcpServers == { } && cfg.lspServers == { } && !cfg.enableMcpIntegration)
+          || cfg.package != null;
+        message = "`programs.claude-code.package` cannot be null when `mcpServers`, `lspServers`, or `enableMcpIntegration` is configured";
       }
       {
         assertion = !(cfg.memory.text != null && cfg.memory.source != null);
@@ -446,6 +475,19 @@ in
               "--append-flags"
               "--mcp-config ${
                 jsonFormat.generate "claude-code-mcp-config.json" { mcpServers = mergedMcpServers; }
+              }"
+            ])
+            (lib.optional (cfg.lspServers != { }) [
+              "--append-flags"
+              "--plugin-dir ${
+                pkgs.runCommand "claude-code-lsp-plugin" { } ''
+                  install -Dm644 ${
+                    jsonFormat.generate "claude-code-lsp-plugin.json" {
+                      name = "claude-code-lsp";
+                      lspServers = cfg.lspServers;
+                    }
+                  } $out/.claude-plugin/plugin.json
+                ''
               }"
             ])
           ]

--- a/tests/modules/programs/claude-code/assertion.nix
+++ b/tests/modules/programs/claude-code/assertion.nix
@@ -47,7 +47,7 @@
   };
 
   test.asserts.assertions.expected = [
-    "`programs.claude-code.package` cannot be null when `mcpServers` or `enableMcpIntegration` is configured"
+    "`programs.claude-code.package` cannot be null when `mcpServers`, `lspServers`, or `enableMcpIntegration` is configured"
     "Cannot specify both `programs.claude-code.memory.text` and `programs.claude-code.memory.source`"
     "Cannot specify both `programs.claude-code.agents` and `programs.claude-code.agentsDir`"
     "Cannot specify both `programs.claude-code.commands` and `programs.claude-code.commandsDir`"

--- a/tests/modules/programs/claude-code/default.nix
+++ b/tests/modules/programs/claude-code/default.nix
@@ -1,6 +1,7 @@
 {
   claude-code-basic = ./basic.nix;
   claude-code-full-config = ./full-config.nix;
+  claude-code-lsp = ./lsp.nix;
   claude-code-mcp = ./mcp.nix;
   claude-code-mcp-integration = ./mcp-integration.nix;
   claude-code-assertion = ./assertion.nix;

--- a/tests/modules/programs/claude-code/expected-lsp-wrapper
+++ b/tests/modules/programs/claude-code/expected-lsp-wrapper
@@ -1,0 +1,2 @@
+#! /nix/store/00000000000000000000000000000000-bash/bin/bash -e
+exec -a "$0" "/nix/store/00000000000000000000000000000000-claude-code/bin/.claude-wrapped"  "$@"  --plugin-dir /nix/store/00000000000000000000000000000000-claude-code-lsp-plugin

--- a/tests/modules/programs/claude-code/lsp.nix
+++ b/tests/modules/programs/claude-code/lsp.nix
@@ -1,0 +1,38 @@
+{ config, ... }:
+
+{
+  programs.claude-code = {
+    package = config.lib.test.mkStubPackage {
+      name = "claude-code";
+      buildScript = ''
+        mkdir -p $out/bin
+        touch $out/bin/claude
+        chmod 755 $out/bin/claude
+      '';
+    };
+    enable = true;
+
+    lspServers = {
+      go = {
+        command = "gopls";
+        args = [ "serve" ];
+        extensionToLanguage = {
+          ".go" = "go";
+        };
+      };
+      typescript = {
+        command = "typescript-language-server";
+        args = [ "--stdio" ];
+        extensionToLanguage = {
+          ".ts" = "typescript";
+          ".tsx" = "typescriptreact";
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    normalizedWrapper=$(normalizeStorePaths home-path/bin/claude)
+    assertFileContent $normalizedWrapper ${./expected-lsp-wrapper}
+  '';
+}


### PR DESCRIPTION
### Description

- Add `lspServers` option to configure LSP servers for Claude Code
- Claude Code only supports LSP via plugins, so the wrapper generates a plugin directory with the LSP configuration and passes it via `--append-flags --plugin-dir <path>`
- This follows the same pattern as the existing `mcpServers` option

#### Reference                                                                                                                                                                          
https://code.claude.com/docs/en/plugins-reference#lsp-servers

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
