### PR TITLE
mkFirefoxModule: serialize path prefs as strings

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -75,7 +75,10 @@ let
   userPrefValue =
     pref:
     builtins.toJSON (
-      if lib.isBool pref || lib.isInt pref || lib.isString pref then pref else builtins.toJSON pref
+      if lib.isBool pref || lib.isInt pref || lib.isString pref || lib.isPath pref then
+        pref
+      else
+        builtins.toJSON pref
     );
 
   extensionSettingsNeedForce =

--- a/tests/modules/programs/firefox/profiles/settings/bookmarks.html
+++ b/tests/modules/programs/firefox/profiles/settings/bookmarks.html
@@ -1,0 +1,1 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>

--- a/tests/modules/programs/firefox/profiles/settings/default.nix
+++ b/tests/modules/programs/firefox/profiles/settings/default.nix
@@ -24,6 +24,7 @@ in
         test = {
           id = 1;
           settings = {
+            "browser.bookmarks.file" = ./bookmarks.html;
             "general.smoothScroll" = false;
             "browser.newtabpage.pinned" = [
               {
@@ -51,8 +52,11 @@ in
 
           assertDirectoryExists "home-files/${cfg.profilesPath}/basic"
 
+          settingsUserJs=$(normalizeStorePaths \
+            "home-files/${cfg.profilesPath}/test/user.js")
+
           assertFileContent \
-            "home-files/${cfg.profilesPath}/test/user.js" \
+            $settingsUserJs \
             ${./expected-user.js}
         '';
     }

--- a/tests/modules/programs/firefox/profiles/settings/expected-user.js
+++ b/tests/modules/programs/firefox/profiles/settings/expected-user.js
@@ -2,8 +2,8 @@
 
 
 
+user_pref("browser.bookmarks.file", "/nix/store/00000000000000000000000000000000-bookmarks.html");
 user_pref("browser.newtabpage.pinned", "[{\"title\":\"NixOS\",\"url\":\"https://nixos.org\"}]");
 user_pref("general.smoothScroll", false);
-
 
 


### PR DESCRIPTION
Treat Nix paths like plain string preferences when generating user.js so values such as browser.bookmarks.file are not JSON-quoted twice.

Add a regression case in the Firefox settings test for a path-valued preference.

closes #5219 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
