### PR TITLE
smug: add project session setting

### DIFF
--- a/modules/misc/news/2026/03/2026-03-15_13-42-27.nix
+++ b/modules/misc/news/2026/03/2026-03-15_13-42-27.nix
@@ -1,0 +1,9 @@
+{ config, pkgs, ... }:
+{
+  time = "2026-03-15T20:42:27+00:00";
+  condition = true;
+  message = ''
+    programs.smug.projects.<name>.session is a new optional setting that
+    can be used to specify a different session name from the project name.
+  '';
+}

--- a/modules/programs/smug.nix
+++ b/modules/programs/smug.nix
@@ -37,9 +37,17 @@ in
 
     projects = lib.mkOption {
       type = lib.types.attrsOf (
-        lib.types.submodule [
+        lib.types.submodule (
+          { name, ... }:
           {
             options = {
+              session = lib.mkOption {
+                type = lib.types.str;
+                default = name;
+                description = "Session name for the smug project.";
+                example = lib.literalExpression ''{ session = "project-\''${worktree}"; }'';
+              };
+
               root = mkOptionRoot ''
                 Root path in filesystem of the smug project. This is where tmux
                 changes its directory to.
@@ -139,7 +147,7 @@ in
               stop = mkOptionCommands "Commands to execute after the tmux-session is destroyed.";
             };
           }
-        ]
+        )
       );
       default = { };
       description = "Attribute set with project configurations.";
@@ -161,7 +169,7 @@ in
                   (lib.attrsets.nameValuePair (if name == "beforeStart" then "before_start" else name) value)
                 ) v
                 // {
-                  session = k;
+                  session = v.session;
                   windows = lib.lists.forEach v.windows (
                     winprop: (lib.filterAttrsRecursive (name: value: value != null) winprop)
                   );

--- a/tests/modules/programs/smug/project.yml
+++ b/tests/modules/programs/smug/project.yml
@@ -1,0 +1,5 @@
+root: ~/project
+session: project-${worktree}
+windows:
+- layout: tiled
+  name: src

--- a/tests/modules/programs/smug/settings.nix
+++ b/tests/modules/programs/smug/settings.nix
@@ -53,11 +53,23 @@
           ];
         };
 
+        project = {
+          root = "~/project";
+          session = "project-\${worktree}";
+          windows = [
+            {
+              name = "src";
+              layout = "tiled";
+            }
+          ];
+        };
+
       };
     };
   };
 
   nmt.script = ''
     assertFileContent home-files/.config/smug/blogdemo.yml ${./blogdemo.yml}
+    assertFileContent home-files/.config/smug/project.yml ${./project.yml}
   '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Add an optional session setting so that session names can be different than the smug project name. This also enables using template variables when naming sessions.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
