### PR TITLE
codex: symlink path-backed skills directories

### DIFF
--- a/modules/misc/news/2026/03/2026-03-09_10-48-04.nix
+++ b/modules/misc/news/2026/03/2026-03-09_10-48-04.nix
@@ -1,0 +1,9 @@
+{ config, lib, ... }:
+{
+  time = "2026-03-09T10:48:04+00:00";
+  condition = config.programs.codex.enable && lib.isPath config.programs.codex.skills;
+  message = ''
+    The `programs.codex.skills` path-backed directory is now symlinked
+    into the Codex config directory, matching the option documentation.
+  '';
+}

--- a/modules/programs/codex.nix
+++ b/modules/programs/codex.nix
@@ -191,7 +191,7 @@ in
           };
           "${skillsDir}" = lib.mkIf (lib.isPath cfg.skills) {
             source = cfg.skills;
-            recursive = true;
+            recursive = false;
           };
         }
         // (lib.mapAttrs' (

--- a/tests/modules/programs/codex/skills-dir.nix
+++ b/tests/modules/programs/codex/skills-dir.nix
@@ -13,6 +13,7 @@ in
   };
 
   nmt.script = ''
+    assertLinkExists home-files/.agents/skills
     assertFileExists home-files/.agents/skills/skill-one/SKILL.md
     assertFileContent home-files/.agents/skills/skill-one/SKILL.md \
       ${./skills-dir/skill-one/SKILL.md}


### PR DESCRIPTION
### Description

When `programs.codex.skills` is set to a directory path, the option
documentation says that directory is symlinked into the Codex config
directory. The current implementation uses recursive linking instead.

This change makes the path-backed case match the documented behavior by
symlinking the directory itself, adds a regression test for that
behavior, and includes a news entry for users of the option.

### Related

- Follow-up to [#8550](https://github.com/nix-community/home-manager/pull/8550), which introduced `programs.codex.skills`
- Relevant context: [#8823](https://github.com/nix-community/home-manager/pull/8823), which updated the Codex skills location for newer Codex versions

### Testing

- `nix fmt`
- `nix run .#tests -- codex`
