### PR TITLE
kvantum: install kvantum packages

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -92,6 +92,7 @@ in
 {
   meta.maintainers = with lib.maintainers; [
     rycee
+    claymorwan
   ];
 
   imports = [

--- a/modules/misc/qt/kvantum.nix
+++ b/modules/misc/qt/kvantum.nix
@@ -14,6 +14,7 @@ let
     mkIf
     mkOption
     types
+    mkPackageOption
     ;
 
   kvconfigFormat = pkgs.formats.ini {
@@ -32,6 +33,17 @@ in
 {
   options.qt.kvantum = {
     enable = mkEnableOption "Kvantum configuration";
+    package = mkPackageOption pkgs.kdePackages "qtstyleplugin-kvantum" { nullable = true; };
+
+    qt5 = {
+      enable = mkEnableOption "Kvantum Qt5 support";
+      package = mkPackageOption pkgs.libsForQt5 "qtstyleplugin-kvantum" {
+        nullable = true;
+        extraDescription = ''
+          The package to use for Kvantum Qt5 support.
+        '';
+      };
+    };
 
     settings = mkOption {
       type = types.submodule {
@@ -117,6 +129,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [
+      cfg.package
+      (mkIf (cfg.qt5.enable && cfg.qt5.package != null) cfg.qt5.package)
+    ];
+
     xdg.configFile = {
       "Kvantum" = mkIf (cfg.themes != [ ]) {
         recursive = true;


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Kvantum theming won't actually work if kvantum isn't installed, and the kvantum hm module doesn't install it.
Addtionally, Qt5 apps won't be themed if the Qt5 version of kvantum isn't installed either
The changes from this PR are:
- Added `qt.kvantum.package` (default: `pkgs.kdePackages.qtstyleplugin-kvantum`)
- Enabling the module will install the package set in `qt.kvantum.package`. 
- Added `qt.kvantum.qt5.enable`(default: `false`), enabling it install the package set in `qt.kvantum.qt5.package`
- Added  `qt.kvantum.qt5.package` (default: `pkgs.libsForQt5.qtstyleplugin-kvantum`)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
