### PR TITLE
keynav: add configuration options

### DIFF
--- a/modules/services/keynav.nix
+++ b/modules/services/keynav.nix
@@ -8,12 +8,27 @@ let
 
   cfg = config.services.keynav;
 
+  keynavFormat = pkgs.formats.keyValue {
+    mkKeyValue = lib.generators.mkKeyValueDefault { } " ";
+  };
+
 in
 {
   options.services.keynav = {
     enable = lib.mkEnableOption "keynav";
 
     package = lib.mkPackageOption pkgs "keynav" { };
+
+    settings = lib.mkOption {
+      inherit (keynavFormat) type;
+      default = { };
+      description = "Configuration for keynav written to {file}`$XDG_CONFIG_HOME/keynav/keynavrc`. Each attribute name is a key binding and the value is the action. See <https://github.com/jordansissel/keynav/blob/master/keynav.pod> for available bindings and actions.";
+      example = {
+        "2" = "doubleclick,end";
+        "4" = "click 4";
+        "5" = "click 5";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -21,11 +36,18 @@ in
       (lib.hm.assertions.assertPlatform "services.keynav" pkgs lib.platforms.linux)
     ];
 
+    xdg.configFile."keynav/keynavrc" = lib.mkIf (cfg.settings != { }) {
+      source = keynavFormat.generate "keynavrc" cfg.settings;
+    };
+
     systemd.user.services.keynav = {
       Unit = {
         Description = "keynav";
         After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
+        X-Restart-Triggers = lib.mkIf (cfg.settings != { }) [
+          "${config.xdg.configFile."keynav/keynavrc".source}"
+        ];
       };
 
       Service = {

--- a/tests/modules/services/keynav/default.nix
+++ b/tests/modules/services/keynav/default.nix
@@ -1,0 +1,6 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  keynav-enable = ./enable.nix;
+  keynav-extra-config = ./extra-config.nix;
+}

--- a/tests/modules/services/keynav/enable-expected.service
+++ b/tests/modules/services/keynav/enable-expected.service
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@keynav@/bin/keynav
+Restart=always
+RestartSec=3
+
+[Unit]
+After=graphical-session.target
+Description=keynav
+PartOf=graphical-session.target

--- a/tests/modules/services/keynav/enable.nix
+++ b/tests/modules/services/keynav/enable.nix
@@ -1,0 +1,18 @@
+{ config, ... }:
+
+{
+  services.keynav = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "keynav";
+      outPath = "@keynav@";
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/keynav.service
+    assertFileExists $serviceFile
+    assertFileContent $serviceFile ${./enable-expected.service}
+    assertPathNotExists home-files/.keynavrc
+  '';
+}

--- a/tests/modules/services/keynav/extra-config-expected.keynavrc
+++ b/tests/modules/services/keynav/extra-config-expected.keynavrc
@@ -1,0 +1,3 @@
+2 doubleclick,end
+4 click 4
+5 click 5

--- a/tests/modules/services/keynav/extra-config-expected.service
+++ b/tests/modules/services/keynav/extra-config-expected.service
@@ -1,0 +1,13 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@keynav@/bin/keynav
+Restart=always
+RestartSec=3
+
+[Unit]
+After=graphical-session.target
+Description=keynav
+PartOf=graphical-session.target
+X-Restart-Triggers=/nix/store/00000000000000000000000000000000-keynavrc

--- a/tests/modules/services/keynav/extra-config.nix
+++ b/tests/modules/services/keynav/extra-config.nix
@@ -1,0 +1,25 @@
+{ config, ... }:
+
+{
+  services.keynav = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "keynav";
+      outPath = "@keynav@";
+    };
+    settings = {
+      "2" = "doubleclick,end";
+      "4" = "click 4";
+      "5" = "click 5";
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/keynav.service
+    assertFileExists $serviceFile
+    assertFileContent $(normalizeStorePaths $serviceFile) ${./extra-config-expected.service}
+
+    assertFileExists home-files/.config/keynav/keynavrc
+    assertFileContent home-files/.config/keynav/keynavrc ${./extra-config-expected.keynavrc}
+  '';
+}


### PR DESCRIPTION
### Description

This PR adds the configuration part of keynav, allowing extra configuration on top of the defaults.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
