### PR TITLE
opencode: add environmentFile option to set OPENCODE_SERVER_PASSWORD

### DIFF
--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -115,6 +115,20 @@ in
           See <https://opencode.ai/docs/web/#config-file> for available options.
         '';
       };
+
+      environmentFile = mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/run/secrets/opencode-web";
+        description = ''
+          Path to a file containing environment variables for the opencode web
+          service, in the format of an EnvironmentFile as described by
+          {manpage}`systemd.exec(5)` (i.e. `KEY=VALUE` pairs, one per line).
+
+          This is the recommended way to set `OPENCODE_SERVER_PASSWORD` without
+          exposing the secret value in the Nix store.
+        '';
+      };
     };
 
     rules = lib.mkOption {
@@ -501,6 +515,9 @@ in
           ExecStart = "${lib.getExe cfg.package} serve ${lib.escapeShellArgs webCfg.extraArgs}";
           Restart = "always";
           RestartSec = 5;
+        }
+        // lib.optionalAttrs (webCfg.environmentFile != null) {
+          EnvironmentFile = webCfg.environmentFile;
         };
 
         Install = {
@@ -513,11 +530,24 @@ in
       opencode-web = {
         enable = true;
         config = {
-          ProgramArguments = [
-            (lib.getExe cfg.package)
-            "serve"
-          ]
-          ++ webCfg.extraArgs;
+          ProgramArguments =
+            let
+              programArguments = [
+                (lib.getExe cfg.package)
+                "serve"
+              ]
+              ++ webCfg.extraArgs;
+              opencodeLaunchdWrapper = pkgs.writeShellScriptBin "opencode-launchd-wrapper" ''
+                source ${webCfg.environmentFile}
+                ${lib.escapeShellArgs programArguments}
+              '';
+            in
+            if webCfg.environmentFile == null then
+              programArguments
+            else
+              [
+                (lib.getExe opencodeLaunchdWrapper)
+              ];
           KeepAlive = {
             Crashed = true;
             SuccessfulExit = false;

--- a/tests/modules/programs/opencode/default.nix
+++ b/tests/modules/programs/opencode/default.nix
@@ -25,4 +25,5 @@
   opencode-mcp-integration = ./mcp-integration.nix;
   opencode-mcp-integration-with-override = ./mcp-integration-with-override.nix;
   opencode-web-service = ./web-service.nix;
+  opencode-web-service-environment-file = ./web-service-environment-file.nix;
 }

--- a/tests/modules/programs/opencode/web-service-environment-file.nix
+++ b/tests/modules/programs/opencode/web-service-environment-file.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  ...
+}:
+{
+  programs.opencode = {
+    enable = true;
+
+    web = {
+      enable = true;
+      environmentFile = "/run/secrets/opencode";
+    };
+  };
+
+  nmt.script =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      ''
+        serviceFile=LaunchAgents/org.nix-community.home.opencode-web.plist
+        assertFileExists "$serviceFile"
+        serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+        assertFileContent "$serviceFileNormalized" ${./web-service-environment-file.plist}
+      ''
+    else
+      ''
+        serviceFile=home-files/.config/systemd/user/opencode-web.service
+        assertFileExists "$serviceFile"
+        assertFileContent "$serviceFile" ${./web-service-environment-file.service}
+      '';
+}

--- a/tests/modules/programs/opencode/web-service-environment-file.plist
+++ b/tests/modules/programs/opencode/web-service-environment-file.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>KeepAlive</key>
+	<dict>
+		<key>Crashed</key>
+		<true/>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+	<key>Label</key>
+	<string>org.nix-community.home.opencode-web</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sh</string>
+		<string>-c</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec /nix/store/00000000000000000000000000000000-opencode-launchd-wrapper/bin/opencode-launchd-wrapper</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/modules/programs/opencode/web-service-environment-file.service
+++ b/tests/modules/programs/opencode/web-service-environment-file.service
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+EnvironmentFile=/run/secrets/opencode
+ExecStart=@opencode@/bin/opencode serve 
+Restart=always
+RestartSec=5
+
+[Unit]
+After=network.target
+Description=OpenCode Web Service


### PR DESCRIPTION
### Description

This commit introduces a new option for the Opencode web service to allow configuring an environment file so that we can safely specify an `OPENCODE_SERVER_PASSWORD` environment variable to secure access to the service without exposing the secret to the Nix store.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
