### PR TITLE
swayidle: Add support for idlehint

### DIFF
--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -84,6 +84,12 @@ in
 
       package = lib.mkPackageOption pkgs "swayidle" { };
 
+      idlehint = mkOption {
+        type = with types; nullOr int;
+        default = null;
+        description = "If non-null, sets the timeout in seconds to indicate an idle login session to logind.";
+      };
+
       timeouts = mkOption {
         type = with types; listOf (submodule timeoutModule);
         default = [ ];
@@ -189,7 +195,11 @@ in
             args =
               cfg.extraArgs
               ++ (lib.concatMap mkTimeout cfg.timeouts)
-              ++ (lib.flatten (lib.mapAttrsToList mkEvent nonemptyEvents));
+              ++ (lib.flatten (lib.mapAttrsToList mkEvent nonemptyEvents))
+              ++ lib.optionals (cfg.idlehint != null) [
+                "idlehint"
+                (toString cfg.idlehint)
+              ];
           in
           "${lib.getExe cfg.package} ${lib.escapeShellArgs args}";
       };

--- a/tests/modules/services/swayidle/basic-configuration.nix
+++ b/tests/modules/services/swayidle/basic-configuration.nix
@@ -23,6 +23,7 @@
       before-sleep = "swaylock -fF";
       lock = "swaylock -fF";
     };
+    idlehint = 300;
   };
 
   nmt.script = ''
@@ -38,7 +39,7 @@
 
       [Service]
       Environment=PATH=@bash-interactive@/bin
-      ExecStart=@swayidle@/bin/dummy -w timeout 50 'notify-send -t 10000 -- "Screen lock in 10 seconds"' timeout 60 'swaylock -fF' timeout 300 'swaymsg "output * dpms off"' resume 'swaymsg "output * dpms on"' before-sleep 'swaylock -fF' lock 'swaylock -fF'
+      ExecStart=@swayidle@/bin/dummy -w timeout 50 'notify-send -t 10000 -- "Screen lock in 10 seconds"' timeout 60 'swaylock -fF' timeout 300 'swaymsg "output * dpms off"' resume 'swaymsg "output * dpms on"' before-sleep 'swaylock -fF' lock 'swaylock -fF' idlehint 300
       Restart=always
       Type=simple
 


### PR DESCRIPTION
### Description

This adds support for idlehint configuration to notify systemd about
idle session.

I've taken a simple path to define a plain new option. I think it makes most
sense since it's the only one that has a timeout but no command. But I can tweak
to make it something like `swayidle.idlehint.timeout` or something similar if that makes more sense. I couldn't come up with a nice way to integrate with timeouts or events.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

<!-- Message of single commit: -->