### PR TITLE
restic: allow setting password command

### DIFF
--- a/modules/services/restic.nix
+++ b/modules/services/restic.nix
@@ -55,6 +55,7 @@ let
       (attrsToEnvs (
         {
           RESTIC_PROGRESS_FPS = backup.progressFps;
+          RESTIC_PASSWORD_COMMAND = lib.escapeShellArg backup.passwordCommand;
           RESTIC_PASSWORD_FILE = backup.passwordFile;
           RESTIC_REPOSITORY = backup.repository;
           RESTIC_REPOSITORY_FILE = backup.repositoryFile;
@@ -104,11 +105,23 @@ in
               ssh-package = lib.mkPackageOption pkgs "openssh" { };
 
               passwordFile = lib.mkOption {
-                type = lib.types.str;
+                type = lib.types.nullOr lib.types.str;
+                default = null;
                 description = ''
                   A file containing the repository password.
                 '';
                 example = "/etc/nixos/restic-password";
+              };
+
+              passwordCommand = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = ''
+                  Command which returns one of the repository's passwords. Since
+                  {env}`PATH` is set in the systemd service you need to provide
+                  the absolute path to the executable.
+                '';
+                example = lib.literalExpression ''"''${lib.getExe pkgs.gopass} show backups"'';
               };
 
               environmentFile = lib.mkOption {
@@ -394,10 +407,26 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    assertions = lib.mapAttrsToList (n: v: {
-      assertion = lib.xor (v.repository == null) (v.repositoryFile == null);
-      message = "services.restic.backups.${n}: exactly one of repository or repositoryFile should be set";
-    }) cfg.backups;
+    assertions =
+      let
+        assertBackup =
+          { assertion, message }:
+          lib.mapAttrsToList (n: v: {
+            assertion = assertion n v;
+            message = "services.restic.backups.${n}: ${message}";
+          }) cfg.backups;
+
+        mustSetRepository = assertBackup {
+          assertion = n: v: lib.xor (v.repository == null) (v.repositoryFile == null);
+          message = "exactly one of repository or repositoryFile should be set";
+        };
+
+        mustSetPassword = assertBackup {
+          assertion = n: v: lib.xor (v.passwordCommand == null) (v.passwordFile == null);
+          message = "exactly one of passwordCommand or passwordFile should be set";
+        };
+      in
+      mustSetPassword ++ mustSetRepository;
 
     systemd.user.services = lib.mapAttrs' (
       name: backup:

--- a/tests/integration/standalone/restic-home.nix
+++ b/tests/integration/standalone/restic-home.nix
@@ -1,6 +1,7 @@
 { pkgs, ... }:
 let
   passwordFile = "/home/alice/password";
+  passwordCommand = "${pkgs.coreutils}/bin/cat /home/alice/password";
   paths = [ "/home/alice/files" ];
   exclude = [ "*exclude*" ];
 in
@@ -41,6 +42,12 @@ in
 
       basic = {
         inherit passwordFile paths exclude;
+        initialize = true;
+        repository = "/home/alice/repos/basic";
+      };
+
+      basic-command = {
+        inherit passwordCommand paths exclude;
         initialize = true;
         repository = "/home/alice/repos/basic";
       };

--- a/tests/integration/standalone/restic.nix
+++ b/tests/integration/standalone/restic.nix
@@ -134,6 +134,23 @@ in
         f"expected diff -ur restore/basic/home/alice/files files to contain \
           {expected1} and {expected2}, but got {actual}"
 
+    with subtest("Basic backup (password command)"):
+      systemctl_succeed_as_alice("start restic-backups-basic-command.service")
+      actual = succeed_as_alice("restic-basic-command ls latest")
+      assert_list("restic-basic-command ls latest", expectedIncluded, actual)
+
+      assert "exclude" not in actual, \
+        f"Paths containing \"*exclude*\" got backed up incorrectly. output: {actual}"
+
+    with subtest("Basic restore (password command)"):
+      succeed_as_alice("restic-basic-command restore latest --target restore/basic")
+      actual = fail_as_alice("diff -urNa restore/basic/home/alice/files files")
+      expected1 = "alices-secret-diary"
+      expected2 = "alices-bank-details"
+      assert expected1 in actual and expected2 in actual, \
+        f"expected diff -ur restore/basic/home/alice/files files to contain \
+          {expected1} and {expected2}, but got {actual}"
+
     with subtest("Fails to start with an un-initialized repo"):
       systemctl_fail_as_alice("start restic-backups-noinit.service")
 


### PR DESCRIPTION
### Description

Includes asserting that either password file or password command should be set.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```