### PR TITLE
rizin: cleanup according to feedback

### DIFF
--- a/modules/programs/rizin.nix
+++ b/modules/programs/rizin.nix
@@ -6,7 +6,6 @@
 }:
 let
   cfg = config.programs.rizin;
-  eValueType = with lib.types; either str (either int (either bool float));
 in
 {
   meta.maintainers = [
@@ -20,7 +19,7 @@ in
       package = lib.mkPackageOption pkgs "rizin" { nullable = true; };
 
       settings = lib.mkOption {
-        type = lib.types.attrsOf eValueType;
+        type = with lib.types; attrsOf (either str (either int (either bool float)));
         default = { };
         example = {
           "asm.bytes" = true;
@@ -53,11 +52,7 @@ in
 
   config =
     let
-      configFile =
-        if config.xdg.enable && config.home.preferXdgDirectories then
-          "${config.xdg.configHome}/rizin/rizinrc"
-        else
-          ".rizinrc";
+      configFile = if config.xdg.enable then "${config.xdg.configHome}/rizin/rizinrc" else ".rizinrc";
       configContent = ''
         # settings
         ${lib.concatStringsSep "\n" (lib.mapAttrsToList (k: v: "e ${k}=${lib.toString v}") cfg.settings)}

--- a/tests/modules/programs/rizin/basic-configuration.nix
+++ b/tests/modules/programs/rizin/basic-configuration.nix
@@ -8,6 +8,6 @@
   };
 
   nmt.script = ''
-    assertFileExists "home-files/.rizinrc"
+    assertFileExists "home-files/.config/rizin/rizinrc"
   '';
 }

--- a/tests/modules/programs/rizin/default.nix
+++ b/tests/modules/programs/rizin/default.nix
@@ -1,6 +1,6 @@
 {
   rizin-basic-configuration = ./basic-configuration.nix;
   rizin-disabled-configuration = ./disabled-configuration.nix;
-  rizin-prefer-xdg = ./prefer-xdg.nix;
+  rizin-xdg-disabled = ./xdg-disabled.nix;
   rizin-settings-configuration = ./settings-configuration.nix;
 }

--- a/tests/modules/programs/rizin/settings-configuration.nix
+++ b/tests/modules/programs/rizin/settings-configuration.nix
@@ -8,6 +8,6 @@
   };
 
   nmt.script = ''
-    assertFileExists "home-files/.rizinrc"
+    assertFileExists "home-files/.config/rizin/rizinrc"
   '';
 }

--- a/tests/modules/programs/rizin/xdg-disabled.nix
+++ b/tests/modules/programs/rizin/xdg-disabled.nix
@@ -1,7 +1,5 @@
 {
-  xdg.enable = true;
-
-  home.preferXdgDirectories = true;
+  xdg.enable = false;
 
   programs.rizin = {
     enable = true;
@@ -12,6 +10,6 @@
   };
 
   nmt.script = ''
-    assertFileExists "home-files/.config/rizin/rizinrc"
+    assertFileExists "home-files/.rizinrc"
   '';
 }


### PR DESCRIPTION
### Description

In both prior feature pull requests for this module there was a review after the pull request got merged, those are addressed here.

Specifically, the `home.preferXdgDirectories` option is apparently only for programs that need extra support to load configuration from XDG directories, not for programs that support this already and `eValueType` is now inlined.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
