### PR TITLE
test(tests): add --big-only filter

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -53,7 +53,12 @@ class TestRunner:
         result = _run_command(cmd)
         return result.stdout.strip()
 
-    def discover_tests(self, integration: bool = False) -> list[str]:
+    def discover_tests(
+        self,
+        integration: bool = False,
+        *,
+        big_only: bool = False,
+    ) -> list[str]:
         """Discover available tests using 'nix eval'."""
         system = self.get_current_system()
         test_prefix = "integration-test-" if integration else "test-"
@@ -66,9 +71,54 @@ class TestRunner:
         cmd = [
             "nix", "eval", "--raw", f".#legacyPackages.{system}", "--apply", nix_apply_expr
         ]
-
         result = _run_command(cmd, cwd=self.repo_root)
-        return result.stdout.splitlines()
+        discovered = result.stdout.splitlines()
+
+        if integration:
+            if not big_only:
+                return discovered
+
+            print(
+                "⚠️ --big-only has no effect for integration tests; returning all discovered integration tests.",
+                file=sys.stderr,
+            )
+            return discovered
+
+        if not big_only:
+            return discovered
+
+        discovered_suffixes = {
+            test.removeprefix(test_prefix)
+            for test in discovered
+        }
+        modules_root = self.repo_root / "tests" / "modules"
+        big_test_suffixes = set()
+
+        for module_path in modules_root.rglob("*.nix"):
+            try:
+                content = module_path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+
+            if "config.test.enableBig" not in content:
+                continue
+
+            name_parts = list(module_path.relative_to(modules_root).with_suffix("").parts)
+            if name_parts and name_parts[-1] == "default":
+                name_parts = name_parts[:-1]
+            if not name_parts:
+                continue
+
+            for i in range(len(name_parts)):
+                candidate = "-".join(name_parts[i:])
+                if candidate in discovered_suffixes:
+                    big_test_suffixes.add(candidate)
+                    break
+
+        return [
+            test for test in discovered
+            if test.removeprefix(test_prefix) in big_test_suffixes
+        ]
 
     def filter_tests(self, tests: list[str], filters: list[str]) -> list[str]:
         """Filter tests based on a list of substrings."""
@@ -191,6 +241,10 @@ def main() -> None:
                 Run all tests matching 'alacritty'.
               %(prog)s -i firefox git
                 Interactively select from tests matching 'firefox' or 'git'.
+              %(prog)s --big-only
+                Run only tests enabled by `test.enableBig`.
+              %(prog)s --big-only -l
+                List only tests enabled by `test.enableBig`.
               %(prog)s -t
                 Run integration tests interactively.
               %(prog)s -- --show-trace
@@ -207,6 +261,9 @@ def main() -> None:
         '-t', '--integration', action='store_true', help='Discover and run integration tests.'
     )
     parser.add_argument(
+        '--big-only', action='store_true', help='Only run tests enabled by `test.enableBig`.'
+    )
+    parser.add_argument(
         'filters', nargs='*', help='Filter tests by name (partial matches work).'
     )
     parser.add_argument(
@@ -221,7 +278,7 @@ def main() -> None:
     runner = TestRunner()
     try:
         print(f"{INFO_EMOJI} Discovering tests...", file=sys.stderr)
-        all_tests = runner.discover_tests(integration=args.integration)
+        all_tests = runner.discover_tests(integration=args.integration, big_only=args.big_only)
         if not all_tests:
             print("No tests found for the current configuration.", file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
Keep the default test list broad so chunk targets remain visible for CI debugging.

The new flag narrows module test discovery to cases gated by test.enableBig when you want to focus on unique big test cases.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
