### PR TITLE
equibop: init

### DIFF
--- a/modules/misc/news/2026/03/2026-03-25_13-00-11.nix
+++ b/modules/misc/news/2026/03/2026-03-25_13-00-11.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+{
+  time = "2026-03-25T12:00:11+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    Added a new module `equibop`.
+
+    Equibop is a fork of Vesktop with more plugins.
+  '';
+}

--- a/modules/programs/equibop.nix
+++ b/modules/programs/equibop.nix
@@ -1,0 +1,19 @@
+{ lib, ... }:
+let
+  mkVesktopLikeModule = import ./vesktop/mkVesktopLikeModule.nix;
+in
+{
+  imports = [
+    (mkVesktopLikeModule {
+      moduleName = "equibop";
+      cordModuleName = "equicord";
+      settingsLink = "https://github.com/Equicord/Equibop/blob/main/src/shared/settings.d.ts";
+      cordSettingsLink = "https://github.com/Equicord/Equicord/blob/main/src/api/Settings.ts";
+      installPackage = true;
+      maintainers = with lib.maintainers; [
+        PerchunPak
+        NotAShelf
+      ];
+    })
+  ];
+}

--- a/modules/programs/vesktop/default.nix
+++ b/modules/programs/vesktop/default.nix
@@ -1,0 +1,30 @@
+{ lib, config, ... }:
+let
+  mkVesktopLikeModule = import ./mkVesktopLikeModule.nix;
+  cfg = config.programs.vesktop;
+in
+{
+  imports = [
+    (mkVesktopLikeModule {
+      moduleName = "vesktop";
+      cordModuleName = "vencord";
+      settingsLink = "https://github.com/Vencord/Vesktop/blob/main/src/shared/settings.d.ts";
+      cordSettingsLink = "https://github.com/Vendicated/Vencord/blob/main/src/api/Settings.ts";
+      installPackage = false;
+      maintainers = with lib.maintainers; [
+        Flameopathic
+        LilleAila
+      ];
+    })
+  ];
+
+  options.programs.vesktop = {
+    vencord.useSystem = lib.mkEnableOption "Vencord package from Nixpkgs";
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [
+      (cfg.package.override { withSystemVencord = cfg.vencord.useSystem; })
+    ];
+  };
+}

--- a/modules/programs/vesktop/mkVesktopLikeModule.nix
+++ b/modules/programs/vesktop/mkVesktopLikeModule.nix
@@ -1,4 +1,18 @@
 {
+  # programs.${moduleName}
+  moduleName,
+  # for vesktop it is vencord, equibop -> equicord
+  cordModuleName,
+  # all config options link
+  settingsLink,
+  # all config options link for ${cordModuleName}
+  cordSettingsLink,
+  # whether to add package to home.packages
+  installPackage,
+  # meta.maintainers
+  maintainers,
+}:
+{
   config,
   lib,
   pkgs,
@@ -6,28 +20,27 @@
 }:
 
 let
-
-  cfg = config.programs.vesktop;
+  cfg = config.programs.${moduleName};
+  cordCfg = config.programs.${moduleName}.${cordModuleName};
+  package = pkgs.${moduleName};
   jsonFormat = pkgs.formats.json { };
 
