### PR TITLE
xdg: add support for local bin path

### DIFF
--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -7,6 +7,7 @@
 
 let
   inherit (lib)
+    mkAfter
     mkOptionDefault
     mkIf
     mkOption
@@ -25,6 +26,7 @@ let
   defaultConfigHome = "${config.home.homeDirectory}/.config";
   defaultDataHome = "${config.home.homeDirectory}/.local/share";
   defaultStateHome = "${config.home.homeDirectory}/.local/state";
+  defaultBinHome = "${config.home.homeDirectory}/.local/bin";
 
   getEnvFallback =
     name: fallback:
@@ -98,6 +100,17 @@ in
       '';
     };
 
+    binHome = mkOption {
+      type = types.path;
+      defaultText = "~/.local/bin";
+      apply = toString;
+      description = ''
+        Absolute path to directory holding user-specific executables.
+
+        Sets `XDG_BIN_HOME` for the user if `xdg.enable` is set `true`.
+      '';
+    };
+
     stateFile = mkOption {
       type = fileType "xdg.stateFile" "<varname>xdg.stateHome</varname>" cfg.stateHome;
       default = { };
@@ -117,12 +130,22 @@ in
         Sets `XDG_STATE_HOME` for the user if `xdg.enable` is set `true`.
       '';
     };
+
+    localBinInPath = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to add {option}`xdg.binHome` to {env}`PATH` when
+        {option}`xdg.enable` is enabled.
+      '';
+    };
   };
 
   config = lib.mkMerge [
     (
       let
         variables = {
+          XDG_BIN_HOME = cfg.binHome;
           XDG_CACHE_HOME = cfg.cacheHome;
           XDG_CONFIG_HOME = cfg.configHome;
           XDG_DATA_HOME = cfg.dataHome;
@@ -133,10 +156,13 @@ in
         xdg.cacheHome = mkOptionDefault defaultCacheHome;
         xdg.configHome = mkOptionDefault defaultConfigHome;
         xdg.dataHome = mkOptionDefault defaultDataHome;
+        xdg.binHome = mkOptionDefault defaultBinHome;
         xdg.stateHome = mkOptionDefault defaultStateHome;
 
         home.sessionVariables = variables;
         systemd.user.sessionVariables = variables;
+
+        home.sessionPath = mkIf cfg.localBinInPath (mkAfter [ cfg.binHome ]);
       }
     )
 
@@ -145,6 +171,7 @@ in
       xdg.cacheHome = mkOptionDefault (getEnvFallback "XDG_CACHE_HOME" defaultCacheHome);
       xdg.configHome = mkOptionDefault (getEnvFallback "XDG_CONFIG_HOME" defaultConfigHome);
       xdg.dataHome = mkOptionDefault (getEnvFallback "XDG_DATA_HOME" defaultDataHome);
+      xdg.binHome = mkOptionDefault (getEnvFallback "XDG_BIN_HOME" defaultBinHome);
       xdg.stateHome = mkOptionDefault (getEnvFallback "XDG_STATE_HOME" defaultStateHome);
     })
 
@@ -153,6 +180,7 @@ in
       xdg.cacheHome = mkOptionDefault defaultCacheHome;
       xdg.configHome = mkOptionDefault defaultConfigHome;
       xdg.dataHome = mkOptionDefault defaultDataHome;
+      xdg.binHome = mkOptionDefault defaultBinHome;
       xdg.stateHome = mkOptionDefault defaultStateHome;
     })
 

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -12,6 +12,7 @@ let
     export LOCALE_ARCHIVE_2_27="${config.i18n.glibcLocales}/lib/locale/locale-archive"
     export V1="v1"
     export V2="v2-v1"
+    export XDG_BIN_HOME="/home/hm-user/.local/bin"
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
@@ -26,6 +27,7 @@ let
 
     export V1="v1"
     export V2="v2-v1"
+    export XDG_BIN_HOME="/home/hm-user/.local/bin"
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"

--- a/tests/modules/misc/xdg/default.nix
+++ b/tests/modules/misc/xdg/default.nix
@@ -4,6 +4,8 @@
   xdg-mime-disabled = ./mime-disabled.nix;
   xdg-autostart = ./autostart.nix;
   xdg-autostart-readonly = ./autostart-readonly.nix;
+  xdg-local-bin-in-path = ./local-bin-in-path.nix;
+  xdg-local-bin-not-in-path = ./local-bin-not-in-path.nix;
   xdg-user-dirs-mixed = ./user-dirs-mixed.nix;
   xdg-user-dirs-null = ./user-dirs-null.nix;
   xdg-user-dirs-short = ./user-dirs-short.nix;

--- a/tests/modules/misc/xdg/local-bin-in-path.nix
+++ b/tests/modules/misc/xdg/local-bin-in-path.nix
@@ -1,0 +1,10 @@
+{
+  xdg.enable = true;
+  xdg.localBinInPath = true;
+
+  nmt.script = ''
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+      'export PATH="/home/hm-user/.local/bin''${PATH:+:}$PATH"'
+  '';
+}

--- a/tests/modules/misc/xdg/local-bin-not-in-path.nix
+++ b/tests/modules/misc/xdg/local-bin-not-in-path.nix
@@ -1,0 +1,10 @@
+{
+  xdg.localBinInPath = false;
+  xdg.enable = true;
+
+  nmt.script = ''
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh \
+      '^export PATH="/home/hm-user/\.local/bin'
+  '';
+}

--- a/tests/modules/misc/xdg/system-dirs.nix
+++ b/tests/modules/misc/xdg/system-dirs.nix
@@ -21,6 +21,7 @@
       assertFileExists $envFile
       assertFileContent $envFile ${pkgs.writeText "expected" ''
         LOCALE_ARCHIVE_2_27=${config.i18n.glibcLocales}/lib/locale/locale-archive
+        XDG_BIN_HOME=/home/hm-user/.local/bin
         XDG_CACHE_HOME=/home/hm-user/.cache
         XDG_CONFIG_DIRS=/etc/xdg:/foo/bar''${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}
         XDG_CONFIG_HOME=/home/hm-user/.config

--- a/tests/modules/systemd/session-variables.nix
+++ b/tests/modules/systemd/session-variables.nix
@@ -13,6 +13,7 @@
       LOCALE_ARCHIVE_2_27=${config.i18n.glibcLocales}/lib/locale/locale-archive
       V_int=1
       V_str=2
+      XDG_BIN_HOME=/home/hm-user/.local/bin
       XDG_CACHE_HOME=/home/hm-user/.cache
       XDG_CONFIG_HOME=/home/hm-user/.config
       XDG_DATA_HOME=/home/hm-user/.local/share


### PR DESCRIPTION
### Description

Closes #3357.

This adds `xdg.localBinInPath`, a boolean option that controls whether
Home Manager prepends `$HOME/.local/bin` to `PATH` when `xdg.enable` is
enabled.

The option defaults to `false`, preserving the old behavior by default
while allowing users to opt in with `xdg.localBinInPath = true;`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted nixf-diagnose --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
