### PR TITLE
aria2: add systemd service

### DIFF
--- a/modules/programs/aria2.nix
+++ b/modules/programs/aria2.nix
@@ -44,6 +44,8 @@ in
         }
       '';
     };
+
+    systemd.enable = lib.mkEnableOption "Aria2 systemd integration";
   };
 
   config = lib.mkIf cfg.enable {
@@ -51,6 +53,23 @@ in
 
     xdg.configFile."aria2/aria2.conf" = lib.mkIf (cfg.settings != { }) {
       source = keyValueFormat.generate "aria2.conf" cfg.settings;
+    };
+
+    systemd.user.services.aria2 = lib.mkIf cfg.systemd.enable {
+      Unit = {
+        Description = "Aria2c daemon";
+        Documentation = "man:aria2c(1)";
+        X-Restart-Triggers = lib.mkIf (cfg.settings != { }) [
+          "${config.xdg.configFile."aria2/aria2.conf".source}"
+        ];
+      };
+
+      Service = {
+        ExecStart = "${lib.getExe cfg.package} --enable-rpc";
+        Restart = "on-failure";
+      };
+
+      Install.WantedBy = [ "default.target" ];
     };
   };
 }

--- a/tests/modules/programs/aria2/default.nix
+++ b/tests/modules/programs/aria2/default.nix
@@ -1,4 +1,8 @@
+{ lib, pkgs, ... }:
 {
   aria2-disabled = ./disabled.nix;
   aria2-settings = ./settings.nix;
+}
+// lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  aria2-systemd = ./systemd.nix;
 }

--- a/tests/modules/programs/aria2/systemd.nix
+++ b/tests/modules/programs/aria2/systemd.nix
@@ -1,0 +1,25 @@
+{ config, ... }:
+{
+  programs.aria2 = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@aria2@"; };
+    systemd.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/systemd/user/aria2.service \
+      ${builtins.toFile "aria2.service" ''
+        [Install]
+        WantedBy=default.target
+
+        [Service]
+        ExecStart=@aria2@/bin/dummy --enable-rpc
+        Restart=on-failure
+
+        [Unit]
+        Description=Aria2c daemon
+        Documentation=man:aria2c(1)
+      ''}
+  '';
+}


### PR DESCRIPTION
### Description

Add a systemd user service for aria2. closes: #5636

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
