### PR TITLE
pipewire: add LADSPA plugin path handling

### DIFF
--- a/modules/services/pipewire.nix
+++ b/modules/services/pipewire.nix
@@ -197,6 +197,19 @@ in
       '';
     };
 
+    extraLadspaPackages = mkOption {
+      type = with types; listOf package;
+      default = [ ];
+      example = literalExpression "[ pkgs.noisetorch-ladspa ]";
+      description = ''
+        List of packages that provide LADSPA plugins, in the form of
+        {file}`lib/ladspa/*` files.
+
+        LADSPA dependencies will be picked up from config packages automatically
+        via `passthru.requiredLadspaPackages`, so they don't need to be set here.
+      '';
+    };
+
     wireplumber = {
       enable = mkEnableOption "WirePlumber configurations";
 
@@ -415,9 +428,26 @@ in
           paths = lv2PluginPaths;
           pathsToLink = [ "/lib/lv2" ];
         };
+
+        ladspaPluginsPaths =
+          cfg.extraLadspaPackages
+          ++ flatten (
+            concatMap (p: attrByPath [ "passthru" "requiredLadspaPackages" ] [ ] p) (
+              cfg.configPackages ++ (optionals cfg.wireplumber.enable cfg.wireplumber.configPackages)
+            )
+          );
+
+        ladspaPlugins = pkgs.buildEnv {
+          name = "pipewire-ladspa-plugins";
+          paths = ladspaPluginsPaths;
+          pathsToLink = [ "/lib/ladspa" ];
+        };
       in
       {
         LV2_PATH = mkIf (lv2PluginPaths != [ ]) "${lv2Plugins}/lib/lv2\${LV2_PATH:+:$LV2_PATH}";
+        LADSPA_PATH = mkIf (
+          ladspaPlugins != [ ]
+        ) "${ladspaPlugins}/lib/ladspa\${LADSPA_PATH:+:$LADSPA_PATH}";
       };
 
     home.activation.reloadPipewire =

--- a/tests/modules/services/pipewire/plugins.nix
+++ b/tests/modules/services/pipewire/plugins.nix
@@ -9,6 +9,12 @@
         bing bong
       '')
     ];
+
+    extraLadspaPackages = [
+      (pkgs.writeTextDir "lib/ladspa/test" ''
+        bing bong
+      '')
+    ];
   };
 
   nmt.script = ''
@@ -17,9 +23,11 @@
     assertPathNotExists 'home-files/.local/share/wireplumber'
 
     file='home-files/.config/environment.d/10-home-manager.conf'
-    regex='^LV2_PATH=/nix/store/.*/lib/lv2\''${LV2_PATH:+:\$LV2_PATH}$'
+    lv2regex='^LV2_PATH=/nix/store/.*/lib/lv2\''${LV2_PATH:+:\$LV2_PATH}$'
+    ladsparegex='^LADSPA_PATH=/nix/store/.*/lib/ladspa\''${LADSPA_PATH:+:\$LADSPA_PATH}$'
 
     assertFileExists "$file"
-    assertFileRegex "$file" "$regex"
+    assertFileRegex "$file" "$lv2regex"
+    assertFileRegex "$file" "$ladsparegex"
   '';
 }


### PR DESCRIPTION
### Description

this is needed for pipewire 1.6.3 since it doesn't load plugins outside of the LADSPA_PATH

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
