### PR TITLE
opencode: set PATH for web service

### DIFF
--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -603,6 +603,9 @@ in
           ExecStart = "${lib.getExe packageWithExtraPackages} serve ${lib.escapeShellArgs webCfg.extraArgs}";
           Restart = "always";
           RestartSec = 5;
+          Environment = [
+            "PATH=${config.home.profileDirectory}/bin"
+          ];
         }
         // lib.optionalAttrs (webCfg.environmentFile != null) {
           EnvironmentFile = webCfg.environmentFile;
@@ -627,7 +630,7 @@ in
               ++ webCfg.extraArgs;
               opencodeLaunchdWrapper = pkgs.writeShellScriptBin "opencode-launchd-wrapper" ''
                 source ${webCfg.environmentFile}
-                ${lib.escapeShellArgs programArguments}
+                exec ${lib.escapeShellArgs programArguments}
               '';
             in
             if webCfg.environmentFile == null then
@@ -642,6 +645,9 @@ in
           };
           ProcessType = "Background";
           RunAtLoad = true;
+          EnvironmentVariables = {
+            PATH = "${config.home.profileDirectory}/bin";
+          };
         };
       };
     };

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -650,6 +650,9 @@ in
           ExecStart = "${lib.getExe packageWithExtraPackages} serve ${lib.escapeShellArgs webCfg.extraArgs}";
           Restart = "always";
           RestartSec = 5;
+          Environment = [
+            "PATH=${config.home.profileDirectory}/bin"
+          ];
         }
         // lib.optionalAttrs (webCfg.environmentFile != null) {
           EnvironmentFile = webCfg.environmentFile;
@@ -674,7 +677,7 @@ in
               ++ webCfg.extraArgs;
               opencodeLaunchdWrapper = pkgs.writeShellScriptBin "opencode-launchd-wrapper" ''
                 source ${webCfg.environmentFile}
-                ${lib.escapeShellArgs programArguments}
+                exec ${lib.escapeShellArgs programArguments}
               '';
             in
             if webCfg.environmentFile == null then
@@ -689,6 +692,9 @@ in
           };
           ProcessType = "Background";
           RunAtLoad = true;
+          EnvironmentVariables = {
+            PATH = "${config.home.profileDirectory}/bin";
+          };
         };
       };
     };

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -101,6 +101,16 @@ let
       fi
     '';
 
+  webProgramArguments = [
+    (lib.getExe packageWithExtraPackages)
+    "serve"
+  ]
+  ++ webCfg.extraArgs;
+
+  opencodeWebLauncher = pkgs.writeShellScriptBin "opencode-web-launcher" ''
+    export PATH="${config.home.profileDirectory}/bin''${PATH:+:$PATH}"
+    exec ${lib.escapeShellArgs webProgramArguments}
+  '';
 in
 {
   meta.maintainers = with lib.maintainers; [ delafthi ];
@@ -647,12 +657,9 @@ in
         };
 
         Service = {
-          ExecStart = "${lib.getExe packageWithExtraPackages} serve ${lib.escapeShellArgs webCfg.extraArgs}";
+          ExecStart = lib.getExe opencodeWebLauncher;
           Restart = "always";
           RestartSec = 5;
-          Environment = [
-            "PATH=${config.home.profileDirectory}/bin"
-          ];
         }
         // lib.optionalAttrs (webCfg.environmentFile != null) {
           EnvironmentFile = webCfg.environmentFile;
@@ -670,18 +677,13 @@ in
         config = {
           ProgramArguments =
             let
-              programArguments = [
-                (lib.getExe packageWithExtraPackages)
-                "serve"
-              ]
-              ++ webCfg.extraArgs;
               opencodeLaunchdWrapper = pkgs.writeShellScriptBin "opencode-launchd-wrapper" ''
                 source ${webCfg.environmentFile}
-                exec ${lib.escapeShellArgs programArguments}
+                exec ${lib.getExe opencodeWebLauncher}
               '';
             in
             if webCfg.environmentFile == null then
-              programArguments
+              [ (lib.getExe opencodeWebLauncher) ]
             else
               [
                 (lib.getExe opencodeLaunchdWrapper)
@@ -692,9 +694,6 @@ in
           };
           ProcessType = "Background";
           RunAtLoad = true;
-          EnvironmentVariables = {
-            PATH = "${config.home.profileDirectory}/bin";
-          };
         };
       };
     };

