### PR TITLE
xdg-user-dirs: add 'projects'

### DIFF
--- a/modules/misc/xdg-user-dirs.nix
+++ b/modules/misc/xdg-user-dirs.nix
@@ -76,6 +76,13 @@ in
       description = "The Pictures directory.";
     };
 
+    projects = mkOption {
+      type = with types; nullOr (coercedTo path toString str);
+      default = "${config.home.homeDirectory}/Projects";
+      defaultText = literalExpression ''"''${config.home.homeDirectory}/Projects"'';
+      description = "The Projects directory.";
+    };
+
     publicShare = mkOption {
       type = with types; nullOr (coercedTo path toString str);
       default = "${config.home.homeDirectory}/Public";
@@ -175,6 +182,7 @@ in
           DOWNLOAD = cfg.download;
           MUSIC = cfg.music;
           PICTURES = cfg.pictures;
+          PROJECTS = cfg.projects;
           PUBLICSHARE = cfg.publicShare;
           TEMPLATES = cfg.templates;
           VIDEOS = cfg.videos;

--- a/tests/modules/misc/xdg/user-dirs-mixed.nix
+++ b/tests/modules/misc/xdg/user-dirs-mixed.nix
@@ -10,7 +10,7 @@
 
     xdg.userDirs = {
       enable = true;
-      extraConfig.PROJECTS = "${config.home.homeDirectory}/Projects";
+      extraConfig.CUSTOM = "${config.home.homeDirectory}/Custom";
       ## This will trigger a warning.
       extraConfig.XDG_MISC_DIR = "${config.home.homeDirectory}/Misc";
     };
@@ -19,13 +19,13 @@
       configFile=home-files/.config/user-dirs.dirs
       assertFileExists $configFile
       assertFileContent $configFile ${pkgs.writeText "expected" ''
+        XDG_CUSTOM_DIR="/home/hm-user/Custom"
         XDG_DESKTOP_DIR="/home/hm-user/Desktop"
         XDG_DOCUMENTS_DIR="/home/hm-user/Documents"
         XDG_DOWNLOAD_DIR="/home/hm-user/Downloads"
         XDG_MISC_DIR="/home/hm-user/Misc"
         XDG_MUSIC_DIR="/home/hm-user/Music"
         XDG_PICTURES_DIR="/home/hm-user/Pictures"
-        XDG_PROJECTS_DIR="/home/hm-user/Projects"
         XDG_PUBLICSHARE_DIR="/home/hm-user/Public"
         XDG_TEMPLATES_DIR="/home/hm-user/Templates"
         XDG_VIDEOS_DIR="/home/hm-user/Videos"

--- a/tests/modules/misc/xdg/user-dirs-mixed.nix
+++ b/tests/modules/misc/xdg/user-dirs-mixed.nix
@@ -26,6 +26,7 @@
         XDG_MISC_DIR="/home/hm-user/Misc"
         XDG_MUSIC_DIR="/home/hm-user/Music"
         XDG_PICTURES_DIR="/home/hm-user/Pictures"
+        XDG_PROJECTS_DIR="/home/hm-user/Projects"
         XDG_PUBLICSHARE_DIR="/home/hm-user/Public"
         XDG_TEMPLATES_DIR="/home/hm-user/Templates"
         XDG_VIDEOS_DIR="/home/hm-user/Videos"

--- a/tests/modules/misc/xdg/user-dirs-null.nix
+++ b/tests/modules/misc/xdg/user-dirs-null.nix
@@ -19,6 +19,7 @@
         XDG_DOWNLOAD_DIR="/home/hm-user/Downloads"
         XDG_MUSIC_DIR="/home/hm-user/Music"
         XDG_PICTURES_DIR="/home/hm-user/Pictures"
+        XDG_PROJECTS_DIR="/home/hm-user/Projects"
         XDG_PUBLICSHARE_DIR="/home/hm-user/Public"
         XDG_TEMPLATES_DIR="/home/hm-user/Templates"
         XDG_VIDEOS_DIR="/home/hm-user/Videos"

--- a/tests/modules/misc/xdg/user-dirs-short.nix
+++ b/tests/modules/misc/xdg/user-dirs-short.nix
@@ -8,19 +8,19 @@
   config = {
     xdg.userDirs = {
       enable = true;
-      extraConfig.PROJECTS = "${config.home.homeDirectory}/Projects";
+      extraConfig.CUSTOM = "${config.home.homeDirectory}/Custom";
     };
 
     nmt.script = ''
       configFile=home-files/.config/user-dirs.dirs
       assertFileExists $configFile
       assertFileContent $configFile ${pkgs.writeText "expected" ''
+        XDG_CUSTOM_DIR="/home/hm-user/Custom"
         XDG_DESKTOP_DIR="/home/hm-user/Desktop"
         XDG_DOCUMENTS_DIR="/home/hm-user/Documents"
         XDG_DOWNLOAD_DIR="/home/hm-user/Downloads"
         XDG_MUSIC_DIR="/home/hm-user/Music"
         XDG_PICTURES_DIR="/home/hm-user/Pictures"
-        XDG_PROJECTS_DIR="/home/hm-user/Projects"
         XDG_PUBLICSHARE_DIR="/home/hm-user/Public"
         XDG_TEMPLATES_DIR="/home/hm-user/Templates"
         XDG_VIDEOS_DIR="/home/hm-user/Videos"

--- a/tests/modules/misc/xdg/user-dirs-short.nix
+++ b/tests/modules/misc/xdg/user-dirs-short.nix
@@ -21,6 +21,7 @@
         XDG_DOWNLOAD_DIR="/home/hm-user/Downloads"
         XDG_MUSIC_DIR="/home/hm-user/Music"
         XDG_PICTURES_DIR="/home/hm-user/Pictures"
+        XDG_PROJECTS_DIR="/home/hm-user/Projects"
         XDG_PUBLICSHARE_DIR="/home/hm-user/Public"
         XDG_TEMPLATES_DIR="/home/hm-user/Templates"
         XDG_VIDEOS_DIR="/home/hm-user/Videos"


### PR DESCRIPTION
### Description

See https://blog.tenstral.net/2026/04/hello-projects-directory.html.

Can probably wait for 0.20 of `xdg-user-dirs` on nixpkgs.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
