### PR TITLE
Opencode config directories

### DIFF
--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -243,11 +243,11 @@ in
 
         If an attribute set is used, the attribute name becomes the agent filename,
         and the value is either:
-        - Inline content as a string (creates `opencode/agent/<name>.md`)
-        - A path to a file (creates `opencode/agent/<name>.md`)
+        - Inline content as a string (creates `opencode/agents/<name>.md`)
+        - A path to a file (creates `opencode/agents/<name>.md`)
 
         If a path is used, it is expected to contain agent files.
-        The directory is symlinked to {file}`$XDG_CONFIG_HOME/opencode/agent/`.
+        The directory is symlinked to {file}`$XDG_CONFIG_HOME/opencode/agents/`.
       '';
       example = lib.literalExpression ''
         {
@@ -482,7 +482,7 @@ in
         recursive = true;
       };
 
-      "opencode/agent" = mkIf (lib.isPath cfg.agents) {
+      "opencode/agents" = mkIf (lib.isPath cfg.agents) {
         source = cfg.agents;
         recursive = true;
       };
@@ -513,7 +513,7 @@ in
     // lib.optionalAttrs (builtins.isAttrs cfg.agents) (
       lib.mapAttrs' (
         name: content:
-        lib.nameValuePair "opencode/agent/${name}.md" (
+        lib.nameValuePair "opencode/agents/${name}.md" (
           if lib.isPath content then { source = content; } else { text = content; }
         )
       ) cfg.agents

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -206,11 +206,11 @@ in
 
         If an attribute set is used, the attribute name becomes the command filename,
         and the value is either:
-        - Inline content as a string (creates `opencode/command/<name>.md`)
-        - A path to a file (creates `opencode/command/<name>.md`)
+        - Inline content as a string (creates `opencode/commands/<name>.md`)
+        - A path to a file (creates `opencode/commands/<name>.md`)
 
         If a path is used, it is expected to contain command files.
-        The directory is symlinked to {file}`$XDG_CONFIG_HOME/opencode/command/`.
+        The directory is symlinked to {file}`$XDG_CONFIG_HOME/opencode/commands/`.
       '';
       example = lib.literalExpression ''
         {
@@ -477,7 +477,7 @@ in
           })
       );
 
-      "opencode/command" = mkIf (lib.isPath cfg.commands) {
+      "opencode/commands" = mkIf (lib.isPath cfg.commands) {
         source = cfg.commands;
         recursive = true;
       };
@@ -505,7 +505,7 @@ in
     // lib.optionalAttrs (builtins.isAttrs cfg.commands) (
       lib.mapAttrs' (
         name: content:
-        lib.nameValuePair "opencode/command/${name}.md" (
+        lib.nameValuePair "opencode/commands/${name}.md" (
           if lib.isPath content then { source = content; } else { text = content; }
         )
       ) cfg.commands

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -358,11 +358,11 @@ in
 
         If an attribute set is used, the attribute name becomes the tool filename,
         and the value is either:
-        - Inline content as a string (creates `opencode/tool/<name>.ts`)
-        - A path to a file (creates `opencode/tool/<name>.ts` or `opencode/tool/<name>.js`)
+        - Inline content as a string (creates `opencode/tools/<name>.ts`)
+        - A path to a file (creates `opencode/tools/<name>.ts` or `opencode/tools/<name>.js`)
 
         If a path is used, it is expected to contain tool files.
-        The directory is symlinked to {file}`$XDG_CONFIG_HOME/opencode/tool/`.
+        The directory is symlinked to {file}`$XDG_CONFIG_HOME/opencode/tools/`.
 
         See <https://opencode.ai/docs/tools/> for the documentation.
       '';
@@ -487,7 +487,7 @@ in
         recursive = true;
       };
 
