### PR TITLE
opencode: add extraPackages option

### DIFF
--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -46,6 +46,22 @@ let
       lib.listToAttrs (lib.mapAttrsToList transformMcpServer config.programs.mcp.servers)
     else
       { };
+
+  packageWithExtraPackages =
+    if cfg.package != null && cfg.extraPackages != [ ] then
+      pkgs.symlinkJoin {
+        inherit (cfg.package) meta;
+        name = "${lib.getName cfg.package}-wrapped-${lib.getVersion cfg.package}";
+        paths = [ cfg.package ];
+        preferLocalBuild = true;
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        postBuild = ''
+          wrapProgram $out/bin/opencode \
+            --suffix PATH : ${lib.makeBinPath cfg.extraPackages}
+        '';
+      }
+    else
+      cfg.package;
 in
 {
   meta.maintainers = with lib.maintainers; [ delafthi ];
@@ -58,6 +74,13 @@ in
     enable = mkEnableOption "opencode";
 
     package = mkPackageOption pkgs "opencode" { nullable = true; };
+
+    extraPackages = mkOption {
+      type = with lib.types; listOf package;
+      default = [ ];
+      example = literalExpression "[ pkgs.uv ]";
+      description = "Extra packages available to OpenCode.";
+    };
 
     enableMcpIntegration = mkOption {
       type = lib.types.bool;
@@ -446,7 +469,7 @@ in
         ''
       ];
 
-    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    home.packages = mkIf (packageWithExtraPackages != null) [ packageWithExtraPackages ];
 
     xdg.configFile = {
       "opencode/opencode.json" = mkIf (cfg.settings != { } || transformedMcpServers != { }) {
@@ -577,7 +600,7 @@ in
         };
 
         Service = {
-          ExecStart = "${lib.getExe cfg.package} serve ${lib.escapeShellArgs webCfg.extraArgs}";
+          ExecStart = "${lib.getExe packageWithExtraPackages} serve ${lib.escapeShellArgs webCfg.extraArgs}";
           Restart = "always";
           RestartSec = 5;
         }
@@ -598,7 +621,7 @@ in
           ProgramArguments =
             let
               programArguments = [
-                (lib.getExe cfg.package)
+                (lib.getExe packageWithExtraPackages)
                 "serve"
               ]
               ++ webCfg.extraArgs;


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
This PR adds an `extraPackages` option to opencode.
This is useful to provide it with formatters and lsps.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
