### PR TITLE
vivid: generate shell colors at build time

### DIFF
--- a/modules/misc/news/2026/09/2026-09-10_12-00-00.nix
+++ b/modules/misc/news/2026/09/2026-09-10_12-00-00.nix
@@ -1,0 +1,15 @@
+{ config, ... }:
+{
+  time = "2026-09-10T12:00:00+00:00";
+  condition = config.programs.vivid.enable;
+  message = ''
+    Vivid shell integrations now generate LS_COLORS at build time when
+    programs.vivid.package and programs.vivid.activeTheme are non-null.
+    Shell startup reads the cached colors without running vivid.
+
+    Configure custom themes and filetypes through programs.vivid.themes and
+    programs.vivid.filetypes. Runtime changes to these files or VIVID_THEME
+    no longer affect the cached colors. Generation remains at shell startup
+    when package or activeTheme is null.
+  '';
+}

--- a/modules/programs/vivid.nix
+++ b/modules/programs/vivid.nix
@@ -132,9 +132,11 @@ in
 
   config =
     let
-      vividCommand = "vivid ${
-        lib.optionalString (cfg.colorMode != null) "-m ${cfg.colorMode}"
-      } generate ${lib.optionalString (cfg.activeTheme != null) cfg.activeTheme}";
+      vividCommand = "${
+        if cfg.package != null then lib.getExe cfg.package else "vivid"
+      } ${lib.optionalString (cfg.colorMode != null) "-m ${cfg.colorMode} "}generate${
+        lib.optionalString (cfg.activeTheme != null) " ${cfg.activeTheme}"
+      }";
     in
     mkIf cfg.enable {
       home.packages = mkIf (cfg.package != null) [ cfg.package ];

--- a/modules/programs/vivid.nix
+++ b/modules/programs/vivid.nix
@@ -20,8 +20,6 @@ let
     mkNushellIntegrationOption
     ;
 
-  inherit (lib.hm.nushell) mkNushellInline;
-
   cfg = config.programs.vivid;
   yamlFormat = pkgs.formats.yaml { };
 in
@@ -89,7 +87,10 @@ in
       default = null;
       example = "molokai";
       description = ''
-        Active theme for vivid.
+        Active theme for vivid. With a managed package, colors are generated
+        at build time; changes to runtime configuration or VIVID_THEME do not
+        affect shell initialization. When null, generation runs at shell
+        startup using VIVID_THEME instead.
       '';
     };
 
@@ -132,9 +133,34 @@ in
 
   config =
     let
-      vividCommand = "vivid ${
-        lib.optionalString (cfg.colorMode != null) "-m ${cfg.colorMode}"
-      } generate ${lib.optionalString (cfg.activeTheme != null) cfg.activeTheme}";
+      generateAtBuildTime = cfg.package != null && cfg.activeTheme != null;
+      vividCommand =
+        theme:
+        lib.escapeShellArgs (
+          [ (if cfg.package != null then lib.getExe cfg.package else "vivid") ]
+          ++ lib.optionals (cfg.colorMode != null) [
+            "-m"
+            cfg.colorMode
+          ]
+          ++ [ "generate" ]
+          ++ lib.optional (theme != null) theme
+        );
+      colors =
+        pkgs.runCommandLocal "vivid-ls-colors"
+          (lib.optionalAttrs (cfg.filetypes != { }) {
+            VIVID_DATABASE = config.xdg.configFile."vivid/filetypes.yml".source;
+          })
+          ''
+            ${
+              vividCommand (
+                if builtins.hasAttr cfg.activeTheme cfg.themes then
+                  "${config.xdg.configFile."vivid/themes/${cfg.activeTheme}.yml".source}"
+                else
+                  cfg.activeTheme
+              )
+            } > "$out"
+          '';
+
     in
     mkIf cfg.enable {
       home.packages = mkIf (cfg.package != null) [ cfg.package ];
@@ -154,19 +180,26 @@ in
       ) cfg.themes);
 
       programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-        export LS_COLORS="$(${vividCommand})"
