### PR TITLE
programs.mcp: add typed server submodule with envFiles support

### DIFF
--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -12,6 +12,7 @@ rec {
   git = import ./git.nix { inherit lib; };
   gvariant = import ./gvariant.nix { inherit lib; };
   maintainers = import ./maintainers.nix;
+  mcp = import ./mcp.nix { inherit lib; };
   strings = import ./strings.nix { inherit lib; };
   types = import ./types.nix { inherit gvariant lib; };
 

--- a/modules/lib/mcp.nix
+++ b/modules/lib/mcp.nix
@@ -1,0 +1,210 @@
+{ lib }:
+
+let
+  /*
+    Checks whether a value is a file reference submodule.
+
+    A file reference has the shape `{ file = "/path/to/file"; }` and is used
+    to indicate that an environment variable's value should be read from a file
+    at runtime (e.g. via sops-nix or systemd credentials).
+
+    Type: isFileRef :: Value -> Bool
+  */
+  isFileRef = value: lib.isAttrs value && value ? file;
+
+  /*
+    Filters an `env` attrset to contain only literal (non-file-ref) values.
+
+    This is useful when a transform needs to produce two separate outputs:
+    one with the literal values and one with the file paths (for wrapping).
+
+    Type: literalEnv :: AttrSet -> AttrSet
+
+    Example:
+      literalEnv { API_KEY = "secret"; TOKEN.file = "/run/secrets/token"; }
+      => { API_KEY = "secret"; }
+  */
+  literalEnv = env: lib.filterAttrs (_: value: !isFileRef value) env;
+
+  /*
+    Extracts only the file paths from file-ref entries in an `env` attrset.
+
+    Returns a flat `attrsOf str` mapping variable names to their file paths.
+    Non-file-ref entries are excluded.
+
+    Type: fileRefEnv :: AttrSet -> AttrSet
+
+    Example:
+      fileRefEnv { API_KEY = "secret"; TOKEN.file = "/run/secrets/token"; }
+      => { TOKEN = "/run/secrets/token"; }
+  */
+  fileRefEnv = env: lib.mapAttrs (_: value: value.file) (lib.filterAttrs (_: isFileRef) env);
+
+  /*
+    Render an `env` attrset (literals + file refs) as a flat `attrsOf str`
+    by mapping file refs through `mkFileRef path` and leaving literals untouched.
+
+    Type: renderEnv :: (String -> String) -> AttrSet -> AttrSet
+
+    Example:
+      renderEnv (path: "{file:${path}}") {
+        API_KEY = "literal";
+        SESSION_TOKEN.file = "/run/secrets/token";
+      }
+      => { API_KEY = "literal"; SESSION_TOKEN = "{file:/run/secrets/token}"; }
+  */
+  renderEnv =
+    mkFileRef: env:
+    lib.mapAttrs (_: value: if isFileRef value then mkFileRef value.file else value) env;
+
+  /*
+    Wrap a local MCP server command in a shell script that reads file-backed
+    env values into the environment before executing the original process.
+    Compatible with file-based secret managers such as sops-nix or systemd
+    credentials. Reads file refs from `server.env`.
+
+    Type: mkEnvFilesWrapper :: { pkgs, name, server } -> Derivation
+  */
+  mkEnvFilesWrapper =
+    {
+      pkgs,
+      name,
+      server,
+    }:
+    let
+      files = fileRefEnv (server.env or { });
+    in
+    pkgs.writeShellScript "mcp-${name}-wrapper" ''
+      ${lib.concatStrings (
+        lib.mapAttrsToList (var: path: ''
+          if ${var}=$(cat ${lib.escapeShellArg path}); then
+            export ${var}
+          else
+            printf '[${name} wrapper ] Failed to read env var %s from %s\n' \
+              ${lib.escapeShellArg var} \
+              ${lib.escapeShellArg path} >&2
+          fi
+        '') files
+      )}
+      exec ${lib.escapeShellArgs ([ server.command ] ++ (server.args or [ ]))}
+    '';
+
+  /*
+    extraTransform factory: when the server has file refs in `env` and a
+    local `command`, replace `command` with a wrapper script that reads
+    those files at startup, reset `args` to `[ ]`, and drop the file refs
+    from `env` (leaving only literal entries).
+
+    When there is nothing to wrap, returns the server unchanged.
+
+    Type: wrapEnvFilesCommand :: { pkgs, name } -> AttrSet -> AttrSet
+  */
+  wrapEnvFilesCommand =
+    { pkgs, name }:
+    server:
+    let
+      files = fileRefEnv (server.env or { });
+      needsWrapping = files != { };
+    in
+    server
+    // lib.optionalAttrs needsWrapping {
+      command = mkEnvFilesWrapper { inherit pkgs name server; };
+      args = [ ];
+      env = literalEnv (server.env or { });
+    };
+
+  /*
+    Resolve the effective `enabled` state from a server config that may
+    have either an `enabled` or a `disabled` field (but not both).
+
+    Returns `null` if neither field is present, allowing callers to omit
+    the attribute from the output via the empty-value filter.
+
+    Type: resolveEnabled :: AttrSet -> Null | Bool
+  */
+  resolveEnabled =
+    server:
+    let
+      hasEnabled = server ? enabled && server.enabled != null;
+      hasDisabled = server ? disabled && server.disabled != null;
+    in
+    if hasEnabled then
+      server.enabled
+    else if hasDisabled then
+      !server.disabled
+    else
+      null;
+
+  /*
+    extraTransform that adds `type = "stdio" | "http"` based on whether the
+    server has a `url`.
+
+    Type: addType :: AttrSet -> AttrSet
+  */
+  addType =
+    server:
+    if server ? type then
+      server
+    else
+      server
+      // {
+        type = if server ? url && server.url != null then "http" else "stdio";
+      };
+in
+{
+  inherit
+    renderEnv
+    mkEnvFilesWrapper
+    wrapEnvFilesCommand
+    addType
+    ;
+
+  /*
+    Normalise an MCP server attribute set for consumption by a client
+    program. Performs only universal steps:
+
+    1. Resolve `enabled` from optional `enabled`/`disabled` fields.
+    2. Apply each function in `extraTransforms` to the server attrs, in
+       order. Transforms run before `mkFileRef`, `exclude` and the
+       empty-value filter, so a transform can still read attrs that will
+       be excluded and operate on the raw env shape (with file refs).
+    3. Render any remaining file refs in `env` through `mkFileRef path`.
+       Callers that consume file refs themselves (e.g. via
+       `wrapEnvFilesCommand`) will have stripped them in an
+       extraTransform, so `mkFileRef` is a no-op for them.
+    4. Remove `disabled` and any keys listed in `exclude`.
+    5. Filter `null`, `[]`, and `{}` values.
+
+    Type: transformMcpServer ::
+      { server, exclude?, extraTransforms?, mkFileRef? }
+      -> AttrSet
+  */
+  transformMcpServer =
+    {
+      server,
+      exclude ? [ ],
+      extraTransforms ? [ ],
+      mkFileRef ? (path: "{file:${path}}"),
+    }:
+    let
+      enabled = resolveEnabled server;
+      normalised = server // {
+        inherit enabled;
+        url = if (server.url or null) != null then server.url else server.serverUrl or null;
+      };
+      transformed = lib.foldl' (acc: transform: transform acc) normalised extraTransforms;
+      withRenderedEnv =
+        transformed
+        // lib.optionalAttrs (transformed ? env) {
+          env = renderEnv mkFileRef transformed.env;
+        };
+      cleaned = removeAttrs withRenderedEnv (
+        [
+          "disabled"
+          "serverUrl"
+        ]
+        ++ exclude
+      );
+    in
+    lib.filterAttrs (_: value: value != null && value != [ ] && value != { }) cleaned;
+}

