### PR TITLE
codex: support store-path skill sources

### DIFF
--- a/modules/programs/codex.nix
+++ b/modules/programs/codex.nix
@@ -150,9 +150,13 @@ in
       # TODO: Remove this workaround once Codex supports symlinked SKILL.md
       # files again. Upstream only supports symlinking the containing skill
       # directory today: https://github.com/openai/codex/issues/10470
+      isStorePathString = content: builtins.isString content && lib.hasPrefix builtins.storeDir content;
+      isPathLikeContent = content: lib.isPath content || isStorePathString content;
       mkSkillDir =
         content:
-        pkgs.writeTextDir "SKILL.md" (if lib.isPath content then builtins.readFile content else content);
+        pkgs.writeTextDir "SKILL.md" (
+          if isPathLikeContent content then builtins.readFile content else content
+        );
       skillSources =
         if builtins.isAttrs cfg.skills then
           cfg.skills
@@ -162,7 +166,7 @@ in
           { };
       mkSkillEntry =
         name: content:
-        if lib.isPath content && lib.pathIsDirectory content then
+        if isPathLikeContent content && lib.pathIsDirectory content then
           lib.nameValuePair "${skillsDir}/${name}" {
             source = content;
           }

--- a/tests/modules/programs/codex/default.nix
+++ b/tests/modules/programs/codex/default.nix
@@ -9,5 +9,6 @@
   codex-skills-inline-null-package = ./skills-inline-null-package.nix;
   codex-skills-inline-legacy-path = ./skills-inline-legacy-path.nix;
   codex-skills-dir = ./skills-dir.nix;
+  codex-skills-store-path = ./skills-store-path.nix;
   codex-skills-path-not-directory = ./skills-path-not-directory.nix;
 }

--- a/tests/modules/programs/codex/skills-store-path.nix
+++ b/tests/modules/programs/codex/skills-store-path.nix
@@ -1,0 +1,34 @@
+{ pkgs, ... }:
+let
+  src = pkgs.writeTextDir "skills/external-skill/SKILL.md" ''
+    ---
+    name: external-skill
+    description: Store path skill fixture.
+    ---
+
+    # External Skill
+
+    This content simulates a skill living inside a package source.
+  '';
+in
+{
+  programs.codex = {
+    enable = true;
+    skills = {
+      dir-skill = "${src}/skills/external-skill";
+      file-skill = "${src}/skills/external-skill/SKILL.md";
+    };
+  };
+
+  nmt.script = ''
+    assertLinkExists home-files/.agents/skills/dir-skill
+    assertFileExists home-files/.agents/skills/dir-skill/SKILL.md
+    assertFileContent home-files/.agents/skills/dir-skill/SKILL.md \
+      "${src}/skills/external-skill/SKILL.md"
+
+    assertLinkExists home-files/.agents/skills/file-skill
+    assertFileExists home-files/.agents/skills/file-skill/SKILL.md
+    assertFileContent home-files/.agents/skills/file-skill/SKILL.md \
+      "${src}/skills/external-skill/SKILL.md"
+  '';
+}


### PR DESCRIPTION
Handle per-skill values that come through as store-path strings, such as fetcher outputs with subdirectories appended. This restores the previously working pattern for packaged skill directories and adds a regression test for both directory and file sources.

Follow up to https://github.com/nix-community/home-manager/pull/8947

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
