### PR TITLE
rofi: support nested extraConfig sections

### DIFF
--- a/modules/misc/news/2026/04/2026-04-20_13-53-30.nix
+++ b/modules/misc/news/2026/04/2026-04-20_13-53-30.nix
@@ -1,0 +1,13 @@
+{ config, ... }:
+{
+  time = "2026-04-20T13:53:30+00:00";
+  condition = config.programs.rofi.enable;
+  message = ''
+    The `programs.rofi.extraConfig` option now supports nested attrsets for
+    top-level Rasi sections such as `filebrowser { ... }` and
+    `run,drun { ... }`.
+
+    Flat `extraConfig` entries continue to be written inside the
+    `configuration { ... }` block.
+  '';
+}

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -82,7 +82,7 @@ let
     left = 8;
   };
 
-  primitive =
+  configValueType =
     with types;
     (oneOf [
       str
@@ -91,8 +91,12 @@ let
       rasiLiteral
     ]);
 
+  sectionType = with types; attrsOf (either configValueType (listOf configValueType));
+
   # Either a `section { foo: "bar"; }` or a `@import/@theme "some-text"`
-  configType = with types; (either (attrsOf (either primitive (listOf primitive))) str);
+  configType = with types; either sectionType str;
+
+  extraConfigType = with types; attrsOf (either sectionType configValueType);
 
   rasiLiteral =
     types.submodule {
@@ -133,6 +137,11 @@ let
       cfg.theme;
 
   modes = map (mode: if isString mode then mode else "${mode.name}:${mode.path}") cfg.modes;
+
+  # Flat entries belong in `configuration { ... }`, while nested attrsets map
+  # to top-level Rasi sections such as `filebrowser { ... }`.
+  configurationExtraConfig = filterAttrs (_: v: !isAttrs v) cfg.extraConfig;
+  sectionExtraConfig = filterAttrs (_: isAttrs) cfg.extraConfig;
 in
 {
   meta.maintainers = [ ];
@@ -295,9 +304,12 @@ in
         {
           kb-primary-paste = "Control+V,Shift+Insert";
           kb-secondary-paste = "Control+v,Insert";
+          "run,drun" = {
+            display-name = "open:";
+          };
         }
       '';
-      type = configType;
+      type = extraConfigType;
       description = "Additional configuration to add.";
     };
 
@@ -344,23 +356,26 @@ in
     home.packages = [ cfg.finalPackage ];
 
     home.file."${cfg.configPath}".text =
-      toRasi {
-        configuration = (
-          {
-            inherit (cfg)
-              cycle
-              font
-              terminal
-              xoffset
-              yoffset
-              ;
-            location = (lib.getAttr cfg.location locationsMap);
-          }
-          // lib.optionalAttrs (modes != [ ]) { inherit modes; }
-          // cfg.extraConfig
-        );
+      toRasi (
+        {
+          configuration = (
+            {
+              inherit (cfg)
+                cycle
+                font
+                terminal
+                xoffset
+                yoffset
+                ;
+              location = (lib.getAttr cfg.location locationsMap);
+            }
+            // lib.optionalAttrs (modes != [ ]) { inherit modes; }
+            // configurationExtraConfig
+          );
+        }
+        // sectionExtraConfig
         # @theme must go after configuration but attrs are output in alphabetical order ('@' first)
-      }
+      )
       + (lib.optionalString (themeName != null) (toRasi {
         "@theme" = themeName;
       }));

--- a/tests/modules/programs/rofi/valid-config-expected.rasi
+++ b/tests/modules/programs/rofi/valid-config-expected.rasi
@@ -9,3 +9,13 @@ terminal: "/some/path";
 xoffset: 0;
 yoffset: 0;
 }
+
+filebrowser {
+directories-first: true;
+directory: "$HOME";
+sorting-method: "name";
+}
+
+run,drun {
+display-name: "open:";
+}

--- a/tests/modules/programs/rofi/valid-config.nix
+++ b/tests/modules/programs/rofi/valid-config.nix
@@ -21,6 +21,14 @@
     extraConfig = {
       kb-primary-paste = "Control+V,Shift+Insert";
       kb-secondary-paste = "Control+v,Insert";
+      "run,drun" = {
+        display-name = "open:";
+      };
+      filebrowser = {
+        directory = "$HOME";
+        sorting-method = "name";
+        directories-first = true;
+      };
     };
   };
 


### PR DESCRIPTION
Render flat extraConfig entries inside the configuration block and nested attrsets as top-level Rasi sections so mode-specific and filebrowser configuration can be expressed directly in Nix. Fold the reported nested cases into the existing valid-config test instead of keeping issue-specific test files.

Closes #4783 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
