### PR TITLE
tmuxinator: move to dedicated module with projects support

### DIFF
--- a/modules/misc/news/2026/03/2026-03-31_12-00-00.nix
+++ b/modules/misc/news/2026/03/2026-03-31_12-00-00.nix
@@ -1,0 +1,13 @@
+{ config, ... }:
+{
+  time = "2026-03-31T12:00:00+00:00";
+  condition = config.programs.tmux.tmuxinator.enable;
+  message = ''
+    The tmuxinator integration in 'programs.tmux.tmuxinator' now supports
+    declaring projects via 'programs.tmux.tmuxinator.projects'. Each
+    project is written to '$HOME/.config/tmuxinator/<name>.yaml'.
+
+    The tmuxinator package can be customised via
+    'programs.tmux.tmuxinator.package'.
+  '';
+}

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -313,8 +313,6 @@ in
 
       tmuxp.enable = mkEnableOption "tmuxp";
 
-      tmuxinator.enable = mkEnableOption "tmuxinator";
-
       plugins = mkOption {
         type =
           with types;
@@ -352,9 +350,7 @@ in
     lib.mkMerge [
       {
         home.packages =
-          lib.optional (cfg.package != null) cfg.package
-          ++ lib.optional cfg.tmuxinator.enable pkgs.tmuxinator
-          ++ lib.optional cfg.tmuxp.enable pkgs.tmuxp;
+          lib.optional (cfg.package != null) cfg.package ++ lib.optional cfg.tmuxp.enable pkgs.tmuxp;
       }
 
       { xdg.configFile."tmux/tmux.conf".text = lib.mkBefore tmuxConf; }

--- a/modules/programs/tmuxinator.nix
+++ b/modules/programs/tmuxinator.nix
@@ -1,0 +1,61 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.tmux;
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = [ lib.maintainers.britter ];
+
+  options.programs.tmux.tmuxinator = {
+    enable = lib.mkEnableOption "tmuxinator";
+
+    package = lib.mkPackageOption pkgs "tmuxinator" { nullable = true; };
+
+    projects = lib.mkOption {
+      type = lib.types.attrsOf yamlFormat.type;
+      default = { };
+      description = ''
+        Tmuxinator projects to write to {file}`$HOME/.config/tmuxinator`.
+        One project configuration file is generated per attribute.
+        See <https://github.com/tmuxinator/tmuxinator> for the project
+        configuration format.
+      '';
+      example = lib.literalExpression ''
+        {
+          myproject = {
+            root = "~/code/myproject";
+            windows = [
+              {
+                editor = {
+                  layout = "main-vertical";
+                  panes = [
+                    { editor = [ "vim" ]; }
+                    "guard"
+                  ];
+                };
+              }
+              { server = "bundle exec rails s"; }
+              { logs = "tail -f log/development.log"; }
+            ];
+          };
+        }
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && cfg.tmuxinator.enable) {
+    home.packages = lib.mkIf (cfg.tmuxinator.package != null) [ cfg.tmuxinator.package ];
+
+    xdg.configFile = lib.mapAttrs' (
+      k: v:
+      lib.nameValuePair "tmuxinator/${k}.yaml" {
+        source = yamlFormat.generate "${k}.yaml" v;
+      }
+    ) cfg.tmuxinator.projects;
+  };
+}

--- a/tests/modules/programs/tmux/default.nix
+++ b/tests/modules/programs/tmux/default.nix
@@ -8,4 +8,5 @@
   tmux-shortcut-without-prefix = ./shortcut-without-prefix.nix;
   tmux-prefix = ./prefix.nix;
   tmux-mouse-enabled = ./mouse-enabled.nix;
+  tmux-tmuxinator-projects = ./tmuxinator-projects.nix;
 }

--- a/tests/modules/programs/tmux/tmuxinator-projects-1.yaml
+++ b/tests/modules/programs/tmux/tmuxinator-projects-1.yaml
@@ -1,0 +1,11 @@
+name: myproject
+root: ~/code/myproject
+windows:
+- editor:
+    layout: main-vertical
+    panes:
+    - editor:
+      - vim
+    - guard
+- server: bundle exec rails s
+- logs: tail -f log/development.log

--- a/tests/modules/programs/tmux/tmuxinator-projects-2.yaml
+++ b/tests/modules/programs/tmux/tmuxinator-projects-2.yaml
@@ -1,0 +1,2 @@
+name: my-second-project
+root: ~/code/my-second-project

--- a/tests/modules/programs/tmux/tmuxinator-projects.nix
+++ b/tests/modules/programs/tmux/tmuxinator-projects.nix
@@ -1,0 +1,40 @@
+{
+  config = {
+    programs.tmux = {
+      enable = true;
+      tmuxinator = {
+        enable = true;
+        projects = {
+          myproject = {
+            name = "myproject";
+            root = "~/code/myproject";
+            windows = [
+              {
+                editor = {
+                  layout = "main-vertical";
+                  panes = [
+                    { editor = [ "vim" ]; }
+                    "guard"
+                  ];
+                };
+              }
+              { server = "bundle exec rails s"; }
+              { logs = "tail -f log/development.log"; }
+            ];
+          };
+          my-second-project = {
+            name = "my-second-project";
+            root = "~/code/my-second-project";
+          };
+        };
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/tmuxinator/myproject.yaml
+      assertFileContent home-files/.config/tmuxinator/myproject.yaml ${./tmuxinator-projects-1.yaml}
+      assertFileExists home-files/.config/tmuxinator/my-second-project.yaml
+      assertFileContent home-files/.config/tmuxinator/my-second-project.yaml ${./tmuxinator-projects-2.yaml}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Extract tmuxinator from tmux.nix into its own programs/tmuxinator.nix module. The new module adds:

- programs.tmux.tmuxinator.package for customising the tmuxinator package
- programs.tmux.tmuxinator.projects for declaring projects declaratively; each project is written to $HOME/.config/tmuxinator/<name>.yaml


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.
- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like
  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