--- a/tests/modules/programs/opencode/web-service-environment-file.nix
+++ b/tests/modules/programs/opencode/web-service-environment-file.nix
@@ -24,6 +24,7 @@
       ''
         serviceFile=home-files/.config/systemd/user/opencode-web.service
         assertFileExists "$serviceFile"
-        assertFileContent "$serviceFile" ${./web-service-environment-file.service}
+        serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+        assertFileContent "$serviceFileNormalized" ${./web-service-environment-file.service}
       '';
 }

--- a/tests/modules/programs/opencode/web-service-environment-file.plist
+++ b/tests/modules/programs/opencode/web-service-environment-file.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/home/hm-user/.nix-profile/bin</string>
+	</dict>
 	<key>KeepAlive</key>
 	<dict>
 		<key>Crashed</key>

--- a/tests/modules/programs/opencode/web-service-environment-file.plist
+++ b/tests/modules/programs/opencode/web-service-environment-file.plist
@@ -2,11 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>EnvironmentVariables</key>
-	<dict>
-		<key>PATH</key>
-		<string>/home/hm-user/.nix-profile/bin</string>
-	</dict>
 	<key>KeepAlive</key>
 	<dict>
 		<key>Crashed</key>

--- a/tests/modules/programs/opencode/web-service-environment-file.service
+++ b/tests/modules/programs/opencode/web-service-environment-file.service
@@ -2,6 +2,7 @@
 WantedBy=default.target
 
 [Service]
+Environment=PATH=/home/hm-user/.nix-profile/bin
 EnvironmentFile=/run/secrets/opencode
 ExecStart=@opencode@/bin/opencode serve 
 Restart=always

--- a/tests/modules/programs/opencode/web-service-environment-file.service
+++ b/tests/modules/programs/opencode/web-service-environment-file.service
@@ -2,9 +2,8 @@
 WantedBy=default.target
 
 [Service]
-Environment=PATH=/home/hm-user/.nix-profile/bin
 EnvironmentFile=/run/secrets/opencode
-ExecStart=@opencode@/bin/opencode serve 
+ExecStart=/nix/store/00000000000000000000000000000000-opencode-web-launcher/bin/opencode-web-launcher
 Restart=always
 RestartSec=5
 

--- a/tests/modules/programs/opencode/web-service.nix
+++ b/tests/modules/programs/opencode/web-service.nix
@@ -30,12 +30,14 @@
       ''
         serviceFile=LaunchAgents/org.nix-community.home.opencode-web.plist
         assertFileExists "$serviceFile"
-        assertFileContent "$serviceFile" ${./web-service.plist}
+        serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+        assertFileContent "$serviceFileNormalized" ${./web-service.plist}
       ''
     else
       ''
         serviceFile=home-files/.config/systemd/user/opencode-web.service
         assertFileExists "$serviceFile"
-        assertFileContent "$serviceFile" ${./web-service.service}
+        serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+        assertFileContent "$serviceFileNormalized" ${./web-service.service}
       '';
 }

--- a/tests/modules/programs/opencode/web-service.nix
+++ b/tests/modules/programs/opencode/web-service.nix
@@ -1,10 +1,29 @@
 {
+  config,
+  lib,
   pkgs,
   ...
 }:
