### PR TITLE
files: add assertion to check for empty target paths

### DIFF
--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -42,7 +42,7 @@ in
               '';
             };
             target = mkOption {
-              type = types.str;
+              type = types.nonEmptyStr;
               apply =
                 p:
                 let


### PR DESCRIPTION
### Description
If `home.file.<name>.target` is an empty string, the home-manager script that links the files raises a "bad array subscript" error. 

I accidentally set one of the files to an empty string without realizing, but I didn't get any warnings or error messages until home-manager was linking files. The crux of the issue is at [files.nix:355](https://github.com/nix-community/home-manager/blob/565e5349208fe7d0831ef959103c9bafbeac0681/modules/files.nix#L355)
```
declare -A seenTargets
...
local relTarget="$2"
...
if [[ ''${seenTargets["$relTarget"]} ]]; then
...
```
This script never verifies whether `relTarget` is an empty string. However, if you try to use an empty string as the key in this array, bash will raise a bad array subscript error.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
