### PR TITLE
fix(claude-code): terminate variadic --mcp-config flag in wrapper

### DIFF
--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -349,7 +349,7 @@ in
           lib.filter (x: x != [ ]) [
             (lib.optional (cfg.mcpServers != { }) [
               "--add-flags"
-              "--mcp-config ${jsonFormat.generate "claude-code-mcp-config.json" { inherit (cfg) mcpServers; }}"
+              "--mcp-config ${jsonFormat.generate "claude-code-mcp-config.json" { inherit (cfg) mcpServers; }} --"
             ])
           ]
         );

--- a/tests/modules/programs/claude-code/expected-mcp-wrapper
+++ b/tests/modules/programs/claude-code/expected-mcp-wrapper
@@ -1,2 +1,2 @@
 #! /nix/store/00000000000000000000000000000000-bash/bin/bash -e
-exec -a "$0" "/nix/store/00000000000000000000000000000000-claude-code/bin/.claude-wrapped"  --mcp-config /nix/store/00000000000000000000000000000000-claude-code-mcp-config.json "$@" 
+exec -a "$0" "/nix/store/00000000000000000000000000000000-claude-code/bin/.claude-wrapped"  --mcp-config /nix/store/00000000000000000000000000000000-claude-code-mcp-config.json -- "$@" 


### PR DESCRIPTION
## Summary

- Adds `--` after the `--mcp-config` path in the generated wrapper to terminate the variadic flag before `"$@"`
- Updates test expected output to match

## Problem

The `--mcp-config` CLI flag accepts variadic arguments (`<configs...>`), so when passed via `--add-flags` in the `makeWrapper` call, it greedily consumes all subsequent arguments — including `"$@"`. This causes subcommands to fail:

```
$ claude doctor
Error: Invalid MCP configuration:
MCP config file not found: /home/user/project/doctor

$ claude mcp list
Error: Invalid MCP configuration:
MCP config file not found: /home/user/project/mcp
MCP config file not found: /home/user/project/list
```

## Fix

Adding `--` after the config file path terminates the variadic `--mcp-config` flag, so `"$@"` is correctly parsed as subcommands/arguments.

Before: `--mcp-config /nix/store/...-config.json "$@"`
After:  `--mcp-config /nix/store/...-config.json -- "$@"`

## Test plan

- [ ] Existing `mcp.nix` test passes with updated expected wrapper output
- [ ] `claude doctor` works when `mcpServers` is configured
- [ ] `claude mcp list` works when `mcpServers` is configured
- [ ] Normal `claude` invocation still loads MCP servers correctly

Fixes #8995