+        export LS_COLORS="$(${if generateAtBuildTime then "<${colors}" else vividCommand cfg.activeTheme})"
       '';
 
       programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
-        export LS_COLORS="$(${vividCommand})"
+        export LS_COLORS="$(${if generateAtBuildTime then "<${colors}" else vividCommand cfg.activeTheme})"
       '';
 
       programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-        set -gx LS_COLORS "$(${vividCommand})"
+        set -gx LS_COLORS "$(${
+          if generateAtBuildTime then "string collect < ${colors}" else vividCommand cfg.activeTheme
+        })"
       '';
 
-      programs.nushell.environmentVariables = mkIf cfg.enableNushellIntegration {
-        LS_COLORS = mkNushellInline vividCommand;
-      };
+      programs.nushell.extraEnv = mkIf cfg.enableNushellIntegration ''
+        $env.LS_COLORS = (${
+          if generateAtBuildTime then
+            ''open --raw ${colors} | str trim --right --char "\n"''
+          else
+            vividCommand cfg.activeTheme
+        })
+      '';
     };
 }

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -181,6 +181,7 @@ let
     "vim-vint"
     "vimPlugins"
     "visidata"
+    "vivid"
     "vscode"
     "wallust"
     "watson"

--- a/tests/modules/programs/vivid/default.nix
+++ b/tests/modules/programs/vivid/default.nix
@@ -1,1 +1,4 @@
-{ vivid-example-config = ./example-config.nix; }
+{
+  vivid-example-config = ./example-config.nix;
+  vivid-zsh-integration = ./zsh-integration.nix;
+}

--- a/tests/modules/programs/vivid/default.nix
+++ b/tests/modules/programs/vivid/default.nix
@@ -1,1 +1,20 @@
-{ vivid-example-config = ./example-config.nix; }
+{
+  vivid-example-config = ./example-config.nix;
+  vivid-shell-integration = ./shell-integration.nix;
+  vivid-custom-shell-integration = {
+    imports = [
+      ./example-config.nix
+      ./shell-integration.nix
+    ];
+  };
+  vivid-runtime-theme =
+    { pkgs, ... }:
+    {
+      imports = [ ./external-package.nix ];
+      programs.vivid.package = pkgs.vivid;
+    };
+  vivid-external-package = {
+    imports = [ ./external-package.nix ];
+    programs.vivid.activeTheme = "molokai";
+  };
+}

--- a/tests/modules/programs/vivid/external-package.nix
+++ b/tests/modules/programs/vivid/external-package.nix
@@ -1,0 +1,30 @@
+{ config, lib, ... }:
+{
+  programs.bash.enable = true;
+  programs.zsh.enable = true;
+  programs.fish.enable = true;
+  programs.nushell = {
+    enable = true;
+    configDir = ".config/nushell";
+  };
+  xdg.enable = true;
+  programs.vivid = {
+    enable = true;
+    package = lib.mkDefault null;
+  };
+  nmt.script =
+    let
+      command =
+        if config.programs.vivid.package == null then "vivid" else lib.getExe config.programs.vivid.package;
+      args = lib.escapeShellArgs (
+        [ "generate" ]
+        ++ lib.optional (config.programs.vivid.activeTheme != null) config.programs.vivid.activeTheme
+      );
+    in
+    ''
+      assertFileContains home-files/.bashrc 'export LS_COLORS="$(${command} ${args})"'
+      assertFileContains home-files/.zshrc 'export LS_COLORS="$(${command} ${args})"'
+      assertFileContains home-files/.config/fish/config.fish 'set -gx LS_COLORS "$(${command} ${args})"'
+      assertFileContains home-files/.config/nushell/env.nu '$env.LS_COLORS = (${command} ${args})'
+    '';
+}

