### PR TITLE
xdg-autostart: allow empty readonly autostart

### DIFF
--- a/modules/misc/xdg-autostart.nix
+++ b/modules/misc/xdg-autostart.nix
@@ -51,7 +51,7 @@ in
     };
   };
 
-  config = mkIf (cfg.enable && cfg.entries != [ ]) {
+  config = mkIf (cfg.enable && (cfg.readOnly || cfg.entries != [ ])) {
     xdg.configFile.autostart = {
       source = linkedDesktopEntries;
       recursive = !cfg.readOnly;

--- a/tests/modules/misc/xdg/autostart-readonly-empty.nix
+++ b/tests/modules/misc/xdg/autostart-readonly-empty.nix
@@ -1,0 +1,10 @@
+{
+  xdg.autostart = {
+    enable = true;
+    readOnly = true;
+  };
+
+  nmt.script = ''
+    assertLinkExists home-files/.config/autostart
+  '';
+}

--- a/tests/modules/misc/xdg/default.nix
+++ b/tests/modules/misc/xdg/default.nix
@@ -4,6 +4,7 @@
   xdg-mime-disabled = ./mime-disabled.nix;
   xdg-autostart = ./autostart.nix;
   xdg-autostart-readonly = ./autostart-readonly.nix;
+  xdg-autostart-readonly-empty = ./autostart-readonly-empty.nix;
   xdg-local-bin-in-path = ./local-bin-in-path.nix;
   xdg-local-bin-not-in-path = ./local-bin-not-in-path.nix;
   xdg-user-dirs-mixed = ./user-dirs-mixed.nix;


### PR DESCRIPTION
Create the readonly autostart link even when no managed entries are present, so the option behavior matches its documentation and stays covered by a focused regression test.

Closes https://github.com/nix-community/home-manager/issues/8859

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
