### PR TITLE
services.darkman: add unified scripts option

### DIFF
--- a/modules/services/darkman.nix
+++ b/modules/services/darkman.nix
@@ -81,6 +81,41 @@ in
       '';
     };
 
+    scripts = lib.mkOption {
+      type = types.attrsOf (
+        types.oneOf [
+          types.path
+          types.lines
+        ]
+      );
+      default = { };
+      example = lib.literalExpression ''
+        {
+          gtk-theme = '''
+            if [ "$1" = "dark" ]; then
+              ''${pkgs.dconf}/bin/dconf write \
+                  /org/gnome/desktop/interface/color-scheme "'prefer-dark'"
+            else
+              ''${pkgs.dconf}/bin/dconf write \
+                  /org/gnome/desktop/interface/color-scheme "'prefer-light'"
+            fi
+          ''';
+        }
+      '';
+      description = ''
+        Scripts to run when switching modes, placed in
+        {file}`$XDG_DATA_HOME/darkman/`. Each script receives the new mode
+        (`dark` or `light`) as its first argument, allowing a single script
+        to handle both modes.
+
+        Multiline strings are interpreted as Bash shell scripts and a shebang
+        is not required.
+
+        These scripts take precedence over legacy scripts of the same name in
+        {option}`darkModeScripts` and {option}`lightModeScripts`.
+      '';
+    };
+
     darkModeScripts = scriptsOptionType "dark";
 
     lightModeScripts = scriptsOptionType "light";
@@ -100,6 +135,7 @@ in
     };
 
     xdg.dataFile = lib.mkMerge [
+      (mkIf (cfg.scripts != { }) (generateScripts "darkman" cfg.scripts))
       (mkIf (cfg.darkModeScripts != { }) (generateScripts "dark-mode.d" cfg.darkModeScripts))
       (mkIf (cfg.lightModeScripts != { }) (generateScripts "light-mode.d" cfg.lightModeScripts))
     ];

--- a/tests/modules/services/darkman/default.nix
+++ b/tests/modules/services/darkman/default.nix
@@ -3,4 +3,5 @@
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   darkman-basic-configuration = ./basic-configuration.nix;
   darkman-no-configuration = ./no-configuration.nix;
+  darkman-unified-scripts = ./unified-scripts.nix;
 }

--- a/tests/modules/services/darkman/unified-scripts.nix
+++ b/tests/modules/services/darkman/unified-scripts.nix
@@ -1,0 +1,34 @@
+{ config, pkgs, ... }:
+
+{
+  services.darkman = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "darkman";
+      outPath = "@darkman@";
+    };
+
+    scripts.color-scheme = ''
+      if [ "$1" = "dark" ]; then
+        dconf write /org/gnome/desktop/interface/color-scheme "'prefer-dark'"
+      else
+        dconf write /org/gnome/desktop/interface/color-scheme "'prefer-light'"
+      fi
+    '';
+  };
+
+  nmt.script = ''
+    scriptFile=$(normalizeStorePaths home-files/.local/share/darkman/color-scheme)
+
+    assertFileExists $scriptFile
+    assertFileContent $scriptFile ${builtins.toFile "expected" ''
+      #!/nix/store/00000000000000000000000000000000-bash/bin/bash
+      if [ "$1" = "dark" ]; then
+        dconf write /org/gnome/desktop/interface/color-scheme "'prefer-dark'"
+      else
+        dconf write /org/gnome/desktop/interface/color-scheme "'prefer-light'"
+      fi
+
+    ''}
+  '';
+}


### PR DESCRIPTION
### Description

Add a `scripts` option that places scripts in `$XDG_DATA_HOME/darkman/`, darkman's unified script interface. The legacy `darkModeScripts` and `lightModeScripts` options remain supported.

Closes #8940

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
