### PR TITLE
telegram: add module

### DIFF
--- a/modules/misc/news/2026/03/2026-03-28_12-16-08.nix
+++ b/modules/misc/news/2026/03/2026-03-28_12-16-08.nix
@@ -1,0 +1,12 @@
+{ config, pkgs, ... }:
+{
+  time = "2026-03-28T16:16:08+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.telegram`.
+
+    Telegram is a popular instant messaging application.
+    The module allows configuring telegram keybindings and
+    autostarting telegram via systemd.
+  '';
+}

--- a/modules/programs/telegram.nix
+++ b/modules/programs/telegram.nix
@@ -1,0 +1,89 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.telegram;
+
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.oneorseveralcats ];
+
+  options.programs.telegram = {
+    enable = lib.mkEnableOption "Telegram the instant messaging client";
+
+    package = lib.mkPackageOption pkgs "telegram-desktop" { nullable = true; };
+
+    bindings = lib.mkOption {
+      type = jsonFormat.type;
+      default = [ ];
+      example = [
+        {
+          command = "previous_chat";
+          keys = "alt+k";
+        }
+        {
+          command = "next_chat";
+          keys = "alt+j";
+        }
+        {
+          command = "search";
+          keys = "alt+/";
+        }
+      ];
+      description = ''
+        Telegram keybindings.
+
+        Full list is available at
+        {file}`$XDG_DATA_HOME/TelegramDesktop/tdata/shortcuts-default.json`
+      '';
+    };
+
+    systemd = {
+      enable = lib.mkEnableOption "Telegram systemd integration";
+
+      targets = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [ "graphical-session.target" ];
+        example = [ "tray.target" ];
+        description = ''
+          The systemd targets that will automatically start Telegram.
+        '';
+      };
+
+      extraArgs = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [ ];
+        example = [ "-startintray" ];
+        description = ''
+          Arguments to pass to the Telegram systemd service.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.dataFile."TelegramDesktop/tdata/shortcuts-custom.json" = lib.mkIf (cfg.bindings != [ ]) {
+      source = jsonFormat.generate "shortcuts-custom.json" cfg.bindings;
+    };
+
+    systemd.user.services.telegram = lib.mkIf cfg.systemd.enable {
+      Unit = {
+        Description = "Telegram, the instant messaging client";
+        Documentation = "https://github.com/telegramdesktop/tdesktop/wiki";
+      };
+
+      Service = {
+        ExecStart = "${lib.getExe cfg.package} ${toString cfg.systemd.extraArgs}";
+        Restart = "on-failure";
+      };
+
+      Install.WantedBy = cfg.systemd.targets;
+    };
+  };
+}

--- a/tests/modules/programs/telegram/bindings.json
+++ b/tests/modules/programs/telegram/bindings.json
@@ -1,0 +1,14 @@
+[
+  {
+    "command": "previous_chat",
+    "keys": "alt+k"
+  },
+  {
+    "command": "next_chat",
+    "keys": "alt+j"
+  },
+  {
+    "command": "search",
+    "keys": "alt+/"
+  }
+]

--- a/tests/modules/programs/telegram/bindings.nix
+++ b/tests/modules/programs/telegram/bindings.nix
@@ -1,0 +1,27 @@
+{
+  programs.telegram = {
+    enable = true;
+    bindings = [
+      {
+        command = "previous_chat";
+        keys = "alt+k";
+      }
+      {
+        command = "next_chat";
+        keys = "alt+j";
+      }
+      {
+        command = "search";
+        keys = "alt+/";
+      }
+    ];
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.local/share/TelegramDesktop/tdata/shortcuts-custom.json
+
+    assertFileContent\
+      home-files/.local/share/TelegramDesktop/tdata/shortcuts-custom.json\
+      ${./bindings.json}
+  '';
+}

--- a/tests/modules/programs/telegram/default.nix
+++ b/tests/modules/programs/telegram/default.nix
@@ -1,0 +1,8 @@
+{ lib, pkgs, ... }:
+{
+  telegram-bindings = ./bindings.nix;
+  telegram-disabled = ./disabled.nix;
+}
+// lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  telegram-systemd = ./systemd.nix;
+}

--- a/tests/modules/programs/telegram/disabled.nix
+++ b/tests/modules/programs/telegram/disabled.nix
@@ -1,0 +1,7 @@
+{
+  programs.telegram.enable = false;
+
+  nmt.script = ''
+    assertPathNotExists home-files/.local/share/TelegramDesktop
+  '';
+}

--- a/tests/modules/programs/telegram/systemd.nix
+++ b/tests/modules/programs/telegram/systemd.nix
@@ -1,0 +1,23 @@
+{ config, ... }:
+{
+  programs.telegram = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@telegram@"; };
+    systemd = {
+      enable = true;
+      targets = [ "tray.target" ];
+      extraArgs = [
+        "-startintray"
+        "-scale 75"
+      ];
+    };
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.local/share/TelegramDesktop
+
+    assertFileContent\
+     home-files/.config/systemd/user/telegram.service\
+     ${./systemd.service}
+  '';
+}

--- a/tests/modules/programs/telegram/systemd.service
+++ b/tests/modules/programs/telegram/systemd.service
@@ -1,0 +1,10 @@
+[Install]
+WantedBy=tray.target
+
+[Service]
+ExecStart=@telegram@/bin/dummy -startintray -scale 75
+Restart=on-failure
+
+[Unit]
+Description=Telegram, the instant messaging client
+Documentation=https://github.com/telegramdesktop/tdesktop/wiki


### PR DESCRIPTION
### Description

Add a module for the IM client telegram. The module allows configuring telegram's keybindings and autostarting via systemd (I want to use this to start telegram in the system tray). 

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
