### PR TITLE
lib: remove rec in shell.nix

### DIFF
--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -22,24 +22,8 @@ let
       type = lib.types.bool;
     };
 
-in
-rec {
-  # Produces a Bourne shell like statement that prepend new values to
-  # an possibly existing variable, using sep(arator).
-  # Example:
-  #   prependToVar ":" "PATH" [ "$HOME/bin" "$HOME/.local/bin" ]
-  #   => "$HOME/bin:$HOME/.local/bin:${PATH:+:}\$PATH"
-  prependToVar =
-    sep: n: v:
-    "${lib.concatStringsSep sep v}\${${n}:+${sep}}\$${n}";
-
   # Produces a Bourne shell like variable export statement.
   export = n: v: ''export ${n}="${toString v}"'';
-
-  # Given an attribute set containing shell variable names and their
-  # assignment, this function produces a string containing an export
-  # statement for each set entry.
-  exportAll = vars: lib.concatStringsSep "\n" (lib.mapAttrsToList export vars);
 
   # Wrap a list of strings to a given line width.
   # Packs as many items as possible per line without exceeding maxWidth.
@@ -69,6 +53,23 @@ rec {
       } items;
     in
     foldResult.finishedLines ++ lib.optional (foldResult.currentLine != "") foldResult.currentLine;
+in
+{
+  inherit export wrapLines;
+
+  # Produces a Bourne shell like statement that prepend new values to
+  # an possibly existing variable, using sep(arator).
+  # Example:
+  #   prependToVar ":" "PATH" [ "$HOME/bin" "$HOME/.local/bin" ]
+  #   => "$HOME/bin:$HOME/.local/bin:${PATH:+:}\$PATH"
+  prependToVar =
+    sep: n: v:
+    "${lib.concatStringsSep sep v}\${${n}:+${sep}}\$${n}";
+
+  # Given an attribute set containing shell variable names and their
+  # assignment, this function produces a string containing an export
+  # statement for each set entry.
+  exportAll = vars: lib.concatStringsSep "\n" (lib.mapAttrsToList export vars);
 
   # Formats a list of items for shell array content with intelligent width optimization.
   # IMPORTANT: This formats the CONTENTS of an array (what goes inside parentheses),


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

deprecating reliance on rec in lib shell

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
