### PR TITLE
proton-pass-agent: adapt the services to match the documentation

### DIFF
--- a/modules/services/proton-pass-agent.nix
+++ b/modules/services/proton-pass-agent.nix
@@ -93,6 +93,7 @@ in
         };
         Service = {
           ExecStart = lib.concatStringsSep " " cmd;
+          Restart = "on-failure";
           KeyringMode = "shared";
         };
       };
@@ -105,10 +106,7 @@ in
             "-c"
             (lib.concatStringsSep " " cmd)
           ];
-          KeepAlive = {
-            Crashed = true;
-            SuccessfulExit = false;
-          };
+          KeepAlive = true;
           ProcessType = "Background";
           RunAtLoad = true;
           StandardOutPath = "${config.home.homeDirectory}/Library/Logs/Proton Pass CLI/ssh-agent-stdout.log";

--- a/tests/modules/services/proton-pass-agent/basic-service-expected.plist
+++ b/tests/modules/services/proton-pass-agent/basic-service-expected.plist
@@ -3,12 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>KeepAlive</key>
-	<dict>
-		<key>Crashed</key>
-		<true/>
-		<key>SuccessfulExit</key>
-		<false/>
-	</dict>
+	<true/>
 	<key>Label</key>
 	<string>org.nix-community.home.proton-pass-agent</string>
 	<key>ProcessType</key>

--- a/tests/modules/services/proton-pass-agent/basic-service-expected.service
+++ b/tests/modules/services/proton-pass-agent/basic-service-expected.service
@@ -4,6 +4,7 @@ WantedBy=default.target
 [Service]
 ExecStart=@proton-pass-cli@/bin/pass-cli ssh-agent start --socket-path %t/proton-pass-agent/socket
 KeyringMode=shared
+Restart=on-failure
 
 [Unit]
 Description=Proton Pass SSH agent

--- a/tests/modules/services/proton-pass-agent/full-service-expected.plist
+++ b/tests/modules/services/proton-pass-agent/full-service-expected.plist
@@ -3,12 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>KeepAlive</key>
-	<dict>
-		<key>Crashed</key>
-		<true/>
-		<key>SuccessfulExit</key>
-		<false/>
-	</dict>
+	<true/>
 	<key>Label</key>
 	<string>org.nix-community.home.proton-pass-agent</string>
 	<key>ProcessType</key>

--- a/tests/modules/services/proton-pass-agent/full-service-expected.service
+++ b/tests/modules/services/proton-pass-agent/full-service-expected.service
@@ -4,6 +4,7 @@ WantedBy=default.target
 [Service]
 ExecStart=@proton-pass-cli@/bin/pass-cli ssh-agent start --socket-path %t/proton-pass-agent/socket --share-id 123456789 --vault-name MySshKeyVault --refresh-interval 7200 --create-new-identities MySshKeyVault
 KeyringMode=shared
+Restart=on-failure
 
 [Unit]
 Description=Proton Pass SSH agent


### PR DESCRIPTION


### Description

Adapts the defined services (both systemd and launchd) to match the examples in the documentation. See https://protonpass.github.io/pass-cli/commands/ssh-agent/#setting-ssh_auth_sock-automatically-on-login section 'Starting the daemon automatically on login'.

Enhances service stability by reducing manual restarts, reducing operational disruption. Especially, on MacOS. I still face issues on Linux with the keyring, which usually involves a manual login and restarting the service after reboot.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
