### PR TITLE
copyApps: workaround for macOS 26.3 signature bug

### DIFF
--- a/modules/targets/darwin/copyapps.nix
+++ b/modules/targets/darwin/copyapps.nix
@@ -121,20 +121,23 @@ in
               run mkdir -p "$targetFolder"
 
               rsyncFlags=(
+                --recursive
                 # mtime is standardized in the nix store, which would leave only file size to distinguish files.
                 # Thus we need checksums, despite the speed penalty.
                 --checksum
+                --perms
+                --links
                 # Converts all symlinks pointing outside of the copied tree (thus unsafe) into real files and directories.
                 # This neatly converts all the symlinks pointing to application bundles in the nix store into
                 # real directories, without breaking any relative symlinks inside of application bundles.
                 # This is good enough, because the make-symlinks-relative.sh setup hook converts all $out internal
                 # symlinks to relative ones.
                 --copy-unsafe-links
-                --archive
+                --specials
                 --delete
                 --chmod=+w
-                --no-group
-                --no-owner
+                # Copied files inherit the current user and group. Avoid copying the file timestamps,
+                # because macOS 26.3 throws a signature verification error when mtime = 1.
               )
 
               run ${lib.getExe pkgs.rsync} "''${rsyncFlags[@]}" ${applications}/Applications/ "$targetFolder"


### PR DESCRIPTION
### Description

macOS throws a code signing error when the modification time on an app is set to 1. This seems to have started on macOS 26.3, but I'm not fully sure. Hitting this is uncommon. macOS caches signatures, so apps that were opened prior to updating macOS continue to work. I ran into this because Ghostty 1.3.0 added a new signature to their bundle.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
