### PR TITLE
retroarch: add core settings

### DIFF
--- a/modules/programs/retroarch.nix
+++ b/modules/programs/retroarch.nix
@@ -6,8 +6,6 @@
 }:
 let
   cfg = config.programs.retroarch;
-
-  enabledCores = lib.filterAttrs (_: core: core.enable) cfg.cores;
 in
 {
   meta.maintainers = [
@@ -77,15 +75,63 @@ in
         for available configuration options.
       '';
     };
+
+    coreSettings = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = {
+        mgba_solar_sensor_level = "0";
+        snes9x_aspect = "4:3";
+        snes9x_overscan = "enabled";
+        snes9x_region = "auto";
+      };
+      description = ''
+        Core-specific configuration settings.
+        Keys are often prefixed with the core's name.
+
+        See <https://docs.libretro.com/guides/core-list/>
+        for available configuration options.
+      '';
+    };
   };
 
-  config = lib.mkIf cfg.enable {
-    programs.retroarch.finalPackage = (
-      cfg.package.wrapper {
-        inherit (cfg) settings;
-        cores = lib.mapAttrsToList (_: core: core.package) enabledCores;
+  config = lib.mkIf cfg.enable (
+    let
+      attrsToText = lib.flip lib.pipe [
+        (lib.mapAttrsToList (n: v: "${n} = \"${v}\""))
+        lib.naturalSort
+        lib.concatLines
+      ];
+      configDir =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "Library/Application Support/RetroArch"
+        else
+          "${config.xdg.configHome}/retroarch";
+      enabledCores = lib.filterAttrs (_: core: core.enable) cfg.cores;
+    in
+    lib.mkMerge [
+      {
+        programs.retroarch.finalPackage = (
+          cfg.package.wrapper {
+            inherit (cfg) settings;
+            cores = lib.mapAttrsToList (_: core: core.package) enabledCores;
+          }
+        );
+        home.packages = [ cfg.finalPackage ];
       }
-    );
-    home.packages = [ cfg.finalPackage ];
-  };
+      (lib.mkIf (cfg.coreSettings != { }) {
+        assertions = [
+          {
+            assertion = cfg.settings.global_core_options or null == "true";
+            message = ''
+              `programs.retroarch.settings.global_core_options` must be set to "true"
+              when `programs.retroarch.coreSettings` is defined.
+            '';
+          }
+        ];
+        home.file."${configDir}/retroarch-core-options.cfg".text = attrsToText cfg.coreSettings;
+        programs.retroarch.settings.global_core_options = lib.mkDefault "true";
+      })
+    ]
+  );
 }

--- a/modules/programs/retroarch.nix
+++ b/modules/programs/retroarch.nix
@@ -8,6 +8,16 @@ let
   cfg = config.programs.retroarch;
 
   enabledCores = lib.filterAttrs (_: core: core.enable) cfg.cores;
+
+  toKeyValue = lib.generators.toKeyValue {
+    mkKeyValue = lib.generators.mkKeyValueDefault { mkValueString = v: "\"${v}\""; } " = ";
+  };
+
+  configDir =
+    if (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) then
+      "Library/Application Support/RetroArch"
+    else
+      "${lib.removePrefix "${config.home.homeDirectory}/" config.xdg.configHome}/retroarch";
 in
 {
   meta.maintainers = [
@@ -71,7 +81,11 @@ in
         video_fullscreen = "true";
       };
       description = ''
-        RetroArch configuration settings.
+        RetroArch configuration settings written to `retroarch.cfg`.
+
+        Because the configuration file is managed declaratively, RetroArch is
+        configured to not overwrite it on exit. Any changes made through the
+        RetroArch UI will therefore not be persisted.
 
         See <https://github.com/libretro/RetroArch/blob/master/retroarch.cfg>
         for available configuration options.
@@ -80,12 +94,14 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    programs.retroarch.finalPackage = (
-      cfg.package.wrapper {
-        inherit (cfg) settings;
-        cores = lib.mapAttrsToList (_: core: core.package) enabledCores;
-      }
-    );
+    programs.retroarch.settings.config_save_on_exit = lib.mkDefault "false";
+
+    programs.retroarch.finalPackage = cfg.package.wrapper {
+      cores = lib.mapAttrsToList (_: core: core.package) enabledCores;
+    };
+
     home.packages = [ cfg.finalPackage ];
+
+    home.file."${configDir}/retroarch.cfg".text = toKeyValue cfg.settings;
   };
 }

