### PR TITLE
glance: add darwin support

### DIFF
--- a/modules/services/glance.nix
+++ b/modules/services/glance.nix
@@ -74,15 +74,31 @@ in
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      (lib.hm.assertions.assertPlatform "services.glance" pkgs lib.platforms.linux)
-    ];
-
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-    xdg.configFile."glance/glance.yml".source = settingsFile;
+    xdg.configFile."glance/glance.yml" = {
+      source = settingsFile;
+      onChange = mkIf pkgs.stdenv.hostPlatform.isDarwin ''
+        /bin/launchctl kickstart -k "gui/$(id -u)/org.nix-community.home.glance" 2>/dev/null || true
+      '';
+    };
 
-    systemd.user.services.glance = lib.mkIf (cfg.package != null) {
+    launchd.agents.glance = mkIf (cfg.package != null) {
+      enable = true;
+      config = {
+        ProgramArguments = [
+          (getExe cfg.package)
+          "--config"
+          configFilePath
+        ];
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/glance.err";
+        StandardOutPath = "${config.home.homeDirectory}/Library/Logs/glance.log";
+      };
+    };
+
+    systemd.user.services.glance = mkIf (cfg.package != null) {
       Unit = {
         Description = "Glance feed dashboard server";
         PartOf = [ "graphical-session.target" ];

--- a/tests/modules/services/glance/default-settings.nix
+++ b/tests/modules/services/glance/default-settings.nix
@@ -1,12 +1,23 @@
+{ lib, pkgs, ... }:
+
 {
   services.glance.enable = true;
 
-  nmt.script = ''
-    configFile=home-files/.config/glance/glance.yml
-    serviceFile=home-files/.config/systemd/user/glance.service
-    serviceFile=$(normalizeStorePaths $serviceFile)
-
-    assertFileContent $configFile ${./glance-default-config.yml}
-    assertFileContent $serviceFile ${./glance.service}
-  '';
+  nmt.script = lib.mkMerge [
+    ''
+      configFile=home-files/.config/glance/glance.yml
+      assertFileContent $configFile ${./glance-default-config.yml}
+    ''
+    (lib.mkIf pkgs.stdenv.hostPlatform.isLinux ''
+      serviceFile=home-files/.config/systemd/user/glance.service
+      serviceFile=$(normalizeStorePaths $serviceFile)
+      assertFileContent $serviceFile ${./glance.service}
+    '')
+    (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin ''
+      serviceFile=LaunchAgents/org.nix-community.home.glance.plist
+      serviceFile=$(normalizeStorePaths $serviceFile)
+      assertFileExists "$serviceFile"
+      assertFileContent "$serviceFile" ${./glance.plist}
+    '')
+  ];
 }

--- a/tests/modules/services/glance/default.nix
+++ b/tests/modules/services/glance/default.nix
@@ -1,6 +1,4 @@
-{ lib, pkgs, ... }:
-
-lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+{
   glance-default-settings = ./default-settings.nix;
   glance-example-settings = ./example-settings.nix;
 }

--- a/tests/modules/services/glance/example-settings.nix
+++ b/tests/modules/services/glance/example-settings.nix
@@ -1,3 +1,4 @@
+{ lib, pkgs, ... }:
 {
   services.glance = {
     enable = true;
@@ -23,12 +24,21 @@
     };
   };
 
-  nmt.script = ''
-    configFile=home-files/.config/glance/glance.yml
-    serviceFile=home-files/.config/systemd/user/glance.service
-    serviceFile=$(normalizeStorePaths $serviceFile)
-
-    assertFileContent $configFile ${./glance-example-config.yml}
-    assertFileContent $serviceFile ${./glance.service}
-  '';
+  nmt.script = lib.mkMerge [
+    ''
+      configFile=home-files/.config/glance/glance.yml
+      assertFileContent $configFile ${./glance-example-config.yml}
+    ''
+    (lib.mkIf pkgs.stdenv.hostPlatform.isLinux ''
+      serviceFile=home-files/.config/systemd/user/glance.service
+      serviceFile=$(normalizeStorePaths $serviceFile)
+      assertFileContent $serviceFile ${./glance.service}
+    '')
+    (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin ''
+      serviceFile=LaunchAgents/org.nix-community.home.glance.plist
+      serviceFile=$(normalizeStorePaths $serviceFile)
+      assertFileExists "$serviceFile"
+      assertFileContent "$serviceFile" ${./glance.plist}
+    '')
+  ];
 }

--- a/tests/modules/services/glance/glance.plist
+++ b/tests/modules/services/glance/glance.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Label</key>
+	<string>org.nix-community.home.glance</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sh</string>
+		<string>-c</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec /nix/store/00000000000000000000000000000000-glance/bin/glance --config /home/hm-user/.config/glance/glance.yml</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/home/hm-user/Library/Logs/glance.err</string>
+	<key>StandardOutPath</key>
+	<string>/home/hm-user/Library/Logs/glance.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Adds Darwin support for `services.glance`. The `glance` package is a cross-platform Go binary, so there is no reason this shouldn't work on Darwin. I've also been running this module on Darwin for the last few weeks without issue.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
