### PR TITLE
services/ssh-agent: treat SIGTERM exit as clean

### DIFF
--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -108,15 +108,18 @@ in
         Description = "SSH authentication agent";
         Documentation = "man:ssh-agent(1)";
       };
-      Service.ExecStart = "${lib.getExe' cfg.package "ssh-agent"} -D -a %t/${cfg.socket}${
-        lib.optionalString (
-          cfg.defaultMaximumIdentityLifetime != null
-        ) " -t ${toString cfg.defaultMaximumIdentityLifetime}"
-      }${
-        lib.optionalString (
-          cfg.pkcs11Whitelist != [ ]
-        ) " -P '${lib.concatStringsSep "," cfg.pkcs11Whitelist}'"
-      }";
+      Service = {
+        ExecStart = "${lib.getExe' cfg.package "ssh-agent"} -D -a %t/${cfg.socket}${
+          lib.optionalString (
+            cfg.defaultMaximumIdentityLifetime != null
+          ) " -t ${toString cfg.defaultMaximumIdentityLifetime}"
+        }${
+          lib.optionalString (
+            cfg.pkcs11Whitelist != [ ]
+          ) " -P '${lib.concatStringsSep "," cfg.pkcs11Whitelist}'"
+        }";
+        SuccessExitStatus = 2;
+      };
     };
 
     launchd.agents.ssh-agent = {

--- a/tests/modules/services/ssh-agent/linux/basic-service-expected.service
+++ b/tests/modules/services/ssh-agent/linux/basic-service-expected.service
@@ -3,6 +3,7 @@ WantedBy=default.target
 
 [Service]
 ExecStart=@openssh@/bin/ssh-agent -D -a %t/ssh-agent/socket
+SuccessExitStatus=2
 
 [Unit]
 Description=SSH authentication agent

--- a/tests/modules/services/ssh-agent/linux/pkcs11-service-expected.service
+++ b/tests/modules/services/ssh-agent/linux/pkcs11-service-expected.service
@@ -3,6 +3,7 @@ WantedBy=default.target
 
 [Service]
 ExecStart=@openssh@/bin/ssh-agent -D -a %t/ssh-agent -P '/nix/store/*/lib,/usr/lib/libpkcs11.so,/usr/lib/other.so'
+SuccessExitStatus=2
 
 [Unit]
 Description=SSH authentication agent

--- a/tests/modules/services/ssh-agent/linux/timeout-service-expected.service
+++ b/tests/modules/services/ssh-agent/linux/timeout-service-expected.service
@@ -3,6 +3,7 @@ WantedBy=default.target
 
 [Service]
 ExecStart=@openssh@/bin/ssh-agent -D -a %t/ssh-agent -t 1337
+SuccessExitStatus=2
 
 [Unit]
 Description=SSH authentication agent


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

OpenSSH ssh-agent exits with status 2 when systemd stops it in
non-socket-activated mode.

Home Manager runs ssh-agent that way, so normal user-manager
shutdowns show up as unit failures.

Set SuccessExitStatus=2 for the Linux user service to match
upstream behavior. Startup failures and other unexpected exits
still fail the unit.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
