### PR TITLE
feat: add amp-cli to home-manager

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -350,6 +350,12 @@
     github = "mainrs";
     githubId = 5113257;
   };
+  mattiasmts = {
+    name = "Mattias Sjödin";
+    email = "mattias.sjodin.6764@hotmail.com";
+    github = "MattiasMTS";
+    githubId = 86059470;
+  };
   mforster = {
     name = "Michael Forster";
     email = "email@michael-forster.de";

--- a/modules/misc/news/2026/03/2026-03-12_15-00-00.nix
+++ b/modules/misc/news/2026/03/2026-03-12_15-00-00.nix
@@ -1,0 +1,17 @@
+{
+  time = "2026-03-12T15:00:00+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.amp-cli'.
+
+    Amp is Sourcegraph's agentic coding CLI, providing an interactive
+    command-line interface for AI-assisted development.
+
+    The module supports:
+    - Configuration through 'programs.amp-cli.settings'
+    - MCP (Model Context Protocol) servers via 'programs.amp-cli.mcpServers'
+    - Shared MCP integration via 'programs.amp-cli.enableMcpIntegration'
+    - Global agent instructions via 'programs.amp-cli.agentConfig'
+    - Package installation control via 'programs.amp-cli.package'
+  '';
+}

--- a/modules/programs/amp-cli.nix
+++ b/modules/programs/amp-cli.nix
@@ -26,7 +26,7 @@ let
     };
 in
 {
-  meta.maintainers = [ ];
+  meta.maintainers = with lib.hm.maintainers; [ mattiasmts ];
 
   options.programs.amp-cli = {
     enable = lib.mkEnableOption "Amp, Sourcegraph's agentic coding CLI";

--- a/modules/programs/amp-cli.nix
+++ b/modules/programs/amp-cli.nix
@@ -1,0 +1,140 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.amp-cli;
+  jsonFormat = pkgs.formats.json { };
+  transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
+    lib.mapAttrs (
+      _name: server:
+      (removeAttrs server [ "disabled" ])
+      // (lib.optionalAttrs (server ? url) { type = "http"; })
+      // (lib.optionalAttrs (server ? command) { type = "stdio"; })
+      // {
+        enabled = !(server.disabled or false);
+      }
+    ) config.programs.mcp.servers
+  );
+  mergedMcpServers = transformedMcpServers // cfg.mcpServers;
+  mergedSettings =
+    cfg.settings
+    // lib.optionalAttrs (mergedMcpServers != { }) {
+      "amp.mcpServers" = mergedMcpServers;
+    };
+in
+{
+  meta.maintainers = [ ];
+
+  options.programs.amp-cli = {
+    enable = lib.mkEnableOption "Amp, Sourcegraph's agentic coding CLI";
+
+    package = lib.mkPackageOption pkgs "amp-cli" { nullable = true; };
+
+    enableMcpIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to integrate the MCP servers config from
+        {option}`programs.mcp.servers` into
+        {option}`programs.amp-cli.mcpServers`.
+
+        Note: Settings defined in {option}`programs.mcp.servers` are merged
+        with {option}`programs.amp-cli.mcpServers`, with Amp CLI servers
+        taking precedence.
+      '';
+    };
+
+    settings = lib.mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = {
+        "amp.terminal.theme" = "catppuccin-mocha";
+        "amp.notifications.enabled" = true;
+        "amp.showCosts" = true;
+        "amp.anthropic.thinking.enabled" = true;
+        "amp.permissions" = [
+          {
+            tool = "Bash";
+            matches = {
+              cmd = "*git commit*";
+            };
+            action = "ask";
+          }
+        ];
+        "amp.tools.disable" = [ "browser_navigate" ];
+        "amp.git.commit.coauthor.enabled" = true;
+        "amp.git.commit.ampThread.enabled" = true;
+      };
+      description = ''
+        JSON configuration for Amp CLI settings.json.
+        Settings are written to {file}`~/.config/amp/settings.json`.
+        All settings use the `amp.` prefix.
+        See <https://ampcode.com/manual> for supported values.
+      '';
+    };
+
+    mcpServers = lib.mkOption {
+      type = lib.types.attrsOf jsonFormat.type;
+      default = { };
+      description = ''
+        MCP (Model Context Protocol) servers configuration.
+        These are merged into {option}`programs.amp-cli.settings` under
+        the `amp.mcpServers` key.
+      '';
+      example = {
+        playwright = {
+          command = "npx";
+          args = [
+            "-y"
+            "@playwright/mcp@latest"
+            "--headless"
+          ];
+        };
+        linear = {
+          url = "https://mcp.linear.app/sse";
+        };
+        sourcegraph = {
+          url = "\${SRC_ENDPOINT}/.api/mcp/v1";
+          headers = {
+            Authorization = "token \${SRC_ACCESS_TOKEN}";
+          };
+        };
+      };
+    };
+
+    agentConfig = lib.mkOption {
+      type = lib.types.nullOr lib.types.lines;
+      default = null;
+      description = ''
+        Global agent instructions written to
+        {file}`~/.config/amp/AGENTS.md`.
+        This provides personal preferences and guidance
+        applied to all Amp sessions.
+      '';
+      example = ''
+        # Personal Preferences
+
+        - Always use conventional commits
+        - Prefer TypeScript over JavaScript
+        - Run tests before committing
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile = {
+      "amp/settings.json" = lib.mkIf (mergedSettings != { }) {
+        source = jsonFormat.generate "amp-cli-settings.json" mergedSettings;
+      };
+
+      "amp/AGENTS.md" = lib.mkIf (cfg.agentConfig != null) {
+        text = cfg.agentConfig;
+      };
+    };
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -11,6 +11,7 @@ let
     "aider-chat"
     "alacritty"
     "alot"
+    "amp-cli"
     "antidote"
     "anvil-editor"
     "aria2"

--- a/tests/modules/programs/amp-cli/agent-config.nix
+++ b/tests/modules/programs/amp-cli/agent-config.nix
@@ -1,0 +1,17 @@
+{
+  programs.amp-cli = {
+    enable = true;
+
+    agentConfig = ''
+      # Personal Preferences
+
+      - Always use conventional commits
+      - Prefer TypeScript over JavaScript
+    '';
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/amp/AGENTS.md
+    assertFileContent home-files/.config/amp/AGENTS.md ${./expected-agents.md}
+  '';
+}

--- a/tests/modules/programs/amp-cli/basic.nix
+++ b/tests/modules/programs/amp-cli/basic.nix
@@ -1,0 +1,7 @@
+{
+  programs.amp-cli.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/amp
+  '';
+}

--- a/tests/modules/programs/amp-cli/default.nix
+++ b/tests/modules/programs/amp-cli/default.nix
@@ -1,0 +1,7 @@
+{
+  amp-cli-basic = ./basic.nix;
+  amp-cli-full-config = ./full-config.nix;
+  amp-cli-mcp = ./mcp.nix;
+  amp-cli-mcp-integration = ./mcp-integration.nix;
+  amp-cli-agent-config = ./agent-config.nix;
+}

--- a/tests/modules/programs/amp-cli/expected-agents.md
+++ b/tests/modules/programs/amp-cli/expected-agents.md
@@ -1,0 +1,4 @@
+# Personal Preferences
+
+- Always use conventional commits
+- Prefer TypeScript over JavaScript

--- a/tests/modules/programs/amp-cli/expected-mcp-integration-settings.json
+++ b/tests/modules/programs/amp-cli/expected-mcp-integration-settings.json
@@ -1,0 +1,31 @@
+{
+  "amp.mcpServers": {
+    "database": {
+      "args": [
+        "-y",
+        "@bytebase/dbhub",
+        "--dsn",
+        "postgresql://user:pass@localhost:5432/db"
+      ],
+      "command": "npx",
+      "enabled": true,
+      "env": {
+        "DATABASE_URL": "postgresql://user:pass@localhost:5432/db"
+      },
+      "type": "stdio"
+    },
+    "linear": {
+      "enabled": true,
+      "type": "http",
+      "url": "https://mcp.linear.app/sse"
+    },
+    "playwright": {
+      "args": [
+        "-y",
+        "@playwright/mcp@latest",
+        "--headless"
+      ],
+      "command": "npx"
+    }
+  }
+}

--- a/tests/modules/programs/amp-cli/expected-mcp-settings.json
+++ b/tests/modules/programs/amp-cli/expected-mcp-settings.json
@@ -1,0 +1,15 @@
+{
+  "amp.mcpServers": {
+    "linear": {
+      "url": "https://mcp.linear.app/sse"
+    },
+    "playwright": {
+      "args": [
+        "-y",
+        "@playwright/mcp@latest",
+        "--headless"
+      ],
+      "command": "npx"
+    }
+  }
+}

--- a/tests/modules/programs/amp-cli/expected-settings.json
+++ b/tests/modules/programs/amp-cli/expected-settings.json
@@ -1,0 +1,24 @@
+{
+  "amp.anthropic.thinking.enabled": true,
+  "amp.git.commit.ampThread.enabled": false,
+  "amp.git.commit.coauthor.enabled": true,
+  "amp.notifications.enabled": true,
+  "amp.permissions": [
+    {
+      "allow": true,
+      "command": "git *",
+      "tool": "Bash"
+    },
+    {
+      "allow": false,
+      "command": "curl *",
+      "tool": "Bash"
+    }
+  ],
+  "amp.showCosts": false,
+  "amp.terminal.theme": "catppuccin-mocha",
+  "amp.tools.disable": [
+    "browser_navigate",
+    "builtin:edit_file"
+  ]
+}

--- a/tests/modules/programs/amp-cli/full-config.nix
+++ b/tests/modules/programs/amp-cli/full-config.nix
@@ -1,0 +1,35 @@
+{
+  programs.amp-cli = {
+    enable = true;
+
+    settings = {
+      "amp.terminal.theme" = "catppuccin-mocha";
+      "amp.notifications.enabled" = true;
+      "amp.showCosts" = false;
+      "amp.anthropic.thinking.enabled" = true;
+      "amp.git.commit.coauthor.enabled" = true;
+      "amp.git.commit.ampThread.enabled" = false;
+      "amp.tools.disable" = [
+        "browser_navigate"
+        "builtin:edit_file"
+      ];
+      "amp.permissions" = [
+        {
+          tool = "Bash";
+          command = "git *";
+          allow = true;
+        }
+        {
+          tool = "Bash";
+          command = "curl *";
+          allow = false;
+        }
+      ];
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/amp/settings.json
+    assertFileContent home-files/.config/amp/settings.json ${./expected-settings.json}
+  '';
+}

--- a/tests/modules/programs/amp-cli/mcp-integration.nix
+++ b/tests/modules/programs/amp-cli/mcp-integration.nix
@@ -1,0 +1,45 @@
+{
+  programs = {
+    amp-cli = {
+      enable = true;
+
+      enableMcpIntegration = true;
+
+      mcpServers = {
+        playwright = {
+          command = "npx";
+          args = [
+            "-y"
+            "@playwright/mcp@latest"
+            "--headless"
+          ];
+        };
+      };
+    };
+    mcp = {
+      enable = true;
+      servers = {
+        linear = {
+          url = "https://mcp.linear.app/sse";
+        };
+        database = {
+          command = "npx";
+          args = [
+            "-y"
+            "@bytebase/dbhub"
+            "--dsn"
+            "postgresql://user:pass@localhost:5432/db"
+          ];
+          env = {
+            DATABASE_URL = "postgresql://user:pass@localhost:5432/db";
+          };
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/amp/settings.json
+    assertFileContent home-files/.config/amp/settings.json ${./expected-mcp-integration-settings.json}
+  '';
+}

--- a/tests/modules/programs/amp-cli/mcp.nix
+++ b/tests/modules/programs/amp-cli/mcp.nix
@@ -1,0 +1,24 @@
+{
+  programs.amp-cli = {
+    enable = true;
+
+    mcpServers = {
+      playwright = {
+        command = "npx";
+        args = [
+          "-y"
+          "@playwright/mcp@latest"
+          "--headless"
+        ];
+      };
+      linear = {
+        url = "https://mcp.linear.app/sse";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/amp/settings.json
+    assertFileContent home-files/.config/amp/settings.json ${./expected-mcp-settings.json}
+  '';
+}


### PR DESCRIPTION
### Description

Add a new programs.amp-cli module for Amp, Sourcegraph's agentic coding CLI.

programs.amp is already taken by amp.rs, so this uses amp-cli to match the nixpkgs package name.

The module manages ~/.config/amp/settings.json (via xdg.configFile) and supports:

settings — arbitrary JSON settings with the amp. prefix convention
mcpServers — MCP server declarations, merged into settings under amp.mcpServers
enableMcpIntegration — pulls shared servers from programs.mcp.servers
agentConfig — global agent instructions written to ~/.config/amp/AGENTS.md
package — nullable, so users who install Amp externally can still use the config management

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [X] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
