### PR TITLE
restic: escape environment variables

### DIFF
--- a/modules/services/restic.nix
+++ b/modules/services/restic.nix
@@ -27,7 +27,7 @@ let
       (upper: "RCLONE_" + upper)
     ];
 
-  toEnvVal = v: if lib.isBool v then lib.boolToString v else toString v;
+  toEnvVal = v: if lib.isBool v then lib.boolToString v else lib.escapeShellArg v;
 
   attrsToEnvs =
     attrs:
@@ -55,7 +55,7 @@ let
       (attrsToEnvs (
         {
           RESTIC_PROGRESS_FPS = backup.progressFps;
-          RESTIC_PASSWORD_COMMAND = lib.escapeShellArg backup.passwordCommand;
+          RESTIC_PASSWORD_COMMAND = backup.passwordCommand;
           RESTIC_PASSWORD_FILE = backup.passwordFile;
           RESTIC_REPOSITORY = backup.repository;
           RESTIC_REPOSITORY_FILE = backup.repositoryFile;

--- a/tests/integration/standalone/restic-home.nix
+++ b/tests/integration/standalone/restic-home.nix
@@ -52,6 +52,12 @@ in
         repository = "/home/alice/repos/basic";
       };
 
+      repository-spaced = {
+        inherit passwordFile paths exclude;
+        initialize = true;
+        repository = "/home/alice/repos/repository with spaces!";
+      };
+
       repo-file = {
         inherit passwordFile paths exclude;
         initialize = true;

--- a/tests/integration/standalone/restic.nix
+++ b/tests/integration/standalone/restic.nix
@@ -134,6 +134,23 @@ in
         f"expected diff -ur restore/basic/home/alice/files files to contain \
           {expected1} and {expected2}, but got {actual}"
 
+    with subtest("Repository with spaces backup"):
+      systemctl_succeed_as_alice("start restic-backups-repository-spaced.service")
+      actual = succeed_as_alice("restic-repository-spaced ls latest")
+      assert_list("restic-repository-spaced ls latest", expectedIncluded, actual)
+
+      assert "exclude" not in actual, \
+        f"Paths containing \"*exclude*\" got backed up incorrectly. output: {actual}"
+
+    with subtest("Repository with spaces restore"):
+      succeed_as_alice("restic-repository-spaced restore latest --target restore/repository-spaced")
+      actual = fail_as_alice("diff -urNa restore/repository-spaced/home/alice/files files")
+      expected1 = "alices-secret-diary"
+      expected2 = "alices-bank-details"
+      assert expected1 in actual and expected2 in actual, \
+        f"expected diff -ur restore/repository-spaced/home/alice/files files to contain \
+          {expected1} and {expected2}, but got {actual}"
+
     with subtest("Basic backup (password command)"):
       systemctl_succeed_as_alice("start restic-backups-basic-command.service")
       actual = succeed_as_alice("restic-basic-command ls latest")
@@ -143,12 +160,12 @@ in
         f"Paths containing \"*exclude*\" got backed up incorrectly. output: {actual}"
 
     with subtest("Basic restore (password command)"):
-      succeed_as_alice("restic-basic-command restore latest --target restore/basic")
-      actual = fail_as_alice("diff -urNa restore/basic/home/alice/files files")
+      succeed_as_alice("restic-basic-command restore latest --target restore/basic-command")
+      actual = fail_as_alice("diff -urNa restore/basic-command/home/alice/files files")
       expected1 = "alices-secret-diary"
       expected2 = "alices-bank-details"
       assert expected1 in actual and expected2 in actual, \
-        f"expected diff -ur restore/basic/home/alice/files files to contain \
+        f"expected diff -ur restore/basic-command/home/alice/files files to contain \
           {expected1} and {expected2}, but got {actual}"
 
     with subtest("Fails to start with an un-initialized repo"):


### PR DESCRIPTION
### Description

This allows better handling of, e.g., file names with spaces.

@ttrssreal Perhaps there was a special reason for using `toString` instead of `escapeShellArg`? I'm assuming "no" in this PR 🙂

### Checklist

- [x] Change is backwards compatible. _I think so. While technically one previously could reference other environment variables in, e.g., the repository path I think it would be somewhat unreliable since they may differ in the systemd service and the shell script_

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