--- a/modules/misc/news/2026/05/2026-05-22_22-55-03.nix
+++ b/modules/misc/news/2026/05/2026-05-22_22-55-03.nix
@@ -1,0 +1,25 @@
+{ config, ... }:
+{
+  time = "2026-05-22T20:55:03+00:00";
+  condition = config.programs.mcp.enable;
+  message = ''
+    The {option}`programs.mcp.servers` schema is now typed.
+
+    Instead of freeform JSON objects, structured options are used:
+    {option}`command` and {option}`args` for local servers,
+    {option}`url` for remote servers,
+    {option}`env` for environment variables.
+
+    Environment variables can be specified as literal strings or as file
+    references that are read at startup:
+
+    ```nix
+    env.API_KEY = "literal";
+    env.SESSION_TOKEN.file = "/run/secrets/token";
+    ```
+
+    The {var}`lib.hm.mcp` library provides helpers for transforming MCP
+    server configurations and is used by opencode, claude-code, codex,
+    antigravity-cli, zed-editor, and vscode for MCP integration.
+  '';
+}

--- a/modules/programs/antigravity-cli.nix
+++ b/modules/programs/antigravity-cli.nix
@@ -407,9 +407,21 @@ in
           ) cfg.context;
         }
         (lib.mkIf useGeminiConfig {
-          programs.antigravity-cli.settings.mcpServers = lib.mkIf (
-            cfg.enableMcpIntegration && config.programs.mcp.enable
-          ) (lib.mapAttrs (_n: lib.mkDefault) config.programs.mcp.servers);
+          programs.antigravity-cli.settings.mcpServers =
+            lib.mkIf (cfg.enableMcpIntegration && config.programs.mcp.enable)
+              (
+                lib.mapAttrs (
+                  name: server:
+                  lib.hm.mcp.transformMcpServer {
+                    inherit server;
+                    extraTransforms = [
+                      lib.hm.mcp.addType
+                      (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
+                      (s: lib.mapAttrs (_: lib.mkDefault) s)
+                    ];
+                  }
+                ) config.programs.mcp.servers
+              );
 
           home.file =
             lib.optionalAttrs (geminiSettings != { }) {
@@ -456,7 +468,32 @@ in
         (lib.mkIf (!useGeminiConfig) {
           programs.antigravity-cli.mcpServers =
             lib.mkIf (cfg.enableMcpIntegration && config.programs.mcp.enable)
-              (lib.mapAttrs (_n: server: lib.mkDefault (transformMcpServer server)) config.programs.mcp.servers);
+              (
+                lib.mapAttrs (
+                  name: server:
+                  lib.hm.mcp.transformMcpServer {
+                    inherit server;
+                    extraTransforms = [
+                      (
+                        s:
+                        removeAttrs s [
+                          "httpUrl"
+                          "url"
+                        ]
+                        // lib.optionalAttrs (s ? httpUrl) {
+                          serverUrl = s.httpUrl;
+                        }
+                        // lib.optionalAttrs (s ? url) {
+                          serverUrl = s.url;
+                        }
+                      )
+                      lib.hm.mcp.addType
+                      (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
+                      (s: lib.mapAttrs (_: lib.mkDefault) s)
+                    ];
+                  }
+                ) config.programs.mcp.servers
+              );
 
           assertions = [
             {

--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -19,17 +19,17 @@ let
 
   upstreamConfigDir = "${config.home.homeDirectory}/.claude";
 
-  mkMcpServer =
-    server:
-    (removeAttrs server [ "disabled" ])
-    // (optionalAttrs (server ? url) { type = "http"; })
-    // (optionalAttrs (server ? command) { type = "stdio"; })
-    // {
-      enabled = !(server.disabled or false);
-    };
-
-  transformedMcpServers = optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
-    lib.mapAttrs (_name: mkMcpServer) config.programs.mcp.servers
+  transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
+    lib.mapAttrs (
+      name: server:
+      lib.hm.mcp.transformMcpServer {
+        inherit server;
+        extraTransforms = [
+          lib.hm.mcp.addType
+          (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; }) # envFiles currently still need wrapping https://github.com/anthropics/claude-code/issues/28942
+        ];
+      }
+    ) config.programs.mcp.servers
   );
 
   mkContentOption =
@@ -632,7 +632,7 @@ in
 
       programs.claude-code.finalPackage =
         let
-          mergedMcpServers = transformedMcpServers // cfg.mcpServers;
+          mergedMcpServers = transformedMcpServers // lib.mapAttrs (_: lib.hm.mcp.addType) cfg.mcpServers;
           pluginFiles =
             lib.optional (mergedMcpServers != { }) {
               name = ".mcp.json";

--- a/modules/programs/codex.nix
+++ b/modules/programs/codex.nix
@@ -17,8 +17,8 @@ let
   settingsFormat = if isTomlConfig then tomlFormat else yamlFormat;
 in
 {
-  meta.maintainers = [
-    lib.maintainers.delafthi
+  meta.maintainers = with lib.maintainers; [
+    delafthi
   ];
 
   imports = [
@@ -221,21 +221,22 @@ in
 
       transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
         lib.mapAttrs (
-          _name: server:
+          name: server:
           # NOTE: Convert shared programs.mcp fields to Codex config keys:
-          # - removeAttrs drops keys that Codex does not use directly
-          # - "disabled" becomes inverse "enabled"
+          # - file-backed env entries are wrapped in a shell script that sets environment variables before exec
           # - "headers" is renamed to "http_headers"
           # See: https://developers.openai.com/codex/mcp#other-configuration-options
-          (lib.removeAttrs server [
-            "disabled"
-            "headers"
-          ])
-          // (lib.optionalAttrs (server ? headers && !(server ? http_headers)) {
-            http_headers = server.headers;
-          })
-          // {
-            enabled = !(server.disabled or false);
+          lib.hm.mcp.transformMcpServer {
+            inherit server;
+            exclude = [
+              "headers"
+              "type"
+            ];
+            extraTransforms = [
+              (s: s // lib.optionalAttrs (s.headers or { } != { }) { http_headers = s.headers; })
+              lib.hm.mcp.addType
+              (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
+            ];
           }
         ) config.programs.mcp.servers
       );

--- a/modules/programs/github-copilot-cli.nix
+++ b/modules/programs/github-copilot-cli.nix
@@ -19,34 +19,57 @@ let
 
   upstreamConfigDir = "${config.home.homeDirectory}/.copilot";
 
-  transformSingleServer =
-    _name: server:
+  forCopilotFormat =
+    server:
     let
-      server' = removeAttrs server [ "disabled" ];
-      type = server'.type or (if server' ? url then "http" else "local");
+      isLocal = server.type == "stdio";
     in
-    server'
+    server
     // {
-      inherit type;
+      type = if server.type == "stdio" then "local" else server.type or "local";
     }
-    // lib.optionalAttrs (type == "local") {
-      args = server'.args or [ ];
+    // lib.optionalAttrs isLocal {
+      args = server.args or [ ];
     }
-    // lib.optionalAttrs (!(server' ? tools)) {
+    // lib.optionalAttrs (!(server ? tools)) {
       tools = [ "*" ];
     };
 
+  enabledServers = lib.filterAttrs (
+    _: server: !(server.disabled or false) && (server ? url || server ? command)
+  ) config.programs.mcp.servers;
+
   transformedMcpServers =
-    if cfg.enableMcpIntegration && config.programs.mcp.enable && config.programs.mcp.servers != { } then
-      lib.mapAttrs transformSingleServer (
-        lib.filterAttrs (
-          _: server: !(server.disabled or false) && (server ? url || server ? command)
-        ) config.programs.mcp.servers
-      )
+    if cfg.enableMcpIntegration && config.programs.mcp.enable && enabledServers != { } then
+      lib.mapAttrs (
+        name: server:
+        lib.hm.mcp.transformMcpServer {
+          inherit server;
+          extraTransforms = [
+            lib.hm.mcp.addType
+            (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
+            forCopilotFormat
+          ];
+        }
+      ) enabledServers
     else
       { };
 
-  mergedMcpServers = transformedMcpServers // cfg.mcpServers;
+  mergedMcpServers =
+    transformedMcpServers
+    // lib.mapAttrs (
+      name: server:
+      lib.hm.mcp.transformMcpServer {
+        inherit server;
+        extraTransforms = [
+          lib.hm.mcp.addType
+          (lib.hm.mcp.wrapEnvFilesCommand {
+            inherit pkgs name;
+          })
+          forCopilotFormat
+        ];
+      }
+    ) cfg.mcpServers;
 in
 {
   meta.maintainers = [ lib.maintainers.ojsef39 ];

--- a/modules/programs/mcp.nix
+++ b/modules/programs/mcp.nix
@@ -13,52 +13,193 @@ let
     ;
 
   cfg = config.programs.mcp;
-
   jsonFormat = pkgs.formats.json { };
+
+  serverModule = lib.types.submodule {
+    freeformType = jsonFormat.type;
+
+    options = {
+      command = mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Executable for a local (stdio) MCP server.
+          Mutually exclusive with {option}`url`.
+        '';
+        example = "npx";
+      };
+
+      args = mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = ''
+          Arguments passed to {option}`command`.
+          Only valid for local servers.
+        '';
+        example = [
+          "-y"
+          "@modelcontextprotocol/server-everything"
+        ];
+      };
+
+      env = mkOption {
+        type = lib.types.attrsOf (
+          lib.types.oneOf [
+            lib.types.str
+            (lib.types.submodule {
+              options = {
+                file = mkOption {
+                  type = lib.types.str;
+                  description = ''
+                    Path to a file whose content is read at startup.
+                    Compatible with file-based secret managers such as sops-nix
+                    or systemd credentials.
+                  '';
+                };
+              };
+            })
+          ]
+        );
+        default = { };
+        description = ''
+          Environment variables set when spawning the MCP server.
+          Each value is either a literal string or a file reference
+          (`{ file = "/path"; }`).
+
+          File references behave differently depending on the consumer:
+          - Clients that understand the `{file:…}` syntax (e.g. opencode)
+            receive the path as a substitution token.
+          - Other clients receive a generated wrapper script that reads
+            the secret at startup instead.
+
+          Only valid for local servers.
+        '';
+        example = literalExpression ''
+          {
+            API_BASE_URL = "https://api.example.com";
+            FORGEJO_ACCESS_TOKEN.file = "/run/secrets/forgejo_token";
+          }
+        '';
+      };
+
+      url = mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          HTTP(S) endpoint for a remote (SSE/HTTP) MCP server.
+          Mutually exclusive with {option}`command`.
+        '';
+        example = "https://mcp.context7.com/mcp";
+      };
+
+      headers = mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        description = ''
+          HTTP headers for requests to a remote MCP server.
+          Only valid for remote servers.
+        '';
+        example = literalExpression ''
+          { MY_API_KEY = "{env:MY_API_KEY}"; }
+        '';
+      };
+
+      enabled = mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        description = ''
+          Whether this MCP server is enabled.
+
+          If this option and `disabled` are both set, they must satisfy
+          `enabled == !disabled`.
+        '';
+      };
+    };
+  };
 in
 {
-  meta.maintainers = with lib.maintainers; [ delafthi ];
+  meta.maintainers = with lib.maintainers; [
+    delafthi
+    malik
+  ];
 
   options.programs.mcp = {
     enable = mkEnableOption "mcp";
 
     servers = mkOption {
-      inherit (jsonFormat) type;
+      type = lib.types.attrsOf serverModule;
       default = { };
       example = literalExpression ''
         {
           everything = {
             command = "npx";
-            args = [
-              "-y"
-              "@modelcontextprotocol/server-everything"
-            ];
+            args = [ "-y" "@modelcontextprotocol/server-everything" ];
           };
           context7 = {
             url = "https://mcp.context7.com/mcp";
-            headers = {
-              CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";
-            };
+            headers.CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";
+          };
+          codeberg = {
+            command = "/path/to/forgejo-mcp";
+            args = [ "transport" "stdio" "--url" "https://codeberg.org" ];
+            env.FORGEJO_ACCESS_TOKEN.file = "/run/secrets/codeberg_token";
           };
         }
       '';
       description = ''
-        MCP server configurations written to
-        {file}`XDG_CONFIG_HOME/mcp/mcp.json`
+        MCP server configurations written to {file}`$XDG_CONFIG_HOME/mcp/mcp.json`.
+
+        Each server is either a local (stdio) server via {option}`command`
+        or a remote (HTTP/SSE) server via {option}`url`.
+
+        Besides declared options, arbitrary MCP fields are allowed.
       '';
     };
   };
 
   config = mkIf cfg.enable {
-    xdg.configFile = mkIf (cfg.servers != { }) (
-      let
-        mcp-config = {
-          mcpServers = cfg.servers;
-        };
-      in
-      {
-        "mcp/mcp.json".source = jsonFormat.generate "mcp.json" mcp-config;
-      }
+    assertions = lib.concatLists (
+      lib.mapAttrsToList (name: server: [
+        {
+          assertion = (server.command != null) != (server.url != null);
+          message = ''
+            programs.mcp.servers.${name}: exactly one of `command` or `url` must be set.
+          '';
+        }
+        {
+          assertion = server.url == null || (server.args == [ ] && server.env == { });
+          message = ''
+            programs.mcp.servers.${name}: `args` and `env` are only valid for local servers (`command`).
+          '';
+        }
+        {
+          assertion = server.headers == { } || server.url != null;
+          message = ''
+            programs.mcp.servers.${name}: `headers` is only valid for remote servers (`url`).
+          '';
+        }
+        {
+          assertion =
+            !(server.enabled != null && server ? disabled && server.disabled != null)
+            || server.enabled != server.disabled;
+          message = ''
+            programs.mcp.servers.${name}: `enabled` and `disabled` are set to incompatible values.
+          '';
+        }
+      ]) cfg.servers
     );
+
+    xdg.configFile = mkIf (cfg.servers != { }) {
+      "mcp/mcp.json".source = jsonFormat.generate "mcp.json" {
+        mcpServers = lib.mapAttrs (
+          _: server:
+          lib.hm.mcp.transformMcpServer {
+            inherit server;
+            extraTransforms = [ lib.hm.mcp.addType ];
+            exclude = [ "serverUrl" ];
+          }
+        ) cfg.servers;
+      };
+    };
   };
 }

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -18,32 +18,39 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
-  transformMcpServer = name: server: {
-    inherit name;
-    value = {
-      enabled = !(server.disabled or false);
+  toOpencodeShape =
+    s:
+    let
+      isRemote = s ? url && s.url != null;
+      renderedEnv = lib.hm.mcp.renderEnv (p: "{file:${p}}") (s.env or { });
+    in
+    lib.optionalAttrs (s.enabled or null != null) { inherit (s) enabled; }
+    // {
+      type = if isRemote then "remote" else "local";
     }
     // (
-      if server ? url then
-        {
-          type = "remote";
-          inherit (server) url;
-        }
-        // (lib.optionalAttrs (server ? headers) { inherit (server) headers; })
-      else if server ? command then
-        {
-          type = "local";
-          command = [ server.command ] ++ (server.args or [ ]);
-        }
-        // (lib.optionalAttrs (server ? env) { environment = server.env; })
+      if isRemote then
+        { inherit (s) url; } // lib.optionalAttrs (s.headers or { } != { }) { inherit (s) headers; }
       else
-        { }
+        {
+          command = [ s.command ] ++ (s.args or [ ]);
+        }
+        // lib.optionalAttrs (renderedEnv != { }) { environment = renderedEnv; }
     );
-  };
 
   transformedMcpServers =
     if cfg.enableMcpIntegration && config.programs.mcp.enable && config.programs.mcp.servers != { } then
