### PR TITLE
swayidle: allow multiple systemd targets

### DIFF
--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -18,6 +18,14 @@ in
 {
   meta.maintainers = [ lib.maintainers.c0deaddict ];
 
+  imports = [
+    (lib.mkChangedOptionModule
+      [ "services" "swayidle" "systemdTarget" ]
+      [ "services" "swayidle" "systemdTargets" ]
+      (config: lib.toList (lib.getAttrFromPath [ "services" "swayidle" "systemdTarget" ] config))
+    )
+  ];
+
   options.services.swayidle =
     let
 
@@ -124,13 +132,13 @@ in
         description = "Extra arguments to pass to swayidle.";
       };
 
-      systemdTarget = mkOption {
-        type = types.str;
-        default = config.wayland.systemd.target;
-        defaultText = literalExpression "config.wayland.systemd.target";
-        example = "sway-session.target";
+      systemdTargets = mkOption {
+        type = with types; listOf str;
+        default = [ config.wayland.systemd.target ];
+        defaultText = literalExpression "[ config.wayland.systemd.target ]";
+        example = [ "sway-session.target" ];
         description = ''
-          Systemd target to bind to.
+          Systemd targets to bind to.
         '';
       };
 
@@ -148,8 +156,8 @@ in
         Description = "Idle manager for Wayland";
         Documentation = "man:swayidle(1)";
         ConditionEnvironment = "WAYLAND_DISPLAY";
-        PartOf = [ cfg.systemdTarget ];
-        After = [ cfg.systemdTarget ];
+        PartOf = cfg.systemdTargets;
+        After = cfg.systemdTargets;
       };
 
       Service = {
@@ -187,7 +195,7 @@ in
       };
 
       Install = {
-        WantedBy = [ cfg.systemdTarget ];
+        WantedBy = cfg.systemdTargets;
       };
     };
   };


### PR DESCRIPTION
### Description

Allows multiple systemd targets for swayidle.

Does using mkChangedOptionModule qualify as backwards compatible? (I am assuming yes)

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