--- a/modules/programs/retroarch.nix
+++ b/modules/programs/retroarch.nix
@@ -18,6 +18,105 @@ let
       "Library/Application Support/RetroArch"
     else
       "${lib.removePrefix "${config.home.homeDirectory}/" config.xdg.configHome}/retroarch";
+
+  # RetroArch reads directory settings at runtime, so they must be absolute.
+  absoluteConfigDir = "${config.home.homeDirectory}/${configDir}";
+
+  mkKeyValueOption =
+    description:
+    lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      inherit description;
+    };
+
+  overrideOptions = {
+    options = {
+      settingsOverrides = mkKeyValueOption ''
+        Overrides of global `retroarch.cfg` settings, written as a `.cfg`
+        override file. Only the settings that differ from the global
+        configuration need to be specified.
+
+        See <https://docs.libretro.com/guides/overrides/> for details.
+      '';
+
+      inputRemaps = mkKeyValueOption ''
+        Input remappings, written as a `.rmp` remap file under the
+        `config/remaps` directory. These override the input bindings from
+        `retroarch.cfg` when the corresponding content is loaded.
+
+        See <https://docs.libretro.com/guides/overrides/> for details.
+      '';
+    };
+  };
+
+  coreType = lib.types.submodule (
+    { name, ... }:
+    {
+      imports = [ overrideOptions ];
+      options = {
+        enable = lib.mkEnableOption "RetroArch core";
+
+        package = lib.mkPackageOption pkgs [ "libretro" name ] { };
+
+        options = mkKeyValueOption ''
+          Core options that configure this core's behavior.
+
+          These are merged with the options of all other cores into the
+          global `retroarch-core-options.cfg`. Keys are typically prefixed
+          with the core's name to avoid collisions.
+
+          These are the settings found under `Quick Menu -> Options`.
+
+          See <https://docs.libretro.com/guides/core-list/> for available
+          options.
+        '';
+
+        perContentDirectory = lib.mkOption {
+          type = lib.types.attrsOf (lib.types.submodule overrideOptions);
+          default = { };
+          description = ''
+            Overrides applied when loading content from a particular directory.
+            The attribute name is the content directory name. These take
+            precedence over the core-level overrides.
+
+            See <https://docs.libretro.com/guides/overrides/> for details.
+          '';
+        };
+
+        perGame = lib.mkOption {
+          type = lib.types.attrsOf (
+            lib.types.submodule {
+              imports = [ overrideOptions ];
+              options = {
+                options = mkKeyValueOption ''
+                  Game-specific core options, written as a `.opt` file. These
+                  take precedence over the core's `options`.
+
+                  See <https://docs.libretro.com/guides/overrides/> for
+                  details.
+                '';
+              };
+            }
+          );
+          default = { };
+          description = ''
+            Overrides applied when loading a particular game. The attribute
+            name is the game (content) name. These take precedence over the
+            per-content-directory overrides.
+
+            See <https://docs.libretro.com/guides/overrides/> for details.
+          '';
+        };
+      };
+    }
+  );
+
+  mkFileIfPresent =
+    path: attrs:
+    lib.optionalAttrs (attrs != { }) {
+      "${configDir}/${path}".text = toKeyValue attrs;
+    };
 in
 {
   meta.maintainers = [
@@ -40,24 +139,18 @@ in
     };
 
     cores = lib.mkOption {
-      type = lib.types.attrsOf (
-        lib.types.submodule (
-          { name, ... }:
-          {
-            options = {
-              enable = lib.mkEnableOption "RetroArch core";
-              package = lib.mkPackageOption pkgs [ "libretro" name ] { };
-            };
-          }
-        )
-      );
+      type = lib.types.attrsOf coreType;
       default = { };
       example = lib.literalExpression ''
         {
-          mgba.enable = true;  # Uses pkgs.libretro.mgba
-          snes9x = {
+          mGBA.enable = true;  # Uses pkgs.libretro.mgba
+          "Snes9x - Current" = {
             enable = true;
-            package = pkgs.libretro.snes9x2010;
+            package = pkgs.libretro.snes9x;
+            options = {
+              snes9x_aspect = "4:3";
+              snes9x_region = "auto";
+            };
           };
           custom-core = {
             enable = true;
@@ -67,6 +160,10 @@ in
       '';
       description = ''
         RetroArch cores to enable. You can provide custom core packages.
+
+        The attribute name must match the core's directory name as reported by
+        RetroArch (its `library_name`), since it is used to locate the
+        per-core options and override files under `config/<name>`.
       '';
     };
 
@@ -94,14 +191,46 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    programs.retroarch.settings.config_save_on_exit = lib.mkDefault "false";
+    programs.retroarch = {
+      settings = {
+        config_save_on_exit = lib.mkDefault "false";
+        game_specific_options = lib.mkDefault "true";
+        global_core_options = lib.mkDefault "true";
+        remap_save_on_exit = lib.mkDefault "false";
+        rgui_config_directory = lib.mkDefault "${absoluteConfigDir}/config";
+        input_remapping_directory = lib.mkDefault "${absoluteConfigDir}/config/remaps";
+      };
 
-    programs.retroarch.finalPackage = cfg.package.wrapper {
-      cores = lib.mapAttrsToList (_: core: core.package) enabledCores;
+      finalPackage = cfg.package.wrapper {
+        cores = lib.mapAttrsToList (_: core: core.package) enabledCores;
+      };
     };
 
-    home.packages = [ cfg.finalPackage ];
+    home = {
+      packages = [ cfg.finalPackage ];
 
-    home.file."${configDir}/retroarch.cfg".text = toKeyValue cfg.settings;
+      file = {
+        "${configDir}/retroarch.cfg".text = toKeyValue cfg.settings;
+        "${configDir}/retroarch-core-options.cfg".text = toKeyValue (
+          lib.concatMapAttrs (_: core: core.options) enabledCores
+        );
+      }
+      // lib.concatMapAttrs (
+        name: core:
+        mkFileIfPresent "config/${name}/${name}.cfg" core.settingsOverrides
+        // mkFileIfPresent "config/remaps/${name}/${name}.rmp" core.inputRemaps
+        // lib.concatMapAttrs (
+          contentDir: scope:
+          mkFileIfPresent "config/${name}/${contentDir}.cfg" scope.settingsOverrides
+          // mkFileIfPresent "config/remaps/${name}/${contentDir}.rmp" scope.inputRemaps
+        ) core.perContentDirectory
+        // lib.concatMapAttrs (
+          game: scope:
+          mkFileIfPresent "config/${name}/${game}.opt" scope.options
+          // mkFileIfPresent "config/${name}/${game}.cfg" scope.settingsOverrides
+          // mkFileIfPresent "config/remaps/${name}/${game}.rmp" scope.inputRemaps
+        ) core.perGame
+      ) enabledCores;
+    };
   };
 }

