### PR TITLE
git: support ordered settings fragments

### DIFF
--- a/modules/misc/news/2026/04/2026-04-20_15-13-25.nix
+++ b/modules/misc/news/2026/04/2026-04-20_15-13-25.nix
@@ -1,0 +1,13 @@
+{ config, ... }:
+{
+  time = "2026-04-20T20:13:25+00:00";
+  condition = config.programs.git.enable;
+  message = ''
+    The 'programs.git.settings' option now supports ordered configuration
+    fragments in addition to the existing attrset shorthand.
+
+    This allows repeated or order-sensitive Git config sections, such as
+    multiple 'credential' blocks, to be expressed directly in Nix while keeping
+    the simple attrset form for normal Git settings.
+  '';
+}

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -7,7 +7,6 @@
 let
   inherit (lib)
     concatStringsSep
-    literalExpression
     mkDefault
     mkEnableOption
     mkIf
@@ -131,7 +130,7 @@ in
         hooks = mkOption {
           type = types.attrsOf types.path;
           default = { };
-          example = literalExpression ''
+          example = lib.literalExpression ''
             {
               pre-commit = ./pre-commit-script;
             }
@@ -189,18 +188,16 @@ in
                   contents = mkOption {
                     type = types.attrsOf types.anything;
                     default = { };
-                    example = literalExpression ''
-                      {
-                        user = {
-                          email = "bob@work.example.com";
-                          name = "Bob Work";
-                          signingKey = "1A2B3C4D5E6F7G8H";
-                        };
-                        commit = {
-                          gpgSign = true;
-                        };
+                    example = {
+                      user = {
+                        email = "bob@work.example.com";
+                        name = "Bob Work";
+                        signingKey = "1A2B3C4D5E6F7G8H";
                       };
-                    '';
+                      commit = {
+                        gpgSign = true;
+                      };
+                    };
                     description = ''
                       Configuration to include. If empty then a path must be given.
 
@@ -230,15 +227,13 @@ in
             )
           );
           default = [ ];
-          example = literalExpression ''
-            [
-              { path = "~/path/to/config.inc"; }
-              {
-                path = "~/path/to/conditional.inc";
-                condition = "gitdir:~/src/dir";
-              }
-            ]
-          '';
+          example = [
+            { path = "~/path/to/config.inc"; }
+            {
+              path = "~/path/to/conditional.inc";
+              condition = "gitdir:~/src/dir";
+            }
+          ];
           description = "List of configuration files to include.";
         };
 

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -102,16 +102,28 @@ in
         };
 
         settings = mkOption {
-          type = gitIniType;
+          type = with types; either gitIniType (listOf gitIniType);
           default = { };
-          example = {
-            core = {
-              whitespace = "trailing-space,space-before-tab";
-            };
-            url."ssh://git@host".insteadOf = "otherhost";
-          };
+          example = [
+            {
+              core = {
+                whitespace = "trailing-space,space-before-tab";
+              };
+              url."ssh://git@host".insteadOf = "otherhost";
+            }
+            {
+              credential."https://example.com".helper = "";
+            }
+            {
+              credential."https://example.com".helper = "oauth";
+            }
+          ];
           description = ''
             Configuration written to {file}`$XDG_CONFIG_HOME/git/config`.
+            This may be either a single attrset of Git settings or an ordered
+            list of attrset fragments when repeated sections or explicit
+            ordering matter.
+
             See {manpage}`git-config(1)` for details.
           '';
         };
