### PR TITLE
opencode: skill -> skills

### DIFF
--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -247,16 +247,16 @@ in
 
         If an attribute set is used, the attribute name becomes the skill directory name,
         and the value is either:
-        - Inline content as a string (creates `opencode/skill/<name>/SKILL.md`)
-        - A path to a file (creates `opencode/skill/<name>/SKILL.md`)
-        - A path to a directory (creates `opencode/skill/<name>/` with all files)
+        - Inline content as a string (creates `opencode/skills/<name>/SKILL.md`)
+        - A path to a file (creates `opencode/skills/<name>/SKILL.md`)
+        - A path to a directory (creates `opencode/skills/<name>/` with all files)
 
         This also accepts Nix store paths (e.g., source from a package), allowing you to
         reference subdirectories within a package source.
 
         If a path is used, it is expected to contain one folder per skill name, each
         containing a {file}`SKILL.md`. The directory is symlinked to
-        {file}`$XDG_CONFIG_HOME/opencode/skill/`.
+        {file}`$XDG_CONFIG_HOME/opencode/skills/`.
 
         See <https://opencode.ai/docs/skills/> for the documentation.
       '';
@@ -419,7 +419,7 @@ in
         recursive = true;
       };
 
-      "opencode/skill" = mkIf (lib.isPath cfg.skills) {
+      "opencode/skills" = mkIf (lib.isPath cfg.skills) {
         source = cfg.skills;
         recursive = true;
       };
@@ -460,12 +460,12 @@ in
         || (builtins.isString content && lib.hasPrefix builtins.storeDir content)
 
       then
-        lib.nameValuePair "opencode/skill/${name}" {
+        lib.nameValuePair "opencode/skills/${name}" {
           source = content;
           recursive = true;
         }
       else
-        lib.nameValuePair "opencode/skill/${name}/SKILL.md" (
+        lib.nameValuePair "opencode/skills/${name}/SKILL.md" (
           if lib.isPath content then { source = content; } else { text = content; }
         )
     ) (if builtins.isAttrs cfg.skills then cfg.skills else { })

--- a/tests/modules/programs/opencode/mixed-content.nix
+++ b/tests/modules/programs/opencode/mixed-content.nix
@@ -78,14 +78,14 @@
       ${./test-tool.ts}
 
     # Skills
-    assertFileExists home-files/.config/opencode/skill/inline-skill/SKILL.md
-    assertFileExists home-files/.config/opencode/skill/path-skill/SKILL.md
-    assertFileExists home-files/.config/opencode/skill/dir-skill/SKILL.md
-    assertFileExists home-files/.config/opencode/skill/dir-skill/notes.txt
+    assertFileExists home-files/.config/opencode/skills/inline-skill/SKILL.md
+    assertFileExists home-files/.config/opencode/skills/path-skill/SKILL.md
+    assertFileExists home-files/.config/opencode/skills/dir-skill/SKILL.md
+    assertFileExists home-files/.config/opencode/skills/dir-skill/notes.txt
 
-    assertFileContent home-files/.config/opencode/skill/path-skill/SKILL.md \
+    assertFileContent home-files/.config/opencode/skills/path-skill/SKILL.md \
       ${./git-release-SKILL.md}
-    assertFileContent home-files/.config/opencode/skill/dir-skill/SKILL.md \
+    assertFileContent home-files/.config/opencode/skills/dir-skill/SKILL.md \
       ${./skill-dir/data-analysis/SKILL.md}
 
     # Themes

--- a/tests/modules/programs/opencode/skills-bulk-directory.nix
+++ b/tests/modules/programs/opencode/skills-bulk-directory.nix
@@ -5,11 +5,11 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/skill/git-release/SKILL.md
-    assertFileExists home-files/.config/opencode/skill/pdf-processing/SKILL.md
-    assertFileContent home-files/.config/opencode/skill/git-release/SKILL.md \
+    assertFileExists home-files/.config/opencode/skills/git-release/SKILL.md
+    assertFileExists home-files/.config/opencode/skills/pdf-processing/SKILL.md
+    assertFileContent home-files/.config/opencode/skills/git-release/SKILL.md \
       ${./skills-bulk/git-release/SKILL.md}
-    assertFileContent home-files/.config/opencode/skill/pdf-processing/SKILL.md \
+    assertFileContent home-files/.config/opencode/skills/pdf-processing/SKILL.md \
       ${./skills-bulk/pdf-processing/SKILL.md}
   '';
 }

--- a/tests/modules/programs/opencode/skills-directory.nix
+++ b/tests/modules/programs/opencode/skills-directory.nix
@@ -7,9 +7,9 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/skill/data-analysis/SKILL.md
-    assertFileExists home-files/.config/opencode/skill/data-analysis/notes.txt
-    assertFileContent home-files/.config/opencode/skill/data-analysis/SKILL.md \
+    assertFileExists home-files/.config/opencode/skills/data-analysis/SKILL.md
+    assertFileExists home-files/.config/opencode/skills/data-analysis/notes.txt
+    assertFileContent home-files/.config/opencode/skills/data-analysis/SKILL.md \
       ${./skill-dir/data-analysis/SKILL.md}
   '';
 }

--- a/tests/modules/programs/opencode/skills-inline.nix
+++ b/tests/modules/programs/opencode/skills-inline.nix
@@ -18,8 +18,8 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/skill/git-release/SKILL.md
-    assertFileContent home-files/.config/opencode/skill/git-release/SKILL.md \
+    assertFileExists home-files/.config/opencode/skills/git-release/SKILL.md
+    assertFileContent home-files/.config/opencode/skills/git-release/SKILL.md \
       ${./git-release-SKILL.md}
   '';
 }

--- a/tests/modules/programs/opencode/skills-path.nix
+++ b/tests/modules/programs/opencode/skills-path.nix
@@ -7,8 +7,8 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/skill/pdf-processing/SKILL.md
-    assertFileContent home-files/.config/opencode/skill/pdf-processing/SKILL.md \
+    assertFileExists home-files/.config/opencode/skills/pdf-processing/SKILL.md
+    assertFileContent home-files/.config/opencode/skills/pdf-processing/SKILL.md \
       ${./pdf-processing-SKILL.md}
   '';
 }

--- a/tests/modules/programs/opencode/skills-store-path.nix
+++ b/tests/modules/programs/opencode/skills-store-path.nix
@@ -16,9 +16,9 @@ in
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/skill/internal-skill/SKILL.md
+    assertFileExists home-files/.config/opencode/skills/internal-skill/SKILL.md
 
-    assertFileContent home-files/.config/opencode/skill/internal-skill/SKILL.md \
+    assertFileContent home-files/.config/opencode/skills/internal-skill/SKILL.md \
       "${src}/skills/external-skill/SKILL.md"
   '';
 }


### PR DESCRIPTION
### Description

The skills option was creating files under ~/.config/opencode/skill/
(singular) but OpenCode documentation only mentions
~/.config/opencode/skills/ (plural). Both work, but using an
undocumented directory can be confusing.

Fixes: https://github.com/nix-community/home-manager/issues/8907


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