--- a/tests/modules/programs/retroarch/by-name/core-options.nix
+++ b/tests/modules/programs/retroarch/by-name/core-options.nix
@@ -1,0 +1,32 @@
+{ pkgs, ... }:
+{
+  programs.retroarch = {
+    enable = true;
+    cores."Snes9x - Current" = {
+      enable = true;
+      package = pkgs.libretro.snes9x2010;
+      options = {
+        snes9x_aspect = "4:3";
+        snes9x_region = "auto";
+      };
+      perGame."Chrono Trigger".options = {
+        snes9x_region = "ntsc";
+      };
+    };
+  };
+
+  nmt.script = ''
+    retroarchConfig="home-files/.config/retroarch/retroarch.cfg"
+    assertFileContains "$retroarchConfig" 'game_specific_options = "true"'
+    assertFileContains "$retroarchConfig" 'global_core_options = "true"'
+
+    coreOptions="home-files/.config/retroarch/retroarch-core-options.cfg"
+    assertFileExists "$coreOptions"
+    assertFileContains "$coreOptions" 'snes9x_aspect = "4:3"'
+    assertFileContains "$coreOptions" 'snes9x_region = "auto"'
+
+    gameOptions="home-files/.config/retroarch/config/Snes9x - Current/Chrono Trigger.opt"
+    assertFileExists "$gameOptions"
+    assertFileContains "$gameOptions" 'snes9x_region = "ntsc"'
+  '';
+}

