### PR TITLE
vicinae: support local sources for raycast extensions

### DIFF
--- a/modules/programs/vicinae/default.nix
+++ b/modules/programs/vicinae/default.nix
@@ -6,6 +6,7 @@
 }:
 let
   cfg = config.programs.vicinae;
+  vicinaeLib = import ./lib.nix { inherit lib pkgs; };
 
   jsonFormat = pkgs.formats.json { };
   tomlFormat = pkgs.formats.toml { };
@@ -170,60 +171,7 @@ in
       }
     ];
 
-    lib.vicinae = {
-      mkExtension =
-        {
-          name,
-          src,
-        }:
-        (pkgs.buildNpmPackage {
-          inherit name src;
-          inherit (pkgs.importNpmLock) npmConfigHook;
-          installPhase = ''
-            runHook preInstall
-
-            mkdir -p $out
-            cp -r /build/.local/share/vicinae/extensions/${name}/* $out/
-
-            runHook postInstall
-          '';
-          npmDeps = pkgs.importNpmLock { npmRoot = src; };
-        });
-
-      mkRayCastExtension =
-        {
-          name,
-          src ? null,
-          rev ? null,
-          sha256 ? null,
-        }:
-        let
-          resolvedSrc =
-            if src != null then
-              src
-            else
-              pkgs.fetchgit {
-                inherit rev sha256;
-                url = "https://github.com/raycast/extensions";
-                sparseCheckout = [ "/extensions/${name}" ];
-              }
-              + "/extensions/${name}";
-        in
-        pkgs.buildNpmPackage {
-          inherit name;
-          inherit (pkgs.importNpmLock) npmConfigHook;
-          src = resolvedSrc;
-          installPhase = ''
-            runHook preInstall
-
-            mkdir -p $out
-            cp -r /build/.config/raycast/extensions/${name}/* $out/
-
-            runHook postInstall
-          '';
-          npmDeps = pkgs.importNpmLock { npmRoot = resolvedSrc; };
-        };
-    };
+    lib.vicinae = vicinaeLib;
 
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 

--- a/modules/programs/vicinae/lib.nix
+++ b/modules/programs/vicinae/lib.nix
@@ -1,0 +1,58 @@
+{
+  pkgs,
+  lib,
+}:
+{
+  mkExtension =
+    {
+      name,
+      src,
+    }:
+    pkgs.buildNpmPackage {
+      inherit name src;
+      inherit (pkgs.importNpmLock) npmConfigHook;
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        cp -r /build/.local/share/vicinae/extensions/${name}/* $out/
+
+        runHook postInstall
+      '';
+      npmDeps = pkgs.importNpmLock { npmRoot = src; };
+    };
+
+  mkRayCastExtension =
+    {
+      name,
+      src ? null,
+      rev ? null,
+      sha256 ? null,
+    }:
+    let
+      resolvedSrc =
+        if src != null then
+          src
+        else
+          pkgs.fetchgit {
+            inherit rev sha256;
+            url = "https://github.com/raycast/extensions";
+            sparseCheckout = [ "/extensions/${name}" ];
+          }
+          + "/extensions/${name}";
+    in
+    pkgs.buildNpmPackage {
+      inherit name;
+      inherit (pkgs.importNpmLock) npmConfigHook;
+      src = resolvedSrc;
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        cp -r /build/.config/raycast/extensions/${name}/* $out/
+
+        runHook postInstall
+      '';
+      npmDeps = pkgs.importNpmLock { npmRoot = resolvedSrc; };
+    };
+}


### PR DESCRIPTION
Support extensions without fetchgit, useful when providing the sources
from a flake input or derivation for all extensions.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
