### PR TITLE
starship: add extraPackages options

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) mkIf mkOption types;
+  inherit (lib)
+    literalExpression
+    mkIf
+    mkOption
+    types
+    ;
 
   cfg = config.programs.starship;
 
@@ -21,6 +26,13 @@ in
     enable = lib.mkEnableOption "starship";
 
     package = lib.mkPackageOption pkgs "starship" { };
+
+    extraPackages = mkOption {
+      type = with types; listOf package;
+      default = [ ];
+      example = literalExpression "[ pkgs.jj-starship ]";
+      description = "Extra packages available to starship.";
+    };
 
     settings = mkOption {
       inherit (tomlFormat) type;
@@ -107,7 +119,22 @@ in
 
   config = mkIf cfg.enable {
     home = {
-      packages = [ cfg.package ];
+      packages =
+        if cfg.extraPackages != [ ] then
+          [
+            (pkgs.symlinkJoin {
+              name = "${lib.getName cfg.package}-wrapped-${lib.getVersion cfg.package}";
+              paths = [ cfg.package ];
+              preferLocalBuild = true;
+              nativeBuildInputs = [ pkgs.makeWrapper ];
+              postBuild = ''
+                wrapProgram $out/bin/starship \
+                  --suffix PATH : ${lib.makeBinPath cfg.extraPackages}
+              '';
+            })
+          ]
+        else
+          [ cfg.package ];
 
       sessionVariables.STARSHIP_CONFIG = cfg.configPath;
 


### PR DESCRIPTION
### Description

This PR adds the extraPackages options do starfish.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
