### PR TITLE
clipman: Add extraArgs option to services.clipman for configuring extra cli args

### DIFF
--- a/modules/services/clipman.nix
+++ b/modules/services/clipman.nix
@@ -28,6 +28,18 @@ in
         otherwise the service may never be started.
       '';
     };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "--max-items"
+        "100"
+      ];
+      description = ''
+        Extra arguments to be passed to the clipman executable.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -46,7 +58,9 @@ in
       };
 
       Service = {
-        ExecStart = "${pkgs.wl-clipboard}/bin/wl-paste -t text --watch ${cfg.package}/bin/clipman store";
+        ExecStart =
+          "${pkgs.wl-clipboard}/bin/wl-paste -t text --watch ${cfg.package}/bin/clipman store"
+          + lib.optionalString (cfg.extraArgs != [ ]) " ${lib.escapeShellArgs cfg.extraArgs}";
         ExecReload = "${pkgs.coreutils}/bin/kill -SIGUSR2 $MAINPID";
         Restart = "on-failure";
         KillMode = "mixed";

--- a/tests/modules/services/clipman/clipman-extraargs.nix
+++ b/tests/modules/services/clipman/clipman-extraargs.nix
@@ -1,0 +1,16 @@
+{
+  home.stateVersion = "21.11";
+
+  services.clipman = {
+    enable = true;
+    extraArgs = [
+      "--max-items"
+      "123"
+    ];
+  };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/clipman.service)
+    assertFileContent "$serviceFile" ${./clipman-extraargs.service}
+  '';
+}

--- a/tests/modules/services/clipman/clipman-extraargs.service
+++ b/tests/modules/services/clipman/clipman-extraargs.service
@@ -1,0 +1,14 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecReload=/nix/store/00000000000000000000000000000000-coreutils/bin/kill -SIGUSR2 $MAINPID
+ExecStart=@wl-clipboard@/bin/wl-paste -t text --watch @clipman@/bin/clipman store --max-items 123
+KillMode=mixed
+Restart=on-failure
+
+[Unit]
+After=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+Description=Clipboard management daemon
+PartOf=graphical-session.target

--- a/tests/modules/services/clipman/default.nix
+++ b/tests/modules/services/clipman/default.nix
@@ -2,4 +2,5 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   clipman-sway-session-target = ./clipman-sway-session-target.nix;
+  clipman-extraargs = ./clipman-extraargs.nix;
 }


### PR DESCRIPTION
### Description

clipman has a --max-items option so it can be configured to remember more items than default.  This CL adds an option to set it.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
