### PR TITLE
clipcat: avoid NixOS-only PATH in service

### DIFF
--- a/modules/services/clipcat.nix
+++ b/modules/services/clipcat.nix
@@ -6,6 +6,7 @@
 }:
 let
   inherit (lib)
+    getExe'
     types
     mkIf
     mkEnableOption
@@ -134,15 +135,8 @@ in
       Install.WantedBy = [ "graphical-session.target" ];
 
       Service = {
-        ExecStartPre = "${pkgs.writeShellScript "clipcatd-exec-start-pre" ''
-          PATH=/run/current-system/sw/bin:
-          rm -f %t/clipcat/grpc.sock
-        ''}";
-
-        ExecStart = "${pkgs.writeShellScript "clipcatd-exec-start" ''
-          PATH=/run/current-system/sw/bin:
-          ${cfg.package}/bin/clipcatd --no-daemon --replace
-        ''}";
+        ExecStartPre = "${getExe' pkgs.coreutils "rm"} -f %t/clipcat/grpc.sock";
+        ExecStart = "${getExe' cfg.package "clipcatd"} --no-daemon --replace";
 
         Restart = "on-failure";
         Type = "simple";

--- a/tests/modules/services/clipcat/example-config.nix
+++ b/tests/modules/services/clipcat/example-config.nix
@@ -48,9 +48,12 @@
   };
 
   nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/clipcat.service
+
     assertFileExists home-files/.config/clipcat/clipcatd.toml
     assertFileExists home-files/.config/clipcat/clipcatctl.toml
     assertFileExists home-files/.config/clipcat/clipcat-menu.toml
+    assertFileExists "$serviceFile"
 
     assertFileContent home-files/.config/clipcat/clipcatd.toml \
     ${./cfg/daemon.toml}
@@ -61,5 +64,10 @@
     assertFileContent home-files/.config/clipcat/clipcat-menu.toml \
     ${./cfg/menu.toml}
 
+    assertFileRegex "$serviceFile" \
+      '^ExecStartPre=/nix/store/.*-coreutils-.*/bin/rm -f %t/clipcat/grpc.sock$'
+    assertFileRegex "$serviceFile" \
+      '^ExecStart=@clipcat@/bin/clipcatd --no-daemon --replace$'
+    assertFileNotRegex "$serviceFile" '/run/current-system/sw/bin'
   '';
 }


### PR DESCRIPTION
### Description
Closes https://github.com/nix-community/home-manager/issues/7440
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
