### PR TITLE
oh-my-zsh: preserve shell expansion in custom and theme

### DIFF
--- a/modules/programs/zsh/plugins/oh-my-zsh.nix
+++ b/modules/programs/zsh/plugins/oh-my-zsh.nix
@@ -98,8 +98,8 @@ in
       ${optionalString (
         cfg.oh-my-zsh.plugins != [ ]
       ) "plugins=(${escapeShellArgs cfg.oh-my-zsh.plugins})"}
-      ${optionalString (cfg.oh-my-zsh.custom != "") "ZSH_CUSTOM=${escapeShellArg cfg.oh-my-zsh.custom}"}
-      ${optionalString (cfg.oh-my-zsh.theme != "") "ZSH_THEME=${escapeShellArg cfg.oh-my-zsh.theme}"}
+      ${optionalString (cfg.oh-my-zsh.custom != "") ''ZSH_CUSTOM="${cfg.oh-my-zsh.custom}"''}
+      ${optionalString (cfg.oh-my-zsh.theme != "") ''ZSH_THEME="${cfg.oh-my-zsh.theme}"''}
       source $ZSH/oh-my-zsh.sh
     '';
   };

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -20,6 +20,7 @@
   zsh-history-path-zdotdir-variable = import ./history-path.nix "zdotdir-variable";
   zsh-history-substring-search = ./history-substring-search.nix;
   zsh-legacy-warning = ./legacy-warning.nix;
+  zsh-shell-expansion = ./shell-expansion.nix;
   zsh-siteFunctions-mkcd = ./siteFunctions-mkcd.nix;
   zsh-plugins = ./plugins.nix;
   zsh-prezto = ./prezto.nix;

--- a/tests/modules/programs/zsh/shell-expansion.nix
+++ b/tests/modules/programs/zsh/shell-expansion.nix
@@ -1,0 +1,19 @@
+{
+  programs.zsh = {
+    enable = true;
+    oh-my-zsh = {
+      enable = true;
+      custom = "$HOME/custom oh-my-zsh";
+      theme = "$ZSH_THEME_NAME";
+      plugins = [ "git" ];
+    };
+  };
+
+  test.stubs.zsh = { };
+
+  nmt.script = ''
+    assertFileContains home-files/.zshrc 'plugins=(git)'
+    assertFileContains home-files/.zshrc 'ZSH_CUSTOM="$HOME/custom oh-my-zsh"'
+    assertFileContains home-files/.zshrc 'ZSH_THEME="$ZSH_THEME_NAME"'
+  '';
+}


### PR DESCRIPTION
### Description

Fixes a regression from #9042.

`programs.zsh.oh-my-zsh.custom` and `programs.zsh.oh-my-zsh.theme` currently use `escapeShellArg`, which single-quotes values like `$HOME/.config/shell`.
That prevents shell expansion and makes oh-my-zsh look for custom themes and plugins in a literal `$HOME/...` path.

This switches the generated assignments back to double-quoted shell strings so runtime expansion still works:

- `ZSH_CUSTOM="..."`
- `ZSH_THEME="..."`

Validation:

- adding a small regression test (`zsh-shell-expansion`) covering the generated `.zshrc` output
- running `nix run .#tests -- zsh-shell-expansion`
- confirming the same test fails against unpatched `upstream/master`
- pointing my NixOS flake at this branch, rebuilding, and verifying that the generated `.zshrc` contains double-quoted `ZSH_CUSTOM` / `ZSH_THEME` and that a custom oh-my-zsh theme loads again

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module
  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
