### PR TITLE
pimsync: working out of the box defaults

### DIFF
--- a/modules/programs/pimsync/accounts.nix
+++ b/modules/programs/pimsync/accounts.nix
@@ -28,12 +28,17 @@ in
 
     extraPairDirectives = mkOption {
       type = SCFGDirectives;
-      default = [ ];
-      description = "Extra directives that should be added under this accounts pair directive";
-      example = [
+      default = [
         {
           name = "collections";
           params = [ "all" ];
+        }
+      ];
+      description = "Extra directives that should be added under this accounts pair directive";
+      example = [
+        {
+          name = "conflict_resolution";
+          params = [ "keep a" ];
         }
       ];
     };


### PR DESCRIPTION
### Description

To debug a test in my pimsync config, I had disabled the 

```
        extraPairDirectives = [
          {
            name = "collections";
            params = [ "all" ];
          }
        ];
```

so nothing was synced. Which means that by default the pimsync service does nothing. 
Now I worry changing the default might lead to dataloss but I dont think there is a better default as the module should work with minimal configuration.

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
