### PR TITLE
modules/helix: fix incorrect string escape

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -234,7 +234,7 @@ in
     xdg.configFile =
       let
         pkillPrefix = if pkgs.stdenv.hostPlatform.isDarwin then "/usr" else pkgs.procps;
-        onChange = "${pkillPrefix}/bin/pkill -u $USER -x -USR1 '(hx|\.hx-wrapped)' || true";
+        onChange = "${pkillPrefix}/bin/pkill -u $USER -x -USR1 '(hx|\\.hx-wrapped)' || true";
 
         settings =
           let


### PR DESCRIPTION
This keeps happening.