### PR TITLE
khal: honor explicit default calendar

### DIFF
--- a/modules/programs/khal/default.nix
+++ b/modules/programs/khal/default.nix
@@ -236,21 +236,26 @@ in
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."khal/config".text = lib.concatStringsSep "\n" (
-      [ "[calendars]" ]
-      ++ lib.mapAttrsToList genCalendarStr khalAccounts
-      ++ [
-        (lib.generators.toINI { } (
-          recursiveUpdate cfg.settings {
-            locale = definedAttrs (cfg.locale // { _module = null; });
-
-            default = lib.optionalAttrs (!isNull primaryAccount) {
+      let
+        settingsWithPrimaryDefaults =
+          cfg.settings
+          // lib.optionalAttrs (!isNull primaryAccount) {
+            default = recursiveUpdate {
               highlight_event_days = true;
               default_calendar =
                 if isNull primaryAccount.primaryCollection then
                   primaryAccount.name
                 else
                   primaryAccount.primaryCollection;
-            };
+            } (cfg.settings.default or { });
+          };
+      in
+      [ "[calendars]" ]
+      ++ lib.mapAttrsToList genCalendarStr khalAccounts
+      ++ [
+        (lib.generators.toINI { } (
+          recursiveUpdate settingsWithPrimaryDefaults {
+            locale = definedAttrs (cfg.locale // { _module = null; });
           }
         ))
       ]

--- a/tests/modules/programs/khal/default-calendar-override.nix
+++ b/tests/modules/programs/khal/default-calendar-override.nix
@@ -1,0 +1,44 @@
+{
+  programs.khal = {
+    enable = true;
+    settings.default.default_calendar = "private";
+  };
+
+  accounts.calendar = {
+    basePath = "$XDG_CONFIG_HOME/cal";
+    accounts = {
+      google = {
+        primary = true;
+        primaryCollection = "google";
+        khal.enable = true;
+        local = {
+          type = "filesystem";
+          fileExt = ".ics";
+        };
+        remote = {
+          type = "http";
+          url = "https://example.com/google.ics";
+        };
+      };
+
+      private = {
+        khal.enable = true;
+        local = {
+          type = "filesystem";
+          fileExt = ".ics";
+        };
+        remote = {
+          type = "http";
+          url = "https://example.com/private.ics";
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    configFile=home-files/.config/khal/config
+    assertFileExists $configFile
+    assertFileRegex $configFile "^default_calendar=private$"
+    assertFileRegex $configFile "^highlight_event_days=true$"
+  '';
+}

--- a/tests/modules/programs/khal/default.nix
+++ b/tests/modules/programs/khal/default.nix
@@ -1,1 +1,4 @@
-{ khal-config = ./config.nix; }
+{
+  khal-config = ./config.nix;
+  khal-default-calendar-override = ./default-calendar-override.nix;
+}


### PR DESCRIPTION
Closes #9040

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
