### PR TITLE
sketchybar: refactor sbarlua support

### DIFF
--- a/modules/programs/sketchybar.nix
+++ b/modules/programs/sketchybar.nix
@@ -104,9 +104,16 @@ in
       extraDescription = "Required when using a lua configuration.";
     };
 
-    luaPackage = lib.mkPackageOption pkgs "lua5_4" {
-      nullable = true;
-      extraDescription = "Lua interpreter to use when configType is lua.";
+    luaPackage = mkOption {
+      type = types.nullOr types.package;
+      default = null;
+      example = literalExpression "pkgs.lua5_5";
+      description = ''
+        Lua interpreter to use when configType is lua.
+
+        By default this is inferred from `sbarLuaPackage.passthru.luaModule`
+        when available.
+      '';
     };
 
     extraLuaPackages = mkOption {
@@ -164,47 +171,56 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    programs.sketchybar.luaPackage = lib.mkIf (
+      cfg.configType == "lua" && lib.hasAttrByPath [ "passthru" "luaModule" ] cfg.sbarLuaPackage
+    ) (lib.mkDefault cfg.sbarLuaPackage.passthru.luaModule);
+
     assertions = [
       (lib.hm.assertions.assertPlatform "programs.sketchybar" pkgs lib.platforms.darwin)
       {
         assertion = !(cfg.configType == "lua" && cfg.sbarLuaPackage == null);
         message = "When configType is set to \"lua\", service.sbarLuaPackage must be specified";
       }
+      {
+        assertion = !(cfg.configType == "lua" && cfg.sbarLuaPackage != null && cfg.luaPackage == null);
+        message = "When configType is set to \"lua\", programs.sketchybar.luaPackage must be specified or inferable from programs.sketchybar.sbarLuaPackage.passthru.luaModule";
+      }
     ];
 
     programs.sketchybar.finalPackage =
       let
-        resolvedExtraLuaPackages = cfg.extraLuaPackages pkgs.lua54Packages;
+        useLua = cfg.configType == "lua";
+        hasLuaPackage = useLua && cfg.luaPackage != null;
+        luaPackages = if hasLuaPackage then cfg.luaPackage.pkgs else null;
+
+        resolvedExtraLuaPackages = if hasLuaPackage then cfg.extraLuaPackages luaPackages else [ ];
+
+        configLuaPath =
+          let
+            configDir = "${config.xdg.configHome}/sketchybar";
+          in
+          "${configDir}/?.lua;${configDir}/?/init.lua;${configDir}/?/?.lua";
 
         pathPackages = [
           cfg.package
         ]
         ++ cfg.extraPackages
-        ++ lib.optional (cfg.configType == "lua" && cfg.luaPackage != null) cfg.luaPackage;
+        ++ lib.optional hasLuaPackage cfg.luaPackage;
 
-        luaPaths = lib.filter (x: x != "") [
-          (lib.optionalString (cfg.configType == "lua" && resolvedExtraLuaPackages != [ ]) (
-            lib.concatMapStringsSep ";" pkgs.lua54Packages.getLuaPath resolvedExtraLuaPackages
-          ))
-          (lib.optionalString (cfg.configType == "lua" && cfg.sbarLuaPackage != null) (
-            pkgs.lua54Packages.getLuaPath cfg.sbarLuaPackage
-          ))
-          (lib.optionalString (cfg.configType == "lua" && cfg.config != null && cfg.config.source != null) (
-            let
-              configDir = "${config.xdg.configHome}/sketchybar";
-            in
-            "${configDir}/?.lua;${configDir}/?/init.lua;${configDir}/?/?.lua"
-          ))
-        ];
+        luaPaths = lib.optionals hasLuaPackage (
+          lib.optional (resolvedExtraLuaPackages != [ ]) (
+            lib.concatMapStringsSep ";" luaPackages.getLuaPath resolvedExtraLuaPackages
+          )
+          ++ lib.optional (cfg.sbarLuaPackage != null) (luaPackages.getLuaPath cfg.sbarLuaPackage)
+          ++ lib.optional (cfg.config != null && cfg.config.source != null) configLuaPath
+        );
 
-        luaCPaths = lib.filter (x: x != "") [
-          (lib.optionalString (cfg.configType == "lua" && resolvedExtraLuaPackages != [ ]) (
-            lib.concatMapStringsSep ";" pkgs.lua54Packages.getLuaCPath resolvedExtraLuaPackages
-          ))
-          (lib.optionalString (cfg.configType == "lua" && cfg.sbarLuaPackage != null) (
-            pkgs.lua54Packages.getLuaCPath cfg.sbarLuaPackage
-          ))
-        ];
+        luaCPaths = lib.optionals hasLuaPackage (
+          lib.optional (resolvedExtraLuaPackages != [ ]) (
+            lib.concatMapStringsSep ";" luaPackages.getLuaCPath resolvedExtraLuaPackages
+          )
+          ++ lib.optional (cfg.sbarLuaPackage != null) (luaPackages.getLuaCPath cfg.sbarLuaPackage)
+        );
 
         makeWrapperArgs = lib.flatten (
           lib.filter (x: x != [ ]) [

--- a/tests/modules/programs/sketchybar/default.nix
+++ b/tests/modules/programs/sketchybar/default.nix
@@ -6,4 +6,5 @@ lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
   sketchybar-invalid-lua-config = ./sketchybar-invalid-lua-config.nix;
   sketchybar-lua-config = ./sketchybar-lua-config.nix;
   sketchybar-service-integration = ./sketchybar-service-integration.nix;
+  sketchybar-uninferrable-lua-package = ./sketchybar-uninferrable-lua-package.nix;
 }

--- a/tests/modules/programs/sketchybar/sketchybar-lua-config.nix
+++ b/tests/modules/programs/sketchybar/sketchybar-lua-config.nix
@@ -1,15 +1,19 @@
 { config, pkgs, ... }:
 
 let
-  pkgsSbarlua = pkgs.writeTextFile {
-    name = "sbarlua";
-    destination = "/bin/sbarlua";
-    executable = true;
-    text = ''
-      #!/bin/sh
-      echo "SbarLua mock"
-    '';
-  };
+  pkgsSbarlua =
+    (pkgs.writeTextFile {
+      name = "sbarlua";
+      destination = "/bin/sbarlua";
+      executable = true;
+      text = ''
+        #!/bin/sh
+        echo "SbarLua mock"
+      '';
+    }).overrideAttrs
+      (_: {
+        passthru.luaModule = pkgs.lua5_5;
+      });
 in
 {
   programs.sketchybar = {
@@ -26,6 +30,7 @@ in
     configType = "lua";
 
     sbarLuaPackage = pkgsSbarlua;
+    extraLuaPackages = luaPkgs: [ luaPkgs.luautf8 ];
 
     config = ''
       -- This is a test Lua configuration
@@ -68,5 +73,13 @@ in
     assertFileContent \
       home-files/.config/sketchybar/sketchybarrc \
       ${./sketchybarrc.lua}
+
+    wrappedSketchybar=$(readlink "$TESTED/home-path/bin/sketchybar")
+    grep -F "/lua-5.5.0/bin" "$wrappedSketchybar" >/dev/null || \
+      echo "$wrappedSketchybar should include the Lua 5.5 interpreter on PATH"
+    grep -F "/share/lua/5.5" "$wrappedSketchybar" >/dev/null || \
+      echo "$wrappedSketchybar should include Lua 5.5 module paths"
+    grep -F "/lib/lua/5.5" "$wrappedSketchybar" >/dev/null || \
+      echo "$wrappedSketchybar should include Lua 5.5 C module paths"
   '';
 }

--- a/tests/modules/programs/sketchybar/sketchybar-uninferrable-lua-package.nix
+++ b/tests/modules/programs/sketchybar/sketchybar-uninferrable-lua-package.nix
@@ -1,0 +1,38 @@
+{ config, pkgs, ... }:
+
+let
+  pkgsSbarlua = pkgs.writeTextFile {
+    name = "sbarlua";
+    destination = "/bin/sbarlua";
+    executable = true;
+    text = ''
+      #!/bin/sh
+      echo "SbarLua mock"
+    '';
+  };
+in
+{
+  programs.sketchybar = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "sketchybar";
+      buildScript = ''
+        mkdir -p $out/bin
+        touch $out/bin/sketchybar
+        chmod 755 $out/bin/sketchybar
+      '';
+    };
+
+    configType = "lua";
+    sbarLuaPackage = pkgsSbarlua;
+
+    config = ''
+      local sbar = require("sbarlua")
+      sbar.bar:set({ height = 30 })
+    '';
+  };
+
+  test.asserts.assertions.expected = [
+    "When configType is set to \"lua\", programs.sketchybar.luaPackage must be specified or inferable from programs.sketchybar.sbarLuaPackage.passthru.luaModule"
+  ];
+}


### PR DESCRIPTION
Needs to handle different lua versions better. Determine lua version for which luaPackages set to reference

### Description
Related https://github.com/NixOS/nixpkgs/pull/498766
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
