### PR TITLE
treewide: refactor to use `lib.mkEnableOption`

### DIFF
--- a/modules/accounts/calendar.nix
+++ b/modules/accounts/calendar.nix
@@ -1,6 +1,6 @@
 { config, lib, ... }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.accounts.calendar;
 
@@ -91,14 +91,7 @@ let
           '';
         };
 
-        primary = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Whether this is the primary account. Only one account may be
-            set as primary.
-          '';
-        };
+        primary = mkEnableOption "marking this as the primary account. Only one account may be set as primary";
 
         primaryCollection = mkOption {
           type = types.nullOr types.str;

--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -5,6 +5,7 @@ let
     mkDefault
     mkIf
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -20,17 +21,9 @@ let
         '';
       };
 
-      signByDefault = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Sign messages by default.";
-      };
+      signByDefault = mkEnableOption "signing messages by default";
 
-      encryptByDefault = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Encrypt outgoing messages by default.";
-      };
+      encryptByDefault = mkEnableOption "encrypting outgoing messages by default";
     };
   };
 
@@ -93,13 +86,7 @@ let
         '';
       };
 
-      useStartTls = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to use STARTTLS.
-        '';
-      };
+      useStartTls = mkEnableOption "STARTTLS";
 
       certificatesFile = mkOption {
         type = types.nullOr types.path;
@@ -374,14 +361,7 @@ let
           '';
         };
 
-        primary = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Whether this is the primary account. Only one account may be
-            set as primary.
-          '';
-        };
+        primary = mkEnableOption "marking this as the primary account. Only one account may be set as primary";
 
         enable = mkOption {
           type = types.bool;

--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -78,12 +78,8 @@ let
 
   tlsModule = types.submodule {
     options = {
-      enable = mkOption {
-        type = types.bool;
+      enable = mkEnableOption "TLS/SSL" // {
         default = true;
-        description = ''
-          Whether to enable TLS/SSL.
-        '';
       };
 
       useStartTls = mkEnableOption "STARTTLS";
@@ -363,15 +359,11 @@ let
 
         primary = mkEnableOption "marking this as the primary account. Only one account may be set as primary";
 
-        enable = mkOption {
-          type = types.bool;
-          default = true;
-          description = ''
-            Whether this account is enabled.  Potentially useful to allow
-            setting email configuration globally then enabling or disabling on
-            specific systems.
-          '';
-        };
+        enable =
+          mkEnableOption "this account. Potentially useful to allow setting email configuration globally then enabling or disabling on specific systems"
+          // {
+            default = true;
+          };
 
         flavor = mkOption {
           type = types.enum [

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -6,7 +6,12 @@
 }:
 
 let
-  inherit (lib) literalExpression mkOption types;
+  inherit (lib)
+    literalExpression
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   inherit (config.home) stateVersion;
 
@@ -555,11 +560,7 @@ in
       '';
     };
 
-    home.preferXdgDirectories = lib.mkEnableOption "" // {
-      description = ''
-        Whether to make programs use XDG directories whenever supported.
-      '';
-    };
+    home.preferXdgDirectories = mkEnableOption "making programs use XDG directories whenever supported";
   };
 
   config = {

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -425,22 +425,21 @@ in
       description = "The derivation installing the user packages.";
     };
 
-    home.emptyActivationPath = mkOption {
-      internal = true;
-      type = types.bool;
-      default = lib.versionAtLeast stateVersion "22.11";
-      defaultText = literalExpression ''
-        false   for state version < 22.11,
-        true    for state version ≥ 22.11
-      '';
-      description = ''
-        Whether the activation script should start with an empty
-        {env}`PATH` variable. When `false` then the
-        user's {env}`PATH` will be accessible in the script. It is
-        recommended to keep this at `true` to avoid
-        uncontrolled use of tools found in PATH.
-      '';
-    };
+    home.emptyActivationPath =
+      mkEnableOption ''
+        starting the activation script with an empty {env}`PATH`.
+
+        When `false` then the user's {env}`PATH` will be accessible in the script.
+        It is recommended to keep this at `true` to avoid uncontrolled use of tools found in PATH
+      ''
+      // {
+        internal = true;
+        default = lib.versionAtLeast stateVersion "22.11";
+        defaultText = literalExpression ''
+          false   for state version < 22.11,
+          true    for state version ≥ 22.11
+        '';
+      };
 
     home.activation = mkOption {
       type = lib.hm.types.dagOf types.str;
@@ -505,17 +504,16 @@ in
       description = "The package containing the complete activation script.";
     };
 
-    home.activationGenerateGcRoot = mkOption {
-      internal = true;
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether the activation script should create a GC root to avoid being
-        garbage collected. Typically you want this but if you know for certain
-        that the Home Manager generation is referenced from some other GC root,
-        then it may be appropriate to not create our own root.
-      '';
-    };
+    home.activationGenerateGcRoot =
+      mkEnableOption ''
+        creating a GC root during activation to avoid being garbage collected.
+
+        Typically you want this but if you know for certain that the Home Manager generation is referenced from some other GC root, then it may be appropriate to not create our own root
+      ''
+      // {
+        internal = true;
+        default = true;
+      };
 
     home.extraActivationPath = mkOption {
       internal = true;
@@ -545,20 +543,18 @@ in
       '';
     };
 
-    home.enableNixpkgsReleaseCheck = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Determines whether to check for release version mismatch between Home
-        Manager and Nixpkgs. Using mismatched versions is likely to cause errors
-        and unexpected behavior. It is therefore highly recommended to use a
-        release of Home Manager that corresponds with your chosen release of
-        Nixpkgs.
+    home.enableNixpkgsReleaseCheck =
+      mkEnableOption ''
+        release version mismatch checks between Home Manager and Nixpkgs.
 
-        When this option is enabled and a mismatch is detected then a warning
-        will be printed when the user configuration is being built.
-      '';
-    };
+        Using mismatched versions is likely to cause errors and unexpected behavior.
+        It is therefore highly recommended to use a release of Home Manager that corresponds with your chosen release of Nixpkgs.
+
+        When this option is enabled and a mismatch is detected then a warning will be printed when the user configuration is being built
+      ''
+      // {
+        default = true;
+      };
 
     home.preferXdgDirectories = mkEnableOption "making programs use XDG directories whenever supported";
   };

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -12,6 +12,7 @@ let
     mkDefault
     mkIf
     mkOption
+    mkEnableOption
     removePrefix
     types
     ;
@@ -85,34 +86,22 @@ in
               '';
             };
 
-            recursive = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                If the file source is a directory, then this option
-                determines whether the directory should be recursively
-                linked to the target location. This option has no effect
-                if the source is a file.
+            recursive = mkEnableOption ''
+              recursively linking directories to the target location.
 
-                If `false` (the default) then the target
-                will be a symbolic link to the source directory. If
-                `true` then the target will be a
-                directory structure matching the source's but whose leaves
-                are symbolic links to the files of the source directory.
-              '';
-            };
+              If the file source is a directory, then this option determines whether the directory should be recursively linked to the target location.
+              This option has no effect if the source is a file.
 
-            ignorelinks = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                When `recursive` is enabled, adds `-ignorelinks` flag to lndir
+              If `false` (the default) then the target will be a symbolic link to the source directory.
+              If `true` then the target will be a directory structure matching the source's but whose leaves are symbolic links to the files of the source directory
+            '';
 
-                It causes lndir to not treat symbolic links in the source directory specially.
-                The link created in the target directory will point back to the corresponding
-                (symbolic link) file in the source directory. If the link is to a directory
-              '';
-            };
+            ignorelinks = mkEnableOption ''
+              passing `-ignorelinks` to lndir when recursive linking is enabled
+
+              It causes lndir to not treat symbolic links in the source directory specially.
+              The link created in the target directory will point back to the corresponding (symbolic link) file in the source directory. If the link is to a directory
+            '';
 
             onChange = mkOption {
               type = types.lines;
@@ -128,16 +117,11 @@ in
               '';
             };
 
-            force = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                Whether the target path should be unconditionally replaced
-                by the managed file source. Warning, this will silently
-                delete the target regardless of whether it is a file or
-                link.
-              '';
-            };
+            force = mkEnableOption ''
+              unconditionally replacing the target path with the managed source.
+
+              Warning: this will silently delete the target regardless of whether it is a file or link
+            '';
           };
 
           config = {

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -34,14 +34,11 @@ in
         { name, config, ... }:
         {
           options = {
-            enable = mkOption {
-              type = types.bool;
-              default = true;
-              description = ''
-                Whether this file should be generated. This option allows specific
-                files to be disabled.
-              '';
-            };
+            enable =
+              mkEnableOption "generating this file. This option allows specific files to be disabled"
+              // {
+                default = true;
+              };
             target = mkOption {
               type = types.str;
               apply =

--- a/modules/misc/dconf.nix
+++ b/modules/misc/dconf.nix
@@ -47,24 +47,19 @@ in
 
   options = {
     dconf = {
-      enable = lib.mkOption {
-        type = types.bool;
-        # While technically dconf on darwin could work, our activation step
-        # requires dbus, which only *lightly* supports Darwin in general, and
-        # not at all in the way it's packaged in nixpkgs. Because of this, we
-        # just disable dconf for darwin hosts by default.
-        # In the future, if someone gets dbus working, this _could_ be
-        # re-enabled, unclear whether there's actual value in it though.
-        default = !pkgs.stdenv.hostPlatform.isDarwin;
-        visible = false;
-        description = ''
-          Whether to enable dconf settings.
-          Note, if you use NixOS then you must add
-          `programs.dconf.enable = true`
+      enable =
+        lib.mkEnableOption ''
+          dconf settings.
+
+          Note: if you use NixOS then you must add `programs.dconf.enable = true`
           to your system configuration. Otherwise you will see a systemd error
-          message when your configuration is activated.
-        '';
-      };
+          message when your configuration is activated
+        ''
+        // {
+          # While technically dconf on darwin could work, our activation step requires dbus, which only *lightly* supports Darwin in general, and not at all in the way it's packaged in nixpkgs. Because of this, we just disable dconf for darwin hosts by default. In the future, if someone gets dbus working, this _could_ be re-enabled, unclear whether there's actual value in it though.
+          default = !pkgs.stdenv.hostPlatform.isDarwin;
+          visible = false;
+        };
 
       settings = lib.mkOption {
         type = with types; attrsOf (attrsOf lib.hm.types.gvariant);

--- a/modules/misc/nix-remote-build.nix
+++ b/modules/misc/nix-remote-build.nix
@@ -5,6 +5,7 @@ let
     concatStringsSep
     mkIf
     mkOption
+    mkEnableOption
     optionalString
     types
     ;
@@ -145,14 +146,7 @@ in
         '';
       };
 
-      distributedBuilds = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to distribute builds to the machines listed in
-          {option}`nix.buildMachines`.
-        '';
-      };
+      distributedBuilds = mkEnableOption "distributing builds to the machines listed in {option}`nix.buildMachines`";
     };
   };
 

--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -181,15 +181,11 @@ in
       '';
     };
 
-    keepOldNixPath = mkOption {
-      type = types.bool;
-      default = true;
-      example = false;
-      description = ''
-        Whether {option}`nix.nixPath` should keep the previously set values in
-        {env}`NIX_PATH`.
-      '';
-    };
+    keepOldNixPath =
+      mkEnableOption "keeping previously set values in {env}`NIX_PATH` when applying {option}`nix.nixPath`"
+      // {
+        default = true;
+      };
 
     channels = lib.mkOption {
       type = with lib.types; attrsOf package;
@@ -248,15 +244,11 @@ in
                   The flake input to which {option}`from>` is to be rewritten.
                 '';
               };
-              exact = mkOption {
-                type = types.bool;
-                default = true;
-                description = ''
-                  Whether the {option}`from` reference needs to match exactly. If set,
-                  a {option}`from` reference like `nixpkgs` does not
-                  match with a reference like `nixpkgs/nixos-20.03`.
-                '';
-              };
+              exact =
+                mkEnableOption "requiring exact match for the {option}`from` reference.  If set, a {option}`from` reference like `nixpkgs` does not match with a reference like `nixpkgs/nixos-20.03`"
+                // {
+                  default = true;
+                };
             };
             config = {
               from = mkDefault {
@@ -289,14 +281,11 @@ in
       description = "The flake registry format version.";
     };
 
-    checkConfig = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        If enabled (the default), checks for data type mismatches and that Nix
-        can parse the generated nix.conf.
-      '';
-    };
+    checkConfig =
+      mkEnableOption "checking the generated nix.conf for type mismatches and parser errors"
+      // {
+        default = true;
+      };
 
     assumeXdg = mkEnableOption ''
       assuming that Nix is configured to use XDG base directories.
@@ -307,8 +296,7 @@ in
       This option is intended for settings in which use-xdg-base-directories is set globally or nix.conf is unmanaged by Home Manager
     '';
 
-    useXdg = mkOption {
-      type = types.bool;
+    useXdg = mkEnableOption "using XDG base directories for Nix" // {
       visible = false;
       readOnly = true;
       defaultText = literalMD ''

--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -298,17 +298,14 @@ in
       '';
     };
 
-    assumeXdg = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether Home Manager should assume that Nix is configured to use XDG
-        base directories. Note that this doesn't change the behavior of Nix. To
-        do that, set nix.settings.use-xdg-base-directories instead. This option
-        is intended for settings in which use-xdg-base-directories is set
-        globally or nix.conf is unmanaged by Home Manager.
-      '';
-    };
+    assumeXdg = mkEnableOption ''
+      assuming that Nix is configured to use XDG base directories.
+
+      Note that this doesn't change the behavior of Nix.
+      To do that, set {option}`nix.settings.use-xdg-base-directories` instead.
+
+      This option is intended for settings in which use-xdg-base-directories is set globally or nix.conf is unmanaged by Home Manager
+    '';
 
     useXdg = mkOption {
       type = types.bool;

--- a/modules/misc/uninstall.nix
+++ b/modules/misc/uninstall.nix
@@ -2,22 +2,16 @@
 
 let
 
-  inherit (lib) mkIf mkOption types;
+  inherit (lib) mkIf mkEnableOption;
 
 in
 {
-  options.uninstall = mkOption {
-    type = types.bool;
-    default = false;
-    description = ''
-      Whether to set up a minimal configuration that will remove all managed
-      files and packages.
+  options.uninstall = mkEnableOption ''
+    setting up a minimal configuration that will remove all managed files and packages.
 
-      Use this with extreme care since running the generated activation script
-      will remove all Home Manager state from your user environment. This
-      includes removing all your historic Home Manager generations.
-    '';
-  };
+    Use this with extreme care since running the generated activation script will remove all Home Manager state from your user environment.
+    This includes removing all your historic Home Manager generations
+  '';
 
   config = mkIf config.uninstall {
     home.packages = lib.mkForce [ ];

--- a/modules/misc/version.nix
+++ b/modules/misc/version.nix
@@ -66,16 +66,13 @@ in
         description = "The Home Manager release.";
       };
 
-      isReleaseBranch = lib.mkOption {
-        internal = true;
-        readOnly = true;
-        type = types.bool;
-        default = releaseInfo.isReleaseBranch;
-        description = ''
-          Whether the Home Manager version is from a versioned
-          release branch.
-        '';
-      };
+      isReleaseBranch =
+        lib.mkEnableOption "the Home Manager version being from a versioned release branch"
+        // {
+          internal = true;
+          readOnly = true;
+          default = releaseInfo.isReleaseBranch;
+        };
 
       revision = lib.mkOption {
         internal = true;

--- a/modules/misc/xdg-mime-apps.nix
+++ b/modules/misc/xdg-mime-apps.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.xdg.mimeApps;
 
@@ -17,15 +17,11 @@ in
   meta.maintainers = with lib.maintainers; [ euxane ];
 
   options.xdg.mimeApps = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to manage {file}`$XDG_CONFIG_HOME/mimeapps.list`.
+    enable = mkEnableOption ''
+      the management of {file}`$XDG_CONFIG_HOME/mimeapps.list`.
 
-        The generated file is read-only.
-      '';
-    };
+      The generated file is read-only.
+    '';
 
     # descriptions from
     # https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-1.0.1.html

--- a/modules/misc/xdg-mime.nix
+++ b/modules/misc/xdg-mime.nix
@@ -12,28 +12,19 @@ let
   inherit (lib)
     getExe
     getExe'
-    mkOption
-    types
+    mkEnableOption
     ;
 
 in
 {
   options = {
     xdg.mime = {
-      enable = mkOption {
-        type = types.bool;
-        default = pkgs.stdenv.hostPlatform.isLinux;
-        defaultText = lib.literalExpression "true if host platform is Linux, false otherwise";
-        description = ''
-          Whether to install programs and files to support the
-          XDG Shared MIME-info specification and XDG MIME Applications
-          specification at
-          <https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html>
-          and
-          <https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html>,
-          respectively.
-        '';
-      };
+      enable =
+        mkEnableOption "installing programs and files to support the XDG Shared MIME-info specification and XDG MIME Applications specification at <https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html> and <https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html>, respectively"
+        // {
+          default = pkgs.stdenv.hostPlatform.isLinux;
+          defaultText = lib.literalExpression "true if host platform is Linux, false otherwise";
+        };
 
       sharedMimeInfoPackage = lib.mkPackageOption pkgs "shared-mime-info" {
         extraDescription = "Used when running update-mime-database.";

--- a/modules/misc/xdg-portal.nix
+++ b/modules/misc/xdg-portal.nix
@@ -12,6 +12,7 @@ let
     mkIf
     mkMerge
     mkOption
+    mkEnableOption
     optional
     types
     ;
@@ -25,24 +26,19 @@ in
   meta.maintainers = [ lib.maintainers.misterio77 ];
 
   options.xdg.portal = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      example = true;
-      description = ''
-        Whether to enable [XDG desktop integration](https://github.com/flatpak/xdg-desktop-portal).
+    enable = mkEnableOption ''
+      [XDG desktop integration](https://github.com/flatpak/xdg-desktop-portal).
 
-        Note, if you installed Home Manager via its NixOS module and
-        'home-manager.useUserPackages' is enabled, make sure to add
+      Note, if you installed Home Manager via its NixOS module and
+      'home-manager.useUserPackages' is enabled, make sure to add
 
-        ``` nix
-        environment.pathsToLink = [ "/share/xdg-desktop-portal" "/share/applications" ];
-        ```
+      ``` nix
+      environment.pathsToLink = [ "/share/xdg-desktop-portal" "/share/applications" ];
+      ```
 
-        to your NixOS configuration so that the portal definitions and DE
-        provided configurations get linked.
-      '';
-    };
+      to your NixOS configuration so that the portal definitions and DE
+      provided configurations get linked.
+    '';
 
     extraPortals = mkOption {
       type = types.listOf types.package;
@@ -61,16 +57,13 @@ in
       '';
     };
 
-    xdgOpenUsePortal = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Sets environment variable `NIXOS_XDG_OPEN_USE_PORTAL` to `1`
-        This will make `xdg-open` use the portal to open programs, which resolves bugs involving
-        programs opening inside FHS envs or with unexpected env vars set from wrappers.
-        See [#160923](https://github.com/NixOS/nixpkgs/issues/160923) for more info.
-      '';
-    };
+    xdgOpenUsePortal = mkEnableOption ''
+      setting environment variable `NIXOS_XDG_OPEN_USE_PORTAL` to `1`.
+
+      This will make `xdg-open` use the portal to open programs, which resolves bugs involving programs opening inside FHS envs or with unexpected env vars set from wrappers.
+
+      See [#160923](https://github.com/NixOS/nixpkgs/issues/160923) for more info
+    '';
 
     config = mkOption {
       type = types.attrsOf associationOptions;

--- a/modules/misc/xdg-user-dirs.nix
+++ b/modules/misc/xdg-user-dirs.nix
@@ -6,7 +6,12 @@
 }:
 
 let
-  inherit (lib) literalExpression mkOption types;
+  inherit (lib)
+    literalExpression
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   cfg = config.xdg.userDirs;
 
@@ -26,15 +31,11 @@ in
   ];
 
   options.xdg.userDirs = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to manage {file}`$XDG_CONFIG_HOME/user-dirs.dirs`.
+    enable = mkEnableOption ''
+      the management of {file}`$XDG_CONFIG_HOME/user-dirs.dirs`.
 
-        The generated file is read-only.
-      '';
-    };
+      The generated file is read-only.
+    '';
 
     package = lib.mkPackageOption pkgs "xdg-user-dirs" { nullable = true; };
 
@@ -132,7 +133,7 @@ in
       '';
     };
 
-    createDirectories = lib.mkEnableOption "automatic creation of the XDG user directories";
+    createDirectories = mkEnableOption "automatic creation of the XDG user directories";
 
     setSessionVariables = mkOption {
       type = with types; bool;

--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -11,6 +11,7 @@ let
     mkOptionDefault
     mkIf
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -42,7 +43,7 @@ let
 in
 {
   options.xdg = {
-    enable = lib.mkEnableOption "management of XDG base directories";
+    enable = mkEnableOption "management of XDG base directories";
 
     cacheFile = mkOption {
       type = fileType "xdg.cacheFile" "{var}`xdg.cacheHome`" cfg.cacheHome;
@@ -135,14 +136,7 @@ in
       '';
     };
 
-    localBinInPath = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to add {option}`xdg.binHome` to {env}`PATH` when
-        {option}`xdg.enable` is enabled.
-      '';
-    };
+    localBinInPath = mkEnableOption "adding {option}`xdg.binHome` to {env}`PATH` when {option}`xdg.enable` is enabled";
   };
 
   config = lib.mkMerge [

--- a/modules/misc/xfconf.nix
+++ b/modules/misc/xfconf.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.xfconf;
 
@@ -79,19 +79,17 @@ in
   meta.maintainers = [ lib.maintainers.chuangzhu ];
 
   options.xfconf = {
-    enable = mkOption {
-      type = types.bool;
-      default = true;
-      visible = false;
-      description = ''
-        Whether to enable Xfconf settings.
+    enable =
+      mkEnableOption ''
+        Xfconf settings.
 
-        Note, if you use NixOS then you must add
-        `programs.xfconf.enable = true`
-        to your system configuration. Otherwise you will see a systemd error
-        message when your configuration is activated.
-      '';
-    };
+        Note: if you use NixOS then you must add `programs.xfconf.enable = true` to your system configuration.
+        Otherwise you will see a systemd error message when your configuration is activated
+      ''
+      // {
+        default = true;
+        visible = false;
+      };
 
     settings = mkOption {
       type =

--- a/modules/programs/aerospace.nix
+++ b/modules/programs/aerospace.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
   cfg = config.programs.aerospace;
 
   tomlFormat = pkgs.formats.toml { };
@@ -59,40 +59,37 @@ in
   ];
 
   options.programs.aerospace = {
-    enable = lib.mkEnableOption "AeroSpace window manager";
+    enable = mkEnableOption "AeroSpace window manager";
 
     package = lib.mkPackageOption pkgs "aerospace" { nullable = true; };
 
     launchd = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Configure the launchd agent to manage the AeroSpace process.
+      enable = mkEnableOption ''
+        the configuration of the launchd agent to manage the AeroSpace process.
 
-          The first time this is enabled, macOS will prompt you to allow this background
-          item in System Settings.
+        The first time this is enabled, macOS will prompt you to allow this background
+        item in System Settings.
 
-          You can verify the service is running correctly from your terminal.
-          Run: `launchctl list | grep aerospace`
+        You can verify the service is running correctly from your terminal.
+        Run: `launchctl list | grep aerospace`
 
-          - A running process will show a Process ID (PID) and a status of 0, for example:
-            `12345	0	org.nix-community.home.aerospace`
+        - A running process will show a Process ID (PID) and a status of 0, for example:
+          `12345	0	org.nix-community.home.aerospace`
 
-          - If the service has crashed or failed to start, the PID will be a dash and the
-            status will be a non-zero number, for example:
-            `-	1	org.nix-community.home.aerospace`
+        - If the service has crashed or failed to start, the PID will be a dash and the
+          status will be a non-zero number, for example:
+          `-	1	org.nix-community.home.aerospace`
 
-          In case of failure, check the logs with `cat /tmp/aerospace.err.log`.
+        In case of failure, check the logs with `cat /tmp/aerospace.err.log`.
 
-          For more detailed service status, run `launchctl print gui/$(id -u)/org.nix-community.home.aerospace`.
+        For more detailed service status, run `launchctl print gui/$(id -u)/org.nix-community.home.aerospace`.
 
-          NOTE: Enabling this option will configure AeroSpace to **not** manage its own
-          launchd agent. Specifically, it will set `start-at-login = false` and
-          `after-login-command = []` in the configuration file, as those are now handled
-          by Home Manager and launchd instead.
-        '';
-      };
+        NOTE: Enabling this option will configure AeroSpace to **not** manage its own
+        launchd agent. Specifically, it will set `start-at-login = false` and
+        `after-login-command = []` in the configuration file, as those are now handled
+        by Home Manager and launchd instead.
+      '';
+
       keepAlive = mkOption {
         type = types.bool;
         default = true;

--- a/modules/programs/aerospace.nix
+++ b/modules/programs/aerospace.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkOption mkEnableOption types;
+  inherit (lib) mkOption mkEnableOption;
   cfg = config.programs.aerospace;
 
   tomlFormat = pkgs.formats.toml { };
@@ -90,10 +90,8 @@ in
         by Home Manager and launchd instead.
       '';
 
-      keepAlive = mkOption {
-        type = types.bool;
+      keepAlive = mkEnableOption "keeping the launchd service alive" // {
         default = true;
-        description = "Whether the launchd service should be kept alive.";
       };
     };
 

--- a/modules/programs/alot/default.nix
+++ b/modules/programs/alot/default.nix
@@ -165,16 +165,11 @@ in
 {
   options = {
     programs.alot = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        example = true;
-        description = ''
-          Whether to enable the Alot mail user agent. Alot uses the
-          Notmuch email system and will therefore be automatically
-          enabled for each email account that is managed by Notmuch.
-        '';
-      };
+      enable = lib.mkEnableOption ''
+        the Alot mail user agent. Alot uses the
+        Notmuch email system and will therefore be automatically
+        enabled for each email account that is managed by Notmuch.
+      '';
 
       package = lib.mkPackageOption pkgs "alot" { nullable = true; };
 

--- a/modules/programs/anyrun.nix
+++ b/modules/programs/anyrun.nix
@@ -27,7 +27,6 @@ let
     str
     enum
     lines
-    bool
     attrs
     ;
 
@@ -133,17 +132,9 @@ in
           '';
         };
 
-        hideIcons = mkOption {
-          type = bool;
-          default = false;
-          description = "Hide match and plugin info icons.";
-        };
+        hideIcons = mkEnableOption "hiding match and plugin info icons";
 
-        ignoreExclusiveZones = mkOption {
-          type = bool;
-          default = false;
-          description = "Ignore exclusive zones, eg. Waybar.";
-        };
+        ignoreExclusiveZones = mkEnableOption "ignoring exclusive zones, eg. Waybar";
 
         layer = mkOption {
           type = enum [
@@ -156,23 +147,11 @@ in
           description = "Layer shell layer (background, bottom, top or overlay).";
         };
 
-        hidePluginInfo = mkOption {
-          type = bool;
-          default = false;
-          description = "Hide the plugin info panel.";
-        };
+        hidePluginInfo = mkEnableOption "hiding the plugin info panel";
 
-        closeOnClick = mkOption {
-          type = bool;
-          default = false;
-          description = "Close window when a click outside the main box is received.";
-        };
+        closeOnClick = mkEnableOption "closing the window when a click outside the main box is received";
 
-        showResultsImmediately = mkOption {
-          type = bool;
-          default = false;
-          description = "Show search results immediately when Anyrun starts.";
-        };
+        showResultsImmediately = mkEnableOption "showing search results immediately when Anyrun starts";
 
         maxEntries = mkOption {
           type = nullOr int;

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -20,7 +20,12 @@ let
     else
       [ "daemon" ];
 
-  inherit (lib) mkIf mkOption types;
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    types
+    ;
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -29,7 +34,7 @@ in
   ];
 
   options.programs.atuin = {
-    enable = lib.mkEnableOption "atuin";
+    enable = mkEnableOption "atuin";
 
     package = lib.mkPackageOption pkgs "atuin" { };
 
@@ -98,19 +103,12 @@ in
       '';
     };
 
-    forceOverwriteSettings = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        When enabled, force overwriting of the Atuin configuration file
-        ({file}`$XDG_CONFIG_HOME/atuin/config.toml`).
-        Any existing Atuin configuration will be lost.
+    forceOverwriteSettings = mkEnableOption ''
+      force overwriting of the Atuin configuration file ({file}`$XDG_CONFIG_HOME/atuin/config.toml`).
+      Any existing Atuin configuration will be lost.
 
-        Enabling this is useful when adding settings for the first time
-        because Atuin writes its default config file after every single
-        shell command, which can make it difficult to manually remove.
-      '';
-    };
+      Enabling this is useful when adding settings for the first time because Atuin writes its default config file after every single shell command, which can make it difficult to manually remove.
+    '';
 
     themes = mkOption {
       type = types.attrsOf (
@@ -143,7 +141,7 @@ in
     };
 
     daemon = {
-      enable = lib.mkEnableOption "Atuin daemon";
+      enable = mkEnableOption "Atuin daemon";
 
       logLevel = mkOption {
         default = null;

--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -74,9 +74,7 @@ let
 
   configModule = types.submodule {
     options = {
-      enable = mkOption {
-        type = types.bool;
-        description = "Whether to enable the output.";
+      enable = mkEnableOption "this output" // {
         default = true;
       };
 

--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -12,6 +12,7 @@ let
     mapAttrsToList
     mkIf
     mkOption
+    mkEnableOption
     optional
     types
     ;
@@ -86,11 +87,7 @@ let
         example = 0;
       };
 
-      primary = mkOption {
-        type = types.bool;
-        description = "Whether output should be marked as primary";
-        default = false;
-      };
+      primary = mkEnableOption "marking this output as primary";
 
       position = mkOption {
         type = types.str;
@@ -342,7 +339,7 @@ in
 
   options = {
     programs.autorandr = {
-      enable = lib.mkEnableOption "Autorandr";
+      enable = mkEnableOption "Autorandr";
 
       package = lib.mkPackageOption pkgs "autorandr" { nullable = true; };
 

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     mkIf
     mkOption
+    mkEnableOption
     optionalAttrs
     types
     ;
@@ -40,31 +41,29 @@ in
 
   options = {
     programs.bash = {
-      enable = lib.mkEnableOption "GNU Bourne-Again SHell";
+      enable = mkEnableOption "GNU Bourne-Again SHell";
 
       package = lib.mkPackageOption pkgs "bash" {
         nullable = true;
         default = "bashInteractive";
       };
 
-      enableCompletion = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to enable Bash completion for all interactive Bash shells.
+      enableCompletion =
+        mkEnableOption ''
+          Bash completion for all interactive Bash shells.
 
-          Note, if you use NixOS or nix-darwin and do not have Bash completion
-          enabled in the system configuration, then make sure to add
+          Note: if you use NixOS or nix-darwin and do not have Bash completion enabled in the system configuration, then make sure to add
 
           ```nix
             environment.pathsToLink = [ "/share/bash-completion" ];
           ```
 
           to your system configuration to get completion for system packages.
-          Note, the legacy {file}`/etc/bash_completion.d` path is
-          not supported by Home Manager.
-        '';
-      };
+          Note: the legacy {file}`/etc/bash_completion.d` path is not supported by Home Manager
+        ''
+        // {
+          default = true;
+        };
 
       historySize = mkOption {
         type = types.nullOr types.int;

--- a/modules/programs/beets.nix
+++ b/modules/programs/beets.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     literalExpression
     mkIf
+    mkEnableOption
     mkOption
     types
     ;
@@ -25,33 +26,33 @@ in
 
   options = {
     programs.beets = {
-      enable = mkOption {
-        type = types.bool;
-        inherit
-          (lib.hm.deprecations.mkStateVersionOptionDefault {
-            inherit (config.home) stateVersion;
-            since = "19.03";
-            optionPath = [
-              "programs"
-              "beets"
-              "enable"
-            ];
-            legacy = {
-              value = cfg.settings != { };
-              text = "config.programs.beets.settings != { }";
-            };
-            current.value = false;
-          })
-          default
-          defaultText
-          ;
-        description = ''
-          Whether to enable the beets music library manager. This
-          defaults to `false` for state
-          version ≥ 19.03. For earlier versions beets is enabled if
-          {option}`programs.beets.settings` is non-empty.
-        '';
-      };
+      enable =
+        mkEnableOption ''
+          the beets music library manager.
+
+          This defaults to `false` for state version ≥ 19.03.
+          For earlier versions, beets is enabled if {option}`programs.beets.settings` is non-empty
+        ''
+        // {
+          inherit
+            (lib.hm.deprecations.mkStateVersionOptionDefault {
+              inherit (config.home) stateVersion;
+              since = "19.03";
+              optionPath = [
+                "programs"
+                "beets"
+                "enable"
+              ];
+              legacy = {
+                value = cfg.settings != { };
+                text = "config.programs.beets.settings != { }";
+              };
+              current.value = false;
+            })
+            default
+            defaultText
+            ;
+        };
 
       package = lib.mkPackageOption pkgs "beets" {
         example = "(pkgs.beets.override { pluginOverrides = { beatport.enable = false; }; })";
@@ -70,9 +71,9 @@ in
       };
 
       mpdIntegration = {
-        enableStats = lib.mkEnableOption "mpdstats plugin and service";
+        enableStats = mkEnableOption "mpdstats plugin and service";
 
-        enableUpdate = lib.mkEnableOption "mpdupdate plugin";
+        enableUpdate = mkEnableOption "mpdupdate plugin";
 
         host = mkOption {
           type = types.str;

--- a/modules/programs/borgmatic.nix
+++ b/modules/programs/borgmatic.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) literalExpression mkOption types;
+  inherit (lib)
+    literalExpression
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   cfg = config.programs.borgmatic;
 
@@ -149,17 +154,7 @@ let
             '';
           };
 
-          excludeHomeManagerSymlinks = mkOption {
-            type = types.bool;
-            description = ''
-              Whether to exclude Home Manager generated symbolic links from
-              the backups. This facilitates restoring the whole home
-              directory when the Nix store doesn't contain the latest
-              Home Manager generation.
-            '';
-            default = false;
-            example = true;
-          };
+          excludeHomeManagerSymlinks = mkEnableOption "excluding Home Manager generated symlinks from backups. This facilitates restoring the whole home directory when the Nix store doesn't contain the latest Home Manager generation";
 
           extraConfig = extraConfigOption;
         };
@@ -274,7 +269,7 @@ in
 
   options = {
     programs.borgmatic = {
-      enable = lib.mkEnableOption "Borgmatic";
+      enable = mkEnableOption "Borgmatic";
 
       package = lib.mkPackageOption pkgs "borgmatic" { nullable = true; };
 

--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -72,12 +72,8 @@ let
       };
     }
     // lib.optionalAttrs (lib.elem browser plasmaSupportedBrowsers) {
-      plasmaSupport = mkOption {
+      plasmaSupport = mkEnableOption "the 'Use QT' theme for ${name}" // {
         inherit visible;
-        type = types.bool;
-        default = false;
-        example = true;
-        description = "Whether to enable the 'Use QT' theme for ${name}.";
       };
     }
     // lib.optionalAttrs (!isProprietaryChrome) {

--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) literalExpression mkOption types;
+  inherit (lib)
+    literalExpression
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   supportedBrowsers = {
     chromium = "Chromium";
@@ -26,12 +31,8 @@ let
       isProprietaryChrome = lib.hasPrefix "Google Chrome" name;
     in
     {
-      enable = mkOption {
+      enable = mkEnableOption name // {
         inherit visible;
-        type = types.bool;
-        default = false;
-        example = true;
-        description = "Whether to enable ${name}.";
       };
 
       package = mkOption {

--- a/modules/programs/delta.nix
+++ b/modules/programs/delta.nix
@@ -10,6 +10,7 @@ let
 
   inherit (lib)
     mkOption
+    mkEnableOption
     types
     ;
 in
@@ -23,7 +24,7 @@ in
   ];
 
   options.programs.delta = {
-    enable = lib.mkEnableOption "delta, a syntax highlighter for git diffs";
+    enable = mkEnableOption "delta, a syntax highlighter for git diffs";
 
     package = lib.mkPackageOption pkgs "delta" { };
 
@@ -54,27 +55,19 @@ in
       '';
     };
 
-    enableGitIntegration = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable git integration for delta.
+    enableGitIntegration = mkEnableOption ''
+      git integration for delta.
 
-        When enabled, delta will be configured as git's pager for
-        {command}`diff`, {command}`log`, and {command}`show`, and as git's diff
-        filter for interactive staging.
-      '';
-    };
+      When enabled, delta will be configured as git's pager for
+      {command}`diff`, {command}`log`, and {command}`show`, and as git's diff
+      filter for interactive staging.
+    '';
 
-    enableJujutsuIntegration = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable jujutsu integration for delta.
+    enableJujutsuIntegration = mkEnableOption ''
+      jujutsu integration for delta.
 
-        When enabled, delta will be configured as jujutsus's pager, diff filter, and merge tool.
-      '';
-    };
+      When enabled, delta will be configured as jujutsus's pager, diff filter, and merge tool.
+    '';
 
     finalPackage = mkOption {
       type = types.package;

--- a/modules/programs/diff-highlight.nix
+++ b/modules/programs/diff-highlight.nix
@@ -49,17 +49,13 @@ in
       '';
     };
 
-    enableGitIntegration = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable git integration for diff-highlight.
+    enableGitIntegration = mkEnableOption ''
+      git integration for diff-highlight.
 
-        When enabled, diff-highlight will be configured as git's pager for
-        {command}`diff`, {command}`log`, and {command}`show`, and as git's diff
-        filter for interactive staging.
-      '';
-    };
+      When enabled, diff-highlight will be configured as git's pager for
+      {command}`diff`, {command}`log`, and {command}`show`, and as git's diff
+      filter for interactive staging.
+    '';
   };
 
   config =

--- a/modules/programs/diff-so-fancy.nix
+++ b/modules/programs/diff-so-fancy.nix
@@ -95,17 +95,13 @@ in
       '';
     };
 
-    enableGitIntegration = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable git integration for diff-so-fancy.
+    enableGitIntegration = mkEnableOption ''
+      git integration for diff-so-fancy.
 
-        When enabled, diff-so-fancy will be configured as git's pager for
-        {command}`diff`, {command}`log`, and {command}`show`, and as git's diff
-        filter for interactive staging.
-      '';
-    };
+      When enabled, diff-so-fancy will be configured as git's pager for
+      {command}`diff`, {command}`log`, and {command}`show`, and as git's diff
+      filter for interactive staging.
+    '';
   };
 
   config =

--- a/modules/programs/difftastic.nix
+++ b/modules/programs/difftastic.nix
@@ -85,27 +85,19 @@ in
     };
 
     git = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable git integration for difftastic.
+      enable = mkEnableOption ''
+        git integration for difftastic.
 
-          When enabled, difftastic will be configured as git's external diff tool or difftool
-          depending on the value of {option}`programs.difftastic.git.diffToolMode`.
-        '';
-      };
+        When enabled, difftastic will be configured as git's external diff tool or difftool
+        depending on the value of {option}`programs.difftastic.git.diffToolMode`.
+      '';
 
-      diffToolMode = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to additionally configure difftastic as a git difftool.
+      diffToolMode = mkEnableOption ''
+        the additional configuration of difftastic as a git difftool.
 
-          When `false`, only `diff.external` is set (used for `git diff`).
-          When `true`, both `diff.external` and difftool config are set (supporting both `git diff` and `git difftool`).
-        '';
-      };
+        When `false`, only `diff.external` is set (used for `git diff`).
+        When `true`, both `diff.external` and difftool config are set (supporting both `git diff` and `git difftool`).
+      '';
     };
 
     jujutsu = {

--- a/modules/programs/difftastic.nix
+++ b/modules/programs/difftastic.nix
@@ -109,13 +109,7 @@ in
     };
 
     jujutsu = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable jujutsu integration for difftastic.
-        '';
-      };
+      enable = mkEnableOption "jujutsu integration for difftastic";
     };
   };
 

--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -19,14 +19,7 @@ in
   meta.maintainers = [ lib.maintainers.justinlovinger ];
 
   options.programs.dircolors = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to manage {file}`.dir_colors`
-        and set `LS_COLORS`.
-      '';
-    };
+    enable = lib.mkEnableOption "the management of {file}`.dir_colors` and set `LS_COLORS`";
 
     package = lib.mkPackageOption pkgs "dircolors" { default = "coreutils"; };
 

--- a/modules/programs/eclipse.nix
+++ b/modules/programs/eclipse.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) mkIf mkOption types;
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   cfg = config.programs.eclipse;
 in
@@ -14,7 +19,7 @@ in
 
   options = {
     programs.eclipse = {
-      enable = lib.mkEnableOption "Eclipse";
+      enable = mkEnableOption "Eclipse";
 
       package = lib.mkPackageOption pkgs "eclipse" {
         default = [
@@ -24,15 +29,7 @@ in
         example = "pkgs.eclipses.eclipse-java";
       };
 
-      enableLombok = mkOption {
-        type = types.bool;
-        default = false;
-        example = true;
-        description = ''
-          Whether to enable the Lombok Java Agent in Eclipse. This is
-          necessary to use the Lombok class annotations.
-        '';
-      };
+      enableLombok = mkEnableOption "the Lombok Java Agent in Eclipse. This is necessary to use the Lombok class annotations";
 
       jvmArgs = mkOption {
         type = types.listOf types.str;

--- a/modules/programs/eza.nix
+++ b/modules/programs/eza.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) mkOption optionalAttrs types;
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    optionalAttrs
+    types
+    ;
   yamlFormat = pkgs.formats.yaml { };
 in
 {
@@ -38,7 +43,7 @@ in
     ])
     ++ [ (lib.mkRemovedOptionModule [ "programs" "eza" "enableAliases" ] msg) ];
   options.programs.eza = {
-    enable = lib.mkEnableOption "eza, a modern replacement for {command}`ls`";
+    enable = mkEnableOption "eza, a modern replacement for {command}`ls`";
 
     enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
@@ -96,13 +101,7 @@ in
       '';
     };
 
-    git = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        List each file's Git status if tracked or ignored ({option}`--git` argument).
-      '';
-    };
+    git = mkEnableOption "listing each file's Git status if tracked or ignored ({option}`--git` argument)";
 
     package = lib.mkPackageOption pkgs "eza" { nullable = true; };
 

--- a/modules/programs/fd.nix
+++ b/modules/programs/fd.nix
@@ -5,13 +5,13 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 in
 {
   meta.maintainers = [ lib.maintainers.uncenter ];
 
   options.programs.fd = {
-    enable = lib.mkEnableOption "fd, a simple, fast and user-friendly alternative to {command}`find`";
+    enable = mkEnableOption "fd, a simple, fast and user-friendly alternative to {command}`find`";
 
     ignores = mkOption {
       type = types.listOf types.str;
@@ -23,13 +23,7 @@ in
       description = "List of paths that should be globally ignored.";
     };
 
-    hidden = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Search hidden files and directories ({option}`--hidden` argument).
-      '';
-    };
+    hidden = mkEnableOption "searching hidden files and directories ({option}`--hidden` argument)";
 
     extraOptions = mkOption {
       type = types.listOf types.str;

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -561,16 +561,11 @@ in
                 description = "Declarative handlers configuration for MIME types and URL schemes.";
               };
 
-              containersForce = mkOption {
-                type = types.bool;
-                default = false;
-                description = ''
-                  Whether to force replace the existing containers configuration.
-                  This is recommended since ${appName} will replace the symlink on
-                  every launch, but note that you'll lose any existing configuration
-                  by enabling this.
-                '';
-              };
+              containersForce = mkEnableOption ''
+                force-replacing the existing containers configuration.
+
+                This is recommended since ${appName} will replace the symlink on every launch, but note that you'll lose any existing configuration
+              '';
 
               containers = mkOption {
                 type = types.attrsOf (
@@ -699,34 +694,18 @@ in
                             '';
                           };
 
-                          force = mkOption {
-                            description = ''
-                              Whether to override all previous firefox settings.
-
-                              This is required when using `settings`.
-                            '';
-                            default = false;
-                            example = true;
-                            type = types.bool;
-                          };
+                          force = mkEnableOption ''
+                            overriding all previous firefox settings.
+                            This is required when using `settings`
+                          '';
 
                           exhaustivePermissions = mkEnableOption "requiring explicit permission authorization for all configured extensions from {option}`${moduleName}.profiles.<profile>.extensions.packages` in {option}`${moduleName}.profiles.<profile>.extensions.settings.<extensionID>.permissions`";
 
-                          exactPermissions = mkOption {
-                            description = ''
-                              When enabled,
-                              {option}`${moduleName}.profiles.<profile>.extensions.settings.<extensionID>.permissions`
-                              must specify the exact set of permissions that the
-                              extension will request.
+                          exactPermissions = mkEnableOption ''
+                            requiring {option}`${moduleName}.profiles.<profile>.extensions.settings.<extensionID>.permissions` to specify the exact set extension of permission sets that the extension will request.
 
-                              This means that if the authorized permissions are
-                              broader than what the extension requests, the
-                              assertion will fail.
-                            '';
-                            default = false;
-                            example = true;
-                            type = types.bool;
-                          };
+                            This means that if the authorized permissions are broader than what the extension requests, the assertion will fail.
+                          '';
 
                           settings = mkOption {
                             default = { };

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -24,6 +24,7 @@ let
     mkMerge
     mkOption
     mkOptionDefault
+    mkEnableOption
     optionalString
     optional
     setAttrByPath
@@ -200,14 +201,9 @@ let
 in
 {
   options = setAttrByPath modulePath {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      example = true;
-      description = ''
-        Whether to enable ${appName}.${optionalString (description != null) " ${description}"}
-      '';
-    };
+    enable = mkEnableOption ''
+      ${appName}.${optionalString (description != null) " ${description}"}
+    '';
 
     package = mkOption {
       type = with types; nullOr package;
@@ -714,18 +710,7 @@ in
                             type = types.bool;
                           };
 
-                          exhaustivePermissions = mkOption {
-                            description = ''
-                              When enabled, the user must authorize requested
-                              permissions for all extensions from
-                              {option}`${moduleName}.profiles.<profile>.extensions.packages`
-                              in
-                              {option}`${moduleName}.profiles.<profile>.extensions.settings.<extensionID>.permissions`
-                            '';
-                            default = false;
-                            example = true;
-                            type = types.bool;
-                          };
+                          exhaustivePermissions = mkEnableOption "requiring explicit permission authorization for all configured extensions from {option}`${moduleName}.profiles.<profile>.extensions.packages` in {option}`${moduleName}.profiles.<profile>.extensions.settings.<extensionID>.permissions`";
 
                           exactPermissions = mkOption {
                             description = ''
@@ -788,15 +773,7 @@ in
                                       for a list of relevant permissions.
                                     '';
                                   };
-                                  force = mkOption {
-                                    type = types.bool;
-                                    default = false;
-                                    example = true;
-                                    description = ''
-                                      Forcibly override any existing configuration for
-                                      this extension.
-                                    '';
-                                  };
+                                  force = mkEnableOption "forcibly overriding existing configuration for this extension";
                                 };
                               }
                             );
@@ -922,16 +899,7 @@ in
       description = "Attribute set of ${appName} profiles.";
     };
 
-    enableGnomeExtensions = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable the GNOME Shell native host connector. Note, you
-        also need to set the NixOS option
-        `services.gnome.gnome-browser-connector.enable` to
-        `true`.
-      '';
-    };
+    enableGnomeExtensions = mkEnableOption "the GNOME Shell native host connector. Note: you also need to set the NixOS option {option}`services.gnome.gnome-browser-connector.enable` to `true`";
 
     pkcs11Modules = mkOption {
       type = types.listOf types.package;

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -516,11 +516,9 @@ in
                 description = "Profile path.";
               };
 
-              isDefault = mkOption {
-                type = types.bool;
+              isDefault = mkEnableOption "this being the default profile" // {
                 default = config.id == 0;
                 defaultText = "true if profile ID is 0";
-                description = "Whether this is a default profile.";
               };
 
               search = mkOption {

--- a/modules/programs/firefox/profiles/bookmark-types.nix
+++ b/modules/programs/firefox/profiles/bookmark-types.nix
@@ -3,7 +3,7 @@
 let
 
   inherit (builtins) attrValues;
-  inherit (lib) types mkOption;
+  inherit (lib) types mkOption mkEnableOption;
 
 in
 rec {
@@ -69,15 +69,7 @@ rec {
             description = "Bookmarks within directory.";
           };
 
-          toolbar = mkOption {
-            type = types.bool;
-            default = false;
-            description = ''
-              Make this the toolbar directory. Note, this does _not_
-              mean that this directory will be added to the toolbar,
-              this directory _is_ the toolbar.
-            '';
-          };
+          toolbar = mkEnableOption "making this the toolbar directory. Note: this does _not_ mean that this directory will be added to the toolbar, this directory _is_ the toolbar";
         };
       }
     )

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -134,13 +134,7 @@ let
         '';
       };
 
-      noScopeShadowing = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Allows the function to access the variables of calling functions.
-        '';
-      };
+      noScopeShadowing = mkEnableOption "allowing the function to access the variables of calling functions";
 
       inheritVariable = mkOption {
         type = with types; nullOr str;
@@ -440,12 +434,12 @@ in
 
   options = {
     programs.fish = {
-      enable = lib.mkEnableOption "fish, the friendly interactive shell";
+      enable = mkEnableOption "fish, the friendly interactive shell";
 
       package = lib.mkPackageOption pkgs "fish" { };
 
       generateCompletions =
-        lib.mkEnableOption "the automatic generation of completions based upon installed man pages"
+        mkEnableOption "the automatic generation of completions based upon installed man pages"
         // {
           default = true;
         };
@@ -485,15 +479,7 @@ in
         '';
       };
 
-      preferAbbrs = mkOption {
-        type = types.bool;
-        default = false;
-        example = true;
-        description = ''
-          If enabled, abbreviations will be preferred over aliases when
-          other modules define aliases for fish.
-        '';
-      };
+      preferAbbrs = mkEnableOption "preferring abbreviations over aliases from other modules";
 
       binds = mkOption {
         type = types.attrsOf bindModule;

--- a/modules/programs/fresh-editor.nix
+++ b/modules/programs/fresh-editor.nix
@@ -28,15 +28,7 @@ in
       example = literalExpression "[ pkgs.rust-analyzer ]";
       description = "Extra package to add to fresh";
     };
-    defaultEditor = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to configure {command}`fresh` as the default
-        editor using the {env}`EDITOR` and {env}`VISUAL`
-        environment variables.
-      '';
-    };
+    defaultEditor = mkEnableOption "configuring {command}`fresh` as the default editor using the {env}`EDITOR` and {env}`VISUAL` environment variables";
     settings = mkOption {
       inherit (jsonFormat) type;
       default = { };

--- a/modules/programs/getmail/accounts.nix
+++ b/modules/programs/getmail/accounts.nix
@@ -30,15 +30,11 @@ in
 
     delete = mkEnableOption "deleting read messages from the server. Most users should either enable `delete` or disable `readAll`";
 
-    readAll = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Enable if you want to fetch all, even the read messages from the
-        server. Most users should either enable `delete` or
-        disable `readAll`.
-      '';
-    };
+    readAll =
+      mkEnableOption "fetching all messages including read ones. Most users should either enable `delete` or disable `readAll`"
+      // {
+        default = true;
+      };
 
   };
 }

