### PR TITLE
neovim: fix test

### DIFF
--- a/tests/modules/programs/neovim/plugin-config.expected
+++ b/tests/modules/programs/neovim/plugin-config.expected
@@ -1,6 +1,7 @@
-vim.cmd [[source /nix/store/00000000000000000000000000000000-nvim-init-home-manager.vim]]
 package.path = "/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/share/lua/5.1/?.lua;/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/share/lua/5.1/?/init.lua".. ";" .. package.path
 package.cpath = "/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/lib/lua/5.1/?.so".. ";" .. package.cpath
+
+vim.cmd [[source /nix/store/00000000000000000000000000000000-nvim-init-home-manager.vim]]
 -- user-associated plugin config {{{
 function HM_PLUGIN_LUA_CONFIG ()
 end


### PR DESCRIPTION
package.path (mkOrder 100) is expected to be before `vim.cmd` (mkBegin -> mkOrder 500). Not sure how the error was not detected before ?

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
