### PR TITLE
home-manager-auto-upgrade: allow passing switchExtraFlags

### DIFF
--- a/modules/services/home-manager-auto-upgrade.nix
+++ b/modules/services/home-manager-auto-upgrade.nix
@@ -11,6 +11,8 @@ let
 
   homeManagerPackage = config.programs.home-manager.package;
 
+  switchExtraFlags = lib.strings.concatStringsSep " " cfg.switchExtraFlags;
+
   autoUpgradeApp = pkgs.writeShellApplication {
     name = "home-manager-auto-upgrade";
     text =
@@ -26,14 +28,14 @@ let
           echo "Update flake inputs"
           nix flake update
           echo "Upgrade Home Manager"
-          home-manager switch --flake .
+          home-manager switch --flake . ${switchExtraFlags}
         ''
       else
         ''
           echo "Update Nix's channels"
           nix-channel --update
           echo "Upgrade Home Manager"
-          home-manager switch
+          home-manager switch ${switchExtraFlags}
         '';
     runtimeInputs = with pkgs; [
       homeManagerPackage
@@ -74,6 +76,15 @@ in
         defaultText = lib.literalExpression ''"''${config.xdg.configHome}/home-manager"'';
         example = "/home/user/dotfiles";
         description = "The directory of the flake to update.";
+      };
+
+      switchExtraFlags = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = lib.literalExpression ''[ "--specialisation" "foo" ]'';
+        description = ''
+          Extra flags to pass to `home-manager switch`.
+        '';
       };
     };
   };

--- a/tests/modules/services/home-manager-auto-upgrade/default.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/default.nix
@@ -3,4 +3,5 @@
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   home-manager-auto-upgrade-basic-configuration = ./basic-configuration.nix;
   home-manager-auto-upgrade-flake-configuration = ./flake-configuration.nix;
+  home-manager-auto-upgrade-flake-switchextraflags-configuration = ./flake-switchextraflags-configuration.nix;
 }

--- a/tests/modules/services/home-manager-auto-upgrade/flake-switchextraflags-configuration.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/flake-switchextraflags-configuration.nix
@@ -1,0 +1,21 @@
+{
+  services.home-manager.autoUpgrade = {
+    enable = true;
+    frequency = "daily";
+    useFlake = true;
+    flakeDir = "/tmp/my-flake";
+    switchExtraFlags = [
+      "--specialisation"
+      "my-specialisation"
+    ];
+  };
+
+  nmt.script = ''
+    serviceFile="home-files/.config/systemd/user/home-manager-auto-upgrade.service"
+    assertFileExists "$serviceFile"
+    assertFileRegex "$serviceFile" "FLAKE_DIR=/tmp/my-flake"
+
+    scriptPath=$(grep -oP 'ExecStart=\K.+' "$TESTED/$serviceFile")
+    assertFileRegex "$scriptPath" "home-manager switch --flake . --specialisation my-specialisation"
+  '';
+}


### PR DESCRIPTION
### Description

Before, when using a specialisation via e. g. "home-manager switch --specialisation foo", the autoupgrade would execute "home-manager switch" without specialisation flag, effectively not only updating inputs and applying updates, but also switch to the unspecialised configuration.

This commit allows to set the specialisation name passed to "home-manager switch". If some specialisation sets it to "its own" name, this allows to effectively preserve the currently activated specialisation.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`. -> Targeted test worked

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```