### PR TITLE
lib/deprecations: suppress no-op state-version warnings

### DIFF
--- a/modules/lib/deprecations.nix
+++ b/modules/lib/deprecations.nix
@@ -193,6 +193,7 @@
       optionUsesDefaultPriority = canDeferWarning && optionInfo.highestPrio >= warningPriority;
 
       usingLegacyBranch = lib.versionOlder stateVersion since;
+      valuesEqual = legacy.value == current.value;
     in
     assert lib.assertMsg (!deferWarningToConfig || canDeferWarning) ''
       `lib.hm.deprecations.mkStateVersionOptionDefault` requires both `config` and `options`
@@ -200,7 +201,10 @@
     '';
     {
       default =
-        if usingLegacyBranch && !deferWarningToConfig then lib.warn warning legacy.value else current.value;
+        if usingLegacyBranch && !deferWarningToConfig && !valuesEqual then
+          lib.warn warning legacy.value
+        else
+          current.value;
       defaultText = lib.literalExpression ''
         if lib.versionAtLeast config.home.stateVersion "${since}" then ${currentText} else ${legacyText}
       '';
@@ -209,6 +213,7 @@
       shouldWarn =
         deferWarningToConfig
         && usingLegacyBranch
+        && !valuesEqual
         && (
           if lib.isFunction shouldWarn then
             shouldWarn { inherit optionInfo optionUsesDefaultPriority; }

--- a/tests/lib/types/state-version-option-default-deferred.nix
+++ b/tests/lib/types/state-version-option-default-deferred.nix
@@ -63,6 +63,18 @@ let
       expectedWarn = true;
       expectedPriority = false;
     };
+    equalValues = {
+      default = mkDeferredDefault "equalValues" {
+        legacy.value = {
+          FOO = "same";
+        };
+        current.value = {
+          FOO = "same";
+        };
+      };
+      expectedWarn = false;
+      expectedPriority = false;
+    };
   };
 in
 {
@@ -111,6 +123,7 @@ in
         };
         priorityOnlyExplicit.BAR = "explicit";
         partial.BAR = "partial";
+        equalValues = { };
       };
 
       asserts.warnings.expected = lib.flatten (
@@ -140,6 +153,9 @@ in
       }
       partialFoo=${(effectiveValue cases.partial.default config.test.values.partial).FOO or ""}
       partialBar=${(effectiveValue cases.partial.default config.test.values.partial).BAR or ""}
+      equalValuesFoo=${
+        (effectiveValue cases.equalValues.default config.test.values.equalValues).FOO or ""
+      }
     '';
 
     nmt.script = ''
@@ -151,6 +167,7 @@ in
         priorityOnlyExplicitBar=explicit
         partialFoo=legacy
         partialBar=partial
+        equalValuesFoo=
       ''}
     '';
   };

--- a/tests/lib/types/state-version-option-default.nix
+++ b/tests/lib/types/state-version-option-default.nix
@@ -28,6 +28,18 @@ let
     legacy.value = "legacy";
     current.value = "new";
   };
+
+  equalDefault = lib.hm.deprecations.mkStateVersionOptionDefault {
+    stateVersion = "25.11";
+    since = "26.05";
+    optionPath = [
+      "test"
+      "values"
+      "equal"
+    ];
+    legacy.value = null;
+    current.value = null;
+  };
 in
 {
   options.test.values = {
@@ -50,6 +62,14 @@ in
     pinnedLegacy = lib.mkOption {
       type = lib.types.str;
       inherit (legacyDefault)
+        default
+        defaultText
+        ;
+    };
+
+    equal = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      inherit (equalDefault)
         default
         defaultText
         ;
@@ -77,6 +97,7 @@ in
       legacy=${config.test.values.legacy}
       new=${config.test.values.new}
       pinnedLegacy=${config.test.values.pinnedLegacy}
+      equal=${if config.test.values.equal == null then "null" else config.test.values.equal}
     '';
 
     test.asserts.evalWarnings.expected = [
@@ -95,6 +116,7 @@ in
         legacy=legacy
         new=new
         pinnedLegacy=legacy
+        equal=null
       ''}
     '';
   };


### PR DESCRIPTION
Closes #9045

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
