### PR TITLE
aerc: provide default keybindings as baseline for cfg.extraBinds

### DIFF
--- a/modules/programs/aerc/accounts.nix
+++ b/modules/programs/aerc/accounts.nix
@@ -182,8 +182,7 @@ in
 
       mkConfig = {
         notmuch = cfg: {
-          source = "notmuch://${config.accounts.email.maildirBasePath}";
-          maildir-store = "${config.accounts.email.maildirBasePath}";
+          source = "notmuch://";
           maildir-account-path = "${cfg.maildir.path}";
         };
         maildir = cfg: {

--- a/modules/programs/aerc/binds.conf
+++ b/modules/programs/aerc/binds.conf
@@ -1,0 +1,187 @@
+# Binds are of the form <key sequence> = <command to run>
+# To use '=' in a key sequence, substitute it with "Eq": "<Ctrl+Eq>"
+# If you wish to bind #, you can wrap the key sequence in quotes: "#" = quit
+<C-p> = :prev-tab<Enter>
+<C-PgUp> = :prev-tab<Enter>
+<C-n> = :next-tab<Enter>
+<C-PgDn> = :next-tab<Enter>
+\[t = :prev-tab<Enter>
+\]t = :next-tab<Enter>
+<C-t> = :term<Enter>
+? = :help keys<Enter>
+<C-c> = :prompt 'Quit?' quit<Enter>
+<C-q> = :prompt 'Quit?' quit<Enter>
+<C-z> = :suspend<Enter>
+
+[messages]
+q = :prompt 'Quit?' quit<Enter>
+
+j = :next<Enter>
+<Down> = :next<Enter>
+<C-d> = :next 50%<Enter>
+<C-f> = :next 100%<Enter>
+<PgDn> = :next 100%<Enter>
+
+k = :prev<Enter>
+<Up> = :prev<Enter>
+<C-u> = :prev 50%<Enter>
+<C-b> = :prev 100%<Enter>
+<PgUp> = :prev 100%<Enter>
+g = :select 0<Enter>
+G = :select -1<Enter>
+
+J = :next-folder<Enter>
+<C-Down> = :next-folder<Enter>
+K = :prev-folder<Enter>
+<C-Up> = :prev-folder<Enter>
+H = :collapse-folder<Enter>
+<C-Left> = :collapse-folder<Enter>
+L = :expand-folder<Enter>
+<C-Right> = :expand-folder<Enter>
+
+v = :mark -t<Enter>
+<Space> = :mark -t<Enter>:next<Enter>
+V = :mark -v<Enter>
+
+T = :toggle-threads<Enter>
+zc = :fold<Enter>
+zo = :unfold<Enter>
+za = :fold -t<Enter>
+zM = :fold -a<Enter>
+zR = :unfold -a<Enter>
+<tab> = :fold -t<Enter>
+
+zz = :align center<Enter>
+zt = :align top<Enter>
+zb = :align bottom<Enter>
+
+<Enter> = :view<Enter>
+d = :choose -o y 'Really delete this message' delete-message<Enter>
+D = :delete<Enter>
+a = :archive flat<Enter>
+A = :unmark -a<Enter>:mark -T<Enter>:archive flat<Enter>
+
+C = :compose<Enter>
+m = :compose<Enter>
+
+b = :bounce<space>
+
+rr = :reply -a<Enter>
+rq = :reply -aq<Enter>
+Rr = :reply<Enter>
+Rq = :reply -q<Enter>
+
+c = :cf<space>
+$ = :term<space>
+! = :term<space>
+| = :pipe<space>
+
+/ = :search<space>
+\ = :filter<space>
+n = :next-result<Enter>
+N = :prev-result<Enter>
+<Esc> = :clear<Enter>
+
+s = :split<Enter>
+S = :vsplit<Enter>
+
+pl = :patch list<Enter>
+pa = :patch apply <Tab>
+pd = :patch drop <Tab>
+pb = :patch rebase<Enter>
+pt = :patch term<Enter>
+ps = :patch switch <Tab>
+
+[messages:folder=Drafts]
+<Enter> = :recall<Enter>
+
+[view]
+/ = :toggle-key-passthrough<Enter>/
+q = :close<Enter>
+O = :open<Enter>
+o = :open<Enter>
+S = :save<space>
+| = :pipe<space>
+D = :delete<Enter>
+A = :archive flat<Enter>
+
+<C-y> = :copy-link <space>
+<C-l> = :open-link <space>
+
+f = :forward<Enter>
+rr = :reply -a<Enter>
+rq = :reply -aq<Enter>
+Rr = :reply<Enter>
+Rq = :reply -q<Enter>
+
+H = :toggle-headers<Enter>
+<C-k> = :prev-part<Enter>
+<C-Up> = :prev-part<Enter>
+<C-j> = :next-part<Enter>
+<C-Down> = :next-part<Enter>
+J = :next<Enter>
+<C-Right> = :next<Enter>
+K = :prev<Enter>
+<C-Left> = :prev<Enter>
+
+[view::passthrough]
+$noinherit = true
+$ex = <C-x>
+<Esc> = :toggle-key-passthrough<Enter>
+
+[compose]
+# Keybindings used when the embedded terminal is not selected in the compose
+# view
+$noinherit = true
+$ex = <C-x>
+$complete = <C-o>
+<C-k> = :prev-field<Enter>
+<C-Up> = :prev-field<Enter>
+<C-j> = :next-field<Enter>
+<C-Down> = :next-field<Enter>
+<A-p> = :switch-account -p<Enter>
+<C-Left> = :switch-account -p<Enter>
+<A-n> = :switch-account -n<Enter>
+<C-Right> = :switch-account -n<Enter>
+<tab> = :next-field<Enter>
+<backtab> = :prev-field<Enter>
+<C-p> = :prev-tab<Enter>
+<C-PgUp> = :prev-tab<Enter>
+<C-n> = :next-tab<Enter>
+<C-PgDn> = :next-tab<Enter>
+
+[compose::editor]
+# Keybindings used when the embedded terminal is selected in the compose view
+$noinherit = true
+$ex = <C-x>
+<C-k> = :prev-field<Enter>
+<C-Up> = :prev-field<Enter>
+<C-j> = :next-field<Enter>
+<C-Down> = :next-field<Enter>
+<C-p> = :prev-tab<Enter>
+<C-PgUp> = :prev-tab<Enter>
+<C-n> = :next-tab<Enter>
+<C-PgDn> = :next-tab<Enter>
+
+[compose::review]
+# Keybindings used when reviewing a message to be sent
+# Inline comments are used as descriptions on the review screen
+y = :send<Enter> # Send
+n = :abort<Enter> # Abort (discard message, no confirmation)
+s = :sign<Enter> # Toggle signing
+x = :encrypt<Enter> # Toggle encryption to all recipients
+v = :preview<Enter> # Preview message
+p = :postpone<Enter> # Postpone
+q = :choose -o d discard abort -o p postpone postpone<Enter> # Abort or postpone
+e = :edit<Enter> # Edit (body and headers)
+a = :attach<space> # Add attachment
+d = :detach<space> # Remove attachment
+
+[terminal]
+$noinherit = true
+$ex = <C-x>
+
+<C-p> = :prev-tab<Enter>
+<C-n> = :next-tab<Enter>
+<C-PgUp> = :prev-tab<Enter>
+<C-PgDn> = :next-tab<Enter>

--- a/modules/programs/aerc/default.nix
+++ b/modules/programs/aerc/default.nix
@@ -146,6 +146,8 @@ in
     let
       joinCfg = cfgs: lib.concatStringsSep "\n" (lib.filter (v: v != "") cfgs);
 
+      bindsConf = builtins.readFile ./binds.conf;
+
       sectionsToINI =
         conf:
         let
@@ -289,6 +291,9 @@ in
         "${configDir}/binds.conf" = mkIf genBindsConf {
           text = joinCfg [
             header
+            # upstream defaults
+            bindsConf
+            # user overrides
             (mkINI cfg.extraBinds)
             (joinContextual accountsExtraBinds)
           ];


### PR DESCRIPTION
### Description
Currently setting up additional keybindings in aerc via `extraBinds` leaves aerc literally unusable as these overwrite the default keybindings. This pr changes this so that keybindings specified in `extraBinds` extend / overwrite the default keybindings.
cc @teto @khaneliman  since both of you looked at the previous `aerc` pr
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ x] Change is backwards compatible.

- [ x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
