### PR TITLE
copyApps: fix migration from linkApps

### DIFF
--- a/modules/targets/darwin/copyapps.nix
+++ b/modules/targets/darwin/copyapps.nix
@@ -55,7 +55,10 @@ in
               return 0
             }
 
-            if ! ensureAppManagement; then
+            # If the directory is a symlink it was most likely created by linkApps
+            # and will be migrated later so we can't test for the App Management
+            # permission and we probably don't need it to do the migration anyway.
+            if [[ ! -L '${cfg.directory}' ]] && ! ensureAppManagement; then
               if [[ "$(/bin/launchctl managername)" != Aqua ]]; then
                 # It is possible to grant the App Management permission to `sshd-keygen-wrapper`, however
                 # there are many pitfalls like requiring the primary user to grant the permission and to

--- a/modules/targets/darwin/copyapps.nix
+++ b/modules/targets/darwin/copyapps.nix
@@ -95,52 +95,51 @@ in
           ''
       );
 
-      copyApps = lib.hm.dag.entryAfter [ "installPackages" ] (
-        let
-          applications = pkgs.buildEnv {
-            name = "home-manager-applications";
-            paths = config.home.packages;
-            pathsToLink = [ "/Applications" ];
-          };
-        in
-        # bash
-        ''
-          targetFolder='${cfg.directory}'
+      # We want to run after linkGeneration so that it will automatically clean
+      # up the linkApps symlink if it exists so we don't have to implement the
+      # migration ourselves.
+      copyApps =
+        lib.hm.dag.entryAfter
+          [
+            "installPackages"
+            "linkGeneration"
+          ]
+          (
+            let
+              applications = pkgs.buildEnv {
+                name = "home-manager-applications";
+                paths = config.home.packages;
+                pathsToLink = [ "/Applications" ];
+              };
+            in
+            # bash
+            ''
+              targetFolder='${cfg.directory}'
 
-          echo "setting up ~/$targetFolder..." >&2
+              echo "setting up ~/$targetFolder..." >&2
 
-          ourLink () {
-            local link
-            link=$(readlink "$1")
-            [ -L "$1" ] && [ "''${link#*-}" = 'home-manager-applications/Applications' ]
-          }
+              run mkdir -p "$targetFolder"
 
-          if [ -e "$targetFolder" ] && ourLink "$targetFolder"; then
-            run rm "$targetFolder"
-          fi
+              rsyncFlags=(
+                # mtime is standardized in the nix store, which would leave only file size to distinguish files.
+                # Thus we need checksums, despite the speed penalty.
+                --checksum
+                # Converts all symlinks pointing outside of the copied tree (thus unsafe) into real files and directories.
+                # This neatly converts all the symlinks pointing to application bundles in the nix store into
+                # real directories, without breaking any relative symlinks inside of application bundles.
+                # This is good enough, because the make-symlinks-relative.sh setup hook converts all $out internal
+                # symlinks to relative ones.
+                --copy-unsafe-links
+                --archive
+                --delete
+                --chmod=+w
+                --no-group
+                --no-owner
+              )
 
-          run mkdir -p "$targetFolder"
-
-          rsyncFlags=(
-            # mtime is standardized in the nix store, which would leave only file size to distinguish files.
-            # Thus we need checksums, despite the speed penalty.
-            --checksum
-            # Converts all symlinks pointing outside of the copied tree (thus unsafe) into real files and directories.
-            # This neatly converts all the symlinks pointing to application bundles in the nix store into
-            # real directories, without breaking any relative symlinks inside of application bundles.
-            # This is good enough, because the make-symlinks-relative.sh setup hook converts all $out internal
-            # symlinks to relative ones.
-            --copy-unsafe-links
-            --archive
-            --delete
-            --chmod=+w
-            --no-group
-            --no-owner
-          )
-
-          run ${lib.getExe pkgs.rsync} "''${rsyncFlags[@]}" ${applications}/Applications/ "$targetFolder"
-        ''
-      );
+              run ${lib.getExe pkgs.rsync} "''${rsyncFlags[@]}" ${applications}/Applications/ "$targetFolder"
+            ''
+          );
     };
   };
 }


### PR DESCRIPTION
### Description

This PR fixes two issues that prevented me from migrating my machine from `linkApps` to `copyApps`, the first issue was that we were unnecessarily checking for the App Management permission when migrating even though it is unlikely to be necessary. The second issue is that we wouldn't correctly detect the symlink created by `linkApps` so our manual migration code would not be run. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
