### PR TITLE
[Backport release-25.11] difftastic: allow repeating options

### DIFF
--- a/modules/programs/difftastic.nix
+++ b/modules/programs/difftastic.nix
@@ -67,11 +67,14 @@ in
     options = mkOption {
       type =
         with types;
-        attrsOf (oneOf [
-          str
-          int
-          bool
-        ]);
+        let
+          atom = oneOf [
+            str
+            int
+            bool
+          ];
+        in
+        attrsOf (either atom (listOf atom));
       default = { };
       example = {
         color = "dark";

--- a/tests/modules/programs/difftastic/difftastic-with-git-external-diff.nix
+++ b/tests/modules/programs/difftastic/difftastic-with-git-external-diff.nix
@@ -8,6 +8,10 @@
     options = {
       color = "always";
       display = "side-by-side";
+      override = [
+        "*.mill:Scala"
+        "*.yuck:Emacs Lisp"
+      ];
     };
   };
 
@@ -17,7 +21,7 @@
     assertFileExists home-files/.config/git/config
     assertFileContains home-files/.config/git/config '[diff]'
     # Should have diff.external set
-    assertFileRegex home-files/.config/git/config 'external = .*/difft.*--color.*--display'
+    assertFileRegex home-files/.config/git/config 'external = .*/difft.*--color.*--display.*--override.*mill:Scala.*--override.*yuck:Emacs Lisp.*'
     # Should NOT have difftool config when diffToolMode is explicitly false
     assertFileNotRegex home-files/.config/git/config 'tool = "difftastic"'
     assertFileNotRegex home-files/.config/git/config '\[difftool "difftastic"\]'


### PR DESCRIPTION
The type was overly restrictive, see
https://github.com/nix-community/home-manager/pull/7947/changes#r2858054388

(cherry picked from commit f3a30376bb9eb2f6f61816be7d6ed954b6d2a3b9)

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
