### PR TITLE
ci: add nix and lix parse checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
       docs: ${{ steps.changes.outputs.docs }}
       format: ${{ steps.changes.outputs.format }}
       hm: ${{ steps.changes.outputs.hm }}
+      parse: ${{ steps.changes.outputs.parse }}
       tests: ${{ steps.changes.outputs.tests }}
     steps:
       - uses: actions/checkout@v6
@@ -39,6 +40,9 @@ jobs:
               - 'flake.lock'
               - 'flake.nix'
               - 'home-manager/**'
+            parse:
+              - '**/*.nix'
+              - 'flake.lock'
   tests:
     needs: changes
     strategy:
@@ -59,6 +63,12 @@ jobs:
       - name: Build docs
         if: github.event_name == 'schedule' || needs.changes.outputs.docs == 'true'
         run: nix build --show-trace .#docs-jsonModuleMaintainers
+      - name: Parse Nix files with latest nix
+        if: github.event_name == 'schedule' || needs.changes.outputs.parse == 'true'
+        run: nix build --show-trace .#ci-parse
+      - name: Parse Nix files with latest Lix
+        if: github.event_name == 'schedule' || needs.changes.outputs.parse == 'true'
+        run: nix build --show-trace .#ci-parse-lix
       - name: Format Check
         if: github.event_name == 'schedule' || needs.changes.outputs.format == 'true'
         run: nix fmt -- --ci
@@ -91,6 +101,12 @@ jobs:
             echo "- ✅ **Format Check:** Triggered" >> $GITHUB_STEP_SUMMARY
           else
             echo "- ☑️ **Format Check:** Skipped (no relevant files changed)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [[ "${{ needs.changes.outputs.parse }}" == "true" ]]; then
+            echo "- ✅ **Nix Parse (nix + Lix):** Triggered" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ☑️ **Nix Parse (nix + Lix):** Skipped (no relevant files changed)" >> $GITHUB_STEP_SUMMARY
           fi
 
           if [[ "${{ needs.changes.outputs.hm }}" == "true" ]]; then

--- a/ci/parse.nix
+++ b/ci/parse.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  nix,
+  runCommand,
+}:
+let
+  home-manager =
+    with lib.fileset;
+    toSource {
+      root = ../.;
+      fileset = (fileFilter (file: file.hasExt "nix") ../.);
+    };
+  parseLog = "$TMPDIR/nix-parse.log";
+in
+runCommand "nix-parse-${nix.name}"
+  {
+    nativeBuildInputs = [
+      nix
+    ];
+  }
+  ''
+    export NIX_STORE_DIR=$TMPDIR/store
+    export NIX_STATE_DIR=$TMPDIR/state
+    nix-store --init
+
+    cd "${home-manager}"
+
+    # This will only show the first parse error, not all of them. That's fine, because
+    # the other CI jobs will report in more detail. This job is about checking parsing
+    # across different implementations / versions, not about providing the best DX.
+    # Returning all parse errors requires significantly more resources.
+    if ! find . -type f -iname '*.nix' | xargs -P $(nproc) nix-instantiate --parse 2> "${parseLog}" > /dev/null; then
+      cat "${parseLog}" >&2
+      echo "Parse failed in nix-instantiate." >&2
+      exit 1
+    fi
+
+    if grep "warning" "${parseLog}"; then
+      cat "${parseLog}" >&2
+      echo "Failing due to warnings in stderr" >&2
+      exit 1
+    fi
+
+    touch $out
+  ''

--- a/flake.nix
+++ b/flake.nix
@@ -189,6 +189,11 @@
             default = hmPkg;
             home-manager = hmPkg;
 
+            ci-parse = pkgs.callPackage ./ci/parse.nix { nix = pkgs.nixVersions.latest; };
+            ci-parse-lix = pkgs.callPackage ./ci/parse.nix {
+              nix = pkgs.lixPackageSets.latest.lix;
+            };
+
             create-news-entry = pkgs.writeShellScriptBin "create-news-entry" ''
               ./modules/misc/news/create-news-entry.sh
             '';


### PR DESCRIPTION
### Description
Same spirit as https://github.com/NixOS/nixpkgs/pull/511836 to prevent issues that keep coming up. 

  - dee1c38cf — modules/helix: fix incorrect string escape
  - 87d6611d2 — desktoppr: fix useless escapes
  - d47357a4c — go: remove unneeded string escapes
  - 084e7e6df — treewide: remove unneeded string escapes
  - 268d02777 — modules/home-manager: fix syntax error
  - 363797f8a — gpg-agent: fix syntax-breaking extraneous new line
  - a8d00f5c0 — irssi: fix syntax error when no channels are specified
  - 6ce3493a3 — kodi: fix syntax error in example
  - 0d3f9ba9 — compton: fix syntax error
  - 7ad849f03 — home-manager: remove escaping
  - 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
