### PR TITLE
cliphist: proper singular systemdTarget deprecation

### DIFF
--- a/modules/services/cliphist.nix
+++ b/modules/services/cliphist.nix
@@ -14,13 +14,10 @@ in
   ];
 
   imports = [
-    (lib.mkRenamedOptionModule
+    (lib.mkChangedOptionModule
       [ "services" "cliphist" "systemdTarget" ]
-      [
-        "services"
-        "cliphist"
-        "systemdTargets"
-      ]
+      [ "services" "cliphist" "systemdTargets" ]
+      (config: lib.toList (lib.getAttrFromPath [ "services" "cliphist" "systemdTarget" ] config))
     )
   ];
 
@@ -53,7 +50,7 @@ in
     };
 
     systemdTargets = lib.mkOption {
-      type = with lib.types; either (listOf str) str;
+      type = with lib.types; listOf str;
       default = [ config.wayland.systemd.target ];
       defaultText = lib.literalExpression "[ config.wayland.systemd.target ]";
       example = "sway-session.target";
@@ -63,8 +60,6 @@ in
         When setting this value to `["sway-session.target"]`,
         make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
         otherwise the service may never be started.
-
-        Note: A single string value is deprecated, please use a list.
       '';
     };
   };
@@ -83,8 +78,8 @@ in
       systemd.user.services.cliphist = {
         Unit = {
           Description = "Clipboard management daemon";
-          PartOf = lib.toList cfg.systemdTargets;
-          After = lib.toList cfg.systemdTargets;
+          PartOf = cfg.systemdTargets;
+          After = cfg.systemdTargets;
         };
 
         Service = {
@@ -94,15 +89,15 @@ in
         };
 
         Install = {
-          WantedBy = lib.toList cfg.systemdTargets;
+          WantedBy = cfg.systemdTargets;
         };
       };
 
       systemd.user.services.cliphist-images = lib.mkIf cfg.allowImages {
         Unit = {
           Description = "Clipboard management daemon - images";
-          PartOf = lib.toList cfg.systemdTargets;
-          After = lib.toList cfg.systemdTargets;
+          PartOf = cfg.systemdTargets;
+          After = cfg.systemdTargets;
         };
 
         Service = {
@@ -112,7 +107,7 @@ in
         };
 
         Install = {
-          WantedBy = lib.toList cfg.systemdTargets;
+          WantedBy = cfg.systemdTargets;
         };
       };
     };

--- a/tests/modules/services/cliphist/cliphist-sway-session-target.nix
+++ b/tests/modules/services/cliphist/cliphist-sway-session-target.nix
@@ -12,7 +12,7 @@
   '';
 
   test.asserts.warnings.expected = [
-    "The option `services.cliphist.systemdTarget' defined in ${lib.showFiles options.services.cliphist.systemdTarget.files} has been renamed to `services.cliphist.systemdTargets'."
+    "The option `services.cliphist.systemdTarget' defined in ${lib.showFiles options.services.cliphist.systemdTarget.files} has been changed to `services.cliphist.systemdTargets' that has a different type. Please read `services.cliphist.systemdTargets' documentation and update your configuration accordingly."
   ];
 
 }


### PR DESCRIPTION
Previously did a silent type change with a docs note. Properly use `mkChangedOptionModule` to enforce the new type.

Related https://github.com/nix-community/home-manager/pull/8977

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