@@ -337,6 +349,14 @@ in
     );
 
   config = mkIf cfg.enable (
+    let
+      settingsFragments = lib.filter (fragment: fragment != { }) (
+        if builtins.isList cfg.settings then cfg.settings else [ ]
+      );
+      renderedIniFragments = lib.filter (text: lib.match "[[:space:]]*" text == null) (
+        [ (lib.generators.toGitINI cfg.iniContent) ] ++ map lib.generators.toGitINI settingsFragments
+      );
+    in
     lib.mkMerge [
       {
         home.packages = lib.optionals (cfg.package != null) [ cfg.package ];
@@ -382,7 +402,7 @@ in
         ];
 
         xdg.configFile = {
-          "git/config".text = lib.generators.toGitINI cfg.iniContent;
+          "git/config".text = concatStringsSep "\n" renderedIniFragments;
 
           "git/ignore" = mkIf (cfg.ignores != [ ]) {
             text = concatStringsSep "\n" cfg.ignores + "\n";
@@ -479,7 +499,7 @@ in
         };
       })
 
-      (mkIf (cfg.settings != { }) {
+      (mkIf (!builtins.isList cfg.settings && cfg.settings != { }) {
         programs.git.iniContent = cfg.settings;
       })
 

--- a/tests/modules/programs/git/default.nix
+++ b/tests/modules/programs/git/default.nix
@@ -11,5 +11,9 @@
   git-with-lfs = ./git-with-lfs.nix;
   git-with-maintenance = ./git-with-maintenance.nix;
   git-settings-deprecations = ./git-settings-deprecations.nix;
+  git-settings-ordered-fragments = ./git-settings-ordered-fragments.nix;
+  git-settings-ordered-fragments-merge = ./git-settings-ordered-fragments-merge.nix;
+  git-settings-ordered-fragments-priority = ./git-settings-ordered-fragments-priority.nix;
+  git-credential-integrations = ./git-credential-integrations.nix;
   git-integration-assertion = ./git-integration-assertion.nix;
 }

--- a/tests/modules/programs/git/git-credential-integrations-expected.conf
+++ b/tests/modules/programs/git/git-credential-integrations-expected.conf
@@ -1,0 +1,10 @@
+[credential]
+	helper = "@git-credential-oauth@/bin/git-credential-oauth"
+
+[credential "https://github.com"]
+	helper = ""
+	helper = "@gh@/bin/gh auth git-credential"
+
+[credential "https://github.example.com"]
+	helper = ""
+	helper = "@gh@/bin/gh auth git-credential"

--- a/tests/modules/programs/git/git-credential-integrations.nix
+++ b/tests/modules/programs/git/git-credential-integrations.nix
@@ -1,0 +1,25 @@
+{
+  programs.gh = {
+    enable = true;
+    gitCredentialHelper = {
+      enable = true;
+      hosts = [
+        "https://github.com"
+        "https://github.example.com"
+      ];
+    };
+  };
+
+  programs.git-credential-oauth.enable = true;
+
+  programs.git = {
+    enable = true;
+    signing.format = null;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContent home-files/.config/git/config \
+      ${./git-credential-integrations-expected.conf}
+  '';
+}

--- a/tests/modules/programs/git/git-settings-ordered-fragments-expected.conf
+++ b/tests/modules/programs/git/git-settings-ordered-fragments-expected.conf
@@ -1,0 +1,8 @@
+[credential "https://example.com"]
+	helper = ""
+
+[credential "https://example.com"]
+	helper = "oauth"
+
+[credential]
+	helper = "store"

--- a/tests/modules/programs/git/git-settings-ordered-fragments-merge-expected.conf
+++ b/tests/modules/programs/git/git-settings-ordered-fragments-merge-expected.conf
@@ -1,0 +1,8 @@
+[credential "https://example.com"]
+	helper = ""
+
+[credential "https://example.com"]
+	helper = "oauth"
+
+[credential]
+	helper = "store"

--- a/tests/modules/programs/git/git-settings-ordered-fragments-merge.nix
+++ b/tests/modules/programs/git/git-settings-ordered-fragments-merge.nix
@@ -1,0 +1,34 @@
+{ lib, pkgs, ... }:
+{
+  programs.git = lib.mkMerge [
+    {
+      enable = true;
+      package = pkgs.gitMinimal;
+      signing.format = null;
+      settings = [
+        {
+          credential."https://example.com".helper = "";
+        }
+      ];
+    }
+    {
+      settings = [
+        {
+          credential."https://example.com".helper = "oauth";
+        }
+      ];
+    }
+    {
+      settings = [
+        {
+          credential.helper = "store";
+        }
+      ];
+    }
+  ];
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContent home-files/.config/git/config ${./git-settings-ordered-fragments-merge-expected.conf}
+  '';
+}

--- a/tests/modules/programs/git/git-settings-ordered-fragments-priority-expected.conf
+++ b/tests/modules/programs/git/git-settings-ordered-fragments-priority-expected.conf
@@ -1,0 +1,8 @@
+[credential "https://example.com"]
+	helper = "before"
+
+[credential "https://example.com"]
+	helper = "middle"
+
+[credential "https://example.com"]
+	helper = "after"

--- a/tests/modules/programs/git/git-settings-ordered-fragments-priority.nix
+++ b/tests/modules/programs/git/git-settings-ordered-fragments-priority.nix
@@ -1,0 +1,37 @@
+{ lib, pkgs, ... }:
+{
+  imports = [
+    (_: {
+      programs.git.settings = lib.mkAfter [
+        {
+          credential."https://example.com".helper = "after";
+        }
+      ];
+    })
+    (_: {
+      programs.git.settings = [
+        {
+          credential."https://example.com".helper = "middle";
+        }
+      ];
+    })
+    (_: {
+      programs.git.settings = lib.mkBefore [
+        {
+          credential."https://example.com".helper = "before";
+        }
+      ];
+    })
+  ];
+
+  programs.git = {
+    enable = true;
+    package = pkgs.gitMinimal;
+    signing.format = null;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContent home-files/.config/git/config ${./git-settings-ordered-fragments-priority-expected.conf}
+  '';
+}

--- a/tests/modules/programs/git/git-settings-ordered-fragments.nix
+++ b/tests/modules/programs/git/git-settings-ordered-fragments.nix
@@ -1,0 +1,24 @@
+{ pkgs, ... }:
+{
+  programs.git = {
+    enable = true;
+    package = pkgs.gitMinimal;
+    signing.format = null;
+    settings = [
+      {
+        credential."https://example.com".helper = "";
+      }
+      {
+        credential."https://example.com".helper = "oauth";
+      }
+      {
+        credential.helper = "store";
+      }
+    ];
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContent home-files/.config/git/config ${./git-settings-ordered-fragments-expected.conf}
+  '';
+}


### PR DESCRIPTION
Allow programs.git.settings to keep its existing attrset shorthand while also accepting an ordered list of fragments for repeated sections and order-sensitive config. Cover the new list form with a focused Git config snapshot test.

closes #4439 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
