### PR TITLE
mergiraf: Prevent warnings related to unmanaged VCSs

### DIFF
--- a/modules/programs/mergiraf.nix
+++ b/modules/programs/mergiraf.nix
@@ -53,6 +53,7 @@ in
         lib.optionals
           (
             cfg.enable
+            && config.programs.git.enable
             && !lib.versionAtLeast config.home.stateVersion "26.05"
             && options.programs.mergiraf.enableGitIntegration.highestPrio >= 1500
           )
@@ -68,6 +69,7 @@ in
           lib.optionals
             (
               cfg.enable
+              && config.programs.jujutsu.enable
               && !lib.versionAtLeast config.home.stateVersion "26.05"
               && options.programs.mergiraf.enableJujutsuIntegration.highestPrio >= 1500
             )

--- a/tests/modules/programs/mergiraf/legacy-warnings.nix
+++ b/tests/modules/programs/mergiraf/legacy-warnings.nix
@@ -1,6 +1,14 @@
 {
-  programs.mergiraf = {
-    enable = true;
+  programs = {
+    mergiraf = {
+      enable = true;
+    };
+    git = {
+      enable = true;
+    };
+    jujutsu = {
+      enable = true;
+    };
   };
 
   test.asserts.warnings.expected = [


### PR DESCRIPTION
### Description

See #8794

Add a guard to prevent people from getting warnings related to VCSs they don't use.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
