### PR TITLE
waybar: allow multiple systemd targets

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -168,6 +168,14 @@ in
     khaneliman
   ];
 
+  imports = [
+    (lib.mkChangedOptionModule
+      [ "programs" "waybar" "systemd" "target" ]
+      [ "programs" "waybar" "systemd" "targets" ]
+      (config: lib.toList (lib.getAttrFromPath [ "programs" "waybar" "systemd" "target" ] config))
+    )
+  ];
+
   options.programs.waybar = with lib.types; {
     enable = mkEnableOption "Waybar";
 
@@ -227,15 +235,15 @@ in
         '';
       };
 
-      target = mkOption {
-        type = str;
-        default = config.wayland.systemd.target;
-        defaultText = literalExpression "config.wayland.systemd.target";
-        example = "sway-session.target";
+      targets = mkOption {
+        type = with lib.types; listOf str;
+        default = [ config.wayland.systemd.target ];
+        defaultText = literalExpression "[ config.wayland.systemd.target ]";
+        example = [ "sway-session.target" ];
         description = ''
-          The systemd target that will automatically start the Waybar service.
+          The systemd targets that will automatically start the Waybar service.
 
-          When setting this value to `"sway-session.target"`,
+          When setting this value to `[ "sway-session.target" ]`,
           make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
           otherwise the service may never be started.
         '';
@@ -340,11 +348,8 @@ in
           Unit = {
             Description = "Highly customizable Wayland bar for Sway and Wlroots based compositors.";
             Documentation = "https://github.com/Alexays/Waybar/wiki";
-            PartOf = [
-              cfg.systemd.target
-              "tray.target"
-            ];
-            After = [ cfg.systemd.target ];
+            PartOf = [ "tray.target" ] ++ cfg.systemd.targets;
+            After = cfg.systemd.targets;
             ConditionEnvironment = "WAYLAND_DISPLAY";
             X-Reload-Triggers =
               optional (settings != [ ]) "${config.xdg.configFile."waybar/config".source}"
@@ -359,10 +364,7 @@ in
             Restart = "on-failure";
           };
 
-          Install.WantedBy = [
-            cfg.systemd.target
-            "tray.target"
-          ];
+          Install.WantedBy = [ "tray.target" ] ++ cfg.systemd.targets;
         };
       })
     ]);

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
@@ -8,7 +8,7 @@
       package = config.lib.test.mkStubPackage { outPath = "@waybar@"; };
       enable = true;
       systemd.enable = true;
-      systemd.target = "sway-session.target";
+      systemd.targets = [ "sway-session.target" ];
     };
 
     nmt.script = ''

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
@@ -1,6 +1,6 @@
 [Install]
-WantedBy=sway-session.target
 WantedBy=tray.target
+WantedBy=sway-session.target
 
 [Service]
 ExecReload=/nix/store/00000000000000000000000000000000-coreutils/bin/kill -SIGUSR2 $MAINPID
@@ -13,5 +13,5 @@ After=sway-session.target
 ConditionEnvironment=WAYLAND_DISPLAY
 Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
 Documentation=https://github.com/Alexays/Waybar/wiki
-PartOf=sway-session.target
 PartOf=tray.target
+PartOf=sway-session.target


### PR DESCRIPTION
### Description

Allow waybar to have multiple systemd targets so I can use it with multiple environments. 

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

**(still having issues with unrelated zed test failures, but made sure the waybar tests passed)**

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
