### PR TITLE
rbw: do not serialize 'null' settings

### DIFF
--- a/modules/programs/rbw.nix
+++ b/modules/programs/rbw.nix
@@ -99,7 +99,7 @@ in
     home.packages = [ cfg.package ];
 
     home.file."${configDir}/rbw/config.json" = lib.mkIf (cfg.settings != null) {
-      source = jsonFormat.generate "rbw-config.json" cfg.settings;
+      source = jsonFormat.generate "rbw-config.json" (lib.filterAttrs (_: v: v != null) cfg.settings);
     };
   };
 }

--- a/tests/modules/programs/rbw/simple-settings.nix
+++ b/tests/modules/programs/rbw/simple-settings.nix
@@ -8,11 +8,8 @@ let
 
   expected = builtins.toFile "rbw-expected.json" ''
     {
-      "base_url": null,
       "email": "name@example.com",
-      "identity_url": null,
-      "lock_timeout": 3600,
-      "pinentry": null
+      "lock_timeout": 3600
     }
   '';
 in


### PR DESCRIPTION
### Description

Closes #9126.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
