### PR TITLE
treewide: remove unneeded string escapes

### DIFF
--- a/modules/programs/desktoppr.nix
+++ b/modules/programs/desktoppr.nix
@@ -22,7 +22,7 @@ in
 
         options = {
           picture = lib.mkOption {
-            type = with lib.types; nullOr (either path (strMatching "^http(s)?:\/\/.*$"));
+            type = with lib.types; nullOr (either path (strMatching "^http(s)?://.*$"));
             default = null;
             example = "/System/Library/Desktop Pictures/Solid Colors/Stone.png";
             description = ''

--- a/tests/modules/programs/go/old-options.nix
+++ b/tests/modules/programs/go/old-options.nix
@@ -30,7 +30,7 @@
 
   nmt.script =
     let
-      goCfgDir = if !pkgs.stdenv.isDarwin then ".config/go" else "Library/Application\ Support/go";
+      goCfgDir = if !pkgs.stdenv.isDarwin then ".config/go" else "Library/Application Support/go";
     in
     ''
       assertFileExists "home-files/${goCfgDir}/env"

--- a/tests/modules/programs/go/suboptions-unset.nix
+++ b/tests/modules/programs/go/suboptions-unset.nix
@@ -14,7 +14,7 @@
 
   nmt.script =
     let
-      goCfgDir = if !pkgs.stdenv.isDarwin then ".config/go" else "Library/Application\ Support/go";
+      goCfgDir = if !pkgs.stdenv.isDarwin then ".config/go" else "Library/Application Support/go";
     in
     ''
       assertFileExists "home-files/${goCfgDir}/env"


### PR DESCRIPTION
### Description


These two string escapes do not actually do anything, and this commit is a semantic no-op. However, as such escapes can be potentially confusing, Lix is [deprecating them](https://docs.lix.systems/manual/lix/stable/contributing/deprecated-features.html?highlight=broken-string#dp-feature-broken-string-escape), and on recent builds they produce warnings.

See also https://github.com/nix-community/home-manager/pull/8916, which does the same for `master`, where there is one escape less.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