-      lib.listToAttrs (lib.mapAttrsToList transformMcpServer config.programs.mcp.servers)
+      lib.mapAttrs (
+        _: server:
+        lib.hm.mcp.transformMcpServer {
+          inherit server;
+          extraTransforms = [ toOpencodeShape ];
+          exclude = [
+            "args"
+            "env"
+          ];
+        }
+      ) config.programs.mcp.servers
     else
       { };
 

--- a/modules/programs/vscode/mkVscodeModule.nix
+++ b/modules/programs/vscode/mkVscodeModule.nix
@@ -70,32 +70,16 @@ let
 
   isPath = p: builtins.isPath p || lib.isStorePath p;
 
-  transformMcpServerForVscode =
-    name: server:
-    let
-      # Remove the disabled field from the server config
-      cleanServer = lib.filterAttrs (n: _v: n != "disabled") server;
-    in
-    {
-      inherit name;
-      value = {
-        enabled = !(server.disabled or false);
-      }
-      // (
-        if server ? url then
-          {
-            type = "http";
-          }
-          // cleanServer
-        else if server ? command then
-          {
-            type = "stdio";
-          }
-          // cleanServer
-        else
-          { }
-      );
+  transformMcpServerForVscode = name: server: {
+    inherit name;
+    value = lib.hm.mcp.transformMcpServer {
+      inherit server;
+      extraTransforms = [
+        lib.hm.mcp.addType
+        (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
+      ];
     };
+  };
 
   profileType = types.submodule {
     options = {

--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -31,19 +31,21 @@ let
 
   transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
     lib.mapAttrs (
-      _name: server:
-      # NOTE: Convert shared programs.mcp fields to Zed config keys:
-      # - removeAttrs drops keys that Zed does not use directly
-      # - "disabled" becomes inverse "enabled"
-      # See: https://zed.dev/docs/ai/mcp
-      (lib.removeAttrs server [ "disabled" ])
-      // {
-        enabled = !(server.disabled or false);
+      name: server:
+      # See: https://zed.dev/docs/ai/mcp & https://github.com/zed-industries/zed/discussions/53780
+      lib.hm.mcp.transformMcpServer {
+        inherit server;
+        extraTransforms = [
+          lib.hm.mcp.addType
+          (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
+        ];
       }
     ) config.programs.mcp.servers
   );
 
-  settingMcpServers = lib.attrByPath [ "context_servers" ] { } cfg.userSettings;
+  settingMcpServers = lib.mapAttrs (_: lib.hm.mcp.addType) (
+    lib.attrByPath [ "context_servers" ] { } cfg.userSettings
+  );
   mergedMcpServers = transformedMcpServers // settingMcpServers;
 
   mergedSettings =

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -179,6 +179,7 @@ import nmtSrc {
           # keep-sorted start case=no numeric=yes
           ./lib/deprecations
           ./lib/generators
+          ./lib/mcp
           ./lib/types
           ./modules/files
           ./modules/home-environment

--- a/tests/lib/mcp/default.nix
+++ b/tests/lib/mcp/default.nix
@@ -1,0 +1,3 @@
+{
+  lib-mcp-wrapper = ./wrapper.nix;
+}

--- a/tests/lib/mcp/wrapper.nix
+++ b/tests/lib/mcp/wrapper.nix
@@ -1,0 +1,45 @@
+{ pkgs, lib, ... }:
+let
+  fakeSecret = pkgs.writeText "fake-npm-token" "supersecret";
+
+  wrapper = lib.hm.mcp.mkEnvFilesWrapper {
+    inherit pkgs;
+    name = "test-server";
+    server = {
+      command = "npx";
+      args = [
+        "-y"
+        "@modelcontextprotocol/server-everything"
+      ];
+      env.NPM_TOKEN.file = "${fakeSecret}";
+    };
+  };
+
+  wrapperNoArgs = lib.hm.mcp.mkEnvFilesWrapper {
+    inherit pkgs;
+    name = "test-server-noargs";
+    server = {
+      command = "npx";
+      env.NPM_TOKEN.file = "${fakeSecret}";
+    };
+  };
+in
+{
+  home.file."mcp-wrapper-under-test" = {
+    source = wrapper;
+  };
+  home.file."mcp-wrapper-noargs-under-test" = {
+    source = wrapperNoArgs;
+  };
+
+  nmt.script = ''
+    assertFileContains home-files/mcp-wrapper-under-test \
+      'if NPM_TOKEN=$(cat ${fakeSecret}); then'
+    assertFileContains home-files/mcp-wrapper-under-test \
+      'export NPM_TOKEN'
+    assertFileContains home-files/mcp-wrapper-under-test \
+      'exec npx -y @modelcontextprotocol/server-everything'
+    assertFileContains home-files/mcp-wrapper-noargs-under-test \
+      'exec npx'
+  '';
+}

--- a/tests/modules/programs/codex/mcp-integration-with-override.toml
+++ b/tests/modules/programs/codex/mcp-integration-with-override.toml
@@ -1,7 +1,6 @@
 model = "gpt-5-codex"
 
 [mcp_servers.context7]
-enabled = true
 url = "https://mcp.context7.com/mcp"
 
 [mcp_servers.context7.http_headers]

--- a/tests/modules/programs/codex/mcp-integration.toml
+++ b/tests/modules/programs/codex/mcp-integration.toml
@@ -1,5 +1,4 @@
 [mcp_servers.context7]
-enabled = true
 url = "https://mcp.context7.com/mcp"
 
 [mcp_servers.context7.http_headers]
@@ -13,4 +12,3 @@ enabled = false
 [mcp_servers.everything]
 args = ["-y", "@modelcontextprotocol/server-everything"]
 command = "npx"
-enabled = true

--- a/tests/modules/programs/github-copilot-cli/expected-mcp-integration-config.json
+++ b/tests/modules/programs/github-copilot-cli/expected-mcp-integration-config.json
@@ -15,7 +15,6 @@
       "type": "local"
     },
     "fetch": {
-      "args": [],
       "command": "mcp-server-fetch",
       "tools": [
         "*"

--- a/tests/modules/programs/mcp/default.nix
+++ b/tests/modules/programs/mcp/default.nix
@@ -1,4 +1,5 @@
 {
   mcp-servers = ./servers.nix;
   mcp-empty-servers = ./empty-servers.nix;
+  mcp-enabled-disabled-conflict = ./enabled-disabled-conflict.nix;
 }

--- a/tests/modules/programs/mcp/enabled-disabled-conflict.nix
+++ b/tests/modules/programs/mcp/enabled-disabled-conflict.nix
@@ -1,0 +1,19 @@
+{
+  programs.mcp = {
+    enable = true;
+    servers = {
+      invalid = {
+        command = "echo";
+        args = [ "test" ];
+        enabled = true;
+        disabled = true;
+      };
+    };
+  };
+
+  test.asserts.assertions.expected = [
+    ''
+      programs.mcp.servers.invalid: `enabled` and `disabled` are set to incompatible values.
+    ''
+  ];
+}

--- a/tests/modules/programs/mcp/mcp.json
+++ b/tests/modules/programs/mcp/mcp.json
@@ -4,14 +4,19 @@
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },
-      "serverUrl": "https://mcp.context7.com/mcp"
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
     },
     "everything": {
       "args": [
         "-y",
         "@modelcontextprotocol/server-everything"
       ],
-      "command": "npx"
+      "command": "npx",
+      "env": {
+        "NPM_TOKEN": "{file:/run/secrets/npm-token}"
+      },
+      "type": "stdio"
     }
   }
 }

--- a/tests/modules/programs/mcp/servers.nix
+++ b/tests/modules/programs/mcp/servers.nix
@@ -8,9 +8,10 @@
           "-y"
           "@modelcontextprotocol/server-everything"
         ];
