### PR TITLE
obsidian: no IFD, use RFC42 settings

### DIFF
--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -14,6 +14,8 @@ let
     types
     ;
 
+  settingsFormat = pkgs.formats.json { };
+
   cfg = config.programs.obsidian;
 
   corePluginsList = [
@@ -50,10 +52,6 @@ let
     "zk-prefixer"
   ];
 
-  appSettingsType = with types; nullOr (attrsOf anything);
-
-  appearanceSettingsType = with types; nullOr (attrsOf anything);
-
   corePluginsOptions = {
     options = {
       enable = mkOption {
@@ -68,7 +66,7 @@ let
       };
 
       settings = mkOption {
-        type = with types; nullOr (attrsOf anything);
+        inherit (settingsFormat) type;
         description = "Plugin settings to include.";
         default = null;
       };
@@ -94,7 +92,7 @@ let
       };
 
       settings = mkOption {
-        type = with types; nullOr (attrsOf anything);
+        inherit (settingsFormat) type;
         description = "Settings to include in the plugin's `data.json`.";
         default = null;
       };
@@ -224,7 +222,7 @@ in
 
           Vault-specific settings take priority and will override these, if set.
         '';
-        type = appSettingsType;
+        inherit (settingsFormat) type;
         default = null;
       };
 
@@ -234,7 +232,7 @@ in
 
           Vault-specific settings take priority and will override these, if set.
         '';
-        type = appearanceSettingsType;
+        inherit (settingsFormat) type;
         default = null;
       };
 
