### PR TITLE
feedr: fix enable option description

### DIFF
--- a/modules/programs/feedr.nix
+++ b/modules/programs/feedr.nix
@@ -12,12 +12,12 @@ in
   meta.maintainers = with lib.maintainers; [ drupol ];
 
   options.programs.feedr = {
-    enable = lib.mkEnableOption "A feature-rich terminal-based RSS/Atom feed reader written in Rust.";
+    enable = lib.mkEnableOption "Feedr, a feature-rich terminal-based RSS/Atom feed reader written in Rust";
 
     package = lib.mkPackageOption pkgs "feedr" { nullable = true; };
 
     settings = lib.mkOption {
-      type = tomlFormat.type;
+      inherit (tomlFormat) type;
       default = { };
       example = lib.literalExpression ''
         {

--- a/tests/modules/programs/feedr/config-exists.nix
+++ b/tests/modules/programs/feedr/config-exists.nix
@@ -1,4 +1,3 @@
-{ ... }:
 {
   programs.feedr = {
     enable = true;
@@ -9,5 +8,10 @@
 
   nmt.script = ''
     assertFileExists "home-files/.config/feedr/config.toml"
+    assertFileContent "home-files/.config/feedr/config.toml" \
+      ${builtins.toFile "feedr-expected.toml" ''
+        [network]
+        http_timeout = 15
+      ''}
   '';
 }

--- a/tests/modules/programs/feedr/disabled.nix
+++ b/tests/modules/programs/feedr/disabled.nix
@@ -1,4 +1,3 @@
-{ ... }:
 {
   programs.feedr.enable = false;
 


### PR DESCRIPTION
### Description

Also minor stylistic fixes.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
