### PR TITLE
docs/nix-flakes: clarify extraSpecialArgs usage

### DIFF
--- a/docs/manual/nix-flakes/nix-darwin.md
+++ b/docs/manual/nix-flakes/nix-darwin.md
@@ -25,10 +25,8 @@ to that of NixOS. The `flake.nix` would be:
           {
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
+            home-manager.extraSpecialArgs = { inherit inputs; };
             home-manager.users.jdoe = ./home.nix;
-
-            # Optionally, use home-manager.extraSpecialArgs to pass
-            # arguments to home.nix
           }
         ];
       };
@@ -36,6 +34,17 @@ to that of NixOS. The `flake.nix` would be:
   };
 }
 ```
+
+Use `home-manager.extraSpecialArgs` to pass arguments from your flake to
+`home.nix` and any imported Home Manager modules. For example, the
+configuration above makes the complete `inputs` attrset available to modules,
+so they can declare arguments such as `{ inputs, ... }:`.
+
+The lower-level mechanism behind this is `_module.args`. Set
+`_module.args.<name>` from inside a module only when you need to provide a
+module argument from within the module graph itself. For values that originate
+outside the module graph, such as flake inputs, prefer
+`home-manager.extraSpecialArgs`.
 
 and it is also rebuilt with the nix-darwin generations. The rebuild
 command here may be `darwin-rebuild switch --flake <flake-uri>`.

--- a/docs/manual/nix-flakes/nixos.md
+++ b/docs/manual/nix-flakes/nixos.md
@@ -23,10 +23,8 @@ be as follows:
           {
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
+            home-manager.extraSpecialArgs = { inherit inputs; };
             home-manager.users.jdoe = ./home.nix;
-
-            # Optionally, use home-manager.extraSpecialArgs to pass
-            # arguments to home.nix
           }
         ];
       };
@@ -34,6 +32,17 @@ be as follows:
   };
 }
 ```
+
+Use `home-manager.extraSpecialArgs` to pass arguments from your flake to
+`home.nix` and any imported Home Manager modules. For example, the
+configuration above makes the complete `inputs` attrset available to modules,
+so they can declare arguments such as `{ inputs, ... }:`.
+
+The lower-level mechanism behind this is `_module.args`. Set
+`_module.args.<name>` from inside a module only when you need to provide a
+module argument from within the module graph itself. For values that originate
+outside the module graph, such as flake inputs, prefer
+`home-manager.extraSpecialArgs`.
 
 The Home Manager configuration is then part of the NixOS configuration
 and is automatically rebuilt with the system when using the appropriate

--- a/docs/manual/nix-flakes/standalone.md
+++ b/docs/manual/nix-flakes/standalone.md
@@ -20,6 +20,36 @@ $ nix run home-manager/release-25.11 -- init --switch
 This will generate a `flake.nix` and a `home.nix` file in
 `~/.config/home-manager`, creating the directory if it does not exist.
 
+If you need to pass additional values from your flake to `home.nix` or any
+imported Home Manager modules, use `extraSpecialArgs` in the call to
+`home-manager.lib.homeManagerConfiguration`:
+
+``` nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = inputs@{ nixpkgs, home-manager, ... }: {
+    homeConfigurations.jdoe = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      extraSpecialArgs = { inherit inputs; };
+      modules = [ ./home.nix ];
+    };
+  };
+}
+```
+
+Any attribute in `extraSpecialArgs` becomes a module argument, so `home.nix`
+or imported modules can declare arguments such as `{ inputs, ... }:`.
+
+The lower-level mechanism behind this is `_module.args`. Set
+`_module.args.<name>` from inside a module only when you need to provide a
+module argument from within the module graph itself. For values that originate
+outside the module graph, such as flake inputs, prefer `extraSpecialArgs`.
+
 If you omit the `--switch` option then the activation will not happen.
 This is useful if you want to inspect and edit the configuration before
 activating it.

--- a/templates/nix-darwin/flake.nix
+++ b/templates/nix-darwin/flake.nix
@@ -10,7 +10,7 @@
   };
 
   outputs =
-    {
+    inputs@{
       home-manager,
       darwin,
       ...
@@ -25,10 +25,8 @@
             {
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
+              home-manager.extraSpecialArgs = { inherit inputs; };
               home-manager.users.jdoe = ./home.nix;
-
-              # Optionally, use home-manager.extraSpecialArgs to pass
-              # arguments to home.nix
             }
           ];
         };

--- a/templates/nixos/flake.nix
+++ b/templates/nixos/flake.nix
@@ -8,7 +8,7 @@
   };
 
   outputs =
-    { nixpkgs, home-manager, ... }:
+    inputs@{ nixpkgs, home-manager, ... }:
     {
       nixosConfigurations = {
         hostname = nixpkgs.lib.nixosSystem {
@@ -19,10 +19,8 @@
             {
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
+              home-manager.extraSpecialArgs = { inherit inputs; };
               home-manager.users.jdoe = ./home.nix;
-
-              # Optionally, use home-manager.extraSpecialArgs to pass
-              # arguments to home.nix
             }
           ];
         };

--- a/templates/standalone/flake.nix
+++ b/templates/standalone/flake.nix
@@ -11,7 +11,7 @@
   };
 
   outputs =
-    { nixpkgs, home-manager, ... }:
+    inputs@{ nixpkgs, home-manager, ... }:
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
@@ -24,8 +24,7 @@
         # the path to your home.nix.
         modules = [ ./home.nix ];
 
-        # Optionally use extraSpecialArgs
-        # to pass through arguments to home.nix
+        extraSpecialArgs = { inherit inputs; };
       };
     };
 }

--- a/tests/integration/standalone/alice-flake-init.nix
+++ b/tests/integration/standalone/alice-flake-init.nix
@@ -11,7 +11,7 @@
   };
 
   outputs =
-    { nixpkgs, home-manager, ... }:
+    inputs@{ nixpkgs, home-manager, ... }:
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
@@ -24,8 +24,7 @@
         # the path to your home.nix.
         modules = [ ./home.nix ];
 
-        # Optionally use extraSpecialArgs
-        # to pass through arguments to home.nix
+        extraSpecialArgs = { inherit inputs; };
       };
     };
 }


### PR DESCRIPTION
Explain when to use extraSpecialArgs versus _module.args in the flake setup guides, and keep the generated standalone fixture aligned with the updated template output.

Closes https://github.com/nix-community/home-manager/issues/8854

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