--- a/tests/modules/programs/retroarch/by-name/core-overrides.nix
+++ b/tests/modules/programs/retroarch/by-name/core-overrides.nix
@@ -1,0 +1,72 @@
+{ config, pkgs, ... }:
+let
+  configDir = "home-files/.config/retroarch";
+  absoluteConfigDir = "${config.xdg.configHome}/retroarch";
+in
+{
+  programs.retroarch = {
+    enable = true;
+    cores."Snes9x - Current" = {
+      enable = true;
+      package = pkgs.libretro.snes9x2010;
+      settingsOverrides = {
+        video_fullscreen = "true";
+      };
+      inputRemaps = {
+        input_player1_a_btn = "1";
+      };
+      perContentDirectory."SNES" = {
+        settingsOverrides = {
+          video_smooth = "true";
+        };
+        inputRemaps = {
+          input_player1_b_btn = "0";
+        };
+      };
+      perGame."Chrono Trigger" = {
+        settingsOverrides = {
+          video_scale = "5.0";
+        };
+        inputRemaps = {
+          input_player1_x_btn = "9";
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    retroarchConfig="${configDir}/retroarch.cfg"
+    assertFileContains "$retroarchConfig" 'remap_save_on_exit = "false"'
+    assertFileContains "$retroarchConfig" \
+      'rgui_config_directory = "${absoluteConfigDir}/config"'
+    assertFileContains "$retroarchConfig" \
+      'input_remapping_directory = "${absoluteConfigDir}/config/remaps"'
+
+    coreDir="${configDir}/config/Snes9x - Current"
+    remapDir="${configDir}/config/remaps/Snes9x - Current"
+
+    coreOverride="$coreDir/Snes9x - Current.cfg"
+    assertFileExists "$coreOverride"
+    assertFileContains "$coreOverride" 'video_fullscreen = "true"'
+
+    directoryOverride="$coreDir/SNES.cfg"
+    assertFileExists "$directoryOverride"
+    assertFileContains "$directoryOverride" 'video_smooth = "true"'
+
+    gameOverride="$coreDir/Chrono Trigger.cfg"
+    assertFileExists "$gameOverride"
+    assertFileContains "$gameOverride" 'video_scale = "5.0"'
+
+    coreRemap="$remapDir/Snes9x - Current.rmp"
+    assertFileExists "$coreRemap"
+    assertFileContains "$coreRemap" 'input_player1_a_btn = "1"'
+
+    directoryRemap="$remapDir/SNES.rmp"
+    assertFileExists "$directoryRemap"
+    assertFileContains "$directoryRemap" 'input_player1_b_btn = "0"'
+
+    gameRemap="$remapDir/Chrono Trigger.rmp"
+    assertFileExists "$gameRemap"
+    assertFileContains "$gameRemap" 'input_player1_x_btn = "9"'
+  '';
+}

--- a/tests/modules/programs/retroarch/by-name/core-settings.nix
+++ b/tests/modules/programs/retroarch/by-name/core-settings.nix
@@ -1,0 +1,20 @@
+_: {
+  programs.retroarch = {
+    enable = true;
+    coreSettings = {
+      snes9x_aspect = "4:3";
+      snes9x_overscan = "enabled";
+      snes9x_region = "auto";
+      mgba_solar_sensor_level = "0";
+    };
+  };
+
+  nmt.script = ''
+    coreOptionsFile=home-files/.config/retroarch/retroarch-core-options.cfg
+    assertFileExists "$coreOptionsFile"
+    assertFileContains "$coreOptionsFile" 'mgba_solar_sensor_level = "0"'
+    assertFileContains "$coreOptionsFile" 'snes9x_aspect = "4:3"'
+    assertFileContains "$coreOptionsFile" 'snes9x_overscan = "enabled"'
+    assertFileContains "$coreOptionsFile" 'snes9x_region = "auto"'
+  '';
+}

--- a/tests/modules/programs/retroarch/by-name/cores.nix
+++ b/tests/modules/programs/retroarch/by-name/cores.nix
@@ -1,7 +1,5 @@
 { config, pkgs, ... }:
 {
-  imports = [ ./stubs.nix ];
-
   programs.retroarch = {
     enable = true;
     cores = {

--- a/tests/modules/programs/retroarch/by-name/settings.nix
+++ b/tests/modules/programs/retroarch/by-name/settings.nix
@@ -1,7 +1,4 @@
-{ pkgs, ... }:
-{
-  imports = [ ./stubs.nix ];
-
+_: {
   programs.retroarch = {
     enable = true;
     settings = {

--- a/tests/modules/programs/retroarch/by-name/settings.nix
+++ b/tests/modules/programs/retroarch/by-name/settings.nix
@@ -1,6 +1,4 @@
-{
-  imports = [ ./stubs.nix ];
-
+_: {
   programs.retroarch = {
     enable = true;
     settings = {
@@ -13,11 +11,9 @@
   };
 
   nmt.script = ''
-    assertFileExists home-path/bin/retroarch
-    assertFileRegex home-path/bin/retroarch 'appendconfig.*declarative-retroarch\.cfg'
-
-    configFile=$(grep -aoP '/nix/store/[a-z0-9]+-declarative-retroarch\.cfg' $TESTED/home-path/bin/retroarch | head -1)
+    configFile="home-files/.config/retroarch/retroarch.cfg"
     assertFileExists "$configFile"
+    assertFileContains "$configFile" 'config_save_on_exit = "false"'
     assertFileContains "$configFile" 'input_max_users = "4"'
     assertFileContains "$configFile" 'menu_scale_factor = "0.950000"'
     assertFileContains "$configFile" 'netplay_nickname = "username"'

--- a/tests/modules/programs/retroarch/default.nix
+++ b/tests/modules/programs/retroarch/default.nix
@@ -1,5 +1,15 @@
 { lib, pkgs, ... }:
-lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
-  retroarch-cores = ./cores.nix;
-  retroarch-settings = ./settings.nix;
-}
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (
+  lib.pipe (builtins.readDir ./by-name) [
+    (lib.filterAttrs (_: kind: kind == "regular"))
+    (lib.mapAttrs' (
+      name: _:
+      lib.nameValuePair "retroarch-${lib.removeSuffix ".nix" name}" {
+        imports = [
+          (./by-name + "/${name}")
+          ./stubs.nix
+        ];
+      }
+    ))
+  ]
+)

--- a/tests/modules/programs/retroarch/default.nix
+++ b/tests/modules/programs/retroarch/default.nix
@@ -1,4 +1,14 @@
-{
-  retroarch-cores = ./cores.nix;
-  retroarch-settings = ./settings.nix;
-}
+{ lib, ... }:
+lib.pipe (builtins.readDir ./by-name) [
+  (lib.filterAttrs (_: kind: kind == "regular"))
+  (lib.mapAttrs' (
+    name: _:
+    lib.nameValuePair "retroarch-${lib.removeSuffix ".nix" name}" {
+      _file = ./by-name + "/${name}";
+      imports = [
+        (./by-name + "/${name}")
+        ./stubs.nix
+      ];
+    }
+  ))
+]

--- a/tests/modules/programs/retroarch/stubs.nix
+++ b/tests/modules/programs/retroarch/stubs.nix
@@ -1,6 +1,5 @@
 {
   config,
-  pkgs,
   realPkgs,
   ...
 }:

--- a/tests/modules/programs/retroarch/stubs.nix
+++ b/tests/modules/programs/retroarch/stubs.nix
@@ -1,20 +1,11 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 let
   mkRetroarchPackage =
-    {
-      cores,
-      settings,
-    }:
-    let
-      settingsFile = pkgs.writeText "declarative-retroarch.cfg" (
-        lib.concatStringsSep "\n" (lib.mapAttrsToList (name: value: ''${name} = "${value}"'') settings)
-      );
-    in
+    { cores }:
     config.lib.test.mkStubPackage {
       name = "retroarch";
       buildScript = ''
@@ -22,7 +13,7 @@ let
         cat > $out/bin/retroarch <<'EOF'
         #!/bin/sh
         # -L $out/lib/retroarch/cores
-        exec retroarch --appendconfig ${settingsFile} "$@"
+        exec retroarch "$@"
         EOF
         chmod 755 $out/bin/retroarch
         ${lib.concatMapStringsSep "\n" (core: ''


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Adds [per-core options](https://docs.libretro.com/guides/overrides/#core-options) and support for the [override hierarchy (per-core, per-dir, and per-game)](https://docs.libretro.com/guides/overrides/#override-configs) to `programs.retroarch`. Closes #9027.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
