### PR TITLE
targets/darwin: set TERMINFO_DIRS

### DIFF
--- a/modules/misc/news/2026/04/2026-04-20_17-47-07.nix
+++ b/modules/misc/news/2026/04/2026-04-20_17-47-07.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+{
+  time = "2026-04-20T17:47:07+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin;
+  message = ''
+    On Darwin, Home Manager now exports `TERMINFO_DIRS` in
+    `hm-session-vars.sh` so that terminfo entries from Home Manager-installed
+    packages (e.g. `kitty`, `alacritty`) are discoverable. The system path
+    `/usr/share/terminfo` is preserved as a fallback.
+
+    `TERM` is also re-exported so the current shell picks up newly available
+    terminfo entries.
+
+    To opt out, override `home.sessionVariables.TERMINFO_DIRS` (which is set
+    with `lib.mkDefault`).
+  '';
+}

--- a/modules/targets/darwin/default.nix
+++ b/modules/targets/darwin/default.nix
@@ -13,5 +13,6 @@
     ./copyapps.nix
     ./linkapps.nix
     ./search.nix
+    ./terminfo.nix
   ];
 }

--- a/modules/targets/darwin/terminfo.nix
+++ b/modules/targets/darwin/terminfo.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (config.home) profileDirectory;
+in
+{
+  # macOS has no systemd/environment.d equivalent, so expose Home Manager's
+  # terminfo via the shell session file sourced by bash/zsh.
+  config = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+    # Not using `home.sessionSearchVariables` because it only prepends, whereas
+    # we need `/usr/share/terminfo` appended as an explicit fallback: once
+    # TERMINFO_DIRS is set, ncurses stops searching the default system path.
+    home.sessionVariables = {
+      TERMINFO_DIRS = lib.mkDefault "${profileDirectory}/share/terminfo:$TERMINFO_DIRS\${TERMINFO_DIRS:+:}/usr/share/terminfo";
+    };
+
+    home.sessionVariablesExtra = ''
+      # reset TERM with new TERMINFO available (if any)
+      export TERM="$TERM"
+    '';
+  };
+}

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -25,6 +25,7 @@ let
     if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
     export __HM_SESS_VARS_SOURCED=1
 
+    export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:$TERMINFO_DIRS''${TERMINFO_DIRS:+:}/usr/share/terminfo"
     export V1="v1"
     export V2="v2-v1"
     export XDG_BIN_HOME="/home/hm-user/.local/bin"
@@ -33,6 +34,8 @@ let
     export XDG_DATA_HOME="/home/hm-user/.local/share"
     export XDG_STATE_HOME="/home/hm-user/.local/state"
 
+    # reset TERM with new TERMINFO available (if any)
+    export TERM="$TERM"
   '';
 
   expected = pkgs.writeText "expected" (if isDarwin then darwinExpected else linuxExpected);

--- a/tests/modules/targets-darwin/default.nix
+++ b/tests/modules/targets-darwin/default.nix
@@ -2,5 +2,6 @@
   # Disabled for now due to conflicting behavior with nix-darwin. See
   # https://github.com/nix-community/home-manager/issues/1341#issuecomment-687286866
   #targets-darwin = ./darwin.nix;
+  terminfo = ./terminfo.nix;
   user-defaults = ./user-defaults.nix;
 }

--- a/tests/modules/targets-darwin/terminfo.nix
+++ b/tests/modules/targets-darwin/terminfo.nix
@@ -1,0 +1,12 @@
+{
+  config = {
+    nmt.script = ''
+      sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
+      assertFileExists $sessionVarsFile
+      assertFileContains $sessionVarsFile \
+        'export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:$TERMINFO_DIRS''${TERMINFO_DIRS:+:}/usr/share/terminfo"'
+      assertFileContains $sessionVarsFile \
+        'export TERM="$TERM"'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Make terminfo descriptions from Home Manager-installed packages (e.g. `kitty`, `alacritty`) discoverable on macOS by exporting `TERMINFO_DIRS` via `hm-session-vars.sh`.

macOS has no `systemd`/`environment.d` equivalent, so the shell session file sourced by bash/zsh is the available entry point. The value prepends Home Manager's profile terminfo directory and appends `/usr/share/terminfo` so the system default remains a fallback.

Closes #2918 for macOS.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt`.
- [x] Test cases updated/added (see `tests/modules/targets-darwin/terminfo.nix`).
- [x] Commit messages are formatted like `{component}: {description}`.