### PR TITLE
neovim: filter attributes passed to makeVimPackageInfo

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -414,12 +414,19 @@ in
       ) allPlugins;
 
       # remove attributes not understood by nixpkgs' "makeVimPackageInfo"
-      suppressIncompatibleConfig = p: lib.filterAttrs
-        (n: v: builtins.elem n ["plugin" "optional" "config"])
-        (if p.type != "viml" then p // { config = null; } else p);
+      suppressIncompatibleConfig =
+        p:
+        lib.filterAttrs (
+          n: v:
+          builtins.elem n [
+            "plugin"
+            "optional"
+            "config"
+          ]
+        ) (if p.type != "viml" then p // { config = null; } else p);
 
       # Lua & Python Package Resolution
-      luaPackages = cfg.finalPackage.unwrapped.lua.pkgs;
+      luaPackages = cfg.package.lua.pkgs;
       resolvedExtraLuaPackages = cfg.extraLuaPackages luaPackages;
 
       # Wrapper Arguments Construction


### PR DESCRIPTION
nixpkgs is going to emit errors when seeing unknown attributes so this preemptively cleans the passe attributes to avoid errors on next nixpkgs bump.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
