### PR TITLE
syncthing: avoid init for default gui address

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -25,6 +25,10 @@ let
     else
       "\${XDG_STATE_HOME:-$HOME/.local/state}/syncthing";
 
+  defaultGuiAddress = "127.0.0.1:8384";
+
+  hasCustomGuiAddress = cfg.guiAddress != defaultGuiAddress;
+
   # Syncthing supports serving the GUI over Unix sockets. If that happens, the
   # API is served over the Unix socket as well.  This function returns the correct
   # curl arguments for the address portion of the curl command for both network
@@ -288,7 +292,7 @@ let
         ''))
         (lib.concatStringsSep "\n")
       ])
-    + lib.optionalString (cfg.guiAddress != null) ''
+    + lib.optionalString hasCustomGuiAddress ''
       curl -X PATCH -d '{"address": "'${cfg.guiAddress}'"}' ${curlAddressArgs "/rest/config/gui"}
     ''
     + ''
@@ -300,7 +304,7 @@ let
     ''
   );
 
-  doUpdateConfig = cleanedConfig != { } || cfg.guiCredentials != null || cfg.guiAddress != null;
+  doUpdateConfig = cleanedConfig != { } || cfg.guiCredentials != null || hasCustomGuiAddress;
 
   defaultSyncthingArgs = [
     "${syncthing}"
@@ -771,7 +775,7 @@ in
 
       guiAddress = mkOption {
         type = types.str;
-        default = "127.0.0.1:8384";
+        default = defaultGuiAddress;
         description = ''
           The address to serve the web interface at.
         '';

--- a/tests/modules/services/syncthing/extra-options.nix
+++ b/tests/modules/services/syncthing/extra-options.nix
@@ -18,6 +18,8 @@ lib.mkMerge [
   (lib.mkIf pkgs.stdenv.isLinux {
     nmt.script = ''
       assertFileExists home-files/.config/systemd/user/syncthing.service
+      assertPathNotExists home-files/.config/systemd/user/syncthing-init.service
+      assertPathNotExists home-files/.config/systemd/user/default.target.wants/syncthing-init.service
       assertFileContains home-files/.config/systemd/user/syncthing.service \
       "ExecStart=@syncthing@/bin/syncthing serve --no-browser --no-restart --no-upgrade '--gui-address=127.0.0.1:8384' -foo '-bar \"baz\"'"
     '';
@@ -27,6 +29,7 @@ lib.mkMerge [
     nmt.script = ''
       serviceFile=LaunchAgents/org.nix-community.home.syncthing.plist
       assertFileExists "$serviceFile"
+      assertPathNotExists LaunchAgents/org.nix-community.home.syncthing-init.plist
       assertFileContent "$serviceFile" ${./expected-agent.plist}
     '';
   })

--- a/tests/modules/services/syncthing/linux/default.nix
+++ b/tests/modules/services/syncthing/linux/default.nix
@@ -1,3 +1,4 @@
 {
+  syncthing-gui-address-init = ./gui-address-init.nix;
   syncthing-tray = ./tray.nix;
 }

--- a/tests/modules/services/syncthing/linux/gui-address-init.nix
+++ b/tests/modules/services/syncthing/linux/gui-address-init.nix
@@ -1,0 +1,16 @@
+{
+  services.syncthing = {
+    enable = true;
+    guiAddress = "127.0.0.1:8385";
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/syncthing-init.service
+    assertFileExists "$serviceFile"
+    assertFileExists home-files/.config/systemd/user/default.target.wants/syncthing-init.service
+    assertFileContains "$serviceFile" "ExecStart="
+
+    updateScript=$(grep -o '/nix/store/[^ ]*-merge-syncthing-config' "$TESTED/$serviceFile")
+    assertFileContains "$updateScript" "127.0.0.1:8385/rest/config/gui"
+  '';
+}


### PR DESCRIPTION
The gui address option always has a default value, so #8644 ended up making syncthing-init run for every enabled Syncthing setup.

Treat the default gui address as unset for updater purposes so the init unit is only generated when Home Manager is actually managing Syncthing configuration. Add regression tests for the default and explicit guiAddress cases.

Closes https://github.com/nix-community/home-manager/issues/9119

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
