### PR TITLE
atool: add module

### DIFF
--- a/modules/misc/news/2026/03/2026-03-22_14-14-47.nix
+++ b/modules/misc/news/2026/03/2026-03-22_14-14-47.nix
@@ -1,0 +1,11 @@
+{
+  time = "2026-03-22T18:14:47+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.atool'.
+
+    Atool is a commandline archive manager that can create,
+    view, and extract archives. It uses common packages
+    like gnutar, p7zip, unrar, and zip as backends.
+  '';
+}

--- a/modules/programs/atool.nix
+++ b/modules/programs/atool.nix
@@ -1,0 +1,83 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkOption
+    types
+    ;
+  cfg = config.programs.atool;
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.oneorseveralcats ];
+
+  options.programs.atool = {
+    enable = lib.mkEnableOption "atool a commandline archive manager.";
+
+    package = lib.mkPackageOption pkgs "atool" { nullable = true; };
+
+    finalPackage = mkOption {
+      type = types.package;
+      readOnly = true;
+      description = ''
+        Final atool package bundled with extraPackages.
+      '';
+    };
+
+    settings = mkOption {
+      type = with types; attrsOf (either str int);
+      default = { };
+      example = {
+        path_unrar = "unrar-free";
+      };
+      description = ''
+        atool settings to generate {file}`~/.atoolrc`.
+      '';
+    };
+
+    extraPackages = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      example = lib.literalExpression ''
+        # all supported archive backends
+        with pkgs; [ bzip2 cpio gnutar gzip lhasa lzop p7zip unrar-free unzip xz zip ]
+      '';
+      description = "Extra packages for atool.";
+    };
+  };
+
+  config =
+    let
+      atoolPackage =
+        if (cfg.extraPackages != [ ]) then
+          (pkgs.symlinkJoin {
+            name = "atool-wrapped";
+            paths = [ cfg.package ];
+            buildInputs = [ pkgs.makeWrapper ];
+            postBuild = ''
+              wrapProgram $out/bin/atool \
+              --suffix PATH : ${lib.makeBinPath cfg.extraPackages}
+            '';
+          })
+        else
+          cfg.package;
+    in
+    lib.mkIf cfg.enable {
+      programs.atool.finalPackage = atoolPackage;
+
+      home.packages = lib.mkIf (cfg.package != null) [
+        cfg.finalPackage
+      ];
+
+      home.file.".atoolrc" = lib.mkIf (cfg.settings != { }) {
+        source = pkgs.writeText ".atoolrc" (
+          lib.generators.toKeyValue {
+            mkKeyValue = lib.generators.mkKeyValueDefault { } " ";
+          } cfg.settings
+        );
+      };
+    };
+}

--- a/tests/modules/programs/atool/config-correct.nix
+++ b/tests/modules/programs/atool/config-correct.nix
@@ -1,0 +1,14 @@
+{ ... }:
+{
+  programs.atool = {
+    enable = true;
+    settings = {
+      path_unrar = "unrar-free";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/.atoolrc"
+    assertFileContains "home-files/.atoolrc" "path_unrar unrar-free"
+  '';
+}

--- a/tests/modules/programs/atool/default.nix
+++ b/tests/modules/programs/atool/default.nix
@@ -1,0 +1,4 @@
+{
+  atool-config-correct = ./config-correct.nix;
+  atool-disabled = ./disabled.nix;
+}

--- a/tests/modules/programs/atool/disabled.nix
+++ b/tests/modules/programs/atool/disabled.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  programs.atool.enable = false;
+
+  nmt.script = ''
+    assertPathNotExists "home-files/.atoolrc"
+  '';
+}


### PR DESCRIPTION
atool is a commandline archive manager that uses common packages like p7zip, gnutar, unrar, zip, etc. as backends to view, create, and extract archives.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)