### PR TITLE
docs: hotfix determinate warning

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -68,6 +68,7 @@ let
     };
 
   hmPath = toString ./..;
+  nixpkgsPath = toString pkgs.path;
 
   # Keep submodule option docs visible when wrapped in `either` (and therefore
   # in `nullOr (either ...)`), which upstream currently omits.
@@ -170,10 +171,15 @@ let
             # source tree.
             declarations = map (
               decl:
-              if lib.hasPrefix hmPath (toString decl) then
+              let
+                declStr = toString decl;
+              in
+              if lib.hasPrefix hmPath declStr then
                 gitHubDeclaration "nix-community" "home-manager" (
-                  lib.removePrefix "/" (lib.removePrefix hmPath (toString decl))
+                  lib.removePrefix "/" (lib.removePrefix hmPath declStr)
                 )
+              else if lib.hasPrefix nixpkgsPath declStr then
+                gitHubDeclaration "NixOS" "nixpkgs" (lib.removePrefix "/" (lib.removePrefix nixpkgsPath declStr))
               else if decl == "lib/modules.nix" then
                 # TODO: handle this in a better way (may require upstream
                 # changes to nixpkgs)

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -68,6 +68,8 @@ let
     };
 
   hmPath = toString ./..;
+  # NOTE: Assume `pkgs.path` is the same Nixpkgs used to eval Home Manager
+  # That is currently true when building Home Manager's docs website, but may not be true when end-users build Home Manager docs.
   nixpkgsPath = toString pkgs.path;
 
   # Keep submodule option docs visible when wrapped in `either` (and therefore


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

hotfix the determinate warning showing up from the docs generation

CLOSES: #7935

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.
- [ ] Code tested through `nix run .#tests -- test-all` or`nix-shell --pure tests -A run.all`.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
