### PR TITLE
giff: Add module

### DIFF
--- a/modules/misc/news/2026/01/2026-04-10_17-27-41.nix
+++ b/modules/misc/news/2026/01/2026-04-10_17-27-41.nix
@@ -1,0 +1,8 @@
+_:
+{
+  time = "2026-04-10T17:27:41+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.giff'.
+  '';
+}

--- a/modules/programs/giff.nix
+++ b/modules/programs/giff.nix
@@ -22,7 +22,7 @@ in
     package = lib.mkPackageOption pkgs "giff" { nullable = true; };
 
     settings = mkOption {
-      type = pkgs.formats.toml;
+      type = tomlFormat.type;
 
       default = { };
 

--- a/modules/programs/giff.nix
+++ b/modules/programs/giff.nix
@@ -46,7 +46,7 @@ in
   config = lib.mkIf cfg.enable {
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-    xdg.configFile."giff/config.toml" = lib.mkIf (cfg.options != { }) {
+    xdg.configFile."giff/config.toml" = lib.mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "giff-config" cfg.options;
     };
   };

--- a/modules/programs/giff.nix
+++ b/modules/programs/giff.nix
@@ -1,0 +1,53 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.giff;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  inherit (lib)
+    mkOption
+    ;
+in
+{
+  meta.maintainers = with lib.maintainers; [ matthiasbeyer ];
+
+  options.programs.giff = {
+    enable = lib.mkEnableOption "giff, a terminal-based Git diff viewer with interactive rebase capabilities";
+
+    package = lib.mkPackageOption pkgs "giff" { nullable = true; };
+
+    settings = mkOption {
+      type = pkgs.formats.toml;
+
+      default = { };
+
+      example = {
+        theme = "dark";
+
+        themes.custom = {
+          base = "dark";
+          accent = "#89b4fa";
+          fg_added = "#a6e3a1";
+          fg_removed = "#f38ba8";
+        };
+      };
+
+      description = ''
+        Options to configure giff.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."giff/config.toml" = lib.mkIf (cfg.options != { }) {
+      source = tomlFormat.generate "giff-config" cfg.options;
+    };
+  };
+}


### PR DESCRIPTION
### Description

Depends on https://github.com/NixOS/nixpkgs/pull/508644

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
