### PR TITLE
yazi: add option for {file}`$XDG_CONFIG_HOME/yazi/vfs.toml`

### DIFF
--- a/modules/misc/news/2026/04/2026-04-14_18-19-27.nix
+++ b/modules/misc/news/2026/04/2026-04-14_18-19-27.nix
@@ -5,8 +5,7 @@
   message = ''
     Added new option for yazi: programs.yazi.vfs
 
-    Yazi has a vfs.toml in it's config directory to manage
-    virtual file systems. The conifguration can now be managed with
-    programs.yazi.vfs
+    Yazi provides a vfs.toml config file to manage virtual file systems,
+    which can now be managed with programs.yazi.vfs
   '';
 }

--- a/modules/misc/news/2026/04/2026-04-14_18-19-27.nix
+++ b/modules/misc/news/2026/04/2026-04-14_18-19-27.nix
@@ -1,8 +1,9 @@
+{ config, ... }:
 {
   time = "2026-04-14T12:49:27+00:00";
   # condition = pkgs.stdenv.hostPlatform.isLinux;
   # condition = config.programs.neovim.enable;
-  condition = true;
+  condition = config.programs.yazi.enable;
   # if behavior changed, explain how to restore previous behavior.
   message = ''
     Added new option for yazi: programs.yazi.vfs

--- a/modules/misc/news/2026/04/2026-04-14_18-19-27.nix
+++ b/modules/misc/news/2026/04/2026-04-14_18-19-27.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+_:
 {
   time = "2026-04-14T12:49:27+00:00";
   # condition = pkgs.stdenv.hostPlatform.isLinux;

--- a/modules/misc/news/2026/04/2026-04-14_18-19-27.nix
+++ b/modules/misc/news/2026/04/2026-04-14_18-19-27.nix
@@ -1,0 +1,15 @@
+{ config, pkgs, ... }:
+{
+  time = "2026-04-14T12:49:27+00:00";
+  # condition = pkgs.stdenv.hostPlatform.isLinux;
+  # condition = config.programs.neovim.enable;
+  condition = true;
+  # if behavior changed, explain how to restore previous behavior.
+  message = ''
+    Added new option for yazi: programs.yazi.vfs
+
+    Yazi has a vfs.toml in it's config directory to manage
+    virtual file systems. The conifguration can now be managed with
+    programs.yazi.vfs
+  '';
+}

--- a/modules/misc/news/2026/04/2026-04-14_18-19-27.nix
+++ b/modules/misc/news/2026/04/2026-04-14_18-19-27.nix
@@ -1,4 +1,3 @@
-_:
 {
   time = "2026-04-14T12:49:27+00:00";
   # condition = pkgs.stdenv.hostPlatform.isLinux;

--- a/modules/misc/news/2026/04/2026-04-14_18-19-27.nix
+++ b/modules/misc/news/2026/04/2026-04-14_18-19-27.nix
@@ -1,10 +1,7 @@
 { config, ... }:
 {
   time = "2026-04-14T12:49:27+00:00";
-  # condition = pkgs.stdenv.hostPlatform.isLinux;
-  # condition = config.programs.neovim.enable;
   condition = config.programs.yazi.enable;
-  # if behavior changed, explain how to restore previous behavior.
   message = ''
     Added new option for yazi: programs.yazi.vfs
 

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -153,6 +153,30 @@ in
       '';
     };
 
+    vfs = mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = literalExpression ''
+        {
+          services = {
+            my-server = {
+              host = "1.2.3.4";
+              port = 22;
+              type = "sftp";
+              user = "root";
+            };
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/yazi/vfs.toml`.
+
+        See <https://yazi-rs.github.io/docs/configuration/vfs>
+        for the full list of options
+      '';
+    };
+
     initLua = mkOption {
       type = with types; nullOr (either path lines);
       default = null;
@@ -282,6 +306,9 @@ in
       };
       "yazi/theme.toml" = mkIf (cfg.theme != { }) {
         source = tomlFormat.generate "yazi-theme" cfg.theme;
+      };
+      "yazi/vfs.toml" = mkIf (cfg.vfs != { }) {
+        source = tomlFormat.generate "yazi-vfs" cfg.vfs;
       };
       "yazi/init.lua" = mkIf (cfg.initLua != null) (
         if builtins.isPath cfg.initLua then


### PR DESCRIPTION
Add option to configure the vfs.toml file in yazi
See <https://yazi-rs.github.io/docs/configuration/vfs> for more details

### Description

<!--

Please provide a brief description of your change.

-->

This module adds the vfs option to yazi, that now generates a vfs.toml file in $XDG_CONFIG_HOME/yazi and allow connecting with virtual file system. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

- If this PR adds an exciting new feature or contains a breaking change.
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  
@eljamm 
@khaneliman 
@XYenon 
