### PR TITLE
grype: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -139,6 +139,12 @@
     github = "Dines97";
     githubId = 19364873;
   };
+  dosten = {
+    name = "Diego Saint Esteben";
+    email = "diego@saintesteben.me";
+    github = "dosten";
+    githubId = 510842;
+  };
   dsoverlord = {
     name = "Kirill Zakharov";
     email = "dsoverlord@vk.com";

--- a/modules/misc/news/2026/03/2026-03-25_14-18-02.nix
+++ b/modules/misc/news/2026/03/2026-03-25_14-18-02.nix
@@ -1,0 +1,10 @@
+{ config, pkgs, ... }:
+{
+  time = "2026-03-25T17:18:02+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.grype`
+
+    Grype is a vulnerability scanner for container images and filesystems.
+  '';
+}

--- a/modules/programs/grype.nix
+++ b/modules/programs/grype.nix
@@ -1,0 +1,49 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    literalExpression
+    mkIf
+    mkOption
+    mkPackageOption
+    mkEnableOption
+    ;
+
+  cfg = config.programs.grype;
+
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ dosten ];
+
+  options.programs.grype = {
+    enable = mkEnableOption "Grype";
+    package = mkPackageOption pkgs "grype" { nullable = true; };
+    settings = mkOption {
+      inherit (yamlFormat) type;
+      default = { };
+      defaultText = literalExpression "{ }";
+      example = literalExpression ''
+        {
+          check-for-app-update = false;
+        }
+      '';
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/grype/config.yaml`.
+        See <https://oss.anchore.com/docs/reference/grype/configuration/> for supported values.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."grype/config.yaml" = mkIf (cfg.settings != { }) {
+      source = yamlFormat.generate "grype-config" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/grype/basic-configuration.nix
+++ b/tests/modules/programs/grype/basic-configuration.nix
@@ -1,0 +1,21 @@
+{
+  programs.grype = {
+    enable = true;
+    settings = {
+      search = {
+        scope = "squashed";
+      };
+      match = {
+        java = {
+          using-cpes = false;
+        };
+      };
+      check-for-app-update = false;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/grype/config.yaml
+    assertFileContent home-files/.config/grype/config.yaml ${./basic-configuration.yaml}
+  '';
+}

--- a/tests/modules/programs/grype/basic-configuration.yaml
+++ b/tests/modules/programs/grype/basic-configuration.yaml
@@ -1,0 +1,6 @@
+check-for-app-update: false
+match:
+  java:
+    using-cpes: false
+search:
+  scope: squashed

--- a/tests/modules/programs/grype/default.nix
+++ b/tests/modules/programs/grype/default.nix
@@ -1,0 +1,4 @@
+{
+  grype-basic-configuration = ./basic-configuration.nix;
+  grype-no-settings = ./no-settings.nix;
+}

--- a/tests/modules/programs/grype/no-settings.nix
+++ b/tests/modules/programs/grype/no-settings.nix
@@ -1,0 +1,9 @@
+{
+  programs.grype = {
+    enable = true;
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/grype/config.yaml
+  '';
+}


### PR DESCRIPTION
Grype is a vulnerability scanner for container images and filesystems.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
