### PR TITLE
timidity: remove amesgen as maintainer

### DIFF
--- a/all-maintainers.nix
+++ b/all-maintainers.nix
@@ -586,14 +586,6 @@
     name = "Bruno BELANYI";
     source = "nixpkgs";
   };
-  amesgen = {
-    email = "amesgen@amesgen.de";
-    github = "amesgen";
-    githubId = 15369874;
-    matrix = "@amesgen:amesgen.de";
-    name = "Alexander Esgen";
-    source = "nixpkgs";
-  };
   andre4ik3 = {
     email = "andre4ik3@fastmail.com";
     github = "andre4ik3";

--- a/modules/programs/timidity.nix
+++ b/modules/programs/timidity.nix
@@ -11,7 +11,7 @@ let
 
 in
 {
-  meta.maintainers = [ lib.maintainers.amesgen ];
+  meta.maintainers = [ ];
 
   options.programs.timidity = {
     enable = lib.mkEnableOption "timidity, a software MIDI renderer";


### PR DESCRIPTION


### Description

Sadly amesgen passed away some time ago, see <https://www.tweag.io/blog/2025-12-16-in-memoriam-amesgen/>.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
