### PR TITLE
neovim: attempt at reusing nixpkgs upstream config

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -433,30 +433,40 @@ in
         (lib.makeBinPath cfg.extraPackages)
       ];
 
-      vimPackageInfo = neovimUtils.makeVimPackageInfo (map suppressIncompatibleConfig pluginsNormalized);
+      nixpkgsCompatiblePlugins = map suppressIncompatibleConfig pluginsNormalized;
+      vimPackageInfo = neovimUtils.makeVimPackageInfo nixpkgsCompatiblePlugins;
 
-      wrappedNeovim' = pkgs.wrapNeovimUnstable cfg.package {
-        withNodeJs = cfg.withNodeJs || cfg.coc.enable;
-        plugins = [ ];
+      wrappedNeovim' =
+        (pkgs.wrapNeovimUnstable cfg.package {
+          withNodeJs = cfg.withNodeJs || cfg.coc.enable;
+          plugins = nixpkgsCompatiblePlugins;
 
-        extraLuaPackages = lp: cfg.extraLuaPackages lp ++ vimPackageInfo.luaDependencies;
-        inherit (cfg)
-          extraName
-          withPython3
-          withRuby
-          withPerl
-          viAlias
-          vimAlias
-          autowrapRuntimeDeps
-          waylandSupport
-          ;
+          extraLuaPackages = lp: cfg.extraLuaPackages lp ++ vimPackageInfo.luaDependencies;
+          inherit (cfg)
+            extraName
+            withPython3
+            withRuby
+            withPerl
+            viAlias
+            vimAlias
+            autowrapRuntimeDeps
+            waylandSupport
+            ;
 
-        extraPython3Packages =
-          ps: (cfg.extraPython3Packages ps) ++ (lib.concatMap (f: f ps) vimPackageInfo.pluginPython3Packages);
-        neovimRcContent = cfg.extraConfig;
-        wrapperArgs = cfg.extraWrapperArgs ++ extraMakeWrapperArgs;
-        wrapRc = false;
-      };
+          extraPython3Packages =
+            ps: (cfg.extraPython3Packages ps) ++ (lib.concatMap (f: f ps) vimPackageInfo.pluginPython3Packages);
+          neovimRcContent = cfg.extraConfig;
+          wrapperArgs = cfg.extraWrapperArgs ++ extraMakeWrapperArgs;
+          wrapRc = false;
+        }).overrideAttrs
+          {
+
+            # nixpkgs implementation dependend: avoid nixpkgs adding rtp/packpath wrapping arguments
+            packpathDirs.myNeovimPackages = {
+              start = [ ];
+              opt = [ ];
+            };
+          };
 
       # This is a hack to avoid breaking config for users that dont want an init.lua to get generated
       # See https://github.com/nix-community/home-manager/pull/8734
@@ -512,12 +522,8 @@ in
             else
               null;
 
-          advisedLua = foldedLuaBlock "home-manager generated: plugin config advised in nixpkgs" (
-            lib.concatStringsSep "\n" vimPackageInfo.pluginAdvisedLua
-          );
         in
         lib.mkMerge [
-          (lib.mkIf (advisedLua != null) (lib.mkOrder 510 advisedLua))
           (lib.mkIf wrapperHasUserConfig (
             # we want it to appear rather early
             lib.mkOrder 200 wrappedNeovim'.luaRcContent

--- a/tests/modules/programs/neovim/plugin-config.expected
+++ b/tests/modules/programs/neovim/plugin-config.expected
@@ -4,6 +4,7 @@ package.cpath = "/nix/store/00000000000000000000000000000000-luajit/lib/lua/5.1/
 vim.g.loaded_node_provider=0;vim.g.loaded_perl_provider=0;vim.g.loaded_ruby_provider=0;vim.g.python3_host_prog='/nix/store/00000000000000000000000000000000-nvim-host-python3/bin/nvim-python3'
 vim.cmd.source "/nix/store/00000000000000000000000000000000-init.vim"
 
+vim.g.Unicode_data_directory="/nix/store/00000000000000000000000000000000-vimplugin-unicode.vim/autoload/unicode"
 -- user-associated plugin config {{{
 function HM_PLUGIN_LUA_CONFIG ()
 end

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -16,17 +16,23 @@ lib.mkIf config.test.enableBig {
       vim-nix
       {
         plugin = vim-commentary;
+        # testing viml config
         config = ''
           let g:hmPlugins='HM_PLUGINS_CONFIG'
         '';
       }
       {
         plugin = vim-nix;
+        # testing lua config
         type = "lua";
         config = ''
           function HM_PLUGIN_LUA_CONFIG ()
           end
         '';
+      }
+      {
+        # to test passthru.initLua is taken into account
+        plugin = unicode-vim;
       }
     ];
     extraLuaPackages = ps: [ ps.luautf8 ];
@@ -42,11 +48,13 @@ lib.mkIf config.test.enableBig {
     in
     ''
       vimout=$(mktemp)
-      echo "redir >> /dev/stdout | echo g:hmExtraConfig | echo g:hmPlugins | redir END" \
+      echo "redir >> /dev/stdout | echo g:hmExtraConfig | echo g:hmPlugins | echo g:Unicode_data_directory | redir END" \
         | ${pkgs.neovim}/bin/nvim -es -u "$TESTED/home-files/.config/nvim/init.lua" \
         > "$vimout" || true
       assertFileContains "$vimout" "HM_EXTRA_CONFIG"
       assertFileContains "$vimout" "HM_PLUGINS_CONFIG"
+      # testing that unicode-vim's value is echoed
+      assertFileContains "$vimout" "autoload/unicode"
 
       initLua="$TESTED/home-files/.config/nvim/init.lua"
       assertFileContent $(normalizeStorePaths "$initLua") ${./plugin-config.expected}


### PR DESCRIPTION
### Description

let nixpkgs handle the `advised lua ` bit.

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