+        env.NPM_TOKEN.file = "/run/secrets/npm-token";
       };
       context7 = {
-        serverUrl = "https://mcp.context7.com/mcp";
+        url = "https://mcp.context7.com/mcp";
         headers = {
           CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";
         };

--- a/tests/modules/programs/opencode/mcp-integration-with-override.json
+++ b/tests/modules/programs/opencode/mcp-integration-with-override.json
@@ -2,7 +2,6 @@
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
     "context7": {
-      "enabled": true,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },

--- a/tests/modules/programs/opencode/mcp-integration.json
+++ b/tests/modules/programs/opencode/mcp-integration.json
@@ -2,7 +2,6 @@
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
     "context7": {
-      "enabled": true,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },
@@ -23,7 +22,9 @@
         "-y",
         "@modelcontextprotocol/server-everything"
       ],
-      "enabled": true,
+      "environment": {
+        "NPM_TOKEN": "{file:/run/secrets/npm-token}"
+      },
       "type": "local"
     }
   }

--- a/tests/modules/programs/opencode/mcp-integration.nix
+++ b/tests/modules/programs/opencode/mcp-integration.nix
@@ -8,6 +8,7 @@
           "-y"
           "@modelcontextprotocol/server-everything"
         ];
+        env.NPM_TOKEN.file = "/run/secrets/npm-token";
       };
       context7 = {
         url = "https://mcp.context7.com/mcp";
@@ -18,7 +19,7 @@
       disabled-server = {
         command = "echo";
         args = [ "test" ];
-        disabled = true;
+        enabled = false;
       };
     };
   };

