### PR TITLE
Module/dprint

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -475,6 +475,11 @@
     github = "prescientmoon";
     githubId = 39400800;
   };
+  rachitvrma = {
+    name = "Rachit Kumar Verma";
+    github = "rachitvrma";
+    githubId = 155641117;
+  };
   rasmus-kirk = {
     name = "Rasmus Kirk";
     email = "mail@rasmuskirk.com";

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -499,6 +499,11 @@
     github = "prescientmoon";
     githubId = 39400800;
   };
+  rachitvrma = {
+    name = "Rachit Kumar Verma";
+    github = "rachitvrma";
+    githubId = 155641117;
+  };
   rasmus-kirk = {
     name = "Rasmus Kirk";
     email = "mail@rasmuskirk.com";

--- a/modules/misc/news/2026/04/2026-04-14_14-50-21.nix
+++ b/modules/misc/news/2026/04/2026-04-14_14-50-21.nix
@@ -1,0 +1,11 @@
+{ config, pkgs, ... }:
+{
+  time = "2026-04-14T09:20:21+00:00";
+  # condition = pkgs.stdenv.hostPlatform.isLinux;
+  # condition = config.programs.neovim.enable;
+  condition = true;
+  # if behavior changed, explain how to restore previous behavior.
+  message = ''
+    PLACEHOLDER
+  '';
+}

--- a/modules/misc/news/2026/04/2026-04-14_14-50-21.nix
+++ b/modules/misc/news/2026/04/2026-04-14_14-50-21.nix
@@ -1,11 +1,14 @@
-{ config, pkgs, ... }:
-{
+_: {
   time = "2026-04-14T09:20:21+00:00";
   # condition = pkgs.stdenv.hostPlatform.isLinux;
   # condition = config.programs.neovim.enable;
   condition = true;
   # if behavior changed, explain how to restore previous behavior.
   message = ''
-    PLACEHOLDER
+    A new module is available: 'programs.dprint'.
+
+    dprint is a code formatter written in rust.
+    It allows formatting toml, markdown, yaml, and many other filetypes.
+    See https://dprint.dev/ for more.
   '';
 }

--- a/modules/misc/news/2026/04/2026-04-14_14-50-21.nix
+++ b/modules/misc/news/2026/04/2026-04-14_14-50-21.nix
@@ -1,0 +1,11 @@
+{
+  time = "2026-04-14T09:20:21+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.dprint'.
+
+    dprint is a code formatter written in rust.
+    It allows formatting toml, markdown, yaml, and many other filetypes.
+    See https://dprint.dev/ for more.
+  '';
+}

--- a/modules/programs/dprint.nix
+++ b/modules/programs/dprint.nix
@@ -1,0 +1,77 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  inherit (lib) mkIf mkOption types;
+
+  cfg = config.programs.dprint;
+
+  jsonFormat = pkgs.formats.json { };
+
+  configJson = cfg.settings // {
+    plugins = map (p: "${p}/plugin.wasm") cfg.plugins;
+  };
+
+  hasConfig = cfg.plugins != [ ] || cfg.settings != { };
+in
+{
+  meta.maintainers = [ lib.maintainers.rachitvrma ];
+
+  options.programs.dprint = {
+    enable = lib.mkEnableOption ''
+      dprint: a code formatter for common filetypes like markdown, toml, yaml,
+      and many more. See https://dprint.dev/
+    '';
+
+    package = lib.mkPackageOption pkgs "dprint" { };
+
+    settings = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      description = ''
+        Settings to add to {file}`$XDG_CONIFG_HOME/dprint/dprint.json`.
+      '';
+
+      example = lib.literalExpression ''
+        {
+          excludes = [
+            "**/node_modules"
+            "**/*-lock.json"
+          ];
+          json = { };
+          malva = { };
+          markdown = { };
+          toml = { };
+          typescript = { };
+          yaml = { };
+        }
+      '';
+    };
+
+    plugins = mkOption {
+      type = with types; listOf package;
+      default = [ ];
+      description = ''
+        Plugins to add to dprint's plugin set
+      '';
+
+      example = lib.literalExpression ''
+        [
+          pkgs.dprint-plugins.gplane-pretty_yaml
+          pkgs.dprint-plugin-typescript
+        ]
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."dprint/dprint.json" = mkIf hasConfig {
+      text = builtins.toJSON configJson;
+    };
+  };
+}

--- a/modules/programs/dprint.nix
+++ b/modules/programs/dprint.nix
@@ -1,0 +1,52 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  inherit (lib) mkIf mkOption;
+  cfg = config.programs.dprint;
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  meta.maintainers = [ lib.maintainers.rachitvrma ];
+  options.programs.dprint = {
+    enable = lib.mkEnableOption ''
+      dprint: a code formatter for common filetypes like markdown, toml, yaml,
+      and many more. See https://dprint.dev/
+    '';
+    package = lib.mkPackageOption pkgs "dprint" { nullable = true; };
+    settings = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      description = ''
+        Settings to add to {file}`$XDG_CONFIG_HOME/dprint/dprint.json`.
+      '';
+      example = lib.literalExpression ''
+        {
+          excludes = [
+            "**/node_modules"
+            "**/*-lock.json"
+          ];
+          plugins = [
+            "https://plugins.dprint.dev/typescript-0.96.1.wasm"
+            "''${pkgs.dprint-plugins.g-plane-pretty_yaml}/plugin.wasm"
+          ];
+          json = { };
+          malva = { };
+          markdown = { };
+          toml = { };
+          typescript = { };
+          yaml = { };
+        }
+      '';
+    };
+  };
+  config = mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."dprint/dprint.json" = mkIf (cfg.settings != { }) {
+      source = jsonFormat.generate "hm_dprintdprint.json" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/dprint/default.nix
+++ b/tests/modules/programs/dprint/default.nix
@@ -1,0 +1,4 @@
+{
+  dprint-example-settings = ./example-dprint.nix;
+  dprint-empty-settings = ./empty-dprint.nix;
+}

--- a/tests/modules/programs/dprint/empty-dprint.nix
+++ b/tests/modules/programs/dprint/empty-dprint.nix
@@ -1,0 +1,6 @@
+{
+  programs.dprint.enable = true;
+  nmt.script = ''
+    assertPathNotExists home-files/.config/dprint
+  '';
+}

--- a/tests/modules/programs/dprint/example-dprint.nix
+++ b/tests/modules/programs/dprint/example-dprint.nix
@@ -1,0 +1,26 @@
+{
+  programs.dprint = {
+    enable = true;
+    settings = {
+      excludes = [ "**/*-lock.json" ];
+      json = {
+        indentWidth = 2;
+      };
+      lineWidth = 80;
+      plugins = [
+        "https://plugins.dprint.dev/typescript-0.96.1.wasm"
+        "https://plugins.dprint.dev/json-0.23.0.wasm"
+        "https://plugins.dprint.dev/markdown-0.22.1.wasm"
+      ];
+      typescript = {
+        "binaryExpression.operatorPosition" = "sameLine";
+        quoteStyle = "preferSingle";
+      };
+    };
+  };
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/dprint/dprint.json \
+      ${./expected-dprint.json}
+  '';
+}

--- a/tests/modules/programs/dprint/expected-dprint.json
+++ b/tests/modules/programs/dprint/expected-dprint.json
@@ -1,0 +1,18 @@
+{
+  "excludes": [
+    "**/*-lock.json"
+  ],
+  "json": {
+    "indentWidth": 2
+  },
+  "lineWidth": 80,
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.96.1.wasm",
+    "https://plugins.dprint.dev/json-0.23.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.22.1.wasm"
+  ],
+  "typescript": {
+    "binaryExpression.operatorPosition": "sameLine",
+    "quoteStyle": "preferSingle"
+  }
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Dprint code formatter module added for use with editors. It can format many basic filetypes (json, markdown, toml, yaml, etc). Written in rust. 
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
