### PR TITLE
mkFirefoxModule.nix: add option to use absolute paths in profiles

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -57,7 +57,7 @@ let
       lib.nameValuePair "Profile${toString profile.id}" {
         Name = profile.name;
         Path = if isDarwin then "Profiles/${profile.path}" else profile.path;
-        IsRelative = 1;
+        IsRelative = if profile.absolutePath then 0 else 1;
         Default = if profile.isDefault then 1 else 0;
       }
     )
@@ -519,7 +519,7 @@ in
               path = mkOption {
                 type = types.str;
                 default = name;
-                description = "Profile path.";
+                description = "Profile path. To use an absolute path, set `programs.firefox.profiles.<name>.absolutePath` to true, because paths in Firefox are relative by default unless explicitly specified.";
               };
 
               isDefault = mkOption {
@@ -527,6 +527,12 @@ in
                 default = config.id == 0;
                 defaultText = "true if profile ID is 0";
                 description = "Whether this is a default profile.";
+              };
+
+              absolutePath = mkOption {
+                type = types.bool;
+                default = false;
+                description = "Whether this profile uses an absolute path.";
               };
 
               search = mkOption {


### PR DESCRIPTION
### Description

This change adds an option for isRelative in Firefox profile configuration, which is useful for those, who have a profile on another drive/directory. I decided to define it as "absolutePath" to avoid potential confusion.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
