### PR TITLE
gurk: change config signal_db_path to data_dir

### DIFF
--- a/modules/programs/gurk-rs.nix
+++ b/modules/programs/gurk-rs.nix
@@ -24,11 +24,10 @@ in
         Configuration written to {file}`$XDG_CONFIG_HOME/gurk/gurk.toml`
         or {file}`Library/Application Support/gurk/gurk.toml`. Options are
         declared at <https://github.com/boxdot/gurk-rs/blob/main/src/config.rs>.
-        Note that `signal_db_path` should be set.
       '';
       example = lib.literalExpression ''
         {
-          signal_db_path = "/home/USERNAME/.local/share/gurk/signal-db";
+          data_dir = "/home/USERNAME/.local/share/gurk/signal-db";
           first_name_only = false;
           show_receipts = true;
           notifications = true;


### PR DESCRIPTION
### Description

The configuration option `signal_db_path` is deprecated, see

https://github.com/boxdot/gurk-rs/blob/c69185026a46658ad9a74a56456baca9c82141c7/src/config.rs#L260-L265

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
