### PR TITLE
infat: allow customization of autoActivate

### DIFF
--- a/modules/programs/infat.nix
+++ b/modules/programs/infat.nix
@@ -7,6 +7,7 @@
 let
   cfg = config.programs.infat;
   tomlFormat = pkgs.formats.toml { };
+  mkCli = lib.cli.toCommandLineShellGNU { };
 
   configDir =
     if config.xdg.enable then
@@ -47,15 +48,72 @@ in
           {file}`$XDG_CONFIG_HOME/infat/config.toml`.
         '';
       };
-      autoActivate = lib.mkEnableOption "auto-activate infat" // {
-        default = true;
-        example = false;
+      autoActivate = lib.mkOption {
+        type =
+          lib.types.coercedTo lib.types.bool
+            (enable: {
+              inherit enable;
+              _legacyBoolean = true;
+            })
+            (
+              lib.types.submodule {
+                options = {
+                  _legacyBoolean = lib.mkOption {
+                    type = lib.types.bool;
+                    default = false;
+                    visible = false;
+                  };
+                  enable = lib.mkEnableOption "auto-activate infat" // {
+                    default = true;
+                    example = false;
+                    description = ''
+                      Automatically activate infat on startup.
+                      This is useful if you want to use infat as a
+                      default application handler for certain file types.
+                      If you don't want this, set this to false.
+                      This option is only effective if `settings` is set.
+                    '';
+                  };
+                  extraArgs = lib.mkOption {
+                    type =
+                      with lib.types;
+                      attrsOf (oneOf [
+                        str
+                        bool
+                      ]);
+                    default = {
+                      robust = true;
+                    };
+                    example = {
+                      quiet = true;
+                    };
+                    description = ''
+                      Additional arguments to pass when auto-activating infat.
+                      This can be used to customize the behavior of infat when
+                      it is auto-activated on startup. Call `infat --help`
+                      for more information on available arguments.
+                      If {option}`programs.infat.settings` is set,
+                      `config` will be added automatically.
+                      Otherwise you can set `config` to point
+                      to a custom configuration file.
+                    '';
+                  };
+                };
+              }
+            );
+        default = { };
+        example = {
+          enable = true;
+          extraArgs = {
+            quiet = true;
+          };
+        };
         description = ''
-          Automatically activate infat on startup.
-          This is useful if you want to use infat as a
-          default application handler for certain file types.
-          If you don't want this, set this to false.
-          This option is only effective if `settings` is set.
+          Auto-activation settings for infat.
+
+          For backwards compatibility, this option also accepts a boolean.
+          Boolean values are deprecated; use
+          {option}`programs.infat.autoActivate.enable` instead.
         '';
       };
     };
@@ -64,16 +122,26 @@ in
     assertions = [
       (lib.hm.assertions.assertPlatform "programs.infat" pkgs lib.platforms.darwin)
     ];
+    warnings = lib.optional cfg.autoActivate._legacyBoolean ''
+      Using `programs.infat.autoActivate` as a Boolean is deprecated and will be
+      removed in a future release. Please use `programs.infat.autoActivate.enable`
+      instead.
+    '';
+    programs.infat.autoActivate.extraArgs = lib.mkIf (cfg.settings != { }) {
+      config = configFile;
+    };
     home = {
       packages = lib.mkIf (cfg.package != null) [ cfg.package ];
       file.${configFile} = lib.mkIf (cfg.settings != { }) {
         source = tomlFormat.generate "infat-settings.toml" cfg.settings;
       };
-      activation = lib.mkIf (cfg.settings != { } && cfg.package != null && cfg.autoActivate) {
-        infat = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-          run ${lib.getExe cfg.package} --config "${configFile}" $VERBOSE_ARG
-        '';
-      };
+      activation =
+        lib.mkIf (cfg.package != null && cfg.autoActivate.enable && cfg.autoActivate.extraArgs ? config)
+          {
+            infat = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+              run ${lib.getExe cfg.package} ${mkCli cfg.autoActivate.extraArgs} $VERBOSE_ARG
+            '';
+          };
     };
   };
 }

--- a/tests/modules/programs/infat/auto-activate-args.nix
+++ b/tests/modules/programs/infat/auto-activate-args.nix
@@ -1,0 +1,30 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  activationScript = pkgs.writeText "activation-script" config.home.activation.infat.data;
+in
+{
+  programs.infat = {
+    enable = true;
+    autoActivate.extraArgs = {
+      quiet = true;
+    };
+    settings = {
+      extensions = {
+        md = "TextEdit";
+      };
+    };
+  };
+
+  test.stubs.infat = { };
+
+  nmt.script = ''
+    assertFileRegex "${activationScript}" '.*--config'
+    assertFileRegex "${activationScript}" '.*--quiet'
+    assertFileNotRegex "${activationScript}" '.*--robust'
+  '';
+}

--- a/tests/modules/programs/infat/default.nix
+++ b/tests/modules/programs/infat/default.nix
@@ -1,6 +1,8 @@
 { lib, pkgs, ... }:
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+  infat-auto-activate-args = ./auto-activate-args.nix;
+  infat-deprecated-auto-activate-bool = ./deprecated-auto-activate-bool.nix;
   infat-example-settings = ./example-settings.nix;
   infat-no-settings = ./no-settings.nix;
 }

--- a/tests/modules/programs/infat/deprecated-auto-activate-bool.nix
+++ b/tests/modules/programs/infat/deprecated-auto-activate-bool.nix
@@ -1,0 +1,29 @@
+_:
+
+{
+  programs.infat = {
+    enable = true;
+    autoActivate = false;
+    settings = {
+      extensions = {
+        md = "TextEdit";
+      };
+    };
+  };
+
+  test = {
+    asserts.warnings.expected = [
+      ''
+        Using `programs.infat.autoActivate` as a Boolean is deprecated and will be
+        removed in a future release. Please use `programs.infat.autoActivate.enable`
+        instead.
+      ''
+    ];
+
+    stubs.infat = { };
+  };
+
+  nmt.script = ''
+    assertFileNotRegex activate '.*@infat@/bin/infat'
+  '';
+}


### PR DESCRIPTION
### Description

Added the `--robust` flag to continue on errors and show more helpful messages. Here is an example of the change in output in case there is an error:

```console
$ infat
Loading configuration from: /Users/mlenz/.config/infat/config.toml
Found 125 associations: 73 extensions, 7 schemes, 45 types
Error:
   0: Failed to load and apply configuration
   1: Failed to apply configuration settings
   2: Launch Services API error: Failed to set UTI handler: error -50

Location:
   infat-cli/src/main.rs:122

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.


$ infat --robust
Loading configuration from: /Users/mlenz/.config/infat/config.toml
Found 125 associations: 73 extensions, 7 schemes, 45 types
2026-03-19T09:23:13.251688Z  WARN infat_lib::config: Failed to set .scss → Zed: Launch Services API error: Failed to set UTI handler: error -50
2026-03-19T09:23:13.252156Z  WARN infat_lib::config: Failed to set .graphql → Zed: Launch Services API error: Failed to set UTI handler: error -50
```

If there are no errors the output is identical.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
