### PR TITLE
thunderbird: allow configuration of EWS accounts

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -231,6 +231,35 @@ let
     };
   };
 
+  ewsModule = types.submodule {
+    options = {
+      host = mkOption {
+        type = types.str;
+        example = "ews.example.org";
+        description = ''
+          Hostname of EWS server.
+        '';
+      };
+      serviceDescriptionURL = mkOption {
+        type = types.str;
+        example = "https://ews.example.org/ews/exchange.asmx";
+        description = ''
+          URL to EWS service description.
+        '';
+      };
+
+      authentication = authenticationOption;
+
+      tls = mkOption {
+        type = tlsModule;
+        default = { };
+        description = ''
+          Configuration for secure connections.
+        '';
+      };
+    };
+  };
+
   maildirModule = types.submodule (
     { config, ... }:
     {
@@ -519,6 +548,14 @@ let
           default = null;
           description = ''
             The SMTP configuration to use for this account.
+          '';
+        };
+
+        ews = mkOption {
+          type = types.nullOr ewsModule;
+          default = null;
+          description = ''
+            The EWS configuration to use for this account.
           '';
         };
 

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -183,6 +183,30 @@ let
           3;
       "mail.smtpserver.smtp_${id}.username" = account.userName;
     }
+    // optionalAttrs (account.ews != null) {
+      "mail.smtpserver.ews_${id}.type" = "ews";
+      "mail.outgoingserver.ews_${id}.auth_method" = 3;
+      "mail.outgoingserver.ews_${id}.ews_url" = account.ews.serviceDescriptionURL;
+      "mail.outgoingserver.ews_${id}.key" = "ews_${id}";
+      "mail.outgoingserver.ews_${id}.username" = account.userName;
+
+      "mail.server.server_${id}.directory" = "${thunderbirdProfilesPath}/${profile.name}/Mail/${id}";
+      "mail.server.server_${id}.directory-rel" = "[ProfD]Mail/${id}";
+      "mail.server.server_${id}.hostname" = account.ews.host;
+      "mail.server.server_${id}.ews_url" = account.ews.serviceDescriptionURL;
+      "mail.server.server_${id}.login_at_startup" = true;
+      "mail.server.server_${id}.name" = account.name;
+      "mail.server.server_${id}.port" = 443;
+      "mail.server.server_${id}.socketType" =
+        if !account.ews.tls.enable then
+          0
+        else if account.ews.tls.useStartTls then
+          2
+        else
+          3;
+      "mail.server.server_${id}.type" = "ews";
+      "mail.server.server_${id}.userName" = account.userName;
+    }
     // builtins.foldl' (a: b: a // b) { } (map (address: toThunderbirdSMTP account address) addresses)
     // optionalAttrs (account.smtp != null && account.primary) {
       "mail.smtp.defaultserver" = "smtp_${id}";
@@ -926,6 +950,8 @@ in
                 flatten (map getAliasesWithId emailAccounts);
               smtp = accountsSmtp ++ aliasesSmtp;
 
+              ews = filter (a: a.ews != null) emailAccounts;
+
               feedAccounts = addId (attrValues profile.feedAccounts);
 
               # NOTE: `calendarAccounts` not added here as calendars are not part of the 'Mail' view
@@ -982,8 +1008,10 @@ in
                     "calendar.list.sortOrder" = concatStringsSep " " orderedCalendarAccounts;
                   })
 
-                  (optionalAttrs (length smtp != 0) {
-                    "mail.smtpservers" = concatStringsSep "," (map (a: "smtp_${a.id}") smtp);
+                  (optionalAttrs (length smtp != 0 || length ews != 0) {
+                    "mail.smtpservers" = concatStringsSep "," (
+                      (map (a: "smtp_${a.id}") smtp) ++ (map (a: "ews_${a.id}") ews)
+                    );
                   })
 
                   { "mail.openpgp.allow_external_gnupg" = profile.withExternalGnupg; }


### PR DESCRIPTION
Add configuration options for EWS in Thunderbird which is supported since version 145.

### Description

Related to #8011: Allows configuration of EWS accounts for Thunderbird.

I am not sure if there is anything that could be tested meaningfully or that may break backwards compatibility so any feedback would be appreciated.

Example Configuration for Outlook:
```
accounts.email.accounts.hm-mail = {
  address = "home.manager@outlook.com";
  realName = "Home Manager";
  userName = "home.manager@outlook.com";
  ews = {
    host = "outlook.office365.com";
    serviceDescriptionURL = "https://outlook.office365.com/ews/exchange.asmx";
    tls.enable = true;
  };
  thunderbird = {
    enable = true;
    settings = id: {
      "mail.outgoingserver.ews_${id}.auth_method" = 10;
      "mail.server.server_${id}.authMethod" = 10;
    };
  };
};
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```