### PR TITLE
ci: misc tests workflow tweaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ permissions: {}
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       docs: ${{ steps.changes.outputs.docs }}
       format: ${{ steps.changes.outputs.format }}
@@ -46,6 +47,7 @@ jobs:
               - 'flake.lock'
   tests:
     needs: changes
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -61,6 +63,8 @@ jobs:
         if: github.event_name == 'schedule' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.tests == 'true' || needs.changes.outputs.hm == 'true' || needs.changes.outputs.format == 'true'
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/${{ steps.get-nixpkgs.outputs.rev }}.tar.gz
+          extra_nix_config: |
+            sandbox = true
       - name: Build docs
         if: github.event_name == 'schedule' || needs.changes.outputs.docs == 'true'
         run: nix build --show-trace .#docs-jsonModuleMaintainers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,12 +63,9 @@ jobs:
       - name: Build docs
         if: github.event_name == 'schedule' || needs.changes.outputs.docs == 'true'
         run: nix build --show-trace .#docs-jsonModuleMaintainers
-      - name: Parse Nix files with latest nix
+      - name: Parse Nix files with nix and Lix
         if: github.event_name == 'schedule' || needs.changes.outputs.parse == 'true'
-        run: nix build --show-trace .#ci-parse
-      - name: Parse Nix files with latest Lix
-        if: github.event_name == 'schedule' || needs.changes.outputs.parse == 'true'
-        run: nix build --show-trace .#ci-parse-lix
+        run: nix build --show-trace --keep-going .#ci-parse .#ci-parse-lix
       - name: Format Check
         if: github.event_name == 'schedule' || needs.changes.outputs.format == 'true'
         run: nix fmt -- --ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
   cancel-in-progress: true
+permissions: {}
 jobs:
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The parse workflow currently runs the nix and Lix checks as two separate
steps. If the first parser fails, GitHub Actions stops the job before
the second parser runs, which hides useful failure information and
weakens the signal from the new parse gate.

Collapse the two steps into a single invocation that builds both parse
derivations with --keep-going. This keeps the job surface small,
preserves the dedicated parse trigger, and ensures both parser variants
are attempted on every relevant run.

The test workflow only needs to evaluate and build repository code. It
does not write statuses, labels, comments, or pull request metadata, so
keeping GitHub's default token scope is broader than necessary.

The test workflow currently relies on GitHub Actions defaults for both
job lifetime and Nix sandboxing. That is acceptable when everything
behaves, but it makes failures noisier: a hung job can run indefinitely
until the platform kills it, and the macOS leg inherits a weaker sandbox
default than Linux.

Add explicit timeout-minutes values to the lightweight change-detection
job and the main test matrix job, and pass sandbox = true through
install-nix-action. The sandbox setting is primarily about making the
macOS runner match the stricter execution model we already expect on
Linux.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
