### PR TITLE
modules/nix-search-tv: add run and shell actions

### DIFF
--- a/modules/programs/nix-search-tv.nix
+++ b/modules/programs/nix-search-tv.nix
@@ -80,6 +80,15 @@ in
 
         source.command = "${path} print";
         preview.command = ''${path} preview "{}"'';
+
+        actions.run = {
+          command = ''nix run {replace:s/\/ /#/g}'';
+          mode = "fork";
+        };
+        actions.shell = {
+          command = ''nix shell {replace:s/\/ /#/g}'';
+          mode = "execute";
+        };
       }
     );
   };

--- a/tests/modules/programs/nix-search-tv/television.nix
+++ b/tests/modules/programs/nix-search-tv/television.nix
@@ -8,6 +8,14 @@
     assertFileExists home-files/.config/television/cable/nix-search-tv.toml
     assertFileContent home-files/.config/television/cable/nix-search-tv.toml \
       ${pkgs.writeText "settings-expected" ''
+        [actions.run]
+        command = "nix run {replace:s/\\/ /#/g}"
+        mode = "fork"
+
+        [actions.shell]
+        command = "nix shell {replace:s/\\/ /#/g}"
+        mode = "execute"
+
         [metadata]
         description = "Search nix options and packages"
         name = "nix-search-tv"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add actions to the default `tv` config which is enabled by `enableTelevisionIntegration`.

They use `nix3-command` to run a program or open a shell respectively; this wouldn't work on everything that `nix-search-tv` indexes, but the user can be expected to not try to run a module or something.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
