### PR TITLE
neovim: Support configuring plugins using Fennel

### DIFF
--- a/modules/programs/neovim/default.nix
+++ b/modules/programs/neovim/default.nix
@@ -21,7 +21,7 @@ let
 
   inherit
     (
-      (import ../lib/file-type.nix {
+      (import ../../lib/file-type.nix {
         inherit (config.home) homeDirectory;
         inherit lib pkgs;
       })
@@ -50,6 +50,7 @@ in
   meta.maintainers = with lib.maintainers; [ khaneliman ];
 
   imports = [
+    ./fennel.nix
     (lib.mkRenamedOptionModule
       [ "programs" "neovim" "extraLuaConfig" ]
       [ "programs" "neovim" "initLua" ]

--- a/modules/programs/neovim/fennel.nix
+++ b/modules/programs/neovim/fennel.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.neovim;
+in
+{
+  config = lib.mkIf cfg.enable {
+    programs.neovim.initLua =
+      lib.mkIf (lib.hasAttr "fennel" cfg.generatedConfigs && cfg.generatedConfigs.fennel != "")
+        (
+          lib.mkAfter ''
+            -- user-associated fennel plugin config {{{
+            require('fennel-plugins')
+            -- }}}
+          ''
+        );
+
+    xdg.configFile."nvim/lua/fennel-plugins.lua" =
+      let
+        compiledFennel =
+          pkgs.runCommand "fennel-plugins.lua"
+            {
+              fnlSrc = cfg.generatedConfigs.fennel;
+              __structuredAttrs = true;
+            }
+            ''
+              ${lib.getExe pkgs.jq} -rj '.fnlSrc' "$NIX_ATTRS_JSON_FILE" > fnlSrc
+              ${lib.getExe cfg.package.lua.pkgs.fennel} --compile fnlSrc > "$out"
+            '';
+      in
+      lib.mkIf (lib.hasAttr "fennel" cfg.generatedConfigs && cfg.generatedConfigs.fennel != "") {
+        source = compiledFennel;
+      };
+  };
+}

--- a/tests/modules/programs/neovim/default.nix
+++ b/tests/modules/programs/neovim/default.nix
@@ -9,4 +9,5 @@
   neovim-extra-lua-default = ./extra-lua-default.nix;
   neovim-extra-lua-empty-plugin = ./extra-lua-empty-plugin.nix;
   neovim-plugin-type-warning = ./plugin-type-warning.nix;
+  neovim-fennel-plugin-config = ./plugin-fennel-config.nix;
 }

--- a/tests/modules/programs/neovim/plugin-fennel-config.nix
+++ b/tests/modules/programs/neovim/plugin-fennel-config.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  realPkgs,
+  ...
+}:
+
+lib.mkIf config.test.enableBig {
+  programs.neovim = {
+    enable = true;
+    withRuby = false;
+    plugins = with pkgs.vimPlugins; [
+      {
+        plugin = vim-nix;
+        type = "fennel";
+        config = ''(vim.cmd "let g:hmFennelPlugin='HM_FENNEL_PLUGIN'")'';
+      }
+    ];
+  };
+
+  _module.args.pkgs = lib.mkForce realPkgs;
+
+  nmt.script = ''
+    export PATH="$TESTED/home-path/bin:$PATH"
+    export HOME=$TMPDIR/hm-user
+    export XDG_CONFIG_HOME="$TESTED/home-files/.config"
+    initLua="$TESTED/home-files/.config/nvim/init.lua"
+
+    assertFileContains "$initLua" "require('fennel-plugins')"
+
+    vimout=$(mktemp)
+    nvim --headless +'lua print(vim.g.hmFennelPlugin)' +q! 2&> $vimout
+    assertFileContains "$vimout" "HM_FENNEL_PLUGIN"
+  '';
+}


### PR DESCRIPTION
### Description

PR #2637 added a 'type' field denoting the language used to configure Neovim plugins. However, when the type is set to "fennel" or "teal" the configuration is silently ignored.

This PR enables support for Fennel by transpiling it to Lua before `require`-ing the generated code in `init.lua`.

This commit __does not__ provide support for configs written in Teal; they are still silently ignored. 

I'm on the fence if this is too niche for home-manager; If the option didn't already exist I wouldn't submit this PR. Additionally, its fairly easy to transpile within users personal configs.

### Checklist

<details>

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module (NA)


  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change. (NA)
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

</details>