### PR TITLE
tmux: reduce default escapeTime

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -189,7 +189,7 @@ in
       enable = mkEnableOption "tmux";
 
       escapeTime = mkOption {
-        default = 500;
+        default = 10;
         example = 0;
         type = types.ints.unsigned;
         description = ''

--- a/tests/modules/programs/tmux/default-shell.conf
+++ b/tests/modules/programs/tmux/default-shell.conf
@@ -22,6 +22,6 @@ set  -g mouse             off
 set  -g focus-events      off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12
-set  -s escape-time       500
+set  -s escape-time       10
 set  -g history-limit     2000
 

--- a/tests/modules/programs/tmux/disable-confirmation-prompt.conf
+++ b/tests/modules/programs/tmux/disable-confirmation-prompt.conf
@@ -22,6 +22,6 @@ set  -g mouse             off
 set  -g focus-events      off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12
-set  -s escape-time       500
+set  -s escape-time       10
 set  -g history-limit     2000
 

--- a/tests/modules/programs/tmux/emacs-with-plugins.conf
+++ b/tests/modules/programs/tmux/emacs-with-plugins.conf
@@ -22,7 +22,7 @@ set  -g mouse             off
 set  -g focus-events      off
 setw -g aggressive-resize on
 setw -g clock-mode-style  24
-set  -s escape-time       500
+set  -s escape-time       10
 set  -g history-limit     2000
 
 # ============================================= #

--- a/tests/modules/programs/tmux/mouse-enabled.conf
+++ b/tests/modules/programs/tmux/mouse-enabled.conf
@@ -20,6 +20,6 @@ set  -g mouse             on
 set  -g focus-events      off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12
-set  -s escape-time       500
+set  -s escape-time       10
 set  -g history-limit     2000
 

--- a/tests/modules/programs/tmux/prefix.conf
+++ b/tests/modules/programs/tmux/prefix.conf
@@ -25,6 +25,6 @@ set  -g mouse             off
 set  -g focus-events      off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12
-set  -s escape-time       500
+set  -s escape-time       10
 set  -g history-limit     2000
 

--- a/tests/modules/programs/tmux/shortcut-without-prefix.conf
+++ b/tests/modules/programs/tmux/shortcut-without-prefix.conf
@@ -25,6 +25,6 @@ set  -g mouse             off
 set  -g focus-events      off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12
-set  -s escape-time       500
+set  -s escape-time       10
 set  -g history-limit     2000
 

--- a/tests/modules/programs/tmux/vi-all-true.conf
+++ b/tests/modules/programs/tmux/vi-all-true.conf
@@ -22,6 +22,6 @@ set  -g mouse             off
 set  -g focus-events      off
 setw -g aggressive-resize on
 setw -g clock-mode-style  24
-set  -s escape-time       500
+set  -s escape-time       10
 set  -g history-limit     2000
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Reduce default `programs.tmux.escapeTime` from 500 to 10.
The default was changed upstream:
https://github.com/tmux/tmux/issues/3844
https://github.com/tmux/tmux/commit/2e9d7ebf15615b51b014a12de03b0e5483aadf99
Though, it's worth noting that the change affects tmux version 3.5 and above.

Change is **NOT** backwards compatible. It only affects people who didn't set `escapeTime` explicitly. This mirrors the change done upstream.

I don't know of a good way to announce the change to the users? I don't think upstream did anything apart from adding the information to the changelog. Maybe we should start displaying a warning for users who have tmux enabled and use the default value of `escapeTime`? And remove the warning after few months.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Code formatted with `nix fmt`.

- [ ] Code tested through `nix run .#tests -- test-all`.

- [x] Test cases updated.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```