### PR TITLE
neovim: reuse more of upstream logic

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -425,10 +425,6 @@ in
           ]
         ) (if p.type != "viml" then p // { config = null; } else p);
 
-      # Lua & Python Package Resolution
-      luaPackages = cfg.package.lua.pkgs;
-      resolvedExtraLuaPackages = cfg.extraLuaPackages luaPackages;
-
       # Wrapper Arguments Construction
       extraMakeWrapperArgs = optionals (cfg.extraPackages != [ ]) [
         "--suffix"
@@ -444,12 +440,13 @@ in
         plugins = [ ];
 
         inherit (cfg)
+          extraLuaPackages
+          extraName
           withPython3
           withRuby
           withPerl
           viAlias
           vimAlias
-          extraName
           autowrapRuntimeDeps
           waylandSupport
           ;
@@ -518,18 +515,8 @@ in
           advisedLua = foldedLuaBlock "home-manager generated: plugin config advised in nixpkgs" (
             lib.concatStringsSep "\n" vimPackageInfo.pluginAdvisedLua
           );
-
-          generatedLuaPath = lib.concatMapStringsSep ";" luaPackages.getLuaPath resolvedExtraLuaPackages;
-          generatedLuaCPath = lib.concatMapStringsSep ";" luaPackages.getLuaCPath resolvedExtraLuaPackages;
         in
-
         lib.mkMerge [
-          (lib.mkIf (resolvedExtraLuaPackages != [ ]) (
-            lib.mkOrder 100 ''
-              package.path = "${generatedLuaPath}".. ";" .. package.path
-              package.cpath = "${generatedLuaCPath}".. ";" .. package.cpath
-            ''
-          ))
           (lib.mkIf (advisedLua != null) (lib.mkOrder 510 advisedLua))
           (lib.mkIf wrapperHasUserConfig (
             # we want it to appear rather early

--- a/tests/modules/programs/neovim/plugin-config.expected
+++ b/tests/modules/programs/neovim/plugin-config.expected
@@ -1,5 +1,5 @@
-package.path = "/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/share/lua/5.1/?.lua;/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/share/lua/5.1/?/init.lua".. ";" .. package.path
-package.cpath = "/nix/store/00000000000000000000000000000000-luajit2.1-luautf8/lib/lua/5.1/?.so".. ";" .. package.cpath
+package.path = "/nix/store/00000000000000000000000000000000-luajit/share/lua/5.1/?.lua;/nix/store/00000000000000000000000000000000-luajit/share/lua/5.1/?/init.lua".. ";" .. package.path
+package.cpath = "/nix/store/00000000000000000000000000000000-luajit/lib/lua/5.1/?.so".. ";" .. package.cpath
 
 vim.g.loaded_node_provider=0;vim.g.loaded_perl_provider=0;vim.g.loaded_ruby_provider=0;vim.g.python3_host_prog='/nix/store/00000000000000000000000000000000-nvim-host-python3/bin/nvim-python3'
 vim.cmd.source "/nix/store/00000000000000000000000000000000-init.vim"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