+  reprName = lib.toSentenceCase moduleName;
+  cordReprName = lib.toSentenceCase cordModuleName;
 in
 {
-  meta.maintainers = with lib.maintainers; [
-    Flameopathic
-    LilleAila
-  ];
+  meta.maintainers = maintainers;
 
-  options.programs.vesktop = {
-    enable = lib.mkEnableOption "Vesktop, an alternate client for Discord with Vencord built-in";
-    package = lib.mkPackageOption pkgs "vesktop" { nullable = true; };
+  options.programs.${moduleName} = {
+    enable = lib.mkEnableOption package.meta.description;
+    package = lib.mkPackageOption pkgs moduleName { nullable = true; };
     settings = lib.mkOption {
       inherit (jsonFormat) type;
       default = { };
       description = ''
-        Vesktop settings written to
-        {file}`$XDG_CONFIG_HOME/vesktop/settings.json`. See
-        <https://github.com/Vencord/Vesktop/blob/main/src/shared/settings.d.ts>
-        for available options.
+        ${reprName} settings written to
+        {file}`$XDG_CONFIG_HOME/${moduleName}/settings.json`. See
+        <${settingsLink}> for available options.
       '';
       example = lib.literalExpression ''
         {
@@ -48,12 +61,12 @@ in
       '';
     };
 
-    vencord = {
-      useSystem = lib.mkEnableOption "Vencord package from Nixpkgs";
+    ${cordModuleName} = {
       themes = lib.mkOption {
         description = ''
-          Themes to add for Vencord, they can be enabled by setting
-          `programs.vesktop.vencord.settings.enabledThemes` to `[ "THEME_NAME.css" ]`
+          Themes to add for ${cordReprName}, they can be enabled by setting
+          `programs.${moduleName}.${cordModuleName}.settings.enabledThemes`
+          to `[ "THEME_NAME.css" ]`
         '';
         default = { };
         type =
@@ -67,10 +80,9 @@ in
         inherit (jsonFormat) type;
         default = { };
         description = ''
-          Vencord settings written to
-          {file}`$XDG_CONFIG_HOME/vesktop/settings/settings.json`. See
-          <https://github.com/Vendicated/Vencord/blob/main/src/api/Settings.ts>
-          for available options.
+          ${cordReprName} settings written to
+          {file}`$XDG_CONFIG_HOME/${moduleName}/settings/settings.json`. See
+          <${cordSettingsLink}> for available options.
         '';
         example = lib.literalExpression ''
           {
@@ -111,34 +123,31 @@ in
       configFiles =
         lib.attrsets.unionOfDisjoint
           {
-            "vesktop/settings.json" = lib.mkIf (cfg.settings != { }) {
-              source = jsonFormat.generate "vesktop-settings" cfg.settings;
+            "${moduleName}/settings.json" = lib.mkIf (cfg.settings != { }) {
+              source = jsonFormat.generate "${moduleName}-settings" cfg.settings;
             };
-            "vesktop/settings/settings.json" = lib.mkIf (cfg.vencord.settings != { }) {
-              source = jsonFormat.generate "vencord-settings" cfg.vencord.settings;
+            "${moduleName}/settings/settings.json" = lib.mkIf (cordCfg.settings != { }) {
+              source = jsonFormat.generate "${cordModuleName}-settings" cordCfg.settings;
             };
-            "vesktop/settings/quickCss.css" = lib.mkIf (cfg.vencord.extraQuickCss != "") {
-              text = cfg.vencord.extraQuickCss;
+            "${moduleName}/settings/quickCss.css" = lib.mkIf (cordCfg.extraQuickCss != "") {
+              text = cordCfg.extraQuickCss;
             };
           }
           (
             lib.mapAttrs' (
               name: value:
-              lib.nameValuePair "vesktop/themes/${name}.css" {
+              lib.nameValuePair "${moduleName}/themes/${name}.css" {
                 source =
                   if builtins.isPath value || lib.isStorePath value then
                     value
                   else
-                    pkgs.writeText "vesktop-themes-${name}" value;
+                    pkgs.writeText "${moduleName}-themes-${name}" value;
               }
-            ) cfg.vencord.themes
+            ) cordCfg.themes
           );
     in
     lib.mkIf cfg.enable {
-      home.packages = lib.mkIf (cfg.package != null) [
-        (cfg.package.override { withSystemVencord = cfg.vencord.useSystem; })
-      ];
-
+      home.packages = lib.mkIf (installPackage && cfg.package != null) [ cfg.package ];
       home.file = lib.mapAttrs' (n: lib.nameValuePair "${configDir}/${n}") configFiles;
     };
 }

--- a/tests/modules/programs/equibop/basic-configuration.nix
+++ b/tests/modules/programs/equibop/basic-configuration.nix
@@ -1,0 +1,57 @@
+{
+  config = {
+    programs.equibop = {
+      enable = true;
+      settings = {
+        tray = false;
+        minimizeToTray = false;
+        hardwareAcceleration = true;
+        customTitleBar = false;
+        staticTitle = true;
+        discordBranch = "stable";
+      };
+      equicord = {
+        themes.my_theme = ''
+          .privateChannels_f0963d::after {
+            content: "";
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            top: 0;
+            left: 0;
+            z-index: 1000;
+            background: linear-gradient(to bottom, transparent 85%, var(--base00));
+            pointer-events: none;
+          }
+        '';
+        settings = {
+          autoUpdate = false;
+          autoUpdateNotification = false;
+          notifyAboutUpdates = false;
+          useQuickCss = true;
+          disableMinSize = true;
+          plugins = {
+            MessageLogger = {
+              enabled = true;
+              ignoreSelf = true;
+            };
+            FakeNitro.enabled = true;
+          };
+        };
+      };
+    };
+
+    nmt.script = ''
+      configDir=home-files/.config/equibop
+      assertFileExists $configDir/settings.json
+      assertFileContent $configDir/settings.json \
+        ${./basic-settings.json}
+      assertFileExists $configDir/settings/settings.json
+      assertFileContent $configDir/settings/settings.json \
+        ${./basic-equicord-settings.json}
+      assertFileExists $configDir/themes/my_theme.css
+      assertFileContent $configDir/themes/my_theme.css \
+        ${./basic-theme.css}
+    '';
+  };
+}

--- a/tests/modules/programs/equibop/basic-equicord-settings.json
+++ b/tests/modules/programs/equibop/basic-equicord-settings.json
@@ -1,0 +1,16 @@
+{
+  "autoUpdate": false,
+  "autoUpdateNotification": false,
+  "disableMinSize": true,
+  "notifyAboutUpdates": false,
+  "plugins": {
+    "FakeNitro": {
+      "enabled": true
+    },
+    "MessageLogger": {
+      "enabled": true,
+      "ignoreSelf": true
+    }
+  },
+  "useQuickCss": true
+}

--- a/tests/modules/programs/equibop/basic-settings.json
+++ b/tests/modules/programs/equibop/basic-settings.json
@@ -1,0 +1,8 @@
+{
+  "customTitleBar": false,
+  "discordBranch": "stable",
+  "hardwareAcceleration": true,
+  "minimizeToTray": false,
+  "staticTitle": true,
+  "tray": false
+}

--- a/tests/modules/programs/equibop/basic-theme.css
+++ b/tests/modules/programs/equibop/basic-theme.css
@@ -1,0 +1,11 @@
+.privateChannels_f0963d::after {
+  content: "";
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  background: linear-gradient(to bottom, transparent 85%, var(--base00));
+  pointer-events: none;
+}

--- a/tests/modules/programs/equibop/default.nix
+++ b/tests/modules/programs/equibop/default.nix
@@ -1,0 +1,4 @@
+{ lib, pkgs, ... }:
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  equibop-basic-configuration = ./basic-configuration.nix;
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

[Equibop](https://equibop.org/) is a fork of [Vencord](https://vencord.dev/) with more plugins.

Since Equibop actively merges changes from Vencord, they are nearly identical for downstream. Thus, I refactored Vesktop's module to `mkVesktopLikeModule` and just call it for Vencord and Equibop. I hope this is not over-engineering.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
