### PR TITLE
files: prefix relative path literal with './'

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -34,7 +34,7 @@ let
 
   inherit
     (
-      (import lib/file-type.nix {
+      (import ./lib/file-type.nix {
         inherit homeDirectory lib pkgs;
       })
     )


### PR DESCRIPTION
## Summary

- Prefixes the relative path literal `lib/file-type.nix` with `./` in `modules/files.nix` to fix the Nix `warn-short-path-literals` warning

## Context

Nix emits the following warning when evaluating home-manager:

```
warning: relative path literal 'lib/file-type.nix' should be prefixed with '.'
for clarity: './lib/file-type.nix'. (warn-short-path-literals = true)
    at «github:nix-community/home-manager/3c7524c»/modules/files.nix:37:15
```

Nix recommends that relative path literals be prefixed with `./` to clearly distinguish them from other path forms. This is a no-op change in behavior.