### PR TITLE
opencode: use serve command for web interface

### DIFF
--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -109,7 +109,7 @@ in
           "DEBUG"
         ];
         description = ''
-          Extra arguments to pass to the opencode web command.
+          Extra arguments to pass to the opencode serve command.
 
           These arguments override the "server" options defined in the configuration file.
           See <https://opencode.ai/docs/web/#config-file> for available options.
@@ -498,7 +498,7 @@ in
         };
 
         Service = {
-          ExecStart = "${lib.getExe cfg.package} web ${lib.escapeShellArgs webCfg.extraArgs}";
+          ExecStart = "${lib.getExe cfg.package} serve ${lib.escapeShellArgs webCfg.extraArgs}";
           Restart = "always";
           RestartSec = 5;
         };
@@ -515,7 +515,7 @@ in
         config = {
           ProgramArguments = [
             (lib.getExe cfg.package)
-            "web"
+            "serve"
           ]
           ++ webCfg.extraArgs;
           KeepAlive = {

--- a/tests/modules/programs/opencode/web-service.plist
+++ b/tests/modules/programs/opencode/web-service.plist
@@ -17,7 +17,7 @@
 	<array>
 		<string>/bin/sh</string>
 		<string>-c</string>
-		<string>/bin/wait4path /nix/store &amp;&amp; exec @opencode@/bin/opencode web --hostname 0.0.0.0 --port 4096 --mdns --cors https://example.com --cors http://localhost:3000 --print-logs --log-level DEBUG</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec @opencode@/bin/opencode serve --hostname 0.0.0.0 --port 4096 --mdns --cors https://example.com --cors http://localhost:3000 --print-logs --log-level DEBUG</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/tests/modules/programs/opencode/web-service.service
+++ b/tests/modules/programs/opencode/web-service.service
@@ -2,7 +2,7 @@
 WantedBy=default.target
 
 [Service]
-ExecStart=@opencode@/bin/opencode web --hostname 0.0.0.0 --port 4096 --mdns --cors https://example.com --cors http://localhost:3000 --print-logs --log-level DEBUG
+ExecStart=@opencode@/bin/opencode serve --hostname 0.0.0.0 --port 4096 --mdns --cors https://example.com --cors http://localhost:3000 --print-logs --log-level DEBUG
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Switches opencode web component to use the `serve` command (which is functionally identical to the `web` command, just doesn't print information or attempt to open a web browser)

closes #9004

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
