### PR TITLE
syncthing: set systemd start limits

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -774,6 +774,8 @@ in
             Description = "Syncthing - Open Source Continuous File Synchronization";
             Documentation = "man:syncthing(1)";
             After = [ "network.target" ];
+            StartLimitIntervalSec = 60;
+            StartLimitBurst = 4;
           };
 
           Service = {


### PR DESCRIPTION
### Description

Add StartLimitIntervalSec and StartLimitBurst configuration to the Syncthing systemd unit.  This prevents Syncthing restarting indefinitely if it hits a bug such as NixOS/nixpkgs#502836.

The values here are taken from [the values provided in the upstream Syncthing example systemd unit][0].

[0]: https://github.com/syncthing/syncthing/blob/1a3cbca0170306541d3d1877cc1a9efbd8d8c017/etc/linux-systemd/user/syncthing.service

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
