### PR TITLE
mpd: expose generated config

### DIFF
--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -121,6 +121,17 @@ in
 
       };
 
+      generatedConfig = mkOption {
+        type = types.str;
+        readOnly = true;
+        description = ''
+          The generated config.
+          Can be used by user as:
+
+            configFile."mpd/mpd.conf".text = config.services.mpd.generatedConfig;
+        '';
+      };
+
       dbFile = mkOption {
         type = types.nullOr types.str;
         default = "${cfg.dataDir}/tag_cache";
@@ -136,32 +147,31 @@ in
 
   config =
     let
-      mpdConf = pkgs.writeText "mpd.conf" (
-        ''
-          music_directory     "${cfg.musicDirectory}"
-          playlist_directory  "${cfg.playlistDirectory}"
-        ''
-        + lib.optionalString (cfg.dbFile != null) ''
-          db_file             "${cfg.dbFile}"
-        ''
-        + lib.optionalString (pkgs.stdenv.hostPlatform.isDarwin) ''
-          log_file            "${config.home.homeDirectory}/Library/Logs/mpd/log.txt"
-        ''
-        + ''
-          state_file          "${cfg.dataDir}/state"
-          sticker_file        "${cfg.dataDir}/sticker.sql"
+      generatedConfig = ''
+        music_directory     "${cfg.musicDirectory}"
+        playlist_directory  "${cfg.playlistDirectory}"
+      ''
+      + lib.optionalString (cfg.dbFile != null) ''
+        db_file             "${cfg.dbFile}"
+      ''
+      + lib.optionalString (pkgs.stdenv.hostPlatform.isDarwin) ''
+        log_file            "${config.home.homeDirectory}/Library/Logs/mpd/log.txt"
+      ''
+      + ''
+        state_file          "${cfg.dataDir}/state"
+        sticker_file        "${cfg.dataDir}/sticker.sql"
 
-        ''
-        + lib.optionalString (cfg.network.listenAddress != "any") ''
-          bind_to_address     "${cfg.network.listenAddress}"
-        ''
-        + lib.optionalString (cfg.network.port != 6600) ''
-          port                "${toString cfg.network.port}"
-        ''
-        + lib.optionalString (cfg.extraConfig != "") ''
-          ${cfg.extraConfig}
-        ''
-      );
+      ''
+      + lib.optionalString (cfg.network.listenAddress != "any") ''
+        bind_to_address     "${cfg.network.listenAddress}"
+      ''
+      + lib.optionalString (cfg.network.port != 6600) ''
+        port                "${toString cfg.network.port}"
+      ''
+      + lib.optionalString (cfg.extraConfig != "") ''
+        ${cfg.extraConfig}
+      '';
+      mpdConf = pkgs.writeText "mpd.conf" generatedConfig;
     in
     mkIf cfg.enable {
       home = {
@@ -184,6 +194,8 @@ in
         (mkIf (lib.versionOlder config.home.stateVersion "22.11") {
           musicDirectory = lib.mkOptionDefault "${config.home.homeDirectory}/music";
         })
+
+        { generatedConfig = generatedConfig; }
       ];
 
       systemd.user = {


### PR DESCRIPTION
The systemd service links a generated config, but some users may like to have it in ~/.config/mpd instead.
This PR helps working around that limitation allowing users to run:

`configFile."mpd/mpd.conf".text = config.services.mpd.generatedConfig;`

this way one can skip systemd altogether and test mpd more easily in CLI.
This is a small hack that doesnt change much. I wonder if some want a mpd config different than the one from the systemd service and why ?

NB: I wonder if we should add a guideline on wether to write config in XDG_CONFIG_HOME or have the systemd service explicitly link that config (on top of https://github.com/nix-community/home-manager/pull/7833#issuecomment-4120798957).   I have a similar problem with the swayidle service.



### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
