### PR TITLE
jjui: Fix default Darwin `configDir`, add support for Lua config

### DIFF
--- a/modules/misc/news/2026/04/2026-04-12_13-50-28.nix
+++ b/modules/misc/news/2026/04/2026-04-12_13-50-28.nix
@@ -1,0 +1,16 @@
+{
+  time = "2026-04-12T11:50:28+00:00";
+  condition = true;
+  message = ''
+    The `programs.jjui` module has been updated to the latest jjui configuration options.
+
+    To adhere to the jjui defaults, `configDir` on Darwin now defaults to `~/.config/jjui/` from the previous `~/Library/Application Support/jjui/`.
+    See https://idursun.github.io/jjui/customization/config-toml/.
+
+    New module options are available:
+      - `configLua` to configure the top-level Lua configuration, and
+      - `plugins` to define Lua plugins.
+    Remember to import and set up the defined plugins in `configLua`.
+    For documentation on Lua configuration, see https://idursun.github.io/jjui/customization/config-lua/.
+  '';
+}

--- a/modules/programs/jjui.nix
+++ b/modules/programs/jjui.nix
@@ -41,9 +41,78 @@ in
         };
       };
       description = ''
-        Options to add to the {file}`config.toml` file. See
-        <https://github.com/idursun/jjui/wiki/Configuration>
+        Options to add to the {file}`(config.programs.jjui.configDir)/config.toml` file. See
+        <https://idursun.github.io/jjui/customization/config-toml/>
         for options.
+      '';
+    };
+
+    configLua = mkOption {
+      type = with lib.types; nullOr (either path lines);
+      default = null;
+      example = /* lua */ ''
+        local foo = require("plugins.foo")
+        local bar = require("plugins.bar")
+
+        function setup(config)
+          foo.setup(config)
+          bar.setup("#5B8DEF", config)
+
+          config.action("show diff in diffnav", function()
+            local change_id = context.change_id()
+            if not change_id or change_id == "" then
+              flash({ text = "No revision selected", error = true })
+              return
+            end
+
+            exec_shell(string.format("jj diff -r %q --git --color always | diffnav", change_id))
+          end, { desc = "show diff in diffnav", key = "ctrl+d", scope = "revisions" })
+        end
+      '';
+      description = ''
+        The content of the {file}`(config.programs.jjui.configDir)/config.lua` file, set either by specifying a path
+        to a Lua file or by providing a multi-line Lua string.
+
+        See <https://idursun.github.io/jjui/customization/config-lua/> for documentation on Lua support.
+
+        Use the option {option}`plugins` to configure Lua plugins imported here.
+      '';
+    };
+
+    plugins = mkOption {
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          path
+          lines
+        ]);
+      default = { };
+      description = ''
+        Lua plugins, one per attribute.
+        The <name> attribute will become the plugin name, and the <value> attribute is a path to a Lua file or a multi-line Lua string.
+        Each attribute will be linked to {file}`(config.programs.jjui.configDir)/plugins/<name>.lua` with <value> content.
+
+        See <https://idursun.github.io/jjui/customization/config-lua/>
+        for documentation on Lua support.
+
+        Remember to import the defined plugins in the {option}`configLua` option.
+      '';
+      example = lib.literalExpression ''
+        {
+          foo = ./foo.lua;
+          bar = /* lua */ '\'
+            local M = {}
+
+            function M.setup(primary, config)
+              config.ui = config.ui or {}
+              config.ui.colors = config.ui.colors or {}
+
+              config.ui.colors.title = { fg = primary, bold = true }
+            end
+
+            return M
+          '\';
+        }
       '';
     };
   };
