### PR TITLE
home-cursor: use submodule-specific 'size'

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -60,12 +60,28 @@ let
           example = "X_cursor";
           description = "The default cursor file to use within the package.";
         };
+
+        size = mkOption {
+          type = types.int;
+          example = 32;
+          default = config.home.pointerCursor.size;
+          defaultText = "config.home.pointerCursor.size";
+          description = "The cursor size for x11.";
+        };
       };
 
       gtk = {
         enable = mkEnableOption ''
           gtk config generation for {option}`home.pointerCursor`
         '';
+
+        size = mkOption {
+          type = types.int;
+          example = 32;
+          default = config.home.pointerCursor.size;
+          defaultText = "config.home.pointerCursor.size";
+          description = "The cursor size for gtk.";
+        };
       };
 
       dotIcons = {
@@ -92,6 +108,14 @@ let
 
       sway = {
         enable = mkEnableOption "sway config generation for {option}`home.pointerCursor`";
+
+        size = mkOption {
+          type = types.int;
+          example = 32;
+          default = config.home.pointerCursor.size;
+          defaultText = "config.home.pointerCursor.size";
+          description = "The cursor size for sway.";
+        };
       };
     };
   };
@@ -197,7 +221,7 @@ in
           ];
 
           home.sessionVariables = {
-            XCURSOR_SIZE = mkDefault cfg.size;
+            XCURSOR_SIZE = mkDefault cfg.x11.size;
             XCURSOR_THEME = mkDefault cfg.name;
           };
 
@@ -224,17 +248,20 @@ in
 
         (mkIf cfg.x11.enable {
           xsession.profileExtra = ''
-            ${lib.getExe pkgs.xsetroot} -xcf ${cursorPath} ${toString cfg.size}
+            ${lib.getExe pkgs.xsetroot} -xcf ${cursorPath} ${toString cfg.x11.size}
           '';
 
           xresources.properties = {
             "Xcursor.theme" = cfg.name;
-            "Xcursor.size" = cfg.size;
+            "Xcursor.size" = cfg.x11.size;
           };
         })
 
         (mkIf cfg.gtk.enable {
-          gtk.cursorTheme = mkDefault { inherit (cfg) package name size; };
+          gtk.cursorTheme = mkDefault {
+            inherit (cfg) package name;
+            inherit (cfg.gtk) size;
+          };
         })
 
         (mkIf cfg.hyprcursor.enable {
@@ -249,7 +276,7 @@ in
             config = {
               seat = {
                 "*" = {
-                  xcursor_theme = "${cfg.name} ${toString cfg.size}";
+                  xcursor_theme = "${cfg.name} ${toString cfg.sway.size}";
                 };
               };
             };


### PR DESCRIPTION
### Description

Rather than have `hyprcursor` be the odd-one-out.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