+let
+  profileHelper = pkgs.writeShellScriptBin "profile-helper" "";
+  extraHelper = pkgs.writeShellScriptBin "extra-helper" "";
+  inheritedHelper = pkgs.writeShellScriptBin "inherited-helper" "";
+  testOpencode = pkgs.writeShellScriptBin "opencode" ''
+    set -e
+    command -v profile-helper >/dev/null
+    command -v extra-helper >/dev/null
+    command -v inherited-helper >/dev/null
+  '';
+  serviceLauncher = config.systemd.user.services.opencode-web.Service.ExecStart;
+  testLauncher = "$TMPDIR/opencode-web-launcher";
+in
 {
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
   programs.opencode = {
     enable = true;
+    package = testOpencode;
+    extraPackages = [ extraHelper ];
 
     web = {
       enable = true;
@@ -26,18 +45,27 @@
   };
 
   nmt.script =
-    if pkgs.stdenv.hostPlatform.isDarwin then
-      ''
-        serviceFile=LaunchAgents/org.nix-community.home.opencode-web.plist
-        assertFileExists "$serviceFile"
-        serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
-        assertFileContent "$serviceFileNormalized" ${./web-service.plist}
-      ''
-    else
-      ''
-        serviceFile=home-files/.config/systemd/user/opencode-web.service
-        assertFileExists "$serviceFile"
-        serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
-        assertFileContent "$serviceFileNormalized" ${./web-service.service}
-      '';
+    (
+      if pkgs.stdenv.hostPlatform.isDarwin then
+        ''
+          serviceFile=LaunchAgents/org.nix-community.home.opencode-web.plist
+          assertFileExists "$serviceFile"
+          serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+          assertFileContent "$serviceFileNormalized" ${./web-service.plist}
+        ''
+      else
+        ''
+          serviceFile=home-files/.config/systemd/user/opencode-web.service
+          assertFileExists "$serviceFile"
+          serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+          assertFileContent "$serviceFileNormalized" ${./web-service.service}
+        ''
+    )
+    + ''
+      mkdir -p "$TMPDIR/hm-user/.nix-profile/bin"
+      ln -s ${lib.getExe profileHelper} "$TMPDIR/hm-user/.nix-profile/bin/profile-helper"
+      substitute ${lib.escapeShellArg serviceLauncher} ${testLauncher} --subst-var TMPDIR
+      chmod +x ${testLauncher}
+      PATH=${lib.makeBinPath [ inheritedHelper ]} ${testLauncher}
+    '';
 }

--- a/tests/modules/programs/opencode/web-service.plist
+++ b/tests/modules/programs/opencode/web-service.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/home/hm-user/.nix-profile/bin</string>
+	</dict>
 	<key>KeepAlive</key>
 	<dict>
 		<key>Crashed</key>

--- a/tests/modules/programs/opencode/web-service.plist
+++ b/tests/modules/programs/opencode/web-service.plist
@@ -2,11 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>EnvironmentVariables</key>
-	<dict>
-		<key>PATH</key>
-		<string>/home/hm-user/.nix-profile/bin</string>
-	</dict>
 	<key>KeepAlive</key>
 	<dict>
 		<key>Crashed</key>
@@ -22,7 +17,7 @@
 	<array>
 		<string>/bin/sh</string>
 		<string>-c</string>
-		<string>/bin/wait4path /nix/store &amp;&amp; exec @opencode@/bin/opencode serve --hostname 0.0.0.0 --port 4096 --mdns --cors https://example.com --cors http://localhost:3000 --print-logs --log-level DEBUG</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec /nix/store/00000000000000000000000000000000-opencode-web-launcher/bin/opencode-web-launcher</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/tests/modules/programs/opencode/web-service.service
+++ b/tests/modules/programs/opencode/web-service.service
@@ -2,6 +2,7 @@
 WantedBy=default.target
 
 [Service]
+Environment=PATH=/home/hm-user/.nix-profile/bin
 ExecStart=@opencode@/bin/opencode serve --hostname 0.0.0.0 --port 4096 --mdns --cors https://example.com --cors http://localhost:3000 --print-logs --log-level DEBUG
 Restart=always
 RestartSec=5

--- a/tests/modules/programs/opencode/web-service.service
+++ b/tests/modules/programs/opencode/web-service.service
@@ -2,8 +2,7 @@
 WantedBy=default.target
 
 [Service]
-Environment=PATH=/home/hm-user/.nix-profile/bin
-ExecStart=@opencode@/bin/opencode serve --hostname 0.0.0.0 --port 4096 --mdns --cors https://example.com --cors http://localhost:3000 --print-logs --log-level DEBUG
+ExecStart=/nix/store/00000000000000000000000000000000-opencode-web-launcher/bin/opencode-web-launcher
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
## Summary

- Set `PATH=${config.home.profileDirectory}/bin` for the opencode-web systemd service and launchd agent
- Set `SHELL=/usr/bin/env bash` so opencode's bash tool spawns the correct shell

## Problem

The opencode web service runs as a systemd user service without inheriting the user's PATH. This causes the bash tool to fail — it only has access to a minimal PATH with no basic utilities (no `ls`, `cat`, `grep`, `git`, etc.).

## Solution

Follow the standard Home Manager pattern used by other services (kdeconnect, mpd, nextcloud-client, etc.) of setting `PATH` to `config.home.profileDirectory/bin`. This gives the service access to all HM-installed packages.

Also sets `SHELL=/usr/bin/env bash` which is the NixOS-standard approach for shell paths, ensuring opencode's bash tool works correctly on NixOS where `/bin/sh` has no utilities.