--- a/modules/programs/getmail/accounts.nix
+++ b/modules/programs/getmail/accounts.nix
@@ -1,10 +1,10 @@
 { lib, ... }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 in
 {
   options.getmail = {
-    enable = lib.mkEnableOption "the getmail mail retriever for this account";
+    enable = mkEnableOption "the getmail mail retriever for this account";
 
     destinationCommand = mkOption {
       type = types.nullOr types.str;
@@ -28,15 +28,7 @@ in
       '';
     };
 
-    delete = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Enable if you want to delete read messages from the server. Most
-        users should either enable `delete` or disable
-        `readAll`.
-      '';
-    };
+    delete = mkEnableOption "deleting read messages from the server. Most users should either enable `delete` or disable `readAll`";
 
     readAll = mkOption {
       type = types.bool;

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -235,15 +235,7 @@ in
 
           package = lib.mkPackageOption pkgs "git-lfs" { nullable = true; };
 
-          skipSmudge = mkOption {
-            type = types.bool;
-            default = false;
-            description = ''
-              Skip automatic downloading of objects on clone or pull.
-              This requires a manual {command}`git lfs pull`
-              every time a new commit is checked out on your repository.
-            '';
-          };
+          skipSmudge = mkEnableOption "skipping automatic object downloads on clone or pull. This requires a manual {command}`git lfs pull` every time a new commit is checked out on your repository";
         };
 
         maintenance = {

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -118,16 +118,12 @@ let
         '';
       };
 
-      scrollOnOutput = mkOption {
+      scrollOnOutput = mkEnableOption "scrolling when output is written" // {
         default = true;
-        type = types.bool;
-        description = "Whether to scroll when output is written.";
       };
 
-      showScrollbar = mkOption {
+      showScrollbar = mkEnableOption "showing the scroll bar" // {
         default = true;
-        type = types.bool;
-        description = "Whether the scroll bar should be visible.";
       };
 
       scrollbackLines = mkOption {
@@ -202,10 +198,8 @@ let
         '';
       };
 
-      audibleBell = mkOption {
+      audibleBell = mkEnableOption "the terminal bell" // {
         default = true;
-        type = types.bool;
-        description = "Turn on/off the terminal's bell.";
       };
 
       transparencyPercent = mkOption {
@@ -327,10 +321,8 @@ in
 
       package = lib.mkPackageOption pkgs "gnome-terminal" { nullable = true; };
 
-      showMenubar = mkOption {
+      showMenubar = mkEnableOption "showing the menubar by default" // {
         default = true;
-        type = types.bool;
-        description = "Whether to show the menubar by default";
       };
 
       themeVariant = mkOption {

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.programs.gnome-terminal;
 
@@ -70,11 +70,7 @@ let
 
   profileSubModule = types.submodule {
     options = {
-      default = mkOption {
-        default = false;
-        type = types.bool;
-        description = "Whether this should be the default profile.";
-      };
+      default = mkEnableOption "this being the default profile";
 
       visibleName = mkOption {
         type = types.str;
@@ -150,11 +146,7 @@ let
         '';
       };
 
-      loginShell = mkOption {
-        default = false;
-        type = types.bool;
-        description = "Run command as a login shell.";
-      };
+      loginShell = mkEnableOption "running command as a login shell";
 
       backspaceBinding = mkOption {
         default = "ascii-delete";
@@ -331,7 +323,7 @@ in
 
   options = {
     programs.gnome-terminal = {
-      enable = lib.mkEnableOption "Gnome Terminal";
+      enable = mkEnableOption "Gnome Terminal";
 
       package = lib.mkPackageOption pkgs "gnome-terminal" { nullable = true; };
 

--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -10,6 +10,7 @@ let
     mkDefault
     mkIf
     mkOption
+    mkEnableOption
     optional
     types
     ;
@@ -160,7 +161,7 @@ let
 in
 {
   options.programs.gpg = {
-    enable = lib.mkEnableOption "GnuPG";
+    enable = mkEnableOption "GnuPG";
 
     package = lib.mkPackageOption pkgs "gnupg" {
       example = "pkgs.gnupg23";
@@ -246,35 +247,30 @@ in
       description = "Directory to store keychains and configuration.";
     };
 
-    mutableKeys = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        If set to `true`, you may manage your keyring as a user
-        using the `gpg` command. Upon activation, the keyring
-        will have managed keys added without overwriting unmanaged keys.
+    mutableKeys =
+      mkEnableOption ''
+        managing the keyring with the {command}`gpg` command.
 
-        If set to `false`, the path
-        {file}`$GNUPGHOME/pubring.kbx` will become an immutable
-        link to the Nix store, denying modifications.
-      '';
-    };
+        Upon activation, the keyring will have managed keys added without overwriting unmanaged keys.
 
-    mutableTrust = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        If set to `true`, you may manage trust as a user using
-        the {command}`gpg` command. Upon activation, trusted keys have
-        their trust set without overwriting unmanaged keys.
+        If set to `false`, the path {file}`$GNUPGHOME/pubring.kbx` will become an immutable link to the Nix store, denying modifications
+      ''
+      // {
+        default = true;
+      };
 
-        If set to `false`, the path
-        {file}`$GNUPGHOME/trustdb.gpg` will be
-        *overwritten* on each activation, removing trust for
-        any unmanaged keys. Be careful to make a backup of your old
-        {file}`trustdb.gpg` before switching to immutable trust!
-      '';
-    };
+    mutableTrust =
+      mkEnableOption ''
+        managing trust with the {command}`gpg` command.
+
+        Upon activation, trusted keys have their trust set without overwriting unmanaged keys.
+
+        If set to `false`, the path {file}`$GNUPGHOME/trustdb.gpg` will be *overwritten* on each activation, removing trust for any unmanaged keys.
+        Be careful to make a backup of your old {file}`trustdb.gpg` before switching to immutable trust
+      ''
+      // {
+        default = true;
+      };
 
     publicKeys = mkOption {
       type = types.listOf (types.submodule publicKeyOpts);

--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -9,6 +9,7 @@ let
     literalExpression
     mkIf
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -19,7 +20,7 @@ in
   meta.maintainers = [ lib.maintainers.Philipp-M ];
 
   options.programs.helix = {
-    enable = lib.mkEnableOption "helix text editor";
+    enable = mkEnableOption "helix text editor";
 
     package = lib.mkPackageOption pkgs "helix" { example = "pkgs.evil-helix"; };
 
@@ -44,15 +45,7 @@ in
       '';
     };
 
-    defaultEditor = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to configure {command}`hx` as the default
-        editor using the {env}`EDITOR` and {env}`VISUAL`
-        environment variables.
-      '';
-    };
+    defaultEditor = mkEnableOption "configuring {command}`hx` as the default editor using the {env}`EDITOR` and {env}`VISUAL` environment variables";
 
     settings = mkOption {
       inherit (tomlFormat) type;

--- a/modules/programs/i3status.nix
+++ b/modules/programs/i3status.nix
@@ -9,6 +9,7 @@ let
     literalExpression
     mkDefault
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -60,15 +61,10 @@ in
   meta.maintainers = [ lib.maintainers.justinlovinger ];
 
   options.programs.i3status = {
-    enable = lib.mkEnableOption "i3status";
+    enable = mkEnableOption "i3status";
 
-    enableDefault = mkOption {
-      type = types.bool;
+    enableDefault = mkEnableOption "the default configuration" // {
       default = true;
-      description = ''
-        Whether or not to enable
-        the default configuration.
-      '';
     };
 
     general = mkOption {
@@ -96,12 +92,8 @@ in
       type = types.attrsOf (
         types.submodule {
           options = {
-            enable = mkOption {
-              type = types.bool;
+            enable = mkEnableOption "this module" // {
               default = true;
-              description = ''
-                Whether or not to enable this module.
-              '';
             };
             position = mkOption {
               type = with types; either int float;

--- a/modules/programs/irssi.nix
+++ b/modules/programs/irssi.nix
@@ -129,16 +129,12 @@ let
           };
 
           ssl = {
-            enable = mkOption {
-              type = types.bool;
+            enable = mkEnableOption "SSL" // {
               default = true;
-              description = "Whether SSL should be used.";
             };
 
-            verify = mkOption {
-              type = types.bool;
+            verify = mkEnableOption "SSL certificate verification" // {
               default = true;
-              description = "Whether the SSL certificate should be verified.";
             };
 
             certificateFile = mkOption {

--- a/modules/programs/irssi.nix
+++ b/modules/programs/irssi.nix
@@ -10,6 +10,7 @@ let
     flip
     mapAttrsToList
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -84,11 +85,7 @@ let
         description = "Name of the channel.";
       };
 
-      autoJoin = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to join this channel on connect.";
-      };
+      autoJoin = mkEnableOption "joining this channel on connect";
     };
   };
 
@@ -154,11 +151,7 @@ let
             };
           };
 
-          autoConnect = mkOption {
-            type = types.bool;
-            default = false;
-            description = "Whether Irssi connects to the server on launch.";
-          };
+          autoConnect = mkEnableOption "connecting to the server on launch";
         };
 
         channels = mkOption {
@@ -167,14 +160,7 @@ let
           default = { };
         };
 
-        saslExternal = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Enable SASL external authentication. This requires setting a path in
-            [](#opt-programs.irssi.networks._name_.server.ssl.certificateFile).
-          '';
-        };
+        saslExternal = mkEnableOption "SASL external authentication. This requires setting a path in [](#opt-programs.irssi.networks._name_.server.ssl.certificateFile)";
       };
     }
   );
@@ -184,7 +170,7 @@ in
 
   options = {
     programs.irssi = {
-      enable = lib.mkEnableOption "the Irssi chat client";
+      enable = mkEnableOption "the Irssi chat client";
 
       package = lib.mkPackageOption pkgs "irssi" { nullable = true; };
 

--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkIf mkOption types;
+  inherit (lib) mkIf mkOption mkEnableOption;
 
   cfg = config.programs.jujutsu;
   tomlFormat = pkgs.formats.toml { };
@@ -38,17 +38,13 @@ in
     ];
 
   options.programs.jujutsu = {
-    enable = lib.mkEnableOption "a Git-compatible DVCS that is both simple and powerful";
+    enable = mkEnableOption "a Git-compatible DVCS that is both simple and powerful";
 
     package = lib.mkPackageOption pkgs "jujutsu" { nullable = true; };
 
-    ediff = mkOption {
-      type = types.bool;
+    ediff = mkEnableOption "ediff as a merge tool" // {
       default = config.programs.emacs.enable;
       defaultText = lib.literalExpression "config.programs.emacs.enable";
-      description = ''
-        Enable ediff as a merge tool
-      '';
     };
 
     settings = mkOption {

--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -69,13 +69,7 @@ let
         '';
       };
 
-      once = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Remove the hook after running it once.
-        '';
-      };
+      once = mkEnableOption "removing the hook after running it once";
 
       group = mkOption {
         type = types.nullOr types.str;
@@ -181,13 +175,7 @@ let
         '';
       };
 
-      alignWithTabs = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Use tabs for the align command.
-        '';
-      };
+      alignWithTabs = mkEnableOption "using tabs for the align command";
 
       autoInfo = mkOption {
         type = types.nullOr (
@@ -273,13 +261,7 @@ let
         type = types.nullOr (
           types.submodule {
             options = {
-              setTitle = mkOption {
-                type = types.bool;
-                default = false;
-                description = ''
-                  Change the title of the terminal emulator.
-                '';
-              };
+              setTitle = mkEnableOption "changing terminal emulator title";
 
               statusLine = mkOption {
                 type = types.enum [
@@ -305,13 +287,7 @@ let
                 '';
               };
 
-              enableMouse = mkOption {
-                type = types.bool;
-                default = false;
-                description = ''
-                  Whether to enable mouse support.
-                '';
-              };
+              enableMouse = mkEnableOption "mouse support";
 
               shiftFunctionKeys = mkOption {
                 type = types.nullOr types.ints.unsigned;
@@ -331,15 +307,7 @@ let
         '';
       };
 
-      showMatching = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Highlight the matching char of the character under the
-          selections' cursor using the `MatchingChar`
-          face.
-        '';
-      };
+      showMatching = mkEnableOption "highlighting the matching char of the character under the selections' cursor using the `MatchingChar` face";
 
       wrapLines = mkOption {
         type = types.nullOr (
@@ -347,21 +315,9 @@ let
             options = {
               enable = mkEnableOption "the wrap lines highlighter";
 
-              word = mkOption {
-                type = types.bool;
-                default = false;
-                description = ''
-                  Wrap at word boundaries instead of codepoint boundaries.
-                '';
-              };
+              word = mkEnableOption "wrapping at word boundaries instead of codepoint boundaries";
 
-              indent = mkOption {
-                type = types.bool;
-                default = false;
-                description = ''
-                  Preserve line indentation when wrapping.
-                '';
-              };
+              indent = mkEnableOption "preserving line indentation when wrapping";
 
               maxWidth = mkOption {
                 type = types.nullOr types.ints.unsigned;
@@ -396,21 +352,9 @@ let
             options = {
               enable = mkEnableOption "the number lines highlighter";
 
-              relative = mkOption {
-                type = types.bool;
-                default = false;
-                description = ''
-                  Show line numbers relative to the main cursor line.
-                '';
-              };
+              relative = mkEnableOption "relative line numbers";
 
-              highlightCursor = mkOption {
-                type = types.bool;
-                default = false;
-                description = ''
-                  Highlight the cursor line with a separate face.
-                '';
-              };
+              highlightCursor = mkEnableOption "highlighting the cursor line with a separate face";
 
               separator = mkOption {
                 type = types.nullOr types.str;
@@ -664,15 +608,7 @@ in
         description = "kakoune configuration options.";
       };
 
-      defaultEditor = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to configure {command}`kak` as the default
-          editor using the {env}`EDITOR` and {env}`VISUAL`
-          environment variables.
-        '';
-      };
+      defaultEditor = mkEnableOption "configuring {command}`kak` as the default editor using the {env}`EDITOR` and {env}`VISUAL` environment variables";
 
       extraConfig = mkOption {
         type = types.lines;

--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -167,12 +167,8 @@ let
         '';
       };
 
-      incrementalSearch = mkOption {
-        type = types.bool;
+      incrementalSearch = mkEnableOption "executing search while typing" // {
         default = true;
-        description = ''
-          Execute a search as it is being typed.
-        '';
       };
 
       alignWithTabs = mkEnableOption "using tabs for the align command";

--- a/modules/programs/keychain.nix
+++ b/modules/programs/keychain.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) mkIf mkOption types;
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   cfg = config.programs.keychain;
 
@@ -21,7 +26,7 @@ in
   meta.maintainers = [ ];
 
   options.programs.keychain = {
-    enable = lib.mkEnableOption "keychain";
+    enable = mkEnableOption "keychain";
 
     package = lib.mkPackageOption pkgs "keychain" { };
 
@@ -72,12 +77,8 @@ in
 
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
-    enableXsessionIntegration = mkOption {
+    enableXsessionIntegration = mkEnableOption "running keychain from {file}`~/.xsession`" // {
       default = true;
-      type = types.bool;
-      description = ''
-        Whether to run keychain from your {file}`~/.xsession`.
-      '';
     };
   };
 

--- a/modules/programs/khal/accounts.nix
+++ b/modules/programs/khal/accounts.nix
@@ -1,18 +1,12 @@
 { lib, ... }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 in
 {
   options.khal = {
-    enable = lib.mkEnableOption "khal access";
+    enable = mkEnableOption "khal access";
 
-    readOnly = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Keep khal from making any changes to this account.
-      '';
-    };
+    readOnly = mkEnableOption "read-only mode for this account";
 
     color = mkOption {
       type = types.nullOr types.str;

--- a/modules/programs/kubecolor.nix
+++ b/modules/programs/kubecolor.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkIf mkOption types;
+  inherit (lib) mkIf mkOption mkEnableOption;
 
   cfg = config.programs.kubecolor;
   yamlFormat = pkgs.formats.yaml { };
@@ -15,18 +15,11 @@ in
   meta.maintainers = with lib.maintainers; [ ajgon ];
 
   options.programs.kubecolor = {
-    enable = lib.mkEnableOption "kubecolor - Colorize your kubectl output";
+    enable = mkEnableOption "kubecolor - Colorize your kubectl output";
 
     package = lib.mkPackageOption pkgs "kubecolor" { };
 
-    enableAlias = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        When set to true, it will create an alias for kubectl pointing to
-        kubecolor, thus making kubecolor the default kubectl client.
-      '';
-    };
+    enableAlias = mkEnableOption "a kubectl alias pointing to kubecolor, thus making kubecolor the default kubectl client";
 
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
 

--- a/modules/programs/lieer.nix
+++ b/modules/programs/lieer.nix
@@ -95,12 +95,8 @@ let
       '';
     };
 
-    remove_local_messages = mkOption {
-      type = types.bool;
+    remove_local_messages = mkEnableOption "removing local messages deleted on the remote" // {
       default = true;
-      description = ''
-        Remove local messages that have been deleted on the remote.
-      '';
     };
 
     replace_slash_with_dot = mkEnableOption "replacing '/' with '.' in Gmail labels";
@@ -134,17 +130,15 @@ let
   lieerOpts = {
     enable = mkEnableOption "lieer Gmail synchronization for notmuch";
 
-    notmuchSetupWarning = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Warn if Notmuch is not also enabled for this account.
+    notmuchSetupWarning =
+      mkEnableOption ''
+        warnings when Notmuch is not also enabled for this account.
 
-        This can safely be disabled if {command}`notmuch init`
-        has been used to configure this account outside of Home
-        Manager.
-      '';
-    };
+        This can safely be disabled if {command}`notmuch init` has been used to configure this account outside of Home Manager
+      ''
+      // {
+        default = true;
+      };
 
     settings = mkOption {
       type = types.submodule {

--- a/modules/programs/lieer.nix
+++ b/modules/programs/lieer.nix
@@ -9,6 +9,7 @@ let
     concatStringsSep
     mkIf
     mkOption
+    mkEnableOption
     mkRenamedOptionModule
     types
     ;
@@ -43,13 +44,7 @@ let
   };
 
   settingsOpts = {
-    drop_non_existing_label = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Allow missing labels on the Gmail side to be dropped.
-      '';
-    };
+    drop_non_existing_label = mkEnableOption "allowing missing labels on the Gmail side to be dropped";
 
     file_extension = mkOption {
       type = types.str;
@@ -114,13 +109,7 @@ let
       '';
     };
 
-    replace_slash_with_dot = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Replace '/' with '.' in Gmail labels.
-      '';
-    };
+    replace_slash_with_dot = mkEnableOption "replacing '/' with '.' in Gmail labels";
 
     timeout = mkOption {
       type = types.ints.unsigned;
@@ -132,7 +121,7 @@ let
   };
 
   syncOpts = {
-    enable = lib.mkEnableOption "lieer synchronization service";
+    enable = mkEnableOption "lieer synchronization service";
 
     frequency = mkOption {
       type = types.str;
@@ -149,7 +138,7 @@ let
   };
 
   lieerOpts = {
-    enable = lib.mkEnableOption "lieer Gmail synchronization for notmuch";
+    enable = mkEnableOption "lieer Gmail synchronization for notmuch";
 
     notmuchSetupWarning = mkOption {
       type = types.bool;
@@ -242,7 +231,7 @@ in
 
   options = {
     programs.lieer = {
-      enable = lib.mkEnableOption "lieer Gmail synchronization for notmuch";
+      enable = mkEnableOption "lieer Gmail synchronization for notmuch";
 
       package = lib.mkPackageOption pkgs "lieer" { };
     };

--- a/modules/programs/lieer.nix
+++ b/modules/programs/lieer.nix
@@ -56,18 +56,12 @@ let
       '';
     };
 
-    ignore_empty_history = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Work around a Gmail API quirk where an empty change history
-        is sometimes returned.
+    ignore_empty_history = mkEnableOption ''
+      ignoring empty Gmail change history responses.
 
-        See this
-        [GitHub issue](https://github.com/gauteh/lieer/issues/120)
-        for more details.
-      '';
-    };
+      Work around a Gmail API quirk where an empty change history is sometimes returned.
+      See this [GitHub issue](https://github.com/gauteh/lieer/issues/120) for more details
+    '';
 
     ignore_remote_labels = mkOption {
       type = types.listOf types.str;

--- a/modules/programs/man.nix
+++ b/modules/programs/man.nix
@@ -5,21 +5,17 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
   cfg = config.programs.man;
 in
 {
   options = {
     programs.man = {
-      enable = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to enable manual pages and the {command}`man`
-          command. This also includes "man" outputs of all
-          `home.packages`.
-        '';
-      };
+      enable =
+        mkEnableOption "manual pages and the {command}`man` command. This also includes 'man' outputs of all `home.packages`"
+        // {
+          default = true;
+        };
 
       package = mkOption {
         type = with types; nullOr package;

--- a/modules/programs/man.nix
+++ b/modules/programs/man.nix
@@ -44,20 +44,16 @@ in
         '';
       };
 
-      generateCaches = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to generate the manual page index caches using
-          {manpage}`mandb(8)`. This allows searching for a page or
-          keyword using utilities like {manpage}`apropos(1)`.
+      generateCaches = lib.mkEnableOption ''
+        the generation of the manual page index caches using
+        {manpage}`mandb(8)`. This allows searching for a page or
+        keyword using utilities like {manpage}`apropos(1)`.
 
-          This feature is disabled by default because it slows down
-          building. If you don't mind waiting a few more seconds when
-          Home Manager builds a new generation, you may safely enable
-          this option.
-        '';
-      };
+        This feature is disabled by default because it slows down
+        building. If you don't mind waiting a few more seconds when
+        Home Manager builds a new generation, you may safely enable
+        this option.
+      '';
     };
   };
 

--- a/modules/programs/mangohud.nix
+++ b/modules/programs/mangohud.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) mkIf mkOption types;
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   cfg = config.programs.mangohud;
 
@@ -45,18 +50,11 @@ in
 
   options = {
     programs.mangohud = {
-      enable = lib.mkEnableOption "Mangohud";
+      enable = mkEnableOption "Mangohud";
 
       package = lib.mkPackageOption pkgs "mangohud" { };
 
-      enableSessionWide = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Sets environment variables so that
-          MangoHud is started on any application that supports it.
-        '';
-      };
+      enableSessionWide = mkEnableOption "the MangoHud environment variables so that MangoHud is started on any application that supports it";
 
       settings = mkOption {
         type = with types; attrsOf settingsType;

--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -10,6 +10,7 @@ let
     optionalString
     mkIf
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -66,7 +67,7 @@ in
   ];
 
   options.programs.mcfly = {
-    enable = lib.mkEnableOption "mcfly";
+    enable = mkEnableOption "mcfly";
 
     package = lib.mkPackageOption pkgs "mcfly" { };
 
@@ -125,15 +126,9 @@ in
       '';
     };
 
-    fzf.enable = lib.mkEnableOption "McFly fzf integration";
+    fzf.enable = mkEnableOption "McFly fzf integration";
 
-    enableLightTheme = mkOption {
-      default = false;
-      type = types.bool;
-      description = ''
-        Whether to enable light mode theme.
-      '';
-    };
+    enableLightTheme = mkEnableOption "light mode theme";
 
     fuzzySearchFactor = mkOption {
       default = 0;

--- a/modules/programs/mujmap.nix
+++ b/modules/programs/mujmap.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.programs.mujmap;
 
@@ -54,14 +54,7 @@ let
     };
 
   tagsOpts = {
-    lowercase = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        If true, translate all mailboxes to lowercase names when mapping to notmuch
-        tags.
-      '';
-    };
+    lowercase = mkEnableOption "lowercasing mailbox names when mapping to notmuch tags";
 
     directory_separator = mkOption {
       type = types.str;
@@ -239,7 +232,7 @@ let
   };
 
   mujmapOpts = {
-    enable = lib.mkEnableOption "mujmap JMAP synchronization for notmuch";
+    enable = mkEnableOption "mujmap JMAP synchronization for notmuch";
 
     notmuchSetupWarning = mkOption {
       type = types.bool;
@@ -279,7 +272,7 @@ in
 
   options = {
     programs.mujmap = {
-      enable = lib.mkEnableOption "mujmap Gmail synchronization for notmuch";
+      enable = mkEnableOption "mujmap Gmail synchronization for notmuch";
 
       package = lib.mkPackageOption pkgs "mujmap" { };
     };

--- a/modules/programs/mujmap.nix
+++ b/modules/programs/mujmap.nix
@@ -196,14 +196,11 @@ let
       '';
     };
 
-    auto_create_new_mailboxes = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to create new mailboxes automatically on the server from notmuch
-        tags.
-      '';
-    };
+    auto_create_new_mailboxes =
+      mkEnableOption "creating new mailboxes automatically on the server from notmuch tags"
+      // {
+        default = true;
+      };
 
     cache_dir = mkOption {
       type = types.nullOr types.str;
@@ -234,16 +231,11 @@ let
   mujmapOpts = {
     enable = mkEnableOption "mujmap JMAP synchronization for notmuch";
 
-    notmuchSetupWarning = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Warn if Notmuch is not also enabled for this account.
-
-        This can safely be disabled if {file}`mujmap.toml` is managed
-        outside of Home Manager.
-      '';
-    };
+    notmuchSetupWarning =
+      mkEnableOption "warnings when Notmuch is not also enabled for this account. This can safely be disabled if {file}`mujmap.toml` is managed outside of Home Manager"
+      // {
+        default = true;
+      };
 
     settings = mkOption {
       type = types.submodule {

--- a/modules/programs/neomutt/accounts.nix
+++ b/modules/programs/neomutt/accounts.nix
@@ -1,6 +1,6 @@
 { config, lib, ... }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   extraMailboxOptions = {
     options = {
@@ -34,7 +34,7 @@ let
 in
 {
   options.notmuch.neomutt = {
-    enable = lib.mkEnableOption "Notmuch support in NeoMutt" // {
+    enable = mkEnableOption "Notmuch support in NeoMutt" // {
       default = true;
     };
 
@@ -57,7 +57,7 @@ in
   };
 
   options.neomutt = {
-    enable = lib.mkEnableOption "NeoMutt";
+    enable = mkEnableOption "NeoMutt";
 
     sendMailCommand = mkOption {
       type = types.nullOr types.str;
@@ -83,10 +83,8 @@ in
       '';
     };
 
-    showDefaultMailbox = mkOption {
-      type = types.bool;
+    showDefaultMailbox = mkEnableOption "showing the default mailbox (INBOX)" // {
       default = true;
-      description = "Show the default mailbox (INBOX)";
     };
 
     mailboxName = mkOption {

--- a/modules/programs/neomutt/default.nix
+++ b/modules/programs/neomutt/default.nix
@@ -455,16 +455,12 @@ in
         default = true;
       };
 
-      unmailboxes = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Set `unmailboxes *` at the start of account configurations.
-          It removes previous sidebar mailboxes when sourcing an account configuration.
+      unmailboxes = mkEnableOption ''
+        setting `unmailboxes *` at the start of account configurations.
+        It removes previous sidebar mailboxes when sourcing an account configuration.
 
-          See <http://www.mutt.org/doc/manual/#mailboxes> for more information.
-        '';
-      };
+        See <http://www.mutt.org/doc/manual/#mailboxes> for more information
+      '';
 
       extraConfig = mkOption {
         type = types.lines;

--- a/modules/programs/neomutt/default.nix
+++ b/modules/programs/neomutt/default.nix
@@ -95,14 +95,11 @@ let
         description = "Width of the sidebar";
       };
 
-      shortPath = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          By default sidebar shows the full path of the mailbox, but
-          with this enabled only the relative name is shown.
-        '';
-      };
+      shortPath =
+        mkEnableOption "showing only relative names instead of the full path in the sidebar"
+        // {
+          default = true;
+        };
 
       format = mkOption {
         type = types.str;

--- a/modules/programs/neomutt/default.nix
+++ b/modules/programs/neomutt/default.nix
@@ -14,6 +14,7 @@ let
     isString
     mkIf
     mkOption
+    mkEnableOption
     optionalString
     types
     ;
@@ -86,7 +87,7 @@ let
 
   sidebarModule = types.submodule {
     options = {
-      enable = lib.mkEnableOption "sidebar support";
+      enable = mkEnableOption "sidebar support";
 
       width = mkOption {
         type = types.int;
@@ -389,7 +390,7 @@ in
 {
   options = {
     programs.neomutt = {
-      enable = lib.mkEnableOption "the NeoMutt mail client";
+      enable = mkEnableOption "the NeoMutt mail client";
 
       package = lib.mkPackageOption pkgs "neomutt" { };
 
@@ -425,11 +426,7 @@ in
         description = "Sorting method on messages.";
       };
 
-      vimKeys = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable vim-like bindings.";
-      };
+      vimKeys = mkEnableOption "vim-like bindings";
 
       checkStatsInterval = mkOption {
         type = types.nullOr types.int;
@@ -450,13 +447,11 @@ in
         description = "Extra configuration appended to the end.";
       };
 
-      changeFolderWhenSourcingAccount =
-        lib.mkEnableOption "changing the folder when sourcing an account"
-        // {
-          default = true;
-        };
+      changeFolderWhenSourcingAccount = mkEnableOption "changing the folder when sourcing an account" // {
+        default = true;
+      };
 
-      sourcePrimaryAccount = lib.mkEnableOption "source the primary account by default" // {
+      sourcePrimaryAccount = mkEnableOption "sourcing the primary account by default" // {
         default = true;
       };
 

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -82,8 +82,7 @@ in
 
       withPerl = mkEnableOption "the Perl provider. Set to `true` to use Perl plugins";
 
-      withPython3 = mkOption {
-        type = types.bool;
+      withPython3 = mkEnableOption "the Python 3 provider. Set to `true` to use Python 3 plugins" // {
         inherit
           (lib.hm.deprecations.mkStateVersionOptionDefault {
             inherit (config.home) stateVersion;
@@ -99,14 +98,9 @@ in
           default
           defaultText
           ;
-        description = ''
-          Enable Python 3 provider. Set to `true` to
-          use Python 3 plugins.
-        '';
       };
 
-      withRuby = mkOption {
-        type = types.bool;
+      withRuby = mkEnableOption "the Ruby provider" // {
         inherit
           (lib.hm.deprecations.mkStateVersionOptionDefault {
             inherit (config.home) stateVersion;
@@ -122,9 +116,6 @@ in
           default
           defaultText
           ;
-        description = ''
-          Enable ruby provider.
-        '';
       };
 
       extraPython3Packages = mkOption {
@@ -162,21 +153,13 @@ in
         '';
       };
 
-      autowrapRuntimeDeps = mkOption {
-        type = types.bool;
+      autowrapRuntimeDeps = mkEnableOption "automatically wrapping runtime dependencies of plugins" // {
         default = true;
-        description = ''
-          Whether to automatically wrap the binary with the runtime dependencies of the plugins.
-        '';
       };
 
-      waylandSupport = mkOption {
-        type = types.bool;
+      waylandSupport = mkEnableOption "Wayland clipboard support" // {
         default = pkgs.stdenv.isLinux;
         defaultText = literalExpression "pkgs.stdenv.isLinux";
-        description = ''
-          Whether to enable Wayland clipboard support.
-        '';
       };
 
       extraWrapperArgs = mkOption {

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -69,58 +69,18 @@ in
       };
 
       # Aliases
-      viAlias = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Symlink {command}`vi` to {command}`nvim` binary.
-        '';
-      };
+      viAlias = mkEnableOption "symlinking {command}`vi` to {command}`nvim`";
 
-      vimAlias = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Symlink {command}`vim` to {command}`nvim` binary.
-        '';
-      };
+      vimAlias = mkEnableOption "symlinking {command}`vim` to {command}`nvim`";
 
-      vimdiffAlias = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Alias {command}`vimdiff` to {command}`nvim -d`.
-        '';
-      };
+      vimdiffAlias = mkEnableOption "aliasing {command}`vimdiff` to {command}`nvim -d`";
 
-      defaultEditor = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to configure {command}`nvim` as the default
-          editor using the {env}`EDITOR` and {env}`VISUAL`
-          environment variables.
-        '';
-      };
+      defaultEditor = mkEnableOption "configuring {command}`nvim` as the default editor using the {env}`EDITOR` and {env}`VISUAL` environment variables";
 
       # Providers & Runtimes
-      withNodeJs = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Enable node provider. Set to `true` to
-          use Node plugins.
-        '';
-      };
+      withNodeJs = mkEnableOption "the Node provider. Set to `true` to use Node plugins";
 
-      withPerl = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Enable perl provider. Set to `true` to
-          use Perl plugins.
-        '';
-      };
+      withPerl = mkEnableOption "the Perl provider. Set to `true` to use Perl plugins";
 
       withPython3 = mkOption {
         type = types.bool;

--- a/modules/programs/newsboat.nix
+++ b/modules/programs/newsboat.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) mkIf mkOption types;
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   cfg = config.programs.newsboat;
   wrapQuote = x: ''"${x}"'';
@@ -44,7 +49,7 @@ in
 
   options = {
     programs.newsboat = {
-      enable = lib.mkEnableOption "the Newsboat feed reader";
+      enable = mkEnableOption "the Newsboat feed reader";
 
       package = lib.mkPackageOption pkgs "newsboat" { nullable = true; };
 
@@ -105,13 +110,7 @@ in
         description = "How many threads to use for updating the feeds.";
       };
 
-      autoReload = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable automatic reloading while newsboat is running.
-        '';
-      };
+      autoReload = mkEnableOption "automatically reloading while newsboat is running";
 
       reloadTime = mkOption {
         type = types.nullOr types.int;
@@ -144,10 +143,10 @@ in
       };
 
       autoFetchArticles = {
-        enable = lib.mkEnableOption "automatic article fetcher timer";
+        enable = mkEnableOption "automatic article fetcher timer";
 
-        onCalendar = lib.mkOption {
-          type = lib.types.str;
+        onCalendar = mkOption {
+          type = types.str;
           default = "daily";
           example = "weekly";
           description = ''
@@ -159,10 +158,10 @@ in
       };
 
       autoVacuum = {
-        enable = lib.mkEnableOption "automatic cleaning of the newsboat cache";
+        enable = mkEnableOption "automatic cleaning of the newsboat cache";
 
-        onCalendar = lib.mkOption {
-          type = lib.types.str;
+        onCalendar = mkOption {
+          type = types.str;
           default = "weekly";
           example = "monthly";
           description = ''

--- a/modules/programs/notmuch/default.nix
+++ b/modules/programs/notmuch/default.nix
@@ -9,6 +9,7 @@ let
     catAttrs
     filter
     mkOption
+    mkEnableOption
     optionalAttrs
     types
     ;
@@ -69,7 +70,7 @@ in
 {
   options = {
     programs.notmuch = {
-      enable = lib.mkEnableOption "Notmuch mail indexer";
+      enable = mkEnableOption "Notmuch mail indexer";
 
       package = lib.mkPackageOption pkgs "notmuch" { };
 
@@ -148,12 +149,8 @@ in
       };
 
       maildir = {
-        synchronizeFlags = mkOption {
-          type = types.bool;
+        synchronizeFlags = mkEnableOption "synchronizing Maildir flags" // {
           default = true;
-          description = ''
-            Whether to synchronize Maildir flags.
-          '';
         };
       };
 
@@ -181,7 +178,7 @@ in
       type =
         with types;
         attrsOf (submodule {
-          options.notmuch.enable = lib.mkEnableOption "notmuch indexing";
+          options.notmuch.enable = mkEnableOption "notmuch indexing";
         });
     };
   };

--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -56,10 +56,8 @@ let
 
   corePluginsOptions = {
     options = {
-      enable = mkOption {
-        type = types.bool;
+      enable = mkEnableOption "this core plugin" // {
         default = true;
-        description = "Whether to enable the plugin.";
       };
 
       name = mkOption {
@@ -82,10 +80,8 @@ let
 
   communityPluginsOptions = {
     options = {
-      enable = mkOption {
-        type = types.bool;
+      enable = mkEnableOption "this community plugin" // {
         default = true;
-        description = "Whether to enable the plugin.";
       };
 
       pkg = mkOption {
@@ -110,10 +106,8 @@ let
     { config, ... }:
     {
       options = {
-        enable = mkOption {
-          type = types.bool;
+        enable = mkEnableOption "this CSS snippet" // {
           default = true;
-          description = "Whether to enable the snippet.";
         };
 
         name = mkOption {
@@ -145,10 +139,8 @@ let
 
   themesOptions = {
     options = {
-      enable = mkOption {
-        type = types.bool;
+      enable = mkEnableOption "this theme as active" // {
         default = true;
-        description = "Whether to set the theme as active.";
       };
 
       pkg = mkOption {
@@ -302,10 +294,8 @@ in
           { name, ... }:
           {
             options = {
-              enable = mkOption {
-                type = types.bool;
+              enable = mkEnableOption "this vault being generated" // {
                 default = true;
-                description = "Whether this vault should be generated.";
               };
 
               target = mkOption {

--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -211,11 +211,7 @@ in
     enable = mkEnableOption "obsidian";
     package = mkPackageOption pkgs "obsidian" { nullable = true; };
 
-    cli.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Whether to enable the Obsidian CLI in `obsidian.json`.";
-    };
+    cli.enable = mkEnableOption "the Obsidian CLI in `obsidian.json`";
 
     defaultSettings = {
       app = mkOption {

--- a/modules/programs/papis.nix
+++ b/modules/programs/papis.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.programs.papis;
 
@@ -26,7 +26,7 @@ in
   meta.maintainers = [ ];
 
   options.programs.papis = {
-    enable = lib.mkEnableOption "papis";
+    enable = mkEnableOption "papis";
 
     package = lib.mkPackageOption pkgs "papis" { nullable = true; };
 
@@ -67,22 +67,17 @@ in
                 description = "This library's name.";
               };
 
-              isDefault = mkOption {
-                type = types.bool;
-                default = false;
-                example = true;
-                description = ''
-                  Whether this is a default library.
+              isDefault = mkEnableOption ''
+                this being a default library.
 
-                  For papis to function without explicit library selection
-                  (i.e. without `-l <library>` or `--pick-lib` flags) there
-                  must be a default library defined.
+                For papis to function without explicit library selection
+                (i.e. without `-l <library>` or `--pick-lib` flags) there
+                must be a default library defined.
 
-                  Note this can be also defined (or overridden) on a local
-                  `$(pwd)/.papis.config` or via python
-                  `$XDG_CONFIG_HOME/papis/config.py` config file.
-                '';
-              };
+                Note this can be also defined (or overridden) on a local
+                `$(pwd)/.papis.config` or via python
+                `$XDG_CONFIG_HOME/papis/config.py` config file
+              '';
 
               settings = mkOption {
                 type =

--- a/modules/programs/parallel.nix
+++ b/modules/programs/parallel.nix
@@ -5,12 +5,7 @@
   ...
 }:
 let
-  inherit (lib)
-    mkIf
-    mkEnableOption
-    mkOption
-    types
-    ;
+  inherit (lib) mkIf mkEnableOption;
 
   cfg = config.programs.parallel;
 in
@@ -22,13 +17,7 @@ in
 
     package = lib.mkPackageOption pkgs "parallel-full" { nullable = true; };
 
-    will-cite = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Accept GNU Parallels citation policy: <https://www.gnu.org/software/parallel/parallel_design.html#citation-notice>
-      '';
-    };
+    will-cite = mkEnableOption "accepting GNU Parallel's citation policy: <https://www.gnu.org/software/parallel/parallel_design.html#citation-notice>";
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/patdiff.nix
+++ b/modules/programs/patdiff.nix
@@ -12,8 +12,6 @@ let
     mkEnableOption
     mkIf
     mkPackageOption
-    mkOption
-    types
     ;
 in
 {
@@ -31,24 +29,18 @@ in
   ];
 
   options.programs.patdiff = {
-    enable = mkEnableOption "" // {
-      description = ''
-        Whether to enable the {command}`patdiff` differ.
-        See <https://opensource.janestreet.com/patdiff/>
-      '';
-    };
+    enable = mkEnableOption ''
+      the {command}`patdiff` differ.
+      See <https://opensource.janestreet.com/patdiff/>
+    '';
 
     package = mkPackageOption pkgs "patdiff" { };
 
-    enableGitIntegration = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable git integration for patdiff.
+    enableGitIntegration = mkEnableOption ''
+      git integration for patdiff.
 
-        When enabled, patdiff will be configured as git's external diff tool.
-      '';
-    };
+      When enabled, patdiff will be configured as git's external diff tool.
+    '';
   };
 
   config =

--- a/modules/programs/powerline-go.nix
+++ b/modules/programs/powerline-go.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     mkIf
     mkOption
+    mkEnableOption
     optionalString
     types
     ;
@@ -58,7 +59,7 @@ in
 
   options = {
     programs.powerline-go = {
-      enable = lib.mkEnableOption "Powerline-go, a beautiful and useful low-latency prompt for your shell";
+      enable = mkEnableOption "Powerline-go, a beautiful and useful low-latency prompt for your shell";
 
       package = lib.mkPackageOption pkgs "powerline-go" { };
 
@@ -96,14 +97,7 @@ in
         ];
       };
 
-      newline = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Set to true if the prompt should be on a line of its own.
-        '';
-        example = true;
-      };
+      newline = mkEnableOption "showing the prompt on its own line";
 
       pathAliases = mkOption {
         default = null;

--- a/modules/programs/pyradio.nix
+++ b/modules/programs/pyradio.nix
@@ -85,11 +85,7 @@ in
               description = "Encoding of the station's metadata block.";
             };
 
-            forceHttp = mkOption {
-              type = bool;
-              default = false;
-              description = "If enabled, the connection is forced to use http (note when false it can either use http or https).";
-            };
+            forceHttp = mkEnableOption "forcing HTTP for the station connection (otherwise, it can either use http or https)";
 
             iconUrl = mkOption {
               type = str;

--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -139,12 +139,8 @@ in
       '';
     };
 
-    enableDefaultBindings = mkOption {
-      type = types.bool;
+    enableDefaultBindings = mkEnableOption "loading default key bindings" // {
       default = true;
-      description = ''
-        Disable to prevent loading default key bindings.
-      '';
     };
 
     keyBindings = mkOption {

--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -11,6 +11,7 @@ let
     mapAttrsToList
     mkIf
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -63,7 +64,7 @@ let
 in
 {
   options.programs.qutebrowser = {
-    enable = lib.mkEnableOption "qutebrowser";
+    enable = mkEnableOption "qutebrowser";
 
     package = lib.mkPackageOption pkgs "qutebrowser" { nullable = true; };
 
@@ -75,13 +76,7 @@ in
       '';
     };
 
-    loadAutoconfig = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Load settings configured via the GUI.
-      '';
-    };
+    loadAutoconfig = mkEnableOption "loading settings configured via the GUI";
 
     searchEngines = mkOption {
       type = types.attrsOf types.str;

--- a/modules/programs/readline.nix
+++ b/modules/programs/readline.nix
@@ -1,6 +1,11 @@
 { config, lib, ... }:
 let
-  inherit (lib) mkIf mkOption types;
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   cfg = config.programs.readline;
 
@@ -59,10 +64,8 @@ in
       '';
     };
 
-    includeSystemConfig = mkOption {
-      type = types.bool;
+    includeSystemConfig = mkEnableOption "including the system-wide readline configuration" // {
       default = true;
-      description = "Whether to include the system-wide configuration.";
     };
 
     extraConfig = mkOption {

--- a/modules/programs/riff.nix
+++ b/modules/programs/riff.nix
@@ -51,15 +51,11 @@ in
       '';
     };
 
-    enableGitIntegration = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable git integration for riff.
+    enableGitIntegration = mkEnableOption ''
+      git integration for riff.
 
-        When enabled, riff will be configured as git's pager for diff, log, and show commands.
-      '';
-    };
+      When enabled, riff will be configured as git's pager for diff, log, and show commands.
+    '';
   };
 
   config =

--- a/modules/programs/sesh.nix
+++ b/modules/programs/sesh.nix
@@ -38,16 +38,12 @@ in
       '';
     };
 
-    enableAlias = mkOption {
-      type = types.bool;
+    enableAlias = mkEnableOption "a shell alias `s` to quickly launch sessions" // {
       default = true;
-      description = "Whether to enable a shell alias `s` to quickly launch sessions.";
     };
 
-    enableTmuxIntegration = mkOption {
-      type = types.bool;
+    enableTmuxIntegration = mkEnableOption "Tmux integration with sesh" // {
       default = true;
-      description = "Enable Tmux integration with sesh.";
     };
 
     tmuxKey = mkOption {
@@ -56,12 +52,8 @@ in
       description = "Keybinding for invoking sesh in Tmux.";
     };
 
-    icons = mkOption {
-      type = types.bool;
+    icons = mkEnableOption "displaying icons next to results ({option}`--icons` argument)" // {
       default = true;
-      description = ''
-        Display icons next to results ({option}`--icons` argument).
-      '';
     };
   };
 

--- a/modules/programs/sketchybar.nix
+++ b/modules/programs/sketchybar.nix
@@ -138,14 +138,11 @@ in
       '';
     };
 
-    includeSystemPath = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to include common system `PATH` in the wrapper.
-        This allows sketchybar to access system binaries.
-      '';
-    };
+    includeSystemPath =
+      mkEnableOption "including common system `PATH` in the wrapper. This allows sketchybar to access system binaries"
+      // {
+        default = true;
+      };
 
     service = {
       enable = mkEnableOption "sketchybar service" // {

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -10,6 +10,7 @@ let
     literalExpression
     mapAttrsToList
     mkOption
+    mkEnableOption
     optional
     types
     ;
@@ -116,35 +117,11 @@ let
         '';
       };
 
-      forwardX11 = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Specifies whether X11 connections will be automatically redirected
-          over the secure channel and {env}`DISPLAY` set.
-        '';
-      };
+      forwardX11 = mkEnableOption "automatic X11 connection forwarding over the secure channel and {env}`DISPLAY` set";
 
-      forwardX11Trusted = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Specifies whether remote X11 clients will have full access to the
-          original X11 display.
-        '';
-      };
+      forwardX11Trusted = mkEnableOption "trusted X11 forwarding with full access to the original X11 display";
 
-      identitiesOnly = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Specifies that ssh should only use the authentication
-          identity explicitly configured in the
-          {file}`~/.ssh/config` files or passed on the
-          ssh command-line, even if {command}`ssh-agent`
-          offers more identities.
-        '';
-      };
+      identitiesOnly = mkEnableOption "only using the authentication identity explicitly configured in the {file}`~/.ssh/config` files or passed on the ssh command-line, even if {command}`ssh-agent` offers more identities";
 
       identityFile = mkOption {
         type = with types; either (listOf str) (nullOr str);
@@ -486,7 +463,7 @@ in
     } renamedOptions;
 
   options.programs.ssh = {
-    enable = lib.mkEnableOption "SSH client configuration";
+    enable = mkEnableOption "SSH client configuration";
 
     package = lib.mkPackageOption pkgs "openssh" {
       nullable = true;

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -202,13 +202,8 @@ let
         '';
       };
 
-      checkHostIP = mkOption {
-        type = types.bool;
+      checkHostIP = mkEnableOption "checking the host IP address in the {file}`known_hosts` file" // {
         default = true;
-        description = ''
-          Check the host IP address in the
-          {file}`known_hosts` file.
-        '';
       };
 
       proxyCommand = mkOption {
@@ -527,15 +522,11 @@ in
       '';
     };
 
-    enableDefaultConfig = mkOption {
-      type = types.bool;
-      default = true;
-      example = false;
-      description = ''
-        Whether to enable or not the old default config values.
+    enableDefaultConfig =
+      mkEnableOption ''
+        the old default config values.
         This option will become deprecated in the future.
-        For an equivalent, copy and paste the following
-        code snippet in your config:
+        For an equivalent, copy and paste the following code snippet in your config:
 
         programs.ssh.matchBlocks."*" = {
           forwardAgent = false;
@@ -549,8 +540,10 @@ in
           controlPath = "~/.ssh/master-%r@%n:%p";
           controlPersist = "no";
         };
-      '';
-    };
+      ''
+      // {
+        default = true;
+      };
   };
 
   config = lib.mkIf cfg.enable (

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -9,6 +9,7 @@ let
     literalExpression
     mkIf
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -23,7 +24,7 @@ in
   meta.maintainers = [ ];
 
   options.programs.starship = {
-    enable = lib.mkEnableOption "starship";
+    enable = mkEnableOption "starship";
 
     package = lib.mkPackageOption pkgs "starship" { };
 
@@ -94,18 +95,11 @@ in
       '';
     };
 
-    enableTransience = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        The TransientPrompt feature of Starship replaces previous prompts with a
-        custom string. This is only a valid option for the Fish shell.
+    enableTransience = mkEnableOption ''
+      The TransientPrompt feature of Starship which replaces previous prompts with a custom string. This is only a valid option for the Fish shell.
 
-        For documentation on how to change the default replacement string and
-        for more information visit
-        https://starship.rs/advanced-config/#transientprompt-and-transientrightprompt-in-cmd
-      '';
-    };
+      For documentation on how to change the default replacement string and for more information visit https://starship.rs/advanced-config/#transientprompt-and-transientrightprompt-in-cmd
+    '';
 
     configPath = mkOption {
       type = lib.types.str;

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -84,16 +84,15 @@ in
 
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
-    enableInteractive = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Only enable starship when the shell is interactive. This option is only
-        valid for the Fish shell.
+    enableInteractive =
+      mkEnableOption ''
+        Only enable starship when the shell is interactive. This option is only valid for the Fish shell.
 
         Some plugins require this to be set to `false` to function correctly.
-      '';
-    };
+      ''
+      // {
+        default = true;
+      };
 
     enableTransience = mkEnableOption ''
       The TransientPrompt feature of Starship which replaces previous prompts with a custom string. This is only a valid option for the Fish shell.

--- a/modules/programs/superfile.nix
+++ b/modules/programs/superfile.nix
@@ -133,12 +133,8 @@ in
       '';
     };
 
-    firstUseCheck = mkOption {
-      type = types.bool;
+    firstUseCheck = mkEnableOption "the first-time use popup" // {
       default = true;
-      description = ''
-        Enables the first time use popup.
-      '';
     };
 
     pinnedFolders = mkOption {

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -15,6 +15,7 @@ let
     mapAttrsToList
     mkIf
     mkOption
+    mkEnableOption
     mkOptionDefault
     optionalAttrs
     optionalString
@@ -334,7 +335,7 @@ in
 
   options = {
     programs.thunderbird = {
-      enable = lib.mkEnableOption "Thunderbird";
+      enable = mkEnableOption "Thunderbird";
 
       package = lib.mkPackageOption pkgs "thunderbird" {
         example = "pkgs.thunderbird-91";
@@ -370,15 +371,7 @@ in
                   description = "This profile's name.";
                 };
 
-                isDefault = mkOption {
-                  type = types.bool;
-                  default = false;
-                  example = true;
-                  description = ''
-                    Whether this is a default profile. There must be exactly one
-                    default profile.
-                  '';
-                };
+                isDefault = mkEnableOption "this being the default profile. There must be exactly one default profile";
 
                 feedAccounts = mkOption {
                   type = types.attrsOf (
@@ -476,12 +469,7 @@ in
                   '';
                 };
 
-                withExternalGnupg = mkOption {
-                  type = types.bool;
-                  default = false;
-                  example = true;
-                  description = "Allow using external GPG keys with GPGME.";
-                };
+                withExternalGnupg = mkEnableOption "using external GPG keys with GPGME";
 
                 userChrome = mkOption {
                   type = types.lines;
@@ -604,7 +592,7 @@ in
               });
             };
             options.thunderbird = {
-              enable = lib.mkEnableOption "the Thunderbird mail client for this account";
+              enable = mkEnableOption "the Thunderbird mail client for this account";
 
               profiles = mkOption {
                 type = with types; listOf str;
@@ -743,7 +731,7 @@ in
         with types;
         attrsOf (submodule {
           options.thunderbird = {
-            enable = lib.mkEnableOption "the Thunderbird mail client for this account";
+            enable = mkEnableOption "the Thunderbird mail client for this account";
 
             profiles = mkOption {
               type = with types; listOf str;
@@ -758,11 +746,7 @@ in
               '';
             };
 
-            readOnly = mkOption {
-              type = bool;
-              default = false;
-              description = "Mark calendar as read only";
-            };
+            readOnly = mkEnableOption "marking calendar as read only";
 
             color = mkOption {
               type = str;
@@ -779,7 +763,7 @@ in
         with types;
         attrsOf (submodule {
           options.thunderbird = {
-            enable = lib.mkEnableOption "the Thunderbird mail client for this account";
+            enable = mkEnableOption "the Thunderbird mail client for this account";
 
             profiles = mkOption {
               type = with types; listOf str;

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -565,17 +565,17 @@ in
         '';
       };
 
-      darwinSetupWarning = mkOption {
-        type = types.bool;
-        default = true;
-        example = false;
-        visible = false;
-        readOnly = !isDarwin;
-        description = ''
-          Using programs.thunderbird.darwinSetupWarning is deprecated. The
-          module is compatible with all Thunderbird installations.
-        '';
-      };
+      darwinSetupWarning =
+        mkEnableOption ''
+          the deprecated Thunderbird Darwin setup warning.
+
+          Using programs.thunderbird.darwinSetupWarning is deprecated. The module is compatible with all Thunderbird installations
+        ''
+        // {
+          default = true;
+          visible = false;
+          readOnly = !isDarwin;
+        };
     };
 
     accounts.email.accounts = mkOption {
@@ -665,10 +665,8 @@ in
                         type = str;
                         description = "Name for the filter.";
                       };
-                      enabled = mkOption {
-                        type = bool;
+                      enabled = mkEnableOption "this filter" // {
                         default = true;
-                        description = "Whether this filter is currently active.";
                       };
                       type = mkOption {
                         type = str;

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -151,14 +151,7 @@ in
 {
   options = {
     programs.tmux = {
-      aggressiveResize = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Resize the window to the size of the smallest session for
-          which it is the current window.
-        '';
-      };
+      aggressiveResize = mkEnableOption "Resizing the window to the size of the smallest session for which it is the current window";
 
       baseIndex = mkOption {
         default = 0;
@@ -167,28 +160,11 @@ in
         description = "Base index for windows and panes.";
       };
 
-      clock24 = mkOption {
-        default = false;
-        type = types.bool;
-        description = "Use 24 hour clock.";
-      };
+      clock24 = mkEnableOption "24-hour clock";
 
-      customPaneNavigationAndResize = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Override the hjkl and HJKL bindings for pane navigation and
-          resizing in VI mode.
-        '';
-      };
+      customPaneNavigationAndResize = mkEnableOption "overriding the hjkl and HJKL bindings for pane navigation and resizing in VI mode";
 
-      disableConfirmationPrompt = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Disable confirmation prompt before killing a pane or window
-        '';
-      };
+      disableConfirmationPrompt = mkEnableOption "disabling pane/window kill confirmation prompts";
 
       enable = mkEnableOption "tmux";
 
@@ -211,14 +187,7 @@ in
         '';
       };
 
-      focusEvents = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          On supported terminals, request focus events and pass them through to
-          applications running in tmux.
-        '';
-      };
+      focusEvents = mkEnableOption "requesting focus events and passing them through to applications running in tmux on supported terminals";
 
       historyLimit = mkOption {
         default = 2000;
@@ -239,22 +208,11 @@ in
 
       mouse = mkEnableOption "mouse support";
 
-      newSession = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Automatically spawn a session if trying to attach and none
-          are running.
-        '';
-      };
+      newSession = mkEnableOption "automatically spawning a session when attaching and none are running";
 
       package = lib.mkPackageOption pkgs "tmux" { nullable = true; };
 
-      reverseSplit = mkOption {
-        default = false;
-        type = types.bool;
-        description = "Reverse the window split shortcuts.";
-      };
+      reverseSplit = mkEnableOption "reversing the window split shortcuts";
 
       resizeAmount = mkOption {
         default = defaultResize;
@@ -263,15 +221,7 @@ in
         description = "Number of lines/columns when resizing.";
       };
 
-      sensibleOnTop = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Run the sensible plugin at the top of the configuration. It
-          is possible to override the sensible settings using the
-          {option}`programs.tmux.extraConfig` option.
-        '';
-      };
+      sensibleOnTop = mkEnableOption "running the sensible plugin at the top of the configuration. It is possible to override the sensible settings using the {option}`programs.tmux.extraConfig` option";
 
       prefix = mkOption {
         default = null;

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -255,15 +255,11 @@ in
         description = "Set the default-shell tmux variable.";
       };
 
-      secureSocket = mkOption {
-        default = pkgs.stdenv.isLinux;
-        type = types.bool;
-        description = ''
-          Store tmux socket under {file}`/run`, which is more
-          secure than {file}`/tmp`, but as a downside it doesn't
-          survive user logout.
-        '';
-      };
+      secureSocket =
+        mkEnableOption "storing the tmux socket under {file}`/run`, which is more secure than {file}`/tmp`, but as a downside it doesn't survive user logout"
+        // {
+          default = pkgs.stdenv.isLinux;
+        };
 
       tmuxp.enable = mkEnableOption "tmuxp";
 

--- a/modules/programs/trippy.nix
+++ b/modules/programs/trippy.nix
@@ -6,7 +6,6 @@
 }:
 let
   inherit (lib)
-    types
     mkIf
     mkEnableOption
     mkPackageOption
@@ -47,18 +46,14 @@ in
         here: <https://trippy.rs/reference/configuration/>
       '';
     };
-    forceUserConfig = mkOption {
-      type = types.bool;
-      default = true;
-      example = false;
-      description = ''
-        Whatever to force trippy to use user's config through the -c flag.
-        This will prevent certain commands such as 'sudo' ignoring
-        the configured settings. This will only work if you have
-        'programs.<shell>.enable' (bash, zsh, fish, ...), depending
-        on your shell.
-      '';
-    };
+    forceUserConfig =
+      mkEnableOption ''
+        forcing trippy to use the user's config through the `-c` flag.
+        This will prevent certain commands such as 'sudo' ignoring the configured settings. This will only work if you have 'programs.<shell>.enable' (bash, zsh, fish, ...), depending on your shell.
+      ''
+      // {
+        default = true;
+      };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/urxvt.nix
+++ b/modules/programs/urxvt.nix
@@ -5,13 +5,13 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.programs.urxvt;
 in
 {
   options.programs.urxvt = {
-    enable = lib.mkEnableOption "rxvt-unicode terminal emulator";
+    enable = mkEnableOption "rxvt-unicode terminal emulator";
 
     package = lib.mkPackageOption pkgs "rxvt-unicode" { };
 
@@ -109,18 +109,10 @@ in
         description = "Whether to scroll to bottom on keyboard input.";
       };
 
-      scrollOnOutput = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to scroll to bottom on TTY output.";
-      };
+      scrollOnOutput = mkEnableOption "scrolling to bottom on TTY output";
     };
 
-    transparent = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Whether to enable pseudo-transparency.";
-    };
+    transparent = mkEnableOption "pseudo-transparency";
 
     shading = mkOption {
       type = types.ints.between 0 200;

--- a/modules/programs/urxvt.nix
+++ b/modules/programs/urxvt.nix
@@ -34,20 +34,16 @@ in
       '';
     };
 
-    iso14755 = mkOption {
-      type = types.bool;
+    iso14755 = mkEnableOption "ISO14755 support for viewing and entering unicode characters" // {
       default = true;
-      description = "ISO14755 support for viewing and entering unicode characters.";
     };
 
     scroll = {
       bar = mkOption {
         type = types.submodule {
           options = {
-            enable = mkOption {
-              type = types.bool;
+            enable = mkEnableOption "the scrollbar" // {
               default = true;
-              description = "Whether to enable the scrollbar";
             };
 
             style = mkOption {
@@ -80,10 +76,8 @@ in
               description = "Scrollbar position.";
             };
 
-            floating = mkOption {
-              type = types.bool;
+            floating = mkEnableOption "an rxvt scrollbar without a trough" // {
               default = true;
-              description = "Whether to display an rxvt scrollbar without a trough.";
             };
           };
         };
@@ -97,16 +91,12 @@ in
         description = "Number of lines to save in the scrollback buffer.";
       };
 
-      keepPosition = mkOption {
-        type = types.bool;
+      keepPosition = mkEnableOption "keeping scroll position when the TTY receives new lines" // {
         default = true;
-        description = "Whether to keep a scroll position when TTY receives new lines.";
       };
 
-      scrollOnKeystroke = mkOption {
-        type = types.bool;
+      scrollOnKeystroke = mkEnableOption "scrolling to bottom on keyboard input" // {
         default = true;
-        description = "Whether to scroll to bottom on keyboard input.";
       };
 
       scrollOnOutput = mkEnableOption "scrolling to bottom on TTY output";

--- a/modules/programs/vdirsyncer/accounts.nix
+++ b/modules/programs/vdirsyncer/accounts.nix
@@ -1,12 +1,12 @@
 { lib, ... }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   collection = types.either types.str (types.listOf types.str);
 in
 {
   options.vdirsyncer = {
-    enable = lib.mkEnableOption "synchronization using vdirsyncer";
+    enable = mkEnableOption "synchronization using vdirsyncer";
 
     urlCommand = mkOption {
       type = types.nullOr (types.listOf types.str);
@@ -118,14 +118,7 @@ in
       '';
     };
 
-    useVcard4 = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Specifies whether vdirsyncer should request vCards in version 4.0.
-        If set to `false` then vdirsyncer will default to version 3.0.
-      '';
-    };
+    useVcard4 = mkEnableOption "requesting vCard version 4.0. Else, uses vCard version 3.0";
 
     verify = mkOption {
       type = types.nullOr types.path;

--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -9,6 +9,7 @@ let
     concatStringsSep
     literalExpression
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -94,7 +95,7 @@ in
 {
   options = {
     programs.vim = {
-      enable = lib.mkEnableOption "Vim";
+      enable = mkEnableOption "Vim";
 
       plugins = mkOption {
         type = with types; listOf (either str package);
@@ -157,15 +158,7 @@ in
         example = "pkgs.vim";
       };
 
-      defaultEditor = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to configure {command}`vim` as the default
-          editor using the {env}`EDITOR` and {env}`VISUAL`
-          environment variables.
-        '';
-      };
+      defaultEditor = mkEnableOption "configuring {command}`vim` as the default editor using the {env}`EDITOR` and {env}`VISUAL` environment variables";
     };
   };
 

--- a/modules/programs/vscode/default.nix
+++ b/modules/programs/vscode/default.nix
@@ -10,6 +10,7 @@ let
     literalExpression
     mapAttrsToList
     mkOption
+    mkEnableOption
     mkIf
     optionalString
     types
@@ -380,7 +381,7 @@ in
       ];
 
   options.programs.vscode = {
-    enable = lib.mkEnableOption "Visual Studio Code";
+    enable = mkEnableOption "Visual Studio Code";
 
     package = lib.mkPackageOption pkgs "vscode" {
       nullable = true;
@@ -402,17 +403,13 @@ in
       '';
     };
 
-    mutableExtensionsDir = mkOption {
-      type = types.bool;
-      default = allProfilesExceptDefault == { };
-      defaultText = lib.literalExpression "(removeAttrs config.programs.vscode.profiles [ \"default\" ]) == { }";
-      example = false;
-      description = ''
-        Whether extensions can be installed or updated manually
-        or by Visual Studio Code. Mutually exclusive to
-        programs.vscode.profiles.
-      '';
-    };
+    mutableExtensionsDir =
+      mkEnableOption "installing and updating extensions manually or by Visual Studio Code. Mutually exclusive to programs.vscode.profiles"
+      // {
+        default = allProfilesExceptDefault == { };
+        defaultText = lib.literalExpression "(removeAttrs config.programs.vscode.profiles [ \"default\" ]) == { }";
+        example = false;
+      };
 
     nameShort = mkOption {
       type = types.str;

--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -224,16 +224,13 @@ in
 
       enableDebug = mkEnableOption "debug logging";
 
-      enableInspect = mkOption {
-        type = bool;
-        default = false;
-        example = true;
-        description = ''
-          Inspect objects and find their CSS classes, experiment with live CSS styles, and lookup the current value of CSS properties.
+      enableInspect = mkEnableOption ''
+        the GTK inspector.
 
-          See <https://developer.gnome.org/documentation/tools/inspector.html>
-        '';
-      };
+        Inspect objects and find their CSS classes, experiment with live CSS styles, and lookup the current value of CSS properties.
+
+        See <https://developer.gnome.org/documentation/tools/inspector.html>
+      '';
 
       targets = mkOption {
         type = with lib.types; listOf str;

--- a/modules/programs/z-lua.nix
+++ b/modules/programs/z-lua.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkIf types;
+  inherit (lib) mkEnableOption mkIf types;
 
   cfg = config.programs.z-lua;
 
@@ -22,7 +22,7 @@ in
   meta.maintainers = [ ];
 
   options.programs.z-lua = {
-    enable = lib.mkEnableOption "z.lua";
+    enable = mkEnableOption "z.lua";
 
     package = lib.mkPackageOption pkgs "z-lua" { };
 
@@ -45,13 +45,7 @@ in
 
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
-    enableAliases = lib.mkOption {
-      default = false;
-      type = types.bool;
-      description = ''
-        Whether to enable recommended z.lua aliases.
-      '';
-    };
+    enableAliases = mkEnableOption "recommended z.lua aliases";
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -10,6 +10,7 @@ let
     mkIf
     mkMerge
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -61,7 +62,7 @@ in
 
   options = {
     programs.zed-editor = {
-      enable = lib.mkEnableOption "Zed, the high performance, multiplayer code editor from the creators of Atom and Tree-sitter";
+      enable = mkEnableOption "Zed, the high performance, multiplayer code editor from the creators of Atom and Tree-sitter";
 
       package = lib.mkPackageOption pkgs "zed-editor" { nullable = true; };
 
@@ -200,33 +201,19 @@ in
         '';
       };
 
-      installRemoteServer = mkOption {
-        type = types.bool;
-        default = false;
-        example = true;
-        description = ''
-          Whether to symlink the Zed's remote server binary to the expected
-          location. This allows remotely connecting to this system from a
-          distant Zed client.
+      installRemoteServer = mkEnableOption ''
+        symlinking the Zed's remote server binary to the expected location. This allows remotely connecting to this system from a distant Zed client.
 
-          For more information, consult the
-          ["Remote Server" section](https://wiki.nixos.org/wiki/Zed#Remote_Server)
-          in the wiki.
-        '';
-      };
+        For more information, consult the
+        ["Remote Server" section](https://wiki.nixos.org/wiki/Zed#Remote_Server)
+        in the wiki
+      '';
 
-      enableMcpIntegration = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to integrate the MCP server config from
-          {option}`programs.mcp.servers` into
-          {option}`programs.zed-editor.userSettings.context_servers`.
+      enableMcpIntegration = mkEnableOption ''
+        MCP server config integrations from {option}`programs.mcp.servers` into {option}`programs.zed-editor.userSettings.context_servers`.
 
-          Note: Settings defined in {option}`programs.zed-editor.userSettings.context_servers`
-          will take precedence over the generated MCP configuration.
-        '';
-      };
+        Note: Settings defined in {option}`programs.zed-editor.userSettings.context_servers` will take precedence over the generated MCP configuration
+      '';
 
       themes = mkOption {
         description = ''

--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -73,41 +73,23 @@ in
         description = "Extra packages available to Zed.";
       };
 
-      mutableUserSettings = mkOption {
-        type = types.bool;
+      mutableUserSettings = mkEnableOption "the mutation of user settings (settings.json) by zed" // {
         default = true;
-        example = false;
-        description = ''
-          Whether user settings (settings.json) can be updated by zed.
-        '';
       };
 
-      mutableUserKeymaps = mkOption {
-        type = types.bool;
+      mutableUserKeymaps = mkEnableOption "the mutation of user keymaps (keymap.json) by zed" // {
         default = true;
-        example = false;
-        description = ''
-          Whether user keymaps (keymap.json) can be updated by zed.
-        '';
       };
 
-      mutableUserTasks = mkOption {
-        type = types.bool;
+      mutableUserTasks = mkEnableOption "the mutation of user tasks (tasks.json) by zed" // {
         default = true;
-        example = false;
-        description = ''
-          Whether user tasks (tasks.json) can be updated by zed.
-        '';
       };
 
-      mutableUserDebug = mkOption {
-        type = types.bool;
-        default = true;
-        example = false;
-        description = ''
-          Whether user debug configurations (debug.json) can be updated by zed.
-        '';
-      };
+      mutableUserDebug =
+        mkEnableOption "the mutation of user debug configurations (debug.json) by zed"
+        // {
+          default = true;
+        };
 
       userSettings = mkOption {
         inherit (jsonFormat) type;

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -6,7 +6,12 @@
 }:
 
 let
-  inherit (lib) mkIf mkOption types;
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   cfg = config.programs.zellij;
   yamlFormat = pkgs.formats.yaml { };
@@ -26,7 +31,7 @@ in
   ];
 
   options.programs.zellij = {
-    enable = lib.mkEnableOption "Zellij";
+    enable = mkEnableOption "Zellij";
 
     package = lib.mkPackageOption pkgs "zellij" { };
 
@@ -211,25 +216,17 @@ in
       '';
     };
 
-    attachExistingSession = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to attach to the default session after being autostarted if a Zellij session already exists.
+    attachExistingSession = mkEnableOption ''
+      attaching to the default session after being autostarted if a Zellij session already exists.
 
-        Variable is checked in `auto-start` script. Requires shell integration to be enabled to have effect.
-      '';
-    };
+      Variable is checked in `auto-start` script. Requires shell integration to be enabled to have effect
+    '';
 
-    exitShellOnExit = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to exit the shell when Zellij exits after being autostarted.
+    exitShellOnExit = mkEnableOption ''
+      exiting the shell when Zellij exits after being autostarted.
 
-        Variable is checked in `auto-start` script. Requires shell integration to be enabled to have effect.
-      '';
-    };
+      Variable is checked in `auto-start` script. Requires shell integration to be enabled to have effect
+    '';
 
     themes = mkOption {
       type = types.attrsOf (

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -170,17 +170,19 @@ in
           type = types.attrsOf types.str;
         };
 
-        enableCompletion = mkOption {
-          default = true;
-          description = ''
-            Enable zsh completion. Don't forget to add
+        enableCompletion =
+          mkEnableOption ''
+            zsh completion.
+
+            Don't forget to add
             ```nix
               environment.pathsToLink = [ "/share/zsh" ];
             ```
-            to your system configuration to get completion for system packages (e.g. systemd).
-          '';
-          type = types.bool;
-        };
+            to your system configuration to get completion for system packages (e.g. systemd)
+          ''
+          // {
+            default = true;
+          };
 
         completionInit = mkOption {
           default = "autoload -U compinit && compinit";

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -195,11 +195,7 @@ in
         };
 
         autosuggestion = {
-          enable = mkOption {
-            type = types.bool;
-            default = false;
-            description = "Enable zsh autosuggestions";
-          };
+          enable = mkEnableOption "zsh autosuggestions";
 
           highlight = mkOption {
             type = types.nullOr types.str;

--- a/modules/programs/zsh/history.nix
+++ b/modules/programs/zsh/history.nix
@@ -61,13 +61,8 @@ in
               '';
             };
 
-            ignoreDups = mkOption {
-              type = types.bool;
+            ignoreDups = mkEnableOption "ignoring command duplicates of the previous history event" // {
               default = true;
-              description = ''
-                Do not enter command lines into the history list
-                if they are duplicates of the previous event.
-              '';
             };
 
             ignoreAllDups = mkEnableOption "removing older duplicate commands when a duplicate is added to history";
@@ -76,23 +71,16 @@ in
 
             findNoDups = mkEnableOption "hiding history lines that were previously found";
 
-            ignoreSpace = mkOption {
-              type = types.bool;
+            ignoreSpace = mkEnableOption "ignoring commands that start with a space in history" // {
               default = true;
-              description = ''
-                Do not enter command lines into the history list
-                if the first character is a space.
-              '';
             };
 
             expireDuplicatesFirst = mkEnableOption "expiring duplicate history entries first";
 
             extended = mkEnableOption "saving timestamps into the history file";
 
-            share = mkOption {
-              type = types.bool;
+            share = mkEnableOption "sharing command history between zsh sessions" // {
               default = true;
-              description = "Share command history between zsh sessions.";
             };
           };
         }

--- a/modules/programs/zsh/history.nix
+++ b/modules/programs/zsh/history.nix
@@ -23,20 +23,12 @@ in
         { config, ... }:
         {
           options = {
-            append = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                If set, zsh sessions will append their history list to the history
-                file, rather than replace it. Thus, multiple parallel zsh sessions
-                will all have the new entries from their history lists added to the
-                history file, in the order that they exit.
+            append = mkEnableOption ''
+              appending zsh session history to the history file instead of replacing it.
+              Thus, multiple parallel zsh sessions will all have the new entries from their history lists added to the history file, in the order that they exit.
 
-                This file will still be periodically re-written to trim it when the
-                number of lines grows 20% beyond the value specified by
-                `programs.zsh.history.save`.
-              '';
-            };
+              This file will still be periodically re-written to trim it when the number of lines grows 20% beyond the value specified by `programs.zsh.history.save`
+            '';
 
             size = mkOption {
               type = types.int;

--- a/modules/programs/zsh/history.nix
+++ b/modules/programs/zsh/history.nix
@@ -7,7 +7,12 @@
 let
   cfg = config.programs.zsh;
 
-  inherit (lib) literalExpression mkOption types;
+  inherit (lib)
+    literalExpression
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   inherit (import ./lib.nix { inherit config lib; }) dotDirAbs mkShellVarPathStr;
 in
@@ -73,32 +78,11 @@ in
               '';
             };
 
-            ignoreAllDups = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                If a new command line being added to the history list
-                duplicates an older one, the older command is removed
-                from the list (even if it is not the previous event).
-              '';
-            };
+            ignoreAllDups = mkEnableOption "removing older duplicate commands when a duplicate is added to history";
 
-            saveNoDups = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                Do not write duplicate entries into the history file.
-              '';
-            };
+            saveNoDups = mkEnableOption "ignoring duplicate entries in the history file";
 
-            findNoDups = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                Do not display a line previously found in the history
-                file.
-              '';
-            };
+            findNoDups = mkEnableOption "hiding history lines that were previously found";
 
             ignoreSpace = mkOption {
               type = types.bool;
@@ -109,17 +93,9 @@ in
               '';
             };
 
-            expireDuplicatesFirst = mkOption {
-              type = types.bool;
-              default = false;
-              description = "Expire duplicates first.";
-            };
+            expireDuplicatesFirst = mkEnableOption "expiring duplicate history entries first";
 
-            extended = mkOption {
-              type = types.bool;
-              default = false;
-              description = "Save timestamp into the history file.";
-            };
+            extended = mkEnableOption "saving timestamps into the history file";
 
             share = mkOption {
               type = types.bool;
@@ -132,7 +108,7 @@ in
 
       historySubstringSearchModule = types.submodule {
         options = {
-          enable = lib.mkEnableOption "history substring search";
+          enable = mkEnableOption "history substring search";
           searchUpKey = mkOption {
             type = with types; either (listOf str) str;
             default = [ "^[[A" ];

--- a/modules/programs/zsh/plugins/zprof.nix
+++ b/modules/programs/zsh/plugins/zprof.nix
@@ -4,7 +4,7 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkEnableOption;
 
   cfg = config.programs.zsh;
 in
@@ -13,15 +13,7 @@ in
     (lib.mkRenamedOptionModule [ "programs" "zsh" "zproof" ] [ "programs" "zsh" "zprof" ])
   ];
 
-  options.programs.zsh.zprof = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Enable zprof in your zshrc.
-      '';
-    };
-  };
+  options.programs.zsh.zprof.enable = mkEnableOption "zprof in your zshrc";
 
   config = lib.mkIf cfg.zprof.enable {
     programs.zsh.initContent = lib.mkMerge [

--- a/modules/services/clipcat.nix
+++ b/modules/services/clipcat.nix
@@ -6,7 +6,6 @@
 }:
 let
   inherit (lib)
-    types
     mkIf
     mkEnableOption
     mkPackageOption
@@ -24,13 +23,8 @@ in
     enable = mkEnableOption "clipcat";
     package = mkPackageOption pkgs "clipcat" { };
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
-    enableSystemdUnit = mkOption {
-      type = types.bool;
+    enableSystemdUnit = mkEnableOption "clipcat systemd unit" // {
       default = true;
-      example = false;
-      description = ''
-        Enable clipcat's Systemd Unit.
-      '';
     };
     daemonSettings = mkOption {
       inherit (formatter) type;

--- a/modules/services/davmail.nix
+++ b/modules/services/davmail.nix
@@ -13,7 +13,6 @@ let
     mkIf
     mkOption
     optionalAttrs
-    types
     ;
 
   cfg = config.services.davmail;
@@ -33,12 +32,7 @@ in
 
     package = lib.mkPackageOption pkgs "davmail" { };
 
-    imitateOutlook = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Whether DavMail pretends to be Outlook.";
-      example = true;
-    };
+    imitateOutlook = mkEnableOption "DavMail pretending to be Outlook";
 
     settings = mkOption {
       inherit (javaProperties) type;

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     mkIf
     mkOption
+    mkEnableOption
     optional
     optionalAttrs
     types
@@ -51,7 +52,7 @@ in
   meta.maintainers = [ lib.maintainers.tadfisher ];
 
   options.services.emacs = {
-    enable = lib.mkEnableOption "the Emacs daemon";
+    enable = mkEnableOption "the Emacs daemon";
 
     package = mkOption {
       type = types.package;
@@ -76,7 +77,7 @@ in
     };
 
     client = {
-      enable = lib.mkEnableOption "generation of Emacs client desktop file";
+      enable = mkEnableOption "the generation of Emacs client desktop file";
       arguments = mkOption {
         type = with types; listOf str;
         default = [ "-c" ];
@@ -90,7 +91,7 @@ in
     # socket path, though allowing for such is not easy to do as systemd socket
     # units don't perform variable expansion for 'ListenStream'.
     socketActivation = {
-      enable = lib.mkEnableOption "systemd socket activation for the Emacs service";
+      enable = mkEnableOption "the systemd socket activation for the Emacs service";
     };
 
     startWithUserSession = mkOption {
@@ -107,16 +108,11 @@ in
       '';
     };
 
-    defaultEditor = mkOption {
-      type = types.bool;
-      default = false;
-      example = true;
-      description = ''
-        Whether to configure {command}`emacsclient` as the default
-        editor using the {env}`EDITOR` and {env}`VISUAL`
-        environment variables.
-      '';
-    };
+    defaultEditor = mkEnableOption ''
+      the configuration of {command}`emacsclient` as the default
+      editor using the {env}`EDITOR` and {env}`VISUAL`
+      environment variables.
+    '';
   };
 
   config = mkIf cfg.enable {

--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -11,7 +11,6 @@ let
     mkEnableOption
     mkIf
     literalExpression
-    types
     mkRemovedOptionModule
     versionAtLeast
     ;
@@ -68,16 +67,12 @@ in
           default = if isLinux && cfg.waylandSupport then pkgs.espanso-wayland else null;
         };
 
-      x11Support = mkOption {
-        type = types.bool;
-        description = "Whether to enable x11 support on linux";
+      x11Support = mkEnableOption "x11 support on Linux" // {
         default = isLinux;
         defaultText = "`true` on linux";
       };
 
-      waylandSupport = mkOption {
-        type = types.bool;
-        description = "Whether to enable wayland support on linux";
+      waylandSupport = mkEnableOption "wayland support on Linux" // {
         default = isLinux;
         defaultText = "`true` on linux";
       };

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -9,6 +9,7 @@ let
   inherit (lib)
     mkIf
     mkOption
+    mkEnableOption
     optional
     optionalString
     types
@@ -184,7 +185,7 @@ in
 
   options = {
     services.gpg-agent = {
-      enable = lib.mkEnableOption "GnuPG private key agent";
+      enable = mkEnableOption "GnuPG private key agent";
 
       defaultCacheTtl = mkOption {
         type = types.nullOr types.int;
@@ -226,13 +227,7 @@ in
         '';
       };
 
-      enableSshSupport = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to use the GnuPG key agent for SSH keys.
-        '';
-      };
+      enableSshSupport = mkEnableOption "the use of the GnuPG key agent for SSH keys";
 
       sshKeys = mkOption {
         type = types.nullOr (types.listOf types.str);
@@ -242,22 +237,9 @@ in
         '';
       };
 
-      enableExtraSocket = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable extra socket of the GnuPG key agent (useful for GPG
-          Agent forwarding).
-        '';
-      };
+      enableExtraSocket = mkEnableOption "extra socket of the GnuPG key agent (useful for GPG Agent forwarding)";
 
-      verbose = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to produce verbose output.
-        '';
-      };
+      verbose = mkEnableOption "verbose output";
 
       grabKeyboardAndMouse = mkOption {
         type = types.bool;

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -241,27 +241,27 @@ in
 
       verbose = mkEnableOption "verbose output";
 
-      grabKeyboardAndMouse = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Tell the pinentry to grab the keyboard and mouse. This
-          option should in general be used to avoid X-sniffing
-          attacks. When disabled, this option passes
-          {option}`no-grab` setting to gpg-agent.
-        '';
-      };
+      grabKeyboardAndMouse =
+        mkEnableOption ''
+          pinentry grabbing keyboard and mouse.
 
-      enableScDaemon = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Make use of the scdaemon tool. This option has the effect of
-          enabling the ability to do smartcard operations. When
-          disabled, this option passes
-          {option}`disable-scdaemon` setting to gpg-agent.
-        '';
-      };
+          This option should in general be used to avoid X-sniffing attacks.
+          When disabled, this option passes {option}`no-grab` setting to gpg-agent
+        ''
+        // {
+          default = true;
+        };
+
+      enableScDaemon =
+        mkEnableOption ''
+          the scdaemon tool.
+
+          This option has the effect of enabling the ability to do smartcard operations.
+          When disabled, this option passes {option}`disable-scdaemon` setting to gpg-agent
+        ''
+        // {
+          default = true;
+        };
 
       noAllowExternalCache = mkEnableOption ''
         disabling external cache features in pinentry.

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -263,20 +263,13 @@ in
         '';
       };
 
-      noAllowExternalCache = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Tell Pinentry not to enable features which use an external cache for
-          passphrases.
+      noAllowExternalCache = mkEnableOption ''
+        disabling external cache features in pinentry.
+        Tell Pinentry not to enable features which use an external cache for passphrases.
 
-          Some desktop environments prefer to unlock all credentials with one
-          master password and may have installed a Pinentry which employs an
-          additional external cache to implement such a policy. By using this
-          option the Pinentry is advised not to make use of such a cache and
-          instead always ask the user for the requested passphrase.
-        '';
-      };
+        Some desktop environments prefer to unlock all credentials with one master password and may have installed a Pinentry which employs an additional external cache to implement such a policy.
+        By using this option the Pinentry is advised not to make use of such a cache and instead always ask the user for the requested passphrase
+      '';
 
       extraConfig = mkOption {
         type = types.lines;

--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -20,11 +20,7 @@ in
         pkgsText = "pkgs.kdePackages";
       };
 
-      indicator = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = "Whether to enable kdeconnect-indicator service.";
-      };
+      indicator = lib.mkEnableOption "kdeconnect-indicator service";
     };
   };
 

--- a/modules/services/linux-wallpaperengine.nix
+++ b/modules/services/linux-wallpaperengine.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.services.linux-wallpaperengine;
 in
@@ -13,7 +13,7 @@ in
   meta.maintainers = [ lib.hm.maintainers.ckgxrg ];
 
   options.services.linux-wallpaperengine = {
-    enable = lib.mkEnableOption "linux-wallpaperengine, an implementation of Wallpaper Engine functionality";
+    enable = mkEnableOption "linux-wallpaperengine, an implementation of Wallpaper Engine functionality";
 
     package = lib.mkPackageOption pkgs "linux-wallpaperengine" { };
 
@@ -82,11 +82,7 @@ in
             };
 
             audio = {
-              silent = mkOption {
-                type = types.bool;
-                default = false;
-                description = "Mutes all sound of the wallpaper.";
-              };
+              silent = mkEnableOption "muting all wallpaper sound";
 
               automute = mkOption {
                 type = types.bool;

--- a/modules/services/linux-wallpaperengine.nix
+++ b/modules/services/linux-wallpaperengine.nix
@@ -84,16 +84,12 @@ in
             audio = {
               silent = mkEnableOption "muting all wallpaper sound";
 
-              automute = mkOption {
-                type = types.bool;
+              automute = mkEnableOption "automuting when another app is playing sound" // {
                 default = true;
-                description = "Automute when another app is playing sound.";
               };
 
-              processing = mkOption {
-                type = types.bool;
+              processing = mkEnableOption "audio processing for background" // {
                 default = true;
-                description = "Enables audio processing for background.";
               };
             };
           };

--- a/modules/services/mbsync.nix
+++ b/modules/services/mbsync.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.services.mbsync;
 
@@ -20,7 +20,7 @@ in
   meta.maintainers = [ lib.maintainers.pjones ];
 
   options.services.mbsync = {
-    enable = lib.mkEnableOption "mbsync";
+    enable = mkEnableOption "mbsync";
 
     package = lib.mkPackageOption pkgs "isync" { };
 
@@ -35,12 +35,8 @@ in
       '';
     };
 
-    verbose = mkOption {
-      type = types.bool;
+    verbose = mkEnableOption "verbose output" // {
       default = true;
-      description = ''
-        Whether mbsync should produce verbose output.
-      '';
     };
 
     configFile = mkOption {

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -21,14 +21,11 @@ in
 
       package = lib.mkPackageOption pkgs "mpd" { };
 
-      enableSessionVariables = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to set {env}`MPD_HOST` {env}`MPD_PORT` environment variables
-          according to {option}`services.mpd.network`.
-        '';
-      };
+      enableSessionVariables =
+        mkEnableOption "setting {env}`MPD_HOST` and {env}`MPD_PORT` environment variables according to {option}`services.mpd.network`"
+        // {
+          default = true;
+        };
 
       musicDirectory = mkOption {
         type = with types; either path str;
@@ -90,14 +87,9 @@ in
       };
 
       network = {
-        startWhenNeeded = mkOption {
-          type = types.bool;
-          default = false;
+        startWhenNeeded = mkEnableOption "systemd socket activation. This is only supported on Linux" // {
           visible = pkgs.stdenv.hostPlatform.isLinux;
           readOnly = pkgs.stdenv.hostPlatform.isDarwin;
-          description = ''
-            Enable systemd socket activation. This is only supported on Linux.
-          '';
         };
 
         listenAddress = mkOption {

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -5,20 +5,19 @@
   ...
 }:
 let
-  inherit (lib) mkIf mkOption types;
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   cfg = config.services.mpd;
 in
 {
   options = {
     services.mpd = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable MPD, the music player daemon.
-        '';
-      };
+      enable = mkEnableOption "MPD, the music player daemon";
 
       package = lib.mkPackageOption pkgs "mpd" { };
 

--- a/modules/services/muchsync.nix
+++ b/modules/services/muchsync.nix
@@ -11,6 +11,7 @@ let
   inherit (lib)
     escapeShellArg
     mkOption
+    mkEnableOption
     optional
     types
     ;
@@ -52,24 +53,14 @@ let
       };
 
       local = {
-        checkForModifiedFiles = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Check for locally modified files.
-            Without this option, muchsync assumes that files in a maildir are
-            never edited.
+        checkForModifiedFiles = mkEnableOption ''
+          checking for locally modified files.
+          Without this option, muchsync assumes that files in a maildir are never edited.
 
-            {option}`checkForModifiedFiles` disables certain
-            optimizations so as to make muchsync at least check the timestamp on
-            every file, which will detect modified files at the cost of a longer
-            startup time.
+          {option}`checkForModifiedFiles` disables certain optimizations so as to make muchsync at least check the timestamp on every file, which will detect modified files at the cost of a longer startup time.
 
-            This option is useful if your software regularly modifies the
-            contents of mail files (e.g., because you are running offlineimap
-            with "synclabels = yes").
-          '';
-        };
+          This option is useful if your software regularly modifies the contents of mail files (e.g., because you are running offlineimap with "synclabels = yes")
+        '';
 
         importNew = mkOption {
           type = types.bool;
@@ -103,24 +94,14 @@ let
           '';
         };
 
-        checkForModifiedFiles = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Check for modified files on the remote side.
-            Without this option, muchsync assumes that files in a maildir are
-            never edited.
+        checkForModifiedFiles = mkEnableOption ''
+          Checking for modified files on the remote side.
+          Without this option, muchsync assumes that files in a maildir are never edited.
 
-            {option}`checkForModifiedFiles` disables certain
-            optimizations so as to make muchsync at least check the timestamp on
-            every file, which will detect modified files at the cost of a longer
-            startup time.
+          {option}`checkForModifiedFiles` disables certain optimizations so as to make muchsync at least check the timestamp on every file, which will detect modified files at the cost of a longer startup time.
 
-            This option is useful if your software regularly modifies the
-            contents of mail files (e.g., because you are running offlineimap
-            with "synclabels = yes").
-          '';
-        };
+          This option is useful if your software regularly modifies the contents of mail files (e.g., because you are running offlineimap with "synclabels = yes")
+        '';
 
         importNew = mkOption {
           type = types.bool;

--- a/modules/services/muchsync.nix
+++ b/modules/services/muchsync.nix
@@ -44,12 +44,8 @@ let
         '';
       };
 
-      upload = mkOption {
-        type = types.bool;
+      upload = mkEnableOption "propagating local changes to the remote" // {
         default = true;
-        description = ''
-          Whether to propagate local changes to the remote.
-        '';
       };
 
       local = {
@@ -62,13 +58,8 @@ let
           This option is useful if your software regularly modifies the contents of mail files (e.g., because you are running offlineimap with "synclabels = yes")
         '';
 
-        importNew = mkOption {
-          type = types.bool;
+        importNew = mkEnableOption "running {command}`notmuch new` locally before synchronisation" // {
           default = true;
-          description = ''
-            Whether to begin the synchronisation by running
-            {command}`notmuch new` locally.
-          '';
         };
       };
 
@@ -103,14 +94,11 @@ let
           This option is useful if your software regularly modifies the contents of mail files (e.g., because you are running offlineimap with "synclabels = yes")
         '';
 
-        importNew = mkOption {
-          type = types.bool;
-          default = true;
-          description = ''
-            Whether to begin the synchronisation by running
-            {command}`notmuch new` on the remote side.
-          '';
-        };
+        importNew =
+          mkEnableOption "running {command}`notmuch new` on the remote side before synchronisation"
+          // {
+            default = true;
+          };
       };
     };
   };

--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -70,17 +70,11 @@ in
         '';
       };
 
-      persistent = mkOption {
-        type = types.bool;
-        default = true;
-        example = false;
-        description = ''
-          If true, the time when the service unit was last triggered is
-          stored on disk. When the timer is activated, the service unit is
-          triggered immediately if it would have been triggered at least once
-          during the time when the timer was inactive.
-        '';
-      };
+      persistent =
+        mkEnableOption "persisting nix-gc timer trigger times on disk. When the timer is activated, the service unit is triggered immediately if it would have been triggered at least once during the time when the timer was inactive"
+        // {
+          default = true;
+        };
     };
   };
 

--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) mkChangedOptionModule mkOption types;
+  inherit (lib)
+    mkChangedOptionModule
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   cfg = config.nix.gc;
 
@@ -23,15 +28,11 @@ in
 
   options = {
     nix.gc = {
-      automatic = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Automatically run the garbage collector at a specific time.
+      automatic = mkEnableOption ''
+        automatically running the garbage collector at a specific time.
 
-          Note: This will only garbage collect the current user's profiles.
-        '';
-      };
+        Note: This will only garbage collect the current user's profiles
+      '';
 
       dates = mkOption {
         type = with types; either singleLineStr (listOf str);

--- a/modules/services/osmscout-server.nix
+++ b/modules/services/osmscout-server.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) mkIf mkOption types;
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   cfg = config.services.osmscout-server;
 in
@@ -14,17 +19,13 @@ in
 
   options = {
     services.osmscout-server = {
-      enable = lib.mkEnableOption "OSM Scout Server";
+      enable = mkEnableOption "OSM Scout Server";
 
       package = lib.mkPackageOption pkgs "osmscout-server" { };
 
       network = {
-        startWhenNeeded = mkOption {
-          type = types.bool;
+        startWhenNeeded = mkEnableOption "systemd socket activation" // {
           default = true;
-          description = ''
-            Enable systemd socket activation.
-          '';
         };
 
         listenAddress = mkOption {

--- a/modules/services/picom.nix
+++ b/modules/services/picom.nix
@@ -117,13 +117,7 @@ in
   options.services.picom = {
     enable = mkEnableOption "Picom X11 compositor";
 
-    fade = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Fade windows in and out.
-      '';
-    };
+    fade = mkEnableOption "window fade animations";
 
     fadeDelta = mkOption {
       type = types.ints.positive;
@@ -163,13 +157,7 @@ in
       '';
     };
 
-    shadow = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Draw window shadows.
-      '';
-    };
+    shadow = mkEnableOption "window shadows";
 
     shadowOffsets = mkOption {
       type = pairOf types.int;
@@ -283,13 +271,7 @@ in
       '';
     };
 
-    vSync = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Enable vertical synchronization.
-      '';
-    };
+    vSync = mkEnableOption "vertical synchronization";
 
     extraArgs = mkOption {
       type = with types; listOf str;

--- a/modules/services/podman/darwin.nix
+++ b/modules/services/podman/darwin.nix
@@ -12,6 +12,7 @@ let
     mapAttrs'
     mkIf
     mkOption
+    mkEnableOption
     mkMerge
     nameValuePair
     optionalString
@@ -95,11 +96,8 @@ let
         '';
       };
 
-      autoStart = mkOption {
-        type = types.bool;
+      autoStart = mkEnableOption "automatically starting this machine on login" // {
         default = true;
-        example = false;
-        description = "Whether to automatically start this machine on login.";
       };
 
       watchdogInterval = mkOption {
@@ -159,16 +157,16 @@ let
 in
 {
   options.services.podman = {
-    useDefaultMachine = mkOption {
-      type = types.bool;
-      default = pkgs.stdenv.hostPlatform.isDarwin;
-      description = ''
-        Whether to create and use the default podman machine.
+    useDefaultMachine =
+      mkEnableOption ''
+        creating and using the default podman machine.
 
-        The default machine will be named `podman-machine-default` and configured with podmans default values.
-      '';
-      readOnly = pkgs.stdenv.hostPlatform.isLinux;
-    };
+        The default machine will be named `podman-machine-default` and configured with podmans default values
+      ''
+      // {
+        default = pkgs.stdenv.hostPlatform.isDarwin;
+        readOnly = pkgs.stdenv.hostPlatform.isLinux;
+      };
 
     machines = mkOption {
       type = types.attrsOf machineDefinitionType;

--- a/modules/services/podman/linux/builds.nix
+++ b/modules/services/podman/linux/builds.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     mkIf
     mkOption
+    mkEnableOption
     mkMerge
     types
     ;
@@ -76,10 +77,8 @@ let
     {
       options = {
 
-        autoStart = mkOption {
-          type = types.bool;
+        autoStart = mkEnableOption "starting the build on boot (requires user lingering)" // {
           default = true;
-          description = "Whether to start the build on boot. Requires user lingering.";
         };
 
         authFile = mkOption {
@@ -161,11 +160,11 @@ let
           description = "The labels to apply to the build.";
         };
 
-        tlsVerify = mkOption {
-          type = types.bool;
-          default = true;
-          description = "Require HTTPS and verification of certificates when contacting registries.";
-        };
+        tlsVerify =
+          mkEnableOption "requiring HTTPS and certificate verification when contacting registries"
+          // {
+            default = true;
+          };
 
         workingDirectory = mkOption {
           type = with types; nullOr path;

--- a/modules/services/podman/linux/containers.nix
+++ b/modules/services/podman/linux/containers.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     mkIf
     mkOption
+    mkEnableOption
     mkMerge
     types
     ;
@@ -186,12 +187,8 @@ let
         description = "The capabilities to add to the container.";
       };
 
-      autoStart = mkOption {
-        type = types.bool;
+      autoStart = mkEnableOption "starting the container on boot (requires user lingering)" // {
         default = true;
-        description = ''
-          Whether to start the container on boot (requires user lingering).
-        '';
       };
 
       autoUpdate = mkOption {

--- a/modules/services/podman/linux/images.nix
+++ b/modules/services/podman/linux/images.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     mkIf
     mkOption
+    mkEnableOption
     mkMerge
     types
     ;
@@ -70,10 +71,8 @@ let
     { name, ... }:
     {
       options = {
-        autoStart = mkOption {
-          type = types.bool;
+        autoStart = mkEnableOption "pulling the image on boot (requires user lingering)" // {
           default = true;
-          description = "Whether to pull the image on boot. Requires user lingering.";
         };
 
         authFile = mkOption {
@@ -142,11 +141,11 @@ let
           description = "FQIN of referenced Image when source is a file or directory archive.";
         };
 
-        tlsVerify = mkOption {
-          type = types.bool;
-          default = true;
-          description = "Require HTTPS and verification of certificates when contacting registries.";
-        };
+        tlsVerify =
+          mkEnableOption "requiring HTTPS and certificate verification when contacting registries"
+          // {
+            default = true;
+          };
 
         username = mkOption {
           type = with types; nullOr str;

--- a/modules/services/podman/linux/networks.nix
+++ b/modules/services/podman/linux/networks.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     mkIf
     mkOption
+    mkEnableOption
     mkMerge
     types
     ;
@@ -90,12 +91,8 @@ let
   networkDefinitionType = types.submodule {
     options = {
 
-      autoStart = mkOption {
-        type = types.bool;
+      autoStart = mkEnableOption "starting the network on boot (requires user lingering)" // {
         default = true;
-        description = ''
-          Whether to start the network on boot (requires user lingering).
-        '';
       };
 
       description = mkOption {

--- a/modules/services/podman/linux/volumes.nix
+++ b/modules/services/podman/linux/volumes.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     mkIf
     mkOption
+    mkEnableOption
     mkMerge
     types
     ;
@@ -83,16 +84,12 @@ let
     {
       options = {
 
-        autoStart = mkOption {
-          type = types.bool;
+        autoStart = mkEnableOption "creating the volume on boot" // {
           default = true;
-          description = "Whether to create the volume on boot.";
         };
 
-        copy = mkOption {
-          type = types.bool;
+        copy = mkEnableOption "copying image content at the volume mountpoint on first run" // {
           default = true;
-          description = "Copy content of the image located at the mountpoint of the volume on first run.";
         };
 
         description = mkOption {
@@ -160,14 +157,14 @@ let
           description = "The labels to apply to the volume.";
         };
 
-        preserve = mkOption {
-          type = types.bool;
-          default = true;
-          description = ''
-            Whether the volume should be preserved if it is removed from the configuration.
+        preserve =
+          mkEnableOption ''
+            preserving the volume when removed from configuration.
             Setting this to false will cause the volume to be deleted if the volume is removed from the configuration
-          '';
-        };
+          ''
+          // {
+            default = true;
+          };
 
         type = mkOption {
           type = with types; nullOr str;

--- a/modules/services/random-background.nix
+++ b/modules/services/random-background.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.services.random-background;
 
@@ -25,17 +25,11 @@ in
 
   options = {
     services.random-background = {
-      enable = lib.mkEnableOption "" // {
-        description = ''
-          Whether to enable random desktop background.
+      enable = mkEnableOption ''
+        random desktop background.
 
-          Note, if you are using NixOS and have set up a custom
-          desktop manager session for Home Manager, then the session
-          configuration must have the `bgSupport`
-          option set to `true` or the background
-          image set by this module may be overwritten.
-        '';
-      };
+        Note: if you are using NixOS and have set up a custom desktop manager session for Home Manager, then the session configuration must have the `bgSupport` option set to `true` or the background image set by this module may be overwritten
+      '';
 
       package = lib.mkPackageOption pkgs "feh" { };
 

--- a/modules/services/random-background.nix
+++ b/modules/services/random-background.nix
@@ -66,15 +66,11 @@ in
         '';
       };
 
-      enableXinerama = mkOption {
-        default = true;
-        type = types.bool;
-        description = ''
-          Will place a separate image per screen when enabled,
-          otherwise a single image will be stretched across all
-          screens.
-        '';
-      };
+      enableXinerama =
+        mkEnableOption "placing a separate image per screen. Otherwise a single image will be stretched across all screens"
+        // {
+          default = true;
+        };
     };
   };
 

--- a/modules/services/redshift-gammastep/lib/options.nix
+++ b/modules/services/redshift-gammastep/lib/options.nix
@@ -13,7 +13,12 @@
   serviceDocumentation,
 }:
 let
-  inherit (lib) mkOption mkIf types;
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    mkIf
+    types
+    ;
 
   cfg = config.services.${moduleName};
   settingsFormat = pkgs.formats.ini { };
@@ -54,7 +59,7 @@ in
     ];
 
   options = {
-    enable = lib.mkEnableOption programName;
+    enable = mkEnableOption programName;
 
     dawnTime = mkOption {
       type = types.nullOr types.str;
@@ -138,16 +143,9 @@ in
       '';
     };
 
-    enableVerboseLogging = lib.mkEnableOption "verbose service logging";
+    enableVerboseLogging = mkEnableOption "verbose service logging";
 
-    tray = mkOption {
-      type = types.bool;
-      default = false;
-      example = true;
-      description = ''
-        Start the ${appletExecutable} tray applet.
-      '';
-    };
+    tray = mkEnableOption "starting the ${appletExecutable} tray applet";
 
     settings = mkOption {
       type = types.submodule { freeformType = settingsFormat.type; };

--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -10,6 +10,7 @@ let
     mkIf
     mkRenamedOptionModule
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -49,7 +50,7 @@ in
     ];
 
   options.services.screen-locker = {
-    enable = lib.mkEnableOption "screen locker for X session";
+    enable = mkEnableOption "screen locker for X session";
 
     lockCmd = mkOption {
       type = types.str;
@@ -57,7 +58,7 @@ in
       example = "\${pkgs.i3lock}/bin/i3lock -n -c 000000";
     };
 
-    lockCmdEnv = lib.mkOption {
+    lockCmdEnv = mkOption {
       type = types.listOf types.str;
       default = [ ];
       example = [ "XSECURELOCK_PAM_SERVICE=xsecurelock" ];
@@ -78,22 +79,17 @@ in
     };
 
     xautolock = {
-      enable = mkOption {
-        type = types.bool;
+      enable = mkEnableOption "xautolock for time-based locking" // {
         default = true;
-        description = "Use xautolock for time-based locking.";
       };
 
       package = lib.mkPackageOption pkgs "xautolock" { };
 
-      detectSleep = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to reset xautolock timers when awaking from sleep.
-          No effect if {option}`xautolock.enable` is false.
-        '';
-      };
+      detectSleep =
+        mkEnableOption "resetting xautolock timers when awaking from sleep. No effect if {option}`xautolock.enable` is false"
+        // {
+          default = true;
+        };
 
       extraOptions = mkOption {
         type = types.listOf types.str;

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -330,9 +330,7 @@ in
 
   options = {
     services.syncthing = {
-      enable = lib.mkEnableOption ''
-        Syncthing, a self-hosted open-source alternative to Dropbox and Bittorrent Sync.
-      '';
+      enable = mkEnableOption "Syncthing, a self-hosted open-source alternative to Dropbox and Bittorrent Sync.";
 
       cert = mkOption {
         type = with types; nullOr str;
@@ -517,14 +515,11 @@ in
                         '';
                       };
 
-                      autoAcceptFolders = mkOption {
-                        type = types.bool;
-                        default = false;
-                        description = ''
-                          Automatically create or share folders that this device advertises at the default path.
-                          See <https://docs.syncthing.net/users/config.html?highlight=autoaccept#config-file-format>.
-                        '';
-                      };
+                      autoAcceptFolders = mkEnableOption ''
+                        Automatically creating or sharing folders that this device advertises at the default path.
+
+                        See <https://docs.syncthing.net/users/config.html?highlight=autoaccept#config-file-format>
+                      '';
 
                     };
                   }
@@ -717,17 +712,10 @@ in
                           });
                       };
 
-                      copyOwnershipFromParent = mkOption {
-                        type = types.bool;
-                        default = false;
-                        description = ''
-                          On Unix systems, tries to copy file/folder ownership from
-                          the parent directory (the directory it’s located in).
-                          Requires running Syncthing as a privileged user, or
-                          granting it additional capabilities (e.g. CAP_CHOWN on
-                          Linux).
-                        '';
-                      };
+                      copyOwnershipFromParent = mkEnableOption ''
+                        copying file/folder ownership from the parent directory (the directory it's located in) on Unix.
+                        Requires running Syncthing as a privileged user, or granting it additional capabilities (e.g. CAP_CHOWN on Linux)
+                      '';
                     };
                   }
                 )

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -388,27 +388,25 @@ in
         );
       };
 
-      overrideDevices = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to delete the devices which are not configured via the
-          [devices](#opt-services.syncthing.settings.devices) option.
-          If set to `false`, devices added via the web
-          interface will persist and will have to be deleted manually.
-        '';
-      };
+      overrideDevices =
+        mkEnableOption ''
+          deleting the devices which are not configured via the [devices](#opt-services.syncthing.settings.devices) option.
 
-      overrideFolders = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to delete the folders which are not configured via the
-          [folders](#opt-services.syncthing.settings.folders) option.
-          If set to `false`, folders added via the web
-          interface will persist and will have to be deleted manually.
-        '';
-      };
+          If set to `false`, devices added via the web interface will persist and will have to be deleted manually
+        ''
+        // {
+          default = true;
+        };
+
+      overrideFolders =
+        mkEnableOption ''
+          deleting the folders which are not configured via the [folders](#opt-services.syncthing.settings.folders) option.
+
+          If set to `false`, folders added via the web interface will persist and will have to be deleted manually
+        ''
+        // {
+          default = true;
+        };
 
       settings = mkOption {
         type = types.submodule {
@@ -552,15 +550,11 @@ in
                     freeformType = settingsFormat.type;
                     options = {
 
-                      enable = mkOption {
-                        type = types.bool;
-                        default = true;
-                        description = ''
-                          Whether to share this folder.
-                          This option is useful when you want to define all folders
-                          in one place, but not every machine should share all folders.
-                        '';
-                      };
+                      enable =
+                        mkEnableOption "sharing this folder. This option is useful when you want to define all folders in one place, but not every machine should share all folders"
+                        // {
+                          default = true;
+                        };
 
                       path = mkOption {
                         type = types.str // {

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     literalExpression
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -801,11 +802,7 @@ in
       package = lib.mkPackageOption pkgs "syncthing" { };
 
       tray = {
-        enable = mkOption {
-          type = types.bool;
-          default = false;
-          description = "Whether to enable a syncthing tray service.";
-        };
+        enable = mkEnableOption "a syncthing tray service";
 
         command = mkOption {
           type = types.str;

--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -63,16 +63,12 @@ in
         '';
       };
 
-      automount = mkOption {
-        type = types.bool;
+      automount = mkEnableOption "automatically mounting new devices" // {
         default = true;
-        description = "Whether to automatically mount new devices.";
       };
 
-      notify = mkOption {
-        type = types.bool;
+      notify = mkEnableOption "pop-up notifications" // {
         default = true;
-        description = "Whether to show pop-up notifications.";
       };
 
       tray = mkOption {

--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -8,6 +8,7 @@
 let
   inherit (lib)
     mkOption
+    mkEnableOption
     types
     ;
 
@@ -33,17 +34,12 @@ in
 
   options = {
     services.udiskie = {
-      enable = lib.mkEnableOption "" // {
-        description = ''
-          Whether to enable the udiskie mount daemon.
+      enable = mkEnableOption ''
+        the udiskie mount daemon.
 
-          Note, if you use NixOS then you must add
-          `services.udisks2.enable = true`
-          to your system configuration. Otherwise mounting will fail because
-          the Udisk2 DBus service is not found.
-        '';
-      };
-
+        Note: if you use NixOS then you must add `services.udisks2.enable = true` to your system configuration.
+        Otherwise mounting will fail because the Udisk2 DBus service is not found
+      '';
       package = lib.mkPackageOption pkgs "udiskie" { };
 
       settings = mkOption {

--- a/modules/services/walker.nix
+++ b/modules/services/walker.nix
@@ -77,12 +77,7 @@ in
       description = "The custom theme used by walker. Setting this option overrides `settings.theme`.";
     };
 
-    systemd.enable = mkOption {
-      type = types.bool;
-      default = false;
-      example = true;
-      description = "Whatever to enable Walker's Systemd Unit.";
-    };
+    systemd.enable = mkEnableOption "Walker's systemd unit";
   };
 
   config = mkIf cfg.enable (mkMerge [

--- a/modules/services/window-managers/awesome.nix
+++ b/modules/services/window-managers/awesome.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.xsession.windowManager.awesome;
   awesome = cfg.package;
@@ -18,7 +18,7 @@ in
 {
   options = {
     xsession.windowManager.awesome = {
-      enable = lib.mkEnableOption "Awesome window manager";
+      enable = mkEnableOption "Awesome window manager";
 
       package = lib.mkPackageOption pkgs "awesome" {
         extraDescription = "to use for running the Awesome WM";
@@ -34,14 +34,7 @@ in
         example = lib.literalExpression "[ pkgs.luaPackages.vicious ]";
       };
 
-      noArgb = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Disable client transparency support, which can be greatly
-          detrimental to performance in some setups
-        '';
-      };
+      noArgb = mkEnableOption "disabling client transparency support, which can be greatly detrimental to performance in some setups";
     };
   };
 

--- a/modules/services/window-managers/bspwm/options.nix
+++ b/modules/services/window-managers/bspwm/options.nix
@@ -1,6 +1,11 @@
 { pkgs, lib }:
 let
-  inherit (lib) literalExpression mkOption types;
+  inherit (lib)
+    literalExpression
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   primitive =
     with types;
@@ -180,7 +185,7 @@ let
 in
 {
   xsession.windowManager.bspwm = {
-    enable = lib.mkEnableOption "bspwm window manager";
+    enable = mkEnableOption "bspwm window manager";
 
     package = lib.mkPackageOption pkgs "bspwm" {
       example = "pkgs.bspwm-unstable";
@@ -226,18 +231,18 @@ in
       };
     };
 
-    alwaysResetDesktops = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        If set to `true`, desktops configured in {option}`monitors` will be reset
-        every time the config is run.
+    alwaysResetDesktops =
+      mkEnableOption ''
+        resetting configured desktops on every bspwm config run.
+
+        If set to `true`, desktops configured in {option}`monitors` will be reset every time the config is run.
 
         If set to `false`, desktops will only be configured the first time the config is run.
-        This is useful if you want to dynamically add desktops and you don't want them to be destroyed if you
-        re-run `bspwmrc`.
-      '';
-    };
+        This is useful if you want to dynamically add desktops and you don't want them to be destroyed if you re-run `bspwmrc`
+      ''
+      // {
+        default = true;
+      };
 
     rules = mkOption {
       type = types.attrsOf rule;

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -7,7 +7,12 @@
   capitalModuleName ? moduleName,
 }:
 let
-  inherit (lib) literalExpression mkOption types;
+  inherit (lib)
+    literalExpression
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   isI3 = moduleName == "i3";
   isSway = !isI3;
@@ -54,11 +59,7 @@ let
         description = "Command that will be executed on startup.";
       };
 
-      always = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to run command on each ${moduleName} restart.";
-      };
+      always = mkEnableOption "running command on each ${moduleName} restart";
     }
     // lib.optionalAttrs isI3 {
       notification = mkOption {

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -62,14 +62,14 @@ let
       always = mkEnableOption "running command on each ${moduleName} restart";
     }
     // lib.optionalAttrs isI3 {
-      notification = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to enable startup-notification support for the command.
-          See {option}`--no-startup-id` option description in the i3 user guide.
-        '';
-      };
+      notification =
+        mkEnableOption ''
+          startup-notification support for the command.
+          See {option}`--no-startup-id` option description in the i3 user guide
+        ''
+        // {
+          default = true;
+        };
 
       workspace = mkOption {
         type = types.nullOr types.str;
@@ -417,8 +417,7 @@ in
   window = mkOption {
     type = types.submodule {
       options = {
-        titlebar = mkOption {
-          type = types.bool;
+        titlebar = mkEnableOption "window titlebars" // {
           default =
             if lib.versionOlder stateVersion "23.05" then (isI3 && (cfg.config.gaps == null)) else true;
           defaultText =
@@ -432,7 +431,6 @@ in
                 true for state version ≥ 23.05
                 false for state version < 23.05
               '';
-          description = "Whether to show window titlebars.";
         };
 
         border = mkOption {
@@ -486,8 +484,7 @@ in
   floating = mkOption {
     type = types.submodule {
       options = {
-        titlebar = mkOption {
-          type = types.bool;
+        titlebar = mkEnableOption "floating window titlebars" // {
           default =
             if lib.versionOlder stateVersion "23.05" then (isI3 && (cfg.config.gaps == null)) else true;
           defaultText =
@@ -501,7 +498,6 @@ in
                 true for state version ≥ 23.05
                 false for state version < 23.05
               '';
-          description = "Whether to show floating window titlebars.";
         };
 
         border = mkOption {

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -596,15 +596,11 @@ in
           '';
         };
 
-        forceWrapping = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Whether to force focus wrapping in tabbed or stacked containers.
+        forceWrapping = mkEnableOption ''
+          forcing focus wrapping in tabbed or stacked containers.
 
-            This option is deprecated, use {option}`focus.wrapping` instead.
-          '';
-        };
+          DEPRECATED, USE {option}`focus.wrapping` INSTEAD
+        '';
 
         mouseWarping = mkOption {
           type =
@@ -674,17 +670,11 @@ in
     '';
   };
 
-  workspaceAutoBackAndForth = mkOption {
-    type = types.bool;
-    default = false;
-    example = true;
-    description = ''
-      Assume you are on workspace "1: www" and switch to "2: IM" using
-      mod+2 because somebody sent you a message. You don’t need to remember
-      where you came from now, you can just press $mod+2 again to switch
-      back to "1: www".
-    '';
-  };
+  workspaceAutoBackAndForth = mkEnableOption ''
+    switching back to the previous workspace when selecting the current one again.
+
+    Assume you are on workspace "1: www" and switch to "2: IM" using mod+2 because somebody sent you a message. You don’t need to remember where you came from now, you can just press $mod+2 again to switch back to "1: www"
+  '';
 
   keycodebindings = mkOption {
     type = types.attrsOf (types.nullOr types.str);

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -530,16 +530,12 @@ in
     };
 
     systemd = {
-      enable = mkOption {
-        type = types.bool;
-        default = pkgs.stdenv.isLinux;
-        example = false;
-        description = ''
-          Whether to enable {file}`sway-session.target` on
-          sway startup. This links to
-          {file}`graphical-session.target`.
-          Some important environment variables will be imported to systemd
-          and dbus user environment before reaching the target, including
+      enable =
+        mkEnableOption ''
+          {file}`sway-session.target` on sway startup.
+          This links to {file}`graphical-session.target`.
+
+          Some important environment variables will be imported to systemd and dbus user environment before reaching the target, including :
           * {env}`DISPLAY`
           * {env}`WAYLAND_DISPLAY`
           * {env}`SWAYSOCK`
@@ -548,9 +544,12 @@ in
           * {env}`NIXOS_OZONE_WL`
           * {env}`XCURSOR_THEME`
           * {env}`XCURSOR_SIZE`
-          You can extend this list using the `systemd.variables` option.
-        '';
-      };
+
+          You can extend this list using the `systemd.variables` option
+        ''
+        // {
+          default = pkgs.stdenv.isLinux;
+        };
 
       variables = mkOption {
         type = types.listOf types.str;
@@ -606,13 +605,11 @@ in
       '';
     };
 
-    xwayland = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Enable xwayland, which is needed for the default configuration of sway.
-      '';
-    };
+    xwayland =
+      mkEnableOption "xwayland support, which is needed for the default configuration of sway"
+      // {
+        default = true;
+      };
 
     wrapperFeatures = mkOption {
       type = wrapperOptions;
@@ -663,11 +660,9 @@ in
       description = "Sway configuration options.";
     };
 
-    checkConfig = mkOption {
-      type = types.bool;
+    checkConfig = mkEnableOption "validating the generated config file" // {
       default = cfg.package != null;
       defaultText = lib.literalExpression "wayland.windowManager.sway.package != null";
-      description = "If enabled, validates the generated config file.";
     };
 
     extraConfig = mkOption {

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -320,32 +320,20 @@ let
         description = "The sway command to execute on state changes";
       };
 
-      locked = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Unless the flag --locked is set, the command
-          will not be run when a screen locking program
-          is active. If there is a matching binding with
-          and without --locked, the one with will be preferred
-          when locked and the one without will be
-          preferred when unlocked.
-        '';
-      };
+      locked = mkEnableOption ''
+        running the command when a screen locking program is active.
 
-      reload = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          If the --reload flag is given, the binding will
-          also be executed when the config is reloaded.
-          toggle bindings will not be executed on reload.
-          The --locked flag will operate as normal so if
-          the config is reloaded while locked and
-          --locked is not given, the binding will not be
-          executed.
-        '';
-      };
+        Otherwise, the command will not be run when a screen locking program is active.
+        If there is a matching binding with and without `--locked`, the one with will be preferred when locked and the one without will be preferred when unlocked
+      '';
+
+      reload = mkEnableOption ''
+        executing the binding when the config is reloaded.
+
+        The binding will also be executed when the config is reloaded.
+        Toggle bindings will not be executed on reload.
+        The `--locked` flag will operate as normal so if the config is reloaded while locked and `--locked` is not given, the binding will not be executed
+      '';
     };
   };
 

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -12,6 +12,7 @@ let
     mapAttrsToList
     mkIf
     mkOption
+    mkEnableOption
     optional
     types
     ;
@@ -194,14 +195,7 @@ let
         '';
       };
 
-      bindkeysToCode = mkOption {
-        type = types.bool;
-        default = false;
-        example = true;
-        description = ''
-          Whether to make use of {option}`--to-code` in keybindings.
-        '';
-      };
+      bindkeysToCode = mkEnableOption "using {option}`--to-code` in keybindings";
 
       input = mkOption {
         type = types.attrsOf (types.attrsOf types.str);
@@ -527,7 +521,7 @@ in
     ];
 
   options.wayland.windowManager.sway = {
-    enable = lib.mkEnableOption "sway wayland compositor";
+    enable = mkEnableOption "sway wayland compositor";
 
     package = mkOption {
       type = with types; nullOr package;
@@ -618,7 +612,7 @@ in
         '';
       };
 
-      xdgAutostart = lib.mkEnableOption ''
+      xdgAutostart = mkEnableOption ''
         autostart of applications using
         {manpage}`systemd-xdg-autostart-generator(8)`
       '';

--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) literalExpression mkOption types;
+  inherit (lib)
+    literalExpression
+    mkOption
+    mkEnableOption
+    types
+    ;
 
   cfg = config.xsession.windowManager.xmonad;
 
@@ -33,7 +38,7 @@ in
 {
   options = {
     xsession.windowManager.xmonad = {
-      enable = lib.mkEnableOption "xmonad window manager";
+      enable = mkEnableOption "xmonad window manager";
 
       haskellPackages = mkOption {
         default = pkgs.haskellPackages;
@@ -64,11 +69,7 @@ in
         '';
       };
 
-      enableContribAndExtras = mkOption {
-        default = false;
-        type = types.bool;
-        description = "Enable xmonad-{contrib,extras} in xmonad.";
-      };
+      enableContribAndExtras = mkEnableOption "xmonad-{contrib,extras} in xmonad";
 
       config = mkOption {
         type = types.nullOr types.path;

--- a/modules/services/xidlehook.nix
+++ b/modules/services/xidlehook.nix
@@ -74,19 +74,9 @@ in
 
     detect-sleep = mkEnableOption "detecting when the system wakes up from a suspended state and resetting the idle timer";
 
-    not-when-fullscreen = mkOption {
-      type = types.bool;
-      default = false;
-      example = true;
-      description = "Disable locking when a fullscreen application is in use.";
-    };
+    not-when-fullscreen = mkEnableOption "disabling locking when a fullscreen application is in use";
 
-    not-when-audio = mkOption {
-      type = types.bool;
-      default = false;
-      example = true;
-      description = "Disable locking when audio is playing.";
-    };
+    not-when-audio = mkEnableOption "disabling locking when audio is playing";
 
     once = mkEnableOption "running the program once and exiting";
 

--- a/modules/services/xsuspender.nix
+++ b/modules/services/xsuspender.nix
@@ -70,14 +70,11 @@ let
         example = "echo resuming ...";
       };
 
-      sendSignals = mkOption {
-        description = ''
-          Whether to send SIGSTOP / SIGCONT signals or not.
-          If false just the exec scripts are run.
-        '';
-        type = types.bool;
-        default = true;
-      };
+      sendSignals =
+        mkEnableOption "sending SIGSTOP / SIGCONT signals. If false just the exec scripts are run"
+        // {
+          default = true;
+        };
 
       suspendSubtreePattern = mkOption {
         description = "Also suspend descendant processes that match this regex.";
@@ -87,14 +84,11 @@ let
 
       onlyOnBattery = mkEnableOption "process suspend only on battery";
 
-      autoSuspendOnBattery = mkOption {
-        description = ''
-          Whether to auto-apply rules when switching to battery
-          power even if the window(s) didn't just lose focus.
-        '';
-        type = types.bool;
-        default = true;
-      };
+      autoSuspendOnBattery =
+        mkEnableOption "auto-applying rules when switching to battery power even if the window(s) didn't just lose focus"
+        // {
+          default = true;
+        };
 
       downclockOnBattery = mkOption {
         description = ''
@@ -113,7 +107,7 @@ in
 
   options = {
     services.xsuspender = {
-      enable = lib.mkEnableOption "XSuspender";
+      enable = mkEnableOption "XSuspender";
 
       package = lib.mkPackageOption pkgs "xsuspender" { };
 

--- a/modules/services/xsuspender.nix
+++ b/modules/services/xsuspender.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.services.xsuspender;
 
@@ -85,11 +85,7 @@ let
         default = null;
       };
 
-      onlyOnBattery = mkOption {
-        description = "Whether to enable process suspend only on battery.";
-        type = types.bool;
-        default = false;
-      };
+      onlyOnBattery = mkEnableOption "process suspend only on battery";
 
       autoSuspendOnBattery = mkOption {
         description = ''
@@ -140,11 +136,7 @@ in
         };
       };
 
-      debug = mkOption {
-        description = "Whether to enable debug output.";
-        type = types.bool;
-        default = false;
-      };
+      debug = mkEnableOption "debug output";
 
       iniContent = mkOption {
         inherit (iniFormat) type;

--- a/modules/targets/generic-linux/gpu/default.nix
+++ b/modules/targets/generic-linux/gpu/default.nix
@@ -16,12 +16,9 @@
         ;
     in
     {
-      enable = mkOption {
-        type = types.bool;
+      enable = mkEnableOption "GPU driver integration for non-NixOS systems" // {
         default = config.targets.genericLinux.enable && config.targets.genericLinux.nixGL.packages == null;
         defaultText = literalExpression "config.targets.genericLinux.enable && config.targets.genericLinux.nixGL.packages == null";
-        example = true;
-        description = "Whether to enable GPU driver integration for non-NixOS systems.";
       };
 
       packages = mkOption {

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption mkEnableOption types;
 
   cfg = config.xsession;
 
@@ -16,7 +16,7 @@ in
 
   options = {
     xsession = {
-      enable = lib.mkEnableOption "X Session";
+      enable = mkEnableOption "X Session";
 
       trayTarget = mkOption {
         readOnly = true;
@@ -72,16 +72,7 @@ in
         '';
       };
 
-      preferStatusNotifierItems = mkOption {
-        type = types.bool;
-        default = false;
-        example = true;
-        description = ''
-          Whether tray applets should prefer using the Status Notifier
-          Items (SNI) protocol, commonly called App Indicators. Note,
-          not all tray applets or status bars support SNI.
-        '';
-      };
+      preferStatusNotifierItems = mkEnableOption "tray applets preferring using the Status Notifier Items (SNI) protocol, commonly called App Indicators. Note, not all tray applets or status bars support SNI";
 
       profileExtra = mkOption {
         type = types.lines;

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -145,17 +145,12 @@ in
 
     verbose = mkEnableOption "verbose output on activation";
 
-    enableLegacyProfileManagement = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable legacy profile management during activation. When
-        enabled, the Home Manager activation will produce a per-user
-        `home-manager` Nix profile, just like in the standalone installation of
-        Home Manager. Typically, this is not desired when Home Manager is
-        embedded in the system configuration.
-      '';
-    };
+    enableLegacyProfileManagement = mkEnableOption ''
+      legacy profile management during activation.
+
+      When enabled, the Home Manager activation will produce a per-user `home-manager` Nix profile, just like in the standalone installation of Home Manager.
+      Typically, this is not desired when Home Manager is embedded in the system configuration
+    '';
 
     users = mkOption {
       type = types.attrsOf hmModule;

--- a/tests/asserts.nix
+++ b/tests/asserts.nix
@@ -1,14 +1,17 @@
 { config, lib, ... }:
 let
-  inherit (lib) concatStringsSep mkOption types;
+  inherit (lib)
+    concatStringsSep
+    mkOption
+    mkEnableOption
+    types
+    ;
 in
 {
   options.test.asserts = {
     warnings = {
-      enable = mkOption {
-        type = types.bool;
+      enable = mkEnableOption "warning asserts" // {
         default = true;
-        description = "Whether warning asserts are enabled.";
       };
 
       expected = mkOption {
@@ -21,10 +24,8 @@ in
     };
 
     assertions = {
-      enable = mkOption {
-        type = types.bool;
+      enable = mkEnableOption "assertion asserts" // {
         default = true;
-        description = "Whether assertion asserts are enabled.";
       };
 
       expected = mkOption {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Refactor valid options to use `lib.mkEnableOption` instead

https://github.com/search?type=code&q=repo:nix-community/home-manager%20(%22type%20=%20types.bool%22%20OR%20%22type%20=%20bool%22)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
