### PR TITLE
atuin: use `daemon start` subcommand on >= 18.13.0

### DIFF
--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -10,6 +10,16 @@ let
 
   tomlFormat = pkgs.formats.toml { };
 
+  # atuin 18.13.0 deprecated `atuin daemon` in favour of `atuin daemon start`
+  daemonArgs =
+    if lib.versionAtLeast cfg.package.version "18.13.0" then
+      [
+        "daemon"
+        "start"
+      ]
+    else
+      [ "daemon" ];
+
   inherit (lib) mkIf mkOption types;
 in
 {
@@ -223,12 +233,6 @@ in
         (mkIf daemonCfg.enable {
           assertions = [
             {
-              assertion = lib.versionAtLeast cfg.package.version "18.2.0";
-              message = ''
-                The Atuin daemon requires at least version 18.2.0 or later.
-              '';
-            }
-            {
               assertion = config.systemd.user.enable || config.launchd.enable;
               message = "The Atuin daemon can only be configured on systems with systemd or launchd.";
             }
@@ -252,7 +256,7 @@ in
               WantedBy = [ "default.target" ];
             };
             Service = {
-              ExecStart = "${lib.getExe cfg.package} daemon";
+              ExecStart = "${lib.getExe cfg.package} ${lib.concatStringsSep " " daemonArgs}";
               Environment = lib.optionals (daemonCfg.logLevel != null) [ "ATUIN_LOG=${daemonCfg.logLevel}" ];
               Restart = "on-failure";
               RestartSteps = 3;
@@ -281,10 +285,7 @@ in
           launchd.agents.atuin-daemon = {
             enable = true;
             config = {
-              ProgramArguments = [
-                "${lib.getExe cfg.package}"
-                "daemon"
-              ];
+              ProgramArguments = [ (lib.getExe cfg.package) ] ++ daemonArgs;
               EnvironmentVariables = lib.optionalAttrs (daemonCfg.logLevel != null) {
                 ATUIN_LOG = daemonCfg.logLevel;
               };


### PR DESCRIPTION
### Description

Atuin 18.13.0 deprecated `atuin daemon` in favour of `atuin daemon start`
and prints a warning on every daemon startup:

```
Warning: `atuin daemon` is deprecated, use `atuin daemon start`
```

This switches to the new subcommand when the package version is >= 18.13.0,
keeping the old invocation for older versions so NixOS stable (currently
shipping 18.10.0) keeps working.

Also drops the 18.2.0 minimum version assertion since all supported nixpkgs
branches ship newer versions.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```
