### PR TITLE
sunsetr: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -476,6 +476,12 @@
       }
     ];
   };
+  rodrada = {
+    name = "Daniel Ramos Rodríguez";
+    email = "daniel.ramos.rodrig@gmail.com";
+    github = "rodrada";
+    githubId = 64539957;
+  };
   rosuavio = {
     name = "Rosario Pulella";
     email = "RosarioPulella@gmail.com";

--- a/modules/misc/news/2026/03/2026-03-14_15-53-25.nix
+++ b/modules/misc/news/2026/03/2026-03-14_15-53-25.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+
+{
+  time = "2026-03-14T14:53:25+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'services.sunsetr'.
+  '';
+}

--- a/modules/services/sunsetr.nix
+++ b/modules/services/sunsetr.nix
@@ -1,0 +1,81 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    getExe
+    hm
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkPackageOption
+    mkOption
+    platforms
+    types
+    ;
+
+  cfg = config.services.sunsetr;
+
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with hm.maintainers; [ rodrada ];
+
+  options.services.sunsetr = {
+
+    enable = mkEnableOption ''
+      sunsetr, a tool to apply blue light filters in Wayland according to the time of day
+    '';
+
+    package = mkPackageOption pkgs "sunsetr" { };
+
+    settings = mkOption {
+      type = types.submodule { freeformType = tomlFormat.type; };
+      default = { };
+      description = ''
+        Settings for the `sunsetr` service.
+        See <https://psi4j.github.io/sunsetr/configuration/> for details.
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    assertions = [
+      (hm.assertions.assertPlatform "services.sunsetr" pkgs platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."sunsetr/sunsetr.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "sunsetr-config.toml" cfg.settings;
+    };
+
+    systemd.user.services.sunsetr = {
+
+      Unit = {
+        Description = "Automatic blue light filter for Wayland";
+        PartOf = [ "graphical-session.target" ];
+        BindsTo = [ "graphical-session.target" ];
+        # NOTE: We don't need a reload trigger since sunsetr monitors changes to its config file.
+      };
+
+      Service = {
+        ExecStart = "${getExe cfg.package}";
+        Restart = "on-failure";
+        TimeoutStopSec = 5;
+        Slice = "background.slice";
+      };
+
+      Install.WantedBy = mkDefault [ "graphical-session.target" ];
+
+    };
+
+  };
+
+}

--- a/tests/modules/services/sunsetr/default.nix
+++ b/tests/modules/services/sunsetr/default.nix
@@ -1,3 +1,5 @@
-{
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   with-settings = ./with-settings.nix;
 }

--- a/tests/modules/services/sunsetr/default.nix
+++ b/tests/modules/services/sunsetr/default.nix
@@ -1,0 +1,3 @@
+{
+  with-settings = ./with-settings.nix;
+}

--- a/tests/modules/services/sunsetr/with-settings.nix
+++ b/tests/modules/services/sunsetr/with-settings.nix
@@ -1,0 +1,70 @@
+{ config, ... }:
+
+let
+  inherit (config.lib.test) mkStubPackage;
+
+  expectedConfig = builtins.toFile "expected.toml" ''
+    backend = "auto"
+    day_gamma = 100
+    day_temp = 6500
+    latitude = 43.0
+    longitude = -7.566667
+    night_gamma = 90
+    night_temp = 3300
+    smoothing = true
+    startup_duration = 1
+    transition_duration = 45
+    transition_mode = "geo"
+    update_interval = 60
+  '';
+
+  expectedService = builtins.toFile "expected.service" ''
+    [Install]
+    WantedBy=graphical-session.target
+
+    [Service]
+    ExecStart=@sunsetr@/bin/sunsetr
+    Restart=on-failure
+    Slice=background.slice
+    TimeoutStopSec=5
+
+    [Unit]
+    BindsTo=graphical-session.target
+    Description=Automatic blue light filter for Wayland
+    PartOf=graphical-session.target
+  '';
+in
+{
+  services.sunsetr = {
+    enable = true;
+    package = mkStubPackage {
+      name = "sunsetr";
+      outPath = "@sunsetr@";
+    };
+    settings = {
+      backend = "auto";
+      smoothing = true;
+      startup_duration = 1;
+      night_temp = 3300;
+      day_temp = 6500;
+      night_gamma = 90;
+      day_gamma = 100;
+      update_interval = 60;
+      transition_mode = "geo";
+      transition_duration = 45;
+      latitude = 43.0;
+      longitude = -7.566667;
+    };
+  };
+
+  nmt.script = ''
+    configFile=home-files/.config/sunsetr/sunsetr.toml
+    serviceFile=home-files/.config/systemd/user/sunsetr.service
+
+    assertFileExists $configFile
+    assertFileContent $configFile ${expectedConfig}
+
+    assertFileExists $serviceFile
+    assertFileContent $serviceFile ${expectedService}
+  '';
+}


### PR DESCRIPTION
### Description

Added a `sunsetr` module with support for basic configuration.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
