### PR TITLE
neovim: update tests to work with latest nixpkgs

### DIFF
--- a/tests/modules/programs/neovim/wrapper-args.nix
+++ b/tests/modules/programs/neovim/wrapper-args.nix
@@ -55,9 +55,20 @@ in
     assertNeovimExpr() {
         local var_name="$1"
         local expected_pattern="$2"
-        if ! nvim -i NONE --headless --cmd "echo $var_name" +q! 2>&1 | grep "$expected_pattern" ; then
-          fail "Provider $var_name doesn't match expected pattern '$expected_pattern'"
+        local output=$(nvim -i NONE --headless --cmd "echo $var_name" +q! 2>&1)
+        local exit_code=$?
+
+        if [ $exit_code -ne 0 ]; then
+          echo "neovim command failed with code: $exit_code and output:"
+          fail "$output"
+        elif ! grep "$expected_pattern" "$output" ; then
+          echo "Provider $var_name doesn't match expected pattern '$expected_pattern'"
+          echo "Output:"
+          fail "$output"
         fi
+
+        # assuming we enabled all providers
+        assertFileExists "$output"
     }
 
     # Ensure the main binary exists
@@ -67,20 +78,16 @@ in
     assertBinaryContains "$nvimBin" "-my-suffix/rplugin.vim"
 
     # 2. withPerl: Check if nvim-perl binary exists and host prog is set
-    assertFileExists "home-path/bin/nvim-perl"
-    assertNeovimExpr "g:perl_host_prog" "nvim-perl"
+    assertNeovimExpr "g:perl_host_prog" "perl"
 
     # 3. withPython3: Check if nvim-python3 binary exists and host prog is set
-    assertFileExists "home-path/bin/nvim-python3"
     assertNeovimExpr "g:python3_host_prog" "python3"
 
     # 4. withRuby: Check if nvim-ruby binary exists, GEM_HOME and host prog are set
-    assertFileExists "home-path/bin/nvim-ruby"
     assertBinaryContains "$nvimBin" "GEM_HOME="
     assertNeovimExpr "g:ruby_host_prog" "ruby"
 
     # 5. withNodeJs: Check if nvim-node binary exists and host prog is set
-    assertFileExists "home-path/bin/nvim-node"
     assertNeovimExpr "g:node_host_prog" "node"
 
     # 6. waylandSupport: Check for wl-clipboard path in wrapper's PATH modification


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/495392, the wrapper doesn't create provider executables along with the neovim wrapper which means that with nixpkgs' master: ` assertFileExists "home-path/bin/nvim-perl"` fails.

 They still exist but at locations indicated by the g:XXX_provider_host variable.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
