### PR TITLE
tests: preserve stub derivation attrs

### DIFF
--- a/tests/stubs.nix
+++ b/tests/stubs.nix
@@ -64,8 +64,19 @@ let
             meta.mainProgram = name;
           } buildScript;
 
+      drvExtraAttrs = lib.filterAttrs (_: v: !lib.isFunction v) extraAttrs;
+
+      outerExtraAttrs = lib.filterAttrs (_: lib.isFunction) extraAttrs;
+
+      overriddenPkg =
+        if drvExtraAttrs == { } then
+          pkg
+        else
+          pkg.overrideAttrs (old: lib.recursiveUpdate old drvExtraAttrs);
+
       stubbedPkg =
-        pkg
+        overriddenPkg
+        // outerExtraAttrs
         // lib.optionalAttrs (outPath != null) {
           inherit outPath;
 
@@ -74,12 +85,11 @@ let
 
           # Allow the original package to be used in derivation inputs
           __spliced = {
-            buildHost = pkg;
-            hostTarget = pkg;
+            buildHost = overriddenPkg;
+            hostTarget = overriddenPkg;
           };
         }
-        // lib.optionalAttrs (version != null) { inherit version; }
-        // extraAttrs;
+        // lib.optionalAttrs (version != null) { inherit version; };
     in
     stubbedPkg;
 


### PR DESCRIPTION
Apply stub extra attributes through overrideAttrs so derivation metadata stays visible to downstream wrappers.

This fixes the Firefox test evaluation failure where wrapFirefox could no longer read browser.meta.description from stubbed packages.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