@@ -52,9 +121,27 @@ in
     home = {
       packages = mkIf (cfg.package != null) [ cfg.package ];
 
-      file."${cfg.configDir}/config.toml" = mkIf (cfg.settings != { }) {
-        source = tomlFormat.generate "jjui-config" cfg.settings;
-      };
+      file =
+        lib.mapAttrs' (name: content: {
+          name = "${cfg.configDir}/plugins/${name}.lua";
+          value =
+            if builtins.isPath content || lib.isStorePath content then
+              { source = content; }
+            else
+              { text = content; };
+        }) cfg.plugins
+        // {
+          "${cfg.configDir}/config.toml" = mkIf (cfg.settings != { }) {
+            source = tomlFormat.generate "jjui-config" cfg.settings;
+          };
+
+          "${cfg.configDir}/config.lua" = mkIf (cfg.configLua != null) (
+            if builtins.isPath cfg.configLua || lib.isStorePath cfg.configLua then
+              { source = cfg.configLua; }
+            else
+              { text = cfg.configLua; }
+          );
+        };
 
       sessionVariables = {
         JJUI_CONFIG_DIR = cfg.configDir;

--- a/modules/programs/jjui.nix
+++ b/modules/programs/jjui.nix
@@ -23,12 +23,8 @@ in
 
     configDir = mkOption {
       type = lib.types.str;
-      default =
-        let
-          dir = if pkgs.stdenv.isDarwin then "Library/Application Support" else config.xdg.configHome;
-        in
-        "${dir}/jjui";
-      defaultText = lib.literalExpression "Darwin: \"Library/Application Support/jjui\" \nLinux: \${config.xdg.configHome}/jjui";
+      default = "${config.xdg.configHome}/jjui";
+      defaultText = lib.literalExpression "\${config.xdg.configHome}/jjui";
       example = lib.literalExpression "\${config.home.homeDirectory}/.jjui";
       description = ''
         The directory to contain jjui configuration files.

--- a/tests/modules/programs/jjui/bar-expected.lua
+++ b/tests/modules/programs/jjui/bar-expected.lua
@@ -1,0 +1,10 @@
+local M = {}
+
+function M.setup(primary, config)
+  config.ui = config.ui or {}
+  config.ui.colors = config.ui.colors or {}
+
+  config.ui.colors.title = { fg = primary, bold = true }
+end
+
+return M

--- a/tests/modules/programs/jjui/config-expected.lua
+++ b/tests/modules/programs/jjui/config-expected.lua
@@ -1,0 +1,17 @@
+local foo = require("plugins.foo")
+local bar = require("plugins.bar")
+
+function setup(config)
+  foo.setup("#5B8DEF", config)
+  bar.setup("#5B8DEF", config)
+
+  config.action("show diff in diffnav", function()
+    local change_id = context.change_id()
+    if not change_id or change_id == "" then
+      flash({ text = "No revision selected", error = true })
+      return
+    end
+
+    exec_shell(string.format("jj diff -r %q --git --color always | diffnav", change_id))
+  end, { desc = "show diff in diffnav", key = "ctrl+d", scope = "revisions" })
+end

--- a/tests/modules/programs/jjui/example-settings.nix
+++ b/tests/modules/programs/jjui/example-settings.nix
@@ -18,7 +18,7 @@
 
     nmt.script =
       let
-        configDir = if !pkgs.stdenv.isDarwin then ".config/jjui" else "Library/Application Support/jjui";
+        configDir = ".config/jjui";
       in
       ''
         assertFileContent \

--- a/tests/modules/programs/jjui/example-settings.nix
+++ b/tests/modules/programs/jjui/example-settings.nix
@@ -1,10 +1,4 @@
 {
-  config,
-  pkgs,
-  ...
-}:
-
-{
   config = {
     programs.jjui = {
       enable = true;
@@ -13,6 +7,40 @@
           template = "builtin_log_compact";
           revset = "ancestors(@ | heads(remote_branches())) ~ empty()";
         };
+      };
+      configLua = /* lua */ ''
+        local foo = require("plugins.foo")
+        local bar = require("plugins.bar")
+
+        function setup(config)
+          foo.setup("#5B8DEF", config)
+          bar.setup("#5B8DEF", config)
+
+          config.action("show diff in diffnav", function()
+            local change_id = context.change_id()
+            if not change_id or change_id == "" then
+              flash({ text = "No revision selected", error = true })
+              return
+            end
+
+            exec_shell(string.format("jj diff -r %q --git --color always | diffnav", change_id))
+          end, { desc = "show diff in diffnav", key = "ctrl+d", scope = "revisions" })
+        end
+      '';
+      plugins = {
+        foo = ./foo.lua;
+        bar = /* lua */ ''
+          local M = {}
+
+          function M.setup(primary, config)
+            config.ui = config.ui or {}
+            config.ui.colors = config.ui.colors or {}
+
+            config.ui.colors.title = { fg = primary, bold = true }
+          end
+
+          return M
+        '';
       };
     };
 
@@ -24,6 +52,18 @@
         assertFileContent \
           "home-files/${configDir}/config.toml" \
           ${./example-settings-expected.toml}
+
+        assertFileContent \
+          "home-files/${configDir}/config.lua" \
+          ${./config-expected.lua}
+
+        assertFileContent \
+          "home-files/${configDir}/plugins/foo.lua" \
+         ${./foo.lua}
+
+        assertFileContent \
+          "home-files/${configDir}/plugins/bar.lua" \
+          ${./bar-expected.lua}
       '';
   };
 }

--- a/tests/modules/programs/jjui/foo.lua
+++ b/tests/modules/programs/jjui/foo.lua
@@ -1,0 +1,10 @@
+local M = {}
+
+function M.setup(primary, config)
+  config.ui = config.ui or {}
+  config.ui.colors = config.ui.colors or {}
+
+  config.ui.colors.selected = { fg = primary, bg = selected_bg, bold = true }
+end
+
+return M

--- a/tests/modules/programs/jjui/null-package.nix
+++ b/tests/modules/programs/jjui/null-package.nix
@@ -1,5 +1,4 @@
 {
-  config,
   pkgs,
   ...
 }:
@@ -16,7 +15,7 @@
 
     nmt.script =
       let
-        configDir = if !pkgs.stdenv.isDarwin then ".config/jjui" else "Library/Application Support/jjui";
+        configDir = ".config/jjui";
       in
       ''
         assertFileContent \


### PR DESCRIPTION
### Description

This PR updates the jjui module to adhere to the newest jjui configuration options:

1. The default configuration directory path on Darwin has been updated, as per the [project documentation defaults](https://idursun.github.io/jjui/customization/config-toml/).
2. New options for [configuring jjui with Lua](https://idursun.github.io/jjui/customization/config-lua/) have been added:
	- `configLua` for the main `${cfg.configDir}/config.lua` Lua configuration file, and
	- `plugins` attrset for declaratively defining jjui Lua plugins.

Fixes #9021.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.
	- I do not consider the change of the default `configDir` to be a breaking change. It could only be breaking if someone relied on the default `configDir` without explicitly setting it, and then **manually** wrote Lua configuration or plugins as `home.file."Library/Application Support/jjui/config.lua".source = ...` instead of `home.file."${config.programs.jjui.configDir}/config.lua".source = ...`. But if needed, we can set the path conditionally for `stateVersion` releases < 26.05 or similar.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
