### PR TITLE
ci: limit number of automated reviewer requests

### DIFF
--- a/lib/python/manage-reviewers.py
+++ b/lib/python/manage-reviewers.py
@@ -13,6 +13,9 @@ import subprocess
 import sys
 from typing import Final
 
+MAX_REVIEWERS: Final[int] = 6
+MAX_MAINTAINERS_THRESHOLD: Final[int] = 10
+
 # Configure logging to output to stderr
 logging.basicConfig(
     level=logging.INFO,
@@ -268,21 +271,36 @@ def main() -> None:
     # --- 3. Determine new reviewers to add ---
     reviewers_to_add: set[str] = set()
     if not no_changed_files and maintainers:
-        users_to_exclude = {args.pr_author} | past_reviewers | pending_reviewers | manually_removed
-        potential_reviewers = maintainers - users_to_exclude
+        if len(maintainers) > MAX_MAINTAINERS_THRESHOLD:
+            logging.info(
+                "Number of maintainers (%d) exceeds threshold (%d). Skipping automated reviewer requests for this large PR.",
+                len(maintainers),
+                MAX_MAINTAINERS_THRESHOLD,
+            )
+        else:
+            users_to_exclude = {args.pr_author} | past_reviewers | pending_reviewers | manually_removed
+            potential_reviewers = maintainers - users_to_exclude
 
-        reviewers_to_add = {
-            user for user in potential_reviewers if is_collaborator(args.owner, args.repo, user)
-        }
+            reviewers_to_add = {
+                user for user in potential_reviewers if is_collaborator(args.owner, args.repo, user)
+            }
 
-        non_collaborators = potential_reviewers - reviewers_to_add
-        if non_collaborators:
-            logging.warning("Ignoring non-collaborators: %s", ", ".join(non_collaborators))
+            non_collaborators = potential_reviewers - reviewers_to_add
+            if non_collaborators:
+                logging.warning("Ignoring non-collaborators: %s", ", ".join(non_collaborators))
 
-        manually_removed_maintainers = reviewers_to_add & manually_removed
-        if manually_removed_maintainers:
-            logging.info("Not re-adding manually removed maintainers: %s", ", ".join(manually_removed_maintainers))
-            reviewers_to_add -= manually_removed
+            manually_removed_maintainers = reviewers_to_add & manually_removed
+            if manually_removed_maintainers:
+                logging.info("Not re-adding manually removed maintainers: %s", ", ".join(manually_removed_maintainers))
+                reviewers_to_add -= manually_removed
+
+            if len(reviewers_to_add) > MAX_REVIEWERS:
+                logging.info(
+                    "Limiting reviewers to add from %d to %d.",
+                    len(reviewers_to_add),
+                    MAX_REVIEWERS,
+                )
+                reviewers_to_add = set(list(sorted(reviewers_to_add))[:MAX_REVIEWERS])
 
     if reviewers_to_add:
         if args.dry_run:


### PR DESCRIPTION
Been meaning to do this to avoid tagging spam on treewides / accidental mass pings. Following the limits set in nixpkgs as example. 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
