### PR TITLE
Obsidian cli option

### DIFF
--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -559,6 +559,12 @@ in
 
         activation.obsidian =
           let
+            obsidianConfigDir =
+              if pkgs.stdenv.isDarwin then
+                "${config.home.homeDirectory}/Library/Application Support/obsidian"
+              else
+                "${config.xdg.configHome}/obsidian";
+
             template = (pkgs.formats.json { }).generate "obsidian.json" {
               vaults = builtins.listToAttrs (
                 map (vault: {
@@ -573,7 +579,7 @@ in
             };
           in
           lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-            OBSIDIAN_CONFIG="$HOME/.config/obsidian/obsidian.json"
+            OBSIDIAN_CONFIG="${obsidianConfigDir}/obsidian.json"
             if [ -f "$OBSIDIAN_CONFIG" ]; then
               verboseEcho "Merging existing Obsidian config with generated template"
               tmp="$(mktemp)"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Fixes #8896

- Add a programs.obsidian.cli boolean option (default: false) that sets the cli field in obsidian.json, enabling the [Obsidian CLI](https://obsidian.md/cli) integration.
- Fix the `obsidian.json` config path on macOS
  - it now correctly resolves to `~/Library/Application Support/obsidian/obsidian.json` instead of the XDG path (`~/.config/obsidian/obsidian.json`), which Obsidian doesn't use on Darwin.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