--- a/tests/modules/programs/vscode/mcp-integration-default.json
+++ b/tests/modules/programs/vscode/mcp-integration-default.json
@@ -1,7 +1,6 @@
 {
   "servers": {
     "context7": {
-      "enabled": true,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },
@@ -19,7 +18,6 @@
         "@modelcontextprotocol/server-everything"
       ],
       "command": "npx",
-      "enabled": true,
       "type": "stdio"
     }
   }

--- a/tests/modules/programs/vscode/mcp-integration-with-override.json
+++ b/tests/modules/programs/vscode/mcp-integration-with-override.json
@@ -5,7 +5,6 @@
       "url": "https://example.com/mcp"
     },
     "context7": {
-      "enabled": true,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },

--- a/tests/modules/programs/zed-editor/mcp-integration-with-override.nix
+++ b/tests/modules/programs/zed-editor/mcp-integration-with-override.nix
@@ -43,7 +43,6 @@
         {
           "context_servers": {
             "custom-server": {
-              "enabled": false
             }
           },
         }
@@ -53,10 +52,10 @@
         {
           "context_servers": {
             "custom-server": {
-              "enabled": false,
               "headers": {
                 "Authorization": "Bearer token"
               },
+              "type": "http",
               "url": "https://custom.example.com/mcp"
             },
             "everything": {
@@ -65,7 +64,7 @@
                 "@modelcontextprotocol/server-everything"
               ],
               "command": "npx",
-              "enabled": true
+              "type": "stdio"
             }
           }
         }