-      "opencode/tool" = mkIf (lib.isPath cfg.tools) {
+      "opencode/tools" = mkIf (lib.isPath cfg.tools) {
         source = cfg.tools;
         recursive = true;
       };
@@ -521,7 +521,7 @@ in
     // lib.optionalAttrs (builtins.isAttrs cfg.tools) (
       lib.mapAttrs' (
         name: content:
-        lib.nameValuePair "opencode/tool/${name}.ts" (
+        lib.nameValuePair "opencode/tools/${name}.ts" (
           if lib.isPath content then { source = content; } else { text = content; }
         )
       ) cfg.tools

--- a/tests/modules/programs/opencode/agents-bulk-directory.nix
+++ b/tests/modules/programs/opencode/agents-bulk-directory.nix
@@ -5,11 +5,11 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/agent/code-reviewer.md
-    assertFileExists home-files/.config/opencode/agent/documentation.md
-    assertFileContent home-files/.config/opencode/agent/code-reviewer.md \
+    assertFileExists home-files/.config/opencode/agents/code-reviewer.md
+    assertFileExists home-files/.config/opencode/agents/documentation.md
+    assertFileContent home-files/.config/opencode/agents/code-reviewer.md \
       ${./agents-bulk/code-reviewer.md}
-    assertFileContent home-files/.config/opencode/agent/documentation.md \
+    assertFileContent home-files/.config/opencode/agents/documentation.md \
       ${./agents-bulk/documentation.md}
   '';
 }

--- a/tests/modules/programs/opencode/agents-inline.nix
+++ b/tests/modules/programs/opencode/agents-inline.nix
@@ -29,11 +29,11 @@
     };
   };
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/agent/code-reviewer.md
-    assertFileExists home-files/.config/opencode/agent/documentation.md
-    assertFileContent home-files/.config/opencode/agent/code-reviewer.md \
+    assertFileExists home-files/.config/opencode/agents/code-reviewer.md
+    assertFileExists home-files/.config/opencode/agents/documentation.md
+    assertFileContent home-files/.config/opencode/agents/code-reviewer.md \
       ${./code-reviewer-agent.md}
-    assertFileContent home-files/.config/opencode/agent/documentation.md \
+    assertFileContent home-files/.config/opencode/agents/documentation.md \
       ${./documentation-agent.md}
   '';
 }

--- a/tests/modules/programs/opencode/agents-path.nix
+++ b/tests/modules/programs/opencode/agents-path.nix
@@ -6,8 +6,8 @@
     };
   };
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/agent/test-agent.md
-    assertFileContent home-files/.config/opencode/agent/test-agent.md \
+    assertFileExists home-files/.config/opencode/agents/test-agent.md
+    assertFileContent home-files/.config/opencode/agents/test-agent.md \
       ${./test-agent.md}
   '';
 }

--- a/tests/modules/programs/opencode/commands-bulk-directory.nix
+++ b/tests/modules/programs/opencode/commands-bulk-directory.nix
@@ -5,11 +5,11 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/command/changelog.md
-    assertFileExists home-files/.config/opencode/command/commit.md
-    assertFileContent home-files/.config/opencode/command/changelog.md \
+    assertFileExists home-files/.config/opencode/commands/changelog.md
+    assertFileExists home-files/.config/opencode/commands/commit.md
+    assertFileContent home-files/.config/opencode/commands/changelog.md \
       ${./commands-bulk/changelog.md}
-    assertFileContent home-files/.config/opencode/command/commit.md \
+    assertFileContent home-files/.config/opencode/commands/commit.md \
       ${./commands-bulk/commit.md}
   '';
 }

--- a/tests/modules/programs/opencode/commands-inline.nix
+++ b/tests/modules/programs/opencode/commands-inline.nix
@@ -17,11 +17,11 @@
     };
   };
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/command/changelog.md
-    assertFileExists home-files/.config/opencode/command/commit.md
-    assertFileContent home-files/.config/opencode/command/changelog.md \
+    assertFileExists home-files/.config/opencode/commands/changelog.md
+    assertFileExists home-files/.config/opencode/commands/commit.md
+    assertFileContent home-files/.config/opencode/commands/changelog.md \
       ${./changelog-command.md}
-    assertFileContent home-files/.config/opencode/command/commit.md \
+    assertFileContent home-files/.config/opencode/commands/commit.md \
       ${./commit-command.md}
   '';
 }

--- a/tests/modules/programs/opencode/commands-path.nix
+++ b/tests/modules/programs/opencode/commands-path.nix
@@ -6,8 +6,8 @@
     };
   };
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/command/test-command.md
-    assertFileContent home-files/.config/opencode/command/test-command.md \
+    assertFileExists home-files/.config/opencode/commands/test-command.md
+    assertFileContent home-files/.config/opencode/commands/test-command.md \
       ${./test-command.md}
   '';
 }

--- a/tests/modules/programs/opencode/mixed-content.nix
+++ b/tests/modules/programs/opencode/mixed-content.nix
@@ -64,10 +64,10 @@
       ${./test-command.md}
 
     # Agents