--- a/tests/modules/programs/vivid/shell-integration.nix
+++ b/tests/modules/programs/vivid/shell-integration.nix
@@ -1,0 +1,48 @@
+{ lib, pkgs, ... }:
+{
+  test.stubs.vivid = {
+    name = "vivid";
+    outPath = null;
+    buildScript = ''
+      mkdir -p "$out/bin"
+      cat > "$out/bin/vivid" <<'EOF'
+      #!${pkgs.runtimeShell}
+      set -eu
+      if [ "$1" = -m ]; then
+        test "$2" = 8-bit
+        test -r "$VIVID_DATABASE"
+        test -r "$4"
+        shift 2
+      fi
+      test "$1" = generate
+      test "$2" = molokai || test -r "$2"
+      printf 'di=01;34\n'
+      EOF
+      chmod +x "$out/bin/vivid"
+    '';
+  };
+
+  programs.bash.enable = true;
+  programs.zsh.enable = true;
+  programs.fish.enable = true;
+  programs.nushell = {
+    enable = true;
+    configDir = ".config/nushell";
+  };
+  programs.vivid = {
+    enable = true;
+    activeTheme = lib.mkDefault "molokai";
+  };
+
+  nmt.script = ''
+    for file in .bashrc .zshrc .config/fish/config.fish .config/nushell/env.nu; do
+      assertFileRegex "home-files/$file" '/nix/store/.*-vivid-ls-colors'
+    done
+    assertFileContains home-files/.bashrc 'export LS_COLORS="$(<'
+    assertFileContains home-files/.zshrc 'export LS_COLORS="$(<'
+    assertFileContains home-files/.config/fish/config.fish 'string collect < /nix/store/'
+    assertFileContains home-files/.config/nushell/env.nu 'open --raw /nix/store/'
+    colors=$(grep -o '/nix/store/[^"]*-vivid-ls-colors' "$TESTED/home-files/.bashrc")
+    assertFileContains "$colors" 'di=01;34'
+  '';
+}

--- a/tests/modules/programs/vivid/zsh-integration.nix
+++ b/tests/modules/programs/vivid/zsh-integration.nix
@@ -1,0 +1,17 @@
+{ config, ... }:
+{
+  programs.zsh.enable = true;
+
+  programs.vivid = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "vivid";
+      outPath = "@vivid@";
+    };
+    enableZshIntegration = true;
+  };
+
+  nmt.script = ''
+    assertFileContains home-files/.zshrc 'export LS_COLORS="$(@vivid@/bin/vivid generate)"'
+  '';
+}


### PR DESCRIPTION
### Description

Generate `LS_COLORS` once with `runCommandLocal` when both `programs.vivid.package` and `activeTheme` are non-null. Bash, Zsh, Fish and Nushell read the same cached data file using shell builtins, without invoking Vivid at startup. No shell-code generators or additional dependencies are needed.

Pass the managed theme and filetype database directly to Vivid. Keep runtime generation when `package = null` or `activeTheme = null`, since those cases depend on an external executable or the session's `VIVID_THEME`. Managed runtime generation uses the selected package's absolute executable path.

This changes when configuration is read: cached colors use `programs.vivid.themes` and `filetypes`, not later edits to runtime files or environment variables. The option documentation and news entry explain that behavior.

Closes #8862

### Verification

- Five focused Vivid NMT tests using an executable Vivid stub to check build arguments, access to custom configuration inputs, cached output, all four generated shell integrations, and both runtime fallbacks. No `realPkgs` test dependencies.
- `nix fmt` and `git diff --check`.
- HTML manual and manpages built with the branch's pinned Nixpkgs.
- Full `test-all` and native Darwin runtime tests were not run locally.

### Checklist

- [ ] Change is backwards compatible (configuration timing changes are documented).
- [x] Code formatted.
- [ ] Full test suite run locally.
- [x] Focused tests added and passed.
- [x] Commit follows repository style and is self-contained.
- [x] News entry added.