--- a/tests/modules/programs/zed-editor/mcp-integration.json
+++ b/tests/modules/programs/zed-editor/mcp-integration.json
@@ -1,10 +1,10 @@
 {
   "context_servers": {
     "context7": {
-      "enabled": true,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },
+      "type": "http",
       "url": "https://mcp.context7.com/mcp"
     },
     "disabled-server": {
@@ -12,7 +12,8 @@
         "test"
       ],
       "command": "echo",
-      "enabled": false
+      "enabled": false,
+      "type": "stdio"
     },
     "everything": {
       "args": [
@@ -20,7 +21,7 @@
         "@modelcontextprotocol/server-everything"
       ],
       "command": "npx",
-      "enabled": true
+      "type": "stdio"
     }
   }
 }

--- a/tests/modules/programs/zed-editor/mcp-integration.nix
+++ b/tests/modules/programs/zed-editor/mcp-integration.nix
@@ -44,10 +44,10 @@
         {
           "context_servers": {
             "context7": {
-              "enabled": true,
               "headers": {
                 "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
               },
+              "type": "http",
               "url": "https://mcp.context7.com/mcp"
             },
             "disabled-server": {
@@ -55,7 +55,8 @@
                 "test"
               ],
               "command": "echo",
-              "enabled": false
+              "enabled": false,
+              "type": "stdio"
             },
             "everything": {
               "args": [
@@ -63,7 +64,7 @@
                 "@modelcontextprotocol/server-everything"
               ],
               "command": "npx",
-              "enabled": true
+              "type": "stdio"
             }
           }
         }


