### PR TITLE
Follow nixpkgs Ruby and Python provider defaults for neovim

### DIFF
--- a/docs/release-notes/rl-2605.md
+++ b/docs/release-notes/rl-2605.md
@@ -50,3 +50,6 @@ changes are only active if the `home.stateVersion` option is set to
   and `whatis`/`man -f` binaries that don't work on Darwin. Nix-installed
   manual pages still work with macOS's built-in `man` via
   [](#opt-home.extraOutputsToInstall).
+
+- The options [](#opt-programs.neovim.withPython3) and
+  [](#opt-programs.neovim.withRuby) now default to `false` following nixpkgs

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -109,7 +109,21 @@ in
 
       withPython3 = mkOption {
         type = types.bool;
-        default = true;
+        inherit
+          (lib.hm.deprecations.mkStateVersionOptionDefault {
+            inherit (config.home) stateVersion;
+            since = "26.05";
+            optionPath = [
+              "programs"
+              "neovim"
+              "withPython3"
+            ];
+            legacy.value = true;
+            current.value = false;
+          })
+          default
+          defaultText
+          ;
         description = ''
           Enable Python 3 provider. Set to `true` to
           use Python 3 plugins.
@@ -117,8 +131,22 @@ in
       };
 
       withRuby = mkOption {
-        type = types.nullOr types.bool;
-        default = false;
+        type = types.bool;
+        inherit
+          (lib.hm.deprecations.mkStateVersionOptionDefault {
+            inherit (config.home) stateVersion;
+            since = "26.05";
+            optionPath = [
+              "programs"
+              "neovim"
+              "withRuby"
+            ];
+            legacy.value = true;
+            current.value = false;
+          })
+          default
+          defaultText
+          ;
         description = ''
           Enable ruby provider.
         '';


### PR DESCRIPTION
### Description

Disable Python and Ruby providers by default to follow nixpkgs (https://github.com/NixOS/nixpkgs/pull/492131 and https://github.com/NixOS/nixpkgs/pull/506332)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.


- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
