### PR TITLE
helix: reload config with USR1 signal

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -233,6 +233,9 @@ in
 
     xdg.configFile =
       let
+        pkillPrefix = if pkgs.stdenv.hostPlatform.isDarwin then "/usr" else pkgs.procps;
+        onChange = "${pkillPrefix}/bin/pkill -u $USER -x -USR1 '(hx|\.hx-wrapped)' || true";
+
         settings =
           let
             hasSettings = cfg.settings != { };
@@ -240,6 +243,7 @@ in
           in
           {
             "helix/config.toml" = mkIf (hasSettings || hasExtraConfig) {
+              inherit onChange;
               source =
                 let
                   configFile = tomlFormat.generate "config.toml" cfg.settings;
@@ -252,6 +256,7 @@ in
                 '';
             };
             "helix/languages.toml" = mkIf (cfg.languages != { }) {
+              inherit onChange;
               source = tomlFormat.generate "helix-languages-config" cfg.languages;
             };
             "helix/ignore" = mkIf (cfg.ignores != [ ]) {
@@ -262,6 +267,7 @@ in
         themes = lib.mapAttrs' (
           n: v:
           lib.nameValuePair "helix/themes/${n}.toml" {
+            inherit onChange;
             source =
               if lib.isString v then
                 pkgs.writeText "helix-theme-${n}" v


### PR DESCRIPTION
### Description

automatically reload config files onChange by sending USR1 to running processes
Documented here: https://docs.helix-editor.com/master/configuration.html
I did not set onChange for helix/ignore because helix seems to [re-read it each time](https://github.com/search?q=repo%3Ahelix-editor%2Fhelix%20join(%22ignore%22)&type=code) and does not consider it part of the "config".

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
