### PR TITLE
neovim: test pure lua dependencies

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -441,8 +441,8 @@ in
           withNodeJs = cfg.withNodeJs || cfg.coc.enable;
           plugins = nixpkgsCompatiblePlugins;
 
-          extraLuaPackages = lp: cfg.extraLuaPackages lp ++ vimPackageInfo.luaDependencies;
           inherit (cfg)
+            extraLuaPackages
             extraName
             withPython3
             withRuby
@@ -521,7 +521,6 @@ in
               ''
             else
               null;
-
         in
         lib.mkMerge [
           (lib.mkIf wrapperHasUserConfig (

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -34,6 +34,10 @@ lib.mkIf config.test.enableBig {
         # to test passthru.initLua is taken into account
         plugin = unicode-vim;
       }
+      {
+        # test pure lua dependencies: telescope relies on the lua version of plenary
+        plugin = telescope-nvim;
+      }
     ];
     extraLuaPackages = ps: [ ps.luautf8 ];
   };
@@ -48,15 +52,26 @@ lib.mkIf config.test.enableBig {
     in
     ''
       vimout=$(mktemp)
+
+      export PATH="$TESTED/home-path/bin:$PATH"
+      export HOME=$TMPDIR/hm-user
+      initLua="$TESTED/home-files/.config/nvim/init.lua"
+
       echo "redir >> /dev/stdout | echo g:hmExtraConfig | echo g:hmPlugins | echo g:Unicode_data_directory | redir END" \
-        | ${pkgs.neovim}/bin/nvim -es -u "$TESTED/home-files/.config/nvim/init.lua" \
+        | nvim -es -i NONE -u "$initLua" \
         > "$vimout" || true
+
       assertFileContains "$vimout" "HM_EXTRA_CONFIG"
       assertFileContains "$vimout" "HM_PLUGINS_CONFIG"
       # testing that unicode-vim's value is echoed
       assertFileContains "$vimout" "autoload/unicode"
 
-      initLua="$TESTED/home-files/.config/nvim/init.lua"
+      # check telescope can find plenary/does not trigger any error
+      if ! nvim -V3log.txt -i NONE -es -u "$initLua" -c "lua require('plenary') " -c "quit"; then
+        fail "Could not require the 'plenary'  dependency pulled by telescope.nvim"
+        cat log.txt
+      fi
+
       assertFileContent $(normalizeStorePaths "$initLua") ${./plugin-config.expected}
 
       # Verify generatedConfigs evaluated properly (issue #8371)


### PR DESCRIPTION
a revert of https://github.com/nix-community/home-manager/pull/8959 since we now relies on nixpkgs wrapper for that.

adding a test to avoid regressions. Choosing  telescope as starting point is https://github.com/nix-community/home-manager/issues/8787

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