@@ -321,14 +319,14 @@ in
               settings = {
                 app = mkOption {
                   description = "Settings to write to app.json.";
-                  type = appSettingsType;
+                  inherit (settingsFormat) type;
                   default = cfg.defaultSettings.app;
                   defaultText = literalExpression "config.programs.obsidian.defaultSettings.app";
                 };
 
                 appearance = mkOption {
                   description = "Settings to write to appearance.json.";
-                  type = appearanceSettingsType;
+                  inherit (settingsFormat) type;
                   default = cfg.defaultSettings.appearance;
                   defaultText = literalExpression "config.programs.obsidian.defaultSettings.appearance";
                 };
@@ -406,7 +404,7 @@ in
               lib.lists.optionals (vault.settings.app != null) [
                 {
                   name = "${vault.target}/.obsidian/app.json";
-                  value.source = (pkgs.formats.json { }).generate "app.json" vault.settings.app;
+                  value.source = settingsFormat.generate "app.json" vault.settings.app;
                 }
               ];
 
@@ -422,7 +420,7 @@ in
                   {
                     name = "${vault.target}/.obsidian/appearance.json";
                     value = {
-                      source = (pkgs.formats.json { }).generate "appearance.json" (
+                      source = settingsFormat.generate "appearance.json" (
                         (lib.attrsets.optionalAttrs (vault.settings.appearance != null) vault.settings.appearance)
                         // (lib.attrsets.optionalAttrs (vault.settings.cssSnippets != null) {
                           enabledCssSnippets = map (snippet: snippet.name) (
@@ -450,7 +448,7 @@ in
                 [
                   {
                     name = "${vault.target}/.obsidian/core-plugins.json";
-                    value.source = (pkgs.formats.json { }).generate "core-plugins.json" (
+                    value.source = settingsFormat.generate "core-plugins.json" (
                       builtins.listToAttrs (
                         map (name: {
                           inherit name;
@@ -462,7 +460,7 @@ in
                 ]
                 ++ map (plugin: {
                   name = "${vault.target}/.obsidian/${plugin.name}.json";
-                  value.source = (pkgs.formats.json { }).generate "${plugin.name}.json" plugin.settings;
+                  value.source = settingsFormat.generate "${plugin.name}.json" plugin.settings;
                 }) (builtins.filter (plugin: plugin.settings != null) vault.settings.corePlugins)
               );
 
@@ -472,7 +470,7 @@ in
                 [
                   {
                     name = "${vault.target}/.obsidian/community-plugins.json";
-                    value.source = (pkgs.formats.json { }).generate "community-plugins.json" (
+                    value.source = settingsFormat.generate "community-plugins.json" (
                       map getManifest (builtins.filter (plugin: plugin.enable) vault.settings.communityPlugins)
                     );
                   }
@@ -486,7 +484,7 @@ in
                 }) vault.settings.communityPlugins
                 ++ map (plugin: {
                   name = "${vault.target}/.obsidian/plugins/${getManifest plugin}/data.json";
-                  value.source = (pkgs.formats.json { }).generate "data.json" plugin.settings;
+                  value.source = settingsFormat.generate "data.json" plugin.settings;
                 }) (builtins.filter (plugin: plugin.settings != null) vault.settings.communityPlugins)
               );
 
@@ -521,7 +519,7 @@ in
               lib.lists.optionals (vault.settings.hotkeys != null) [
                 {
                   name = "${vault.target}/.obsidian/hotkeys.json";
-                  value.source = (pkgs.formats.json { }).generate "hotkeys.json" vault.settings.hotkeys;
+                  value.source = settingsFormat.generate "hotkeys.json" vault.settings.hotkeys;
                 }
               ];
 
@@ -565,7 +563,7 @@ in
               else
                 "${config.xdg.configHome}/obsidian";
 
-            template = (pkgs.formats.json { }).generate "obsidian.json" {
+            template = settingsFormat.generate "obsidian.json" {
               vaults = builtins.listToAttrs (
                 map (vault: {
                   name = builtins.substring 0 16 (builtins.hashString "md5" vault.target);

--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -597,23 +597,23 @@ in
             vault:
             builtins.all (
               snippet:
-              (snippet.source == null || snippet.text == null) && (snippet.source != null || snippet.text != null)
+              (snippet.source != null && snippet.text == null) || (snippet.source == null && snippet.text != null)
             ) (lib.lists.optionals (vault.settings.cssSnippets != null) vault.settings.cssSnippets)
           ) (builtins.attrValues cfg.vaults);
-          message = "Each CSS snippet must have one of 'source' or 'text' set";
+          message = "Each CSS snippet must have exactly one of 'source' or 'text' set";
         }
         {
           assertion = builtins.all (
             vault:
             builtins.all
-              (file: (file.source == null || file.text == null) && (file.source != null || file.text != null))
+              (file: (file.source != null && file.text == null) || (file.source == null && file.text != null))
               (
                 lib.lists.optionals (vault.settings.extraFiles != null) (
                   builtins.attrValues vault.settings.extraFiles
                 )
               )
           ) (builtins.attrValues cfg.vaults);
-          message = "Each extra file must have one of 'source' or 'text' set";
+          message = "Each extra file must have exactly one of 'source' or 'text' set";
         }
       ];
     };

--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -391,7 +391,7 @@ in
         let
           manifest = builtins.fromJSON (builtins.readFile "${item.pkg}/manifest.json");
         in
-        manifest.id or manifest.name;
+        item.pkg.manifestId or manifest.id or manifest.name;
     in
     lib.mkIf cfg.enable {
       home = {


### PR DESCRIPTION
### Description

- The current `communityPlugins` and `themes` implementations do [IFD](https://nix.dev/manual/nix/2.31/language/import-from-derivation), slowing down evaluation of user configurations. Instead of reading the plugin IDs and theme names [from the package outputs' `manifest.json`](https://github.com/nix-community/home-manager/blob/565e5349208fe7d0831ef959103c9bafbeac0681/modules/programs/obsidian.nix#L391), I have made it so the plugin ID / theme name is read from the package's `passthru` if possible.

- Using `(pkgs.formats.json { }).type` gives better type checking than `nullOr (attrsOf anything)`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
