### PR TITLE
nixos: guard home.uid with tryEval

### DIFF
--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -53,9 +53,16 @@ let
             };
 
             home = {
+              uid =
+                let
+                  # `users.users.<name>.uid` may be declared but unset on
+                  # nix-darwin, so probe it with `tryEval` instead of forcing a
+                  # no-value-defined error during module evaluation.
+                  userUid = builtins.tryEval config.users.users.${name}.uid;
+                in
+                mkIf (userUid.success && userUid.value != null) userUid.value;
               username = config.users.users.${name}.name;
               homeDirectory = config.users.users.${name}.home;
-              uid = mkIf (options.users.users.${name}.uid.isDefined or false) config.users.users.${name}.uid;
             };
 
             nix = {

--- a/tests/modules/home-environment/default.nix
+++ b/tests/modules/home-environment/default.nix
@@ -3,6 +3,7 @@
   home-session-search-variables = ./session-search-variables.nix;
   home-session-variables = ./session-variables.nix;
   home-nixpkgs-release-check-pkgs = ./nixpkgs-release-check-pkgs.nix;
+  home-uid-from-nixos = ./uid-from-nixos.nix;
   home-uid = ./uid.nix;
   home-uid-null = ./uid-null.nix;
 }

--- a/tests/modules/home-environment/uid-from-nixos.nix
+++ b/tests/modules/home-environment/uid-from-nixos.nix
@@ -1,0 +1,115 @@
+{ lib, pkgs, ... }:
+let
+  nixosLib = import /${pkgs.path}/nixos/lib { inherit lib; };
+
+  getHomeUid =
+    userConfig:
+    (nixosLib.evalTest {
+      hostPkgs = pkgs;
+      nodes.machine.imports = [
+        ../../../nixos
+        {
+          users.users.alice = {
+            isNormalUser = true;
+          }
+          // userConfig;
+
+          home-manager.users.alice.home.stateVersion = "24.11";
+        }
+      ];
+    }).config.nodes.machine.home-manager.users.alice.home.uid;
+
+  getCommonModuleHomeUidResult =
+    userConfig:
+    builtins.tryEval (
+      (lib.evalModules {
+        specialArgs = {
+          inherit pkgs;
+          _class = "darwin";
+        };
+
+        modules = [
+          ../../../nixos/common.nix
+          (_: {
+            options.users.users = lib.mkOption {
+              type = lib.types.attrsOf (
+                lib.types.submodule (
+                  { name, ... }:
+                  {
+                    options = {
+                      name = lib.mkOption {
+                        type = lib.types.str;
+                        default = name;
+                      };
+                      home = lib.mkOption { type = lib.types.str; };
+                      uid = lib.mkOption { type = lib.types.int; };
+                      packages = lib.mkOption {
+                        type = lib.types.listOf lib.types.package;
+                        default = [ ];
+                      };
+                    };
+                  }
+                )
+              );
+              default = { };
+            };
+
+            options.environment.pathsToLink = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+            };
+
+            options.nix.enable = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+            };
+
+            options.nix.package = lib.mkOption {
+              type = lib.types.package;
+              default = pkgs.nix;
+            };
+
+            options.warnings = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+            };
+
+            options.assertions = lib.mkOption {
+              type = lib.types.listOf (
+                lib.types.submodule (_: {
+                  options.assertion = lib.mkOption { type = lib.types.bool; };
+                  options.message = lib.mkOption { type = lib.types.str; };
+                })
+              );
+              default = [ ];
+            };
+
+            config.users.users.alice = {
+              home = "/Users/alice";
+            }
+            // userConfig;
+
+            config.home-manager.users.alice.home.stateVersion = "24.11";
+          })
+        ];
+      }).config.home-manager.users.alice.home.uid
+    );
+
+  forwardedUid = builtins.toJSON (getHomeUid {
+    uid = 1000;
+  });
+  unsetUid = builtins.toJSON (getHomeUid { });
+  commonUnsetUidResult = getCommonModuleHomeUidResult { };
+  commonUnsetUidSuccess = builtins.toJSON commonUnsetUidResult.success;
+  commonUnsetUidValue = builtins.toJSON (
+    if commonUnsetUidResult.success then commonUnsetUidResult.value else "failed"
+  );
+in
+{
+  nmt.script = ''
+    test "${forwardedUid}" = '1000'
+    test "${unsetUid}" = 'null'
+    test "${commonUnsetUidSuccess}" = 'true'
+    test "${commonUnsetUidValue}" = 'null'
+  '';
+}


### PR DESCRIPTION
Use tryEval when reading users.users.<name>.uid so configured NixOS UIDs still propagate to home.uid while nix-darwin users without a UID do not trigger a no-value-defined eval error.

Closes #8351

Tested with both my nixos desktop and macbook and seemed to eval fine when I don't set `uid` on my macbook, now. 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
