### PR TITLE
vscode: add null package support

### DIFF
--- a/modules/programs/vscode/default.nix
+++ b/modules/programs/vscode/default.nix
@@ -17,8 +17,8 @@ let
 
   cfg = config.programs.vscode;
 
-  vscodePname = cfg.package.pname;
-  vscodeVersion = cfg.package.version;
+  vscodePname = cfg.package.pname or cfg.pname;
+  vscodeVersion = cfg.package.version or pkgs.vscode.version;
 
   jsonFormat = pkgs.formats.json { };
 
@@ -383,8 +383,23 @@ in
     enable = lib.mkEnableOption "Visual Studio Code";
 
     package = lib.mkPackageOption pkgs "vscode" {
+      nullable = true;
       example = "pkgs.vscodium";
       extraDescription = "Version of Visual Studio Code to install.";
+    };
+
+    pname = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "vscode";
+      description = ''
+        The package name (pname) of the VS Code variant being used.
+        Required when {option}`programs.vscode.package` is set to
+        `null`, so that {option}`programs.vscode.nameShort` and
+        {option}`programs.vscode.dataFolderName` can be derived from
+        known products. Has no effect when
+        {option}`programs.vscode.package` is set.
+      '';
     };
 
     mutableExtensionsDir = mkOption {
@@ -449,6 +464,13 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.package != null || cfg.pname != null;
+        message = "programs.vscode.pname must be set when programs.vscode.package is null.";
+      }
+    ];
+
     warnings = [
       (mkIf (allProfilesExceptDefault != { } && cfg.mutableExtensionsDir)
         "programs.vscode.mutableExtensionsDir can be used only if no profiles apart from default are set."
@@ -465,7 +487,7 @@ in
       )
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     # The file `${userDir}/globalStorage/storage.json` needs to be writable by VSCode,
     # since it contains other data, such as theme backgrounds, recently opened folders, etc.
@@ -625,6 +647,7 @@ in
                     ]
                   )
                   && defaultProfile != { }
+                  && cfg.package != null
                 )
                 {
                   # Whenever our immutable extensions.json changes, force VSCode to regenerate

--- a/tests/modules/programs/vscode/default.nix
+++ b/tests/modules/programs/vscode/default.nix
@@ -35,6 +35,10 @@ let
   unknownTests = lib.mapAttrs' (
     k: v: lib.nameValuePair "vscode-${k}-unknown" (v unknownPackage)
   ) tests;
+
+  nullPackageTests = {
+    vscode-null-package = import ./null-package.nix;
+  };
 in
 
-knownTests // unknownTests
+knownTests // unknownTests // nullPackageTests

--- a/tests/modules/programs/vscode/null-package.nix
+++ b/tests/modules/programs/vscode/null-package.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.vscode;
+
+  settingsPath =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/${cfg.nameShort}/User/settings.json"
+    else
+      ".config/${cfg.nameShort}/User/settings.json";
+
+  expectedSettings = pkgs.writeText "expected-settings.json" ''
+    {
+      "editor.fontSize": 14
+    }
+  '';
+in
+
+{
+  programs.vscode = {
+    enable = true;
+    package = null;
+    pname = "vscode";
+    profiles.default.userSettings."editor.fontSize" = 14;
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/${settingsPath}"
+    assertFileContent "home-files/${settingsPath}" "${expectedSettings}"
+  '';
+}


### PR DESCRIPTION
### Description

Make it possible to set the package to null but use the configuration options from the module. I tried to change as little as possible.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [X] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