### PR DESCRIPTION
## Description

Closes #9078

This PR extends `programs.mcp` with a typed submodule for server definitions, while preserving full flexibility via `freeformType` for consumer-specific and future MCP fields.

### Changes

**`modules/programs/mcp.nix`**
- Add `freeformType = jsonFormat.type` to the server submodule so that consumer-specific and unknown fields are accepted without explicit declaration
- Declare typed options for the known canonical fields: `command`, `args`, `env`, `envFiles`, `url`, `headers`, `disabled`
- The new `envFiles` option maps environment variable names to file paths, enabling integration with file-based secret managers (sops-nix, systemd credentials, Docker secrets)
- consumer modules are responsible for translating `envFiles` it into their native mechanism

**`modules/programs/opencode.nix`**
- Adapt `transformMcpServer` to the now-typed submodule fields (replace `server ? foo` has-attr checks with `null`/empty comparisons)
- Translate `envFiles` entries to opencode's native `{file:...}` variable substitution syntax, merged with `env` before emitting the `environment` block
- Emit `lib.warn` when a server has neither `command` nor `url` set

### Motivation

File-based secret managers such as sops-nix, systemd credentials, and Docker secrets expose secrets as files at runtime under paths like `/run/secrets/my_token`. These are never available as host environment variables. Without `envFiles`, users have no declarative way to inject such secrets into MCP server processes via `programs.mcp.servers`.

## Consumer module status

- [x] `opencode` — translates `envFiles` via `{file:...}` syntax
- [x] `programs.codex` — `envFiles` cause command to be wrapped
- [x] `VScode`
- [x] `claude-code`
- [x] `gemini-cli`
- [x] `zed-editor`
- [ ] `crush` future PR - first downstream https://github.com/charmbracelet/nur/pull/60

## new tests
- [x] mcp-config including envFiles
- [x] testing the env wrapping
- [x] testing the result of envFiles in opencode

## Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
