### PR TITLE
macos-terminal: init module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -284,6 +284,12 @@
     github = "kalhauge";
     githubId = 1182166;
   };
+  kayskayskays = {
+    name = "Kays";
+    email = "115312476+kayskayskays@users.noreply.github.com";
+    github = "kayskayskays";
+    githubId = 115312476;
+  };
   kmaasrud = {
     name = "Knut Magnus Aasrud";
     email = "km@aasrud.com";

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -302,6 +302,12 @@
     github = "kalhauge";
     githubId = 1182166;
   };
+  kayskayskays = {
+    name = "Kays";
+    email = "115312476+kayskayskays@users.noreply.github.com";
+    github = "kayskayskays";
+    githubId = 115312476;
+  };
   kmaasrud = {
     name = "Knut Magnus Aasrud";
     email = "km@aasrud.com";

--- a/modules/misc/news/2026/04/2026-04-15_21-57-57.nix
+++ b/modules/misc/news/2026/04/2026-04-15_21-57-57.nix
@@ -1,0 +1,14 @@
+{
+  pkgs,
+  ...
+}:
+{
+  time = "2026-04-15T11:57:57+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin;
+  message = ''
+    A new module is available: `programs.macos-terminal`.
+
+    This module allows for configuration of preferences for the macOS
+    Terminal.app application.
+  '';
+}

--- a/modules/programs/macos-terminal.nix
+++ b/modules/programs/macos-terminal.nix
@@ -1,0 +1,186 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    maintainers
+    mapAttrs
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkOption
+    literalExpression
+    types
+    ;
+
+  inherit (lib.hm)
+    assertions
+    dag
+    ;
+
+  inherit (lib.platforms) darwin;
+  inherit (pkgs.formats) plist;
+
+  cfg = config.programs.macos-terminal;
+  inherit (cfg) preferences;
+
+  plistFormat = plist { escape = true; };
+
+  profileType = types.submodule {
+    options = {
+      # These settings will be passed directly to the plist generator.
+      settings = mkOption {
+        type = types.attrsOf plistFormat.type;
+
+        default = { };
+
+        example = literalExpression ''
+          {
+            FontAntialias = true;
+            ShowActiveProcessInTitle = true;
+            ShowCommandKeyInTitle = true;
+          };
+        '';
+
+        description = ''
+          Raw plist-compatible settings for profiles within the Terminal.app
+          application.
+
+          This attribute set is intended for simple settings that have a well
+          defined mapping to plist properties.
+
+          Properties that are more obscure and require serialization as
+          archived Cocoa objects, for example, are unsupported here - they may
+          require dedicated module options in future.
+
+          Attribute names should reflect the name of plist properties understood
+          by the Terminal.app application. Unknown attributes will still be
+          serialized, but may remain unrecognised - and thus unhonored - by the
+          Terminal.app application.
+        '';
+      };
+    };
+
+    config.settings = {
+      # For profiles, the "type" plist property should always be "Window
+      # Settings".
+      type = mkDefault "Window Settings";
+
+      # Other common profile defaults.
+      rowCount = mkDefault 24;
+      columnCount = mkDefault 80;
+      ProfileCurrentVersion = mkDefault 2.07;
+    };
+  };
+
+  preferencesType = types.submodule {
+    options = {
+      importSettings = mkOption {
+        type = types.bool;
+
+        default = true;
+
+        description = ''
+          Whether to import the generated plist into the `com.apple.Terminal`
+          preferences domain during activation.
+        '';
+      };
+
+      writeFile = mkOption {
+        type = types.bool;
+
+        default = false;
+
+        description = ''
+          Whether to write the generated plist into the
+          `~/Library/Preferences/com.apple.Terminal.plist` file during
+          activation.
+
+          This is primarily useful for inspection and testing purposes.
+        '';
+      };
+    };
+  };
+
+  # Flatten out the settings.
+  finalSettings = mapAttrs (name: profile: profile.settings // { inherit name; }) cfg.profiles;
+
+  # Write out the config to a plist file. This will be used to set the default
+  # preferences for the Terminal.app application.
+  plistFile = plistFormat.generate "com.apple.Terminal.plist" {
+    "Window Settings" = finalSettings;
+  };
+in
+{
+  meta.maintainers = with maintainers; [
+    kayskayskays
+  ];
+
+  options.programs.macos-terminal = {
+    enable = mkEnableOption "macOS Terminal";
+
+    profiles = mkOption {
+      type = types.attrsOf profileType;
+
+      default = { };
+
+      example = literalExpression ''
+        {
+          Basic.settings = {
+            FontAntialias = true;
+            ShowActiveProcessInTitle = true;
+          };
+
+          "Red Sands".settings = {
+            BackgroundAlphaInactive = 0.5;
+            CommandString = "ssh compute";
+          };
+        }
+      '';
+
+      description = ''
+        Configuration settings for profiles within the Terminal.app application.
+
+        Each attribute name is used as the name of the profile, and the value
+        defines the plist-compatible settings for that profile.
+      '';
+    };
+
+    preferences = mkOption {
+      type = preferencesType;
+
+      default = { };
+
+      example = literalExpression ''
+        {
+          importSettings = true;
+          writeFile = false;
+        }
+      '';
+
+      description = ''
+        Options controlling how Terminal.app preferences are applied and
+        managed.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (assertions.assertPlatform "programs.macos-terminal" pkgs darwin)
+    ];
+
+    home.file."Library/Preferences/com.apple.Terminal.plist" = mkIf preferences.writeFile {
+      source = plistFile;
+    };
+
+    home.activation.appleTerminal = mkIf preferences.importSettings (
+      dag.entryAfter [ "writeBoundary" ] ''
+        run /usr/bin/defaults import com.apple.Terminal "${plistFile}"
+      ''
+    );
+  };
+}

--- a/modules/programs/macos-terminal.nix
+++ b/modules/programs/macos-terminal.nix
@@ -1,0 +1,179 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    maintainers
+    mapAttrs
+    mkEnableOption
+    mkIf
+    mkOption
+    mkOptionDefault
+    types
+    ;
+
+  inherit (lib.hm)
+    assertions
+    dag
+    ;
+
+  inherit (lib.platforms) darwin;
+  inherit (pkgs.formats) plist;
+
+  cfg = config.programs.macos-terminal;
+  plistFormat = plist { escape = true; };
+in
+{
+  meta.maintainers = with maintainers; [
+    kayskayskays
+  ];
+
+  options.programs.macos-terminal = {
+    enable = mkEnableOption "macOS Terminal";
+
+    profiles = mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          # These settings will be passed directly to the plist generator.
+          options.settings = mkOption {
+            type = types.attrsOf plistFormat.type;
+
+            default = { };
+
+            example = ''
+              {
+                FontAntialias = true;
+                ShowActiveProcessInTitle = true;
+                ShowCommandKeyInTitle = true;
+              };
+            '';
+
+            description = ''
+              Raw plist-compatible settings for profiles within the Terminal.app
+              application.
+
+              This attribute set is intended for simple settings that have a
+              well defined mapping to plist properties.
+
+              Properties that are more obscure and require serialization as
+              archived Cocoa objects, for example, are unsupported here - they
+              may require dedicated module options in future.
+
+              Attribute names should reflect the name of plist properties
+              understood by the Terminal.app application. Unknown attributes
+              will still be serialized, but may remain unrecognised - and thus
+              unhonored - by the Terminal.app application.
+            '';
+          };
+
+          config.settings = {
+            # For profiles, the "type" plist property should always be "Window
+            # Settings".
+            type = mkOptionDefault "Window Settings";
+
+            # Other common profile defaults.
+            rowCount = mkOptionDefault 24;
+            columnCount = mkOptionDefault 80;
+            ProfileCurrentVersion = mkOptionDefault 2.07;
+          };
+        }
+      );
+
+      default = { };
+
+      example = ''
+        {
+          Basic.settings = {
+            FontAntialias = true;
+            ShowActiveProcessInTitle = true;
+          };
+
+          "Red Sands".settings = {
+            BackgroundAlphaInactive = 0.5;
+            CommandString = "ssh compute";
+          };
+        }
+      '';
+
+      description = ''
+        Configuration settings for profiles within the Terminal.app application.
+
+        Each attribute name is used as the name of the profile, and the value
+        defines the plist-compatible settings for that profile.
+      '';
+    };
+
+    preferences = mkOption {
+      type = types.submodule {
+        options = {
+          importSettings = mkOption {
+            type = types.bool;
+
+            default = true;
+
+            description = ''
+              Whether to import the generated plist into the
+              `com.apple.Terminal` preferences domain during activation.
+            '';
+          };
+
+          writeFile = mkOption {
+            type = types.bool;
+
+            default = false;
+
+            description = ''
+              Whether to write the generated plist into the
+              `~/Library/Preferences/com.apple.Terminal.plist` file during
+               activation.
+
+               This is primarily useful for inspection and testing purposes.
+            '';
+          };
+        };
+      };
+
+      default = { };
+
+      example = ''
+        {
+          importSettings = true;
+          writeFile = false;
+        }
+      '';
+
+      description = ''
+        Options controlling how Terminal.app preferences are applied and
+        managed.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable (
+    let
+      finalSettings = mapAttrs (name: profile: profile.settings // { inherit name; }) cfg.profiles;
+
+      plistFile = plistFormat.generate "com.apple.Terminal.plist" {
+        "Window Settings" = finalSettings;
+      };
+    in
+    {
+      assertions = [
+        (assertions.assertPlatform "programs.macos-terminal" pkgs darwin)
+      ];
+
+      home.file."Library/Preferences/com.apple.Terminal.plist" = mkIf cfg.preferences.writeFile {
+        source = plistFile;
+      };
+
+      home.activation.appleTerminal = mkIf cfg.preferences.importSettings (
+        dag.entryAfter [ "writeBoundary" ] ''
+          run /usr/bin/defaults import com.apple.Terminal "${plistFile}"
+        ''
+      );
+    }
+  );
+}

--- a/tests/modules/programs/macos-terminal/basic-configuration.nix
+++ b/tests/modules/programs/macos-terminal/basic-configuration.nix
@@ -1,0 +1,30 @@
+{
+  programs.macos-terminal = {
+    enable = true;
+
+    profiles = {
+      Basic.settings = {
+        CommandString = "echo test";
+
+        ShowActiveProcessArgumentsInTitle = false;
+        ShowTTYNameInTitle = true;
+
+        columnCount = 50;
+      };
+    };
+
+    preferences = {
+      importSettings = false;
+      writeFile = true;
+    };
+  };
+
+  nmt.script =
+    let
+      plistFile = "home-files/Library/Preferences/com.apple.Terminal.plist";
+    in
+    ''
+      assertFileExists "${plistFile}"
+      assertFileContent "${plistFile}" ${./expected-basic-configuration.plist}
+    '';
+}

--- a/tests/modules/programs/macos-terminal/default.nix
+++ b/tests/modules/programs/macos-terminal/default.nix
@@ -1,0 +1,8 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+  macos-terminal-basic-configuration = ./basic-configuration.nix;
+}

--- a/tests/modules/programs/macos-terminal/expected-basic-configuration.plist
+++ b/tests/modules/programs/macos-terminal/expected-basic-configuration.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Window Settings</key>
+	<dict>
+		<key>Basic</key>
+		<dict>
+			<key>CommandString</key>
+			<string>echo test</string>
+			<key>ProfileCurrentVersion</key>
+			<real>2.070000</real>
+			<key>ShowActiveProcessArgumentsInTitle</key>
+			<false/>
+			<key>ShowTTYNameInTitle</key>
+			<true/>
+			<key>columnCount</key>
+			<integer>50</integer>
+			<key>name</key>
+			<string>Basic</string>
+			<key>rowCount</key>
+			<integer>24</integer>
+			<key>type</key>
+			<string>Window Settings</string>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Created a new `macos-terminal` module to allow for the configuration of the macOS Terminal.app application.

Currently, the module supports the specification of simple plist key-value pairs. More complex base-64 encoded data is, as of yet, unsupported (and is, potentially, pending some enhancements to the nixpkgs plist generator).

#### Note on testing attempts:
I attempted to execute the tests using the `nix-shell --pure tests -A run.all` command, but I encountered an error unrelated to my module:

```       
error: attribute 'description' missing
       at /nix/store/f9zw9nsp96n5zlfr2cwl8msrd1mfbzm1-source/pkgs/applications/networking/browsers/firefox/wrapper.nix:592:32:
          591|       meta = browser.meta // {
          592|         inherit (browser.meta) description;
             |                                ^
          593|         mainProgram = launcherName;
```

Since this wasn't working, I settled for running the test that was written alongside this module, which passed.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
