### PR TITLE
fish: add name field to binds module

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -250,11 +250,13 @@ let
           description = "Specify the bind mode that the bind is used in";
           type =
             with types;
-            nullOr (enum [
-              "default"
-              "insert"
-              "paste"
-            ]);
+            nullOr (
+              either (enum [
+                "default"
+                "insert"
+                "paste"
+              ]) str
+            );
           default = null;
         };
         command = mkOption {
@@ -279,11 +281,13 @@ let
           description = "Change current mode after bind is executed";
           type =
             with types;
-            nullOr (enum [
-              "default"
-              "insert"
-              "paste"
-            ]);
+            nullOr (
+              either (enum [
+                "default"
+                "insert"
+                "paste"
+              ]) str
+            );
           default = null;
         };
         erase = mkEnableOption "remove bind";

--- a/tests/modules/programs/fish/binds.nix
+++ b/tests/modules/programs/fish/binds.nix
@@ -14,6 +14,12 @@
           command = "exit";
         };
 
+        # Allow arbitrary modes
+        "f" = {
+          mode = "something-non-default";
+          command = "exit";
+        };
+
         "ctrl-c" = {
           mode = "insert";
           command = [
@@ -57,6 +63,8 @@
           "bind --preset alt-s 'fish_commandline_prepend sudo"
         assertFileContains home-files/.config/fish/functions/fish_user_key_bindings.fish \
           "bind --mode visual ctrl-d exit"
+        assertFileContains home-files/.config/fish/functions/fish_user_key_bindings.fish \
+          "bind --mode something-non-default f exit"
       '';
     };
   };


### PR DESCRIPTION
### Description

- fish: add `name` field to `binds` module
- fish: change `mode` & `setsMode` bind options to allow arbitrary strings additional to default enum values

Resolves #8795

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