-    assertFileExists home-files/.config/opencode/agent/inline-agent.md
-    assertFileExists home-files/.config/opencode/agent/path-agent.md
+    assertFileExists home-files/.config/opencode/agents/inline-agent.md
+    assertFileExists home-files/.config/opencode/agents/path-agent.md
 
-    assertFileContent home-files/.config/opencode/agent/path-agent.md \
+    assertFileContent home-files/.config/opencode/agents/path-agent.md \
       ${./test-agent.md}
 
     # Tools

--- a/tests/modules/programs/opencode/mixed-content.nix
+++ b/tests/modules/programs/opencode/mixed-content.nix
@@ -57,10 +57,10 @@
   };
   nmt.script = ''
     # Commands
-    assertFileExists home-files/.config/opencode/command/inline-command.md
-    assertFileExists home-files/.config/opencode/command/path-command.md
+    assertFileExists home-files/.config/opencode/commands/inline-command.md
+    assertFileExists home-files/.config/opencode/commands/path-command.md
 
-    assertFileContent home-files/.config/opencode/command/path-command.md \
+    assertFileContent home-files/.config/opencode/commands/path-command.md \
       ${./test-command.md}
 
     # Agents

--- a/tests/modules/programs/opencode/mixed-content.nix
+++ b/tests/modules/programs/opencode/mixed-content.nix
@@ -71,10 +71,10 @@
       ${./test-agent.md}
 
     # Tools
-    assertFileExists home-files/.config/opencode/tool/inline-tool.ts
-    assertFileExists home-files/.config/opencode/tool/path-tool.ts
+    assertFileExists home-files/.config/opencode/tools/inline-tool.ts
+    assertFileExists home-files/.config/opencode/tools/path-tool.ts
 
-    assertFileContent home-files/.config/opencode/tool/path-tool.ts \
+    assertFileContent home-files/.config/opencode/tools/path-tool.ts \
       ${./test-tool.ts}
 
     # Skills

--- a/tests/modules/programs/opencode/tools-bulk-directory.nix
+++ b/tests/modules/programs/opencode/tools-bulk-directory.nix
@@ -5,11 +5,11 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/tool/database-query.ts
-    assertFileExists home-files/.config/opencode/tool/api-client.ts
-    assertFileContent home-files/.config/opencode/tool/database-query.ts \
+    assertFileExists home-files/.config/opencode/tools/database-query.ts
+    assertFileExists home-files/.config/opencode/tools/api-client.ts
+    assertFileContent home-files/.config/opencode/tools/database-query.ts \
       ${./tools-bulk/database-query.ts}
-    assertFileContent home-files/.config/opencode/tool/api-client.ts \
+    assertFileContent home-files/.config/opencode/tools/api-client.ts \
       ${./tools-bulk/api-client.ts}
   '';
 }

--- a/tests/modules/programs/opencode/tools-inline.nix
+++ b/tests/modules/programs/opencode/tools-inline.nix
@@ -32,11 +32,11 @@
     };
   };
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/tool/database-query.ts
-    assertFileExists home-files/.config/opencode/tool/api-client.ts
-    assertFileContent home-files/.config/opencode/tool/database-query.ts \
+    assertFileExists home-files/.config/opencode/tools/database-query.ts
+    assertFileExists home-files/.config/opencode/tools/api-client.ts
+    assertFileContent home-files/.config/opencode/tools/database-query.ts \
       ${./database-query-tool.ts}
-    assertFileContent home-files/.config/opencode/tool/api-client.ts \
+    assertFileContent home-files/.config/opencode/tools/api-client.ts \
       ${./api-client-tool.ts}
   '';
 }

--- a/tests/modules/programs/opencode/tools-path.nix
+++ b/tests/modules/programs/opencode/tools-path.nix
@@ -6,8 +6,8 @@
     };
   };
   nmt.script = ''
-    assertFileExists home-files/.config/opencode/tool/test-tool.ts
-    assertFileContent home-files/.config/opencode/tool/test-tool.ts \
+    assertFileExists home-files/.config/opencode/tools/test-tool.ts
+    assertFileContent home-files/.config/opencode/tools/test-tool.ts \
       ${./test-tool.ts}
   '';
 }


### PR DESCRIPTION
### Description

The module was creating directories for agents, commands and tools in `agent`, `command` and `tool`.

According to upstream documentation these directories should be called `agents` etc. [^1][^2][^3]

[^1]: https://opencode.ai/docs/commands/#configure
[^2]: https://opencode.ai/docs/custom-tools#location
[^3]: https://opencode.ai/docs/agents/#markdown

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
