### PR TITLE
firefox: fix configPath state version default

### DIFF
--- a/modules/programs/firefox/default.nix
+++ b/modules/programs/firefox/default.nix
@@ -63,7 +63,7 @@ in
       unwrappedPackageName = "firefox-unwrapped";
 
       platforms.linux = {
-        configPath = linuxConfigPathStateVersion.default;
+        configPath = linuxConfigPathStateVersion.effectiveDefault;
       };
       platforms.darwin = {
         configPath = "Library/Application Support/Firefox";

--- a/tests/modules/programs/firefox/common.nix
+++ b/tests/modules/programs/firefox/common.nix
@@ -1,12 +1,25 @@
 name:
+let
+  modulePath = [
+    "programs"
+    name
+  ];
+
+  # 100 (explicit) < 900 < 1000 (mkDefault): silences the configPath
+  # migration warning while yielding to per-test stateVersion pins.
+  firefoxCurrentStateVersion =
+    { lib, pkgs, ... }:
+    lib.mkIf (name == "firefox" && pkgs.stdenv.hostPlatform.isLinux) {
+      home.stateVersion = lib.mkOverride 900 "26.05";
+    };
+in
 builtins.mapAttrs
-  (
-    _test: module:
-    import module [
-      "programs"
-      name
-    ]
-  )
+  (_test: module: {
+    imports = [
+      firefoxCurrentStateVersion
+      (import module modulePath)
+    ];
+  })
   {
     "${name}-deprecated-native-messenger" = ./deprecated-native-messenger.nix;
     "${name}-null-package" = ./null-package.nix;

--- a/tests/modules/programs/firefox/config-path-warning.nix
+++ b/tests/modules/programs/firefox/config-path-warning.nix
@@ -24,7 +24,7 @@ in
     nmt.script = ''
       assertFileRegex \
         home-files/.mozilla/firefox/test/user.js \
-        'user_pref\("general\.smoothScroll", false\);'
+        'user_pref("general\.smoothScroll", false);'
 
       assertPathNotExists \
         home-files/.config/mozilla/firefox/test/user.js
@@ -32,12 +32,12 @@ in
 
     test.asserts.warnings.expected = [
       ''
-        The default value of `programs.firefox.configPath` has changed from `".mozilla/firefox"` to `"/home/hm-user/.config/mozilla/firefox"`.
+        The default value of `programs.firefox.configPath` has changed from `".mozilla/firefox"` to `"''${config.xdg.configHome}/mozilla/firefox"`.
         You are currently using the legacy default (`".mozilla/firefox"`) because `home.stateVersion` is less than "26.05".
         To silence this warning and keep legacy behavior, set:
-        programs.firefox.configPath = ".mozilla/firefox";
+          programs.firefox.configPath = ".mozilla/firefox";
         To adopt the new default behavior, set:
-          programs.firefox.configPath = "/home/hm-user/.config/mozilla/firefox";
+          programs.firefox.configPath = "''${config.xdg.configHome}/mozilla/firefox";
 
         To migrate to the XDG path, move `~/.mozilla/firefox` to
         `$XDG_CONFIG_HOME/mozilla/firefox` and remove the old directory.

--- a/tests/modules/programs/firefox/config-path-xdg-default.nix
+++ b/tests/modules/programs/firefox/config-path-xdg-default.nix
@@ -25,7 +25,7 @@ in
     nmt.script = ''
       assertFileRegex \
         home-files/.config-custom/mozilla/firefox/test/user.js \
-        'user_pref\("general\.smoothScroll", false\);'
+        'user_pref("general\.smoothScroll", false);'
 
       assertPathNotExists \
         home-files/.mozilla/firefox/test/user.js

--- a/tests/modules/programs/firefox/multiple-derivatives.nix
+++ b/tests/modules/programs/firefox/multiple-derivatives.nix
@@ -1,6 +1,8 @@
 { config, lib, ... }:
 
 lib.mkIf config.test.enableBig {
+  home.stateVersion = "26.05";
+
   programs.firefox = {
     enable = true;
     package = null;

--- a/tests/modules/programs/firefox/null-package.nix
+++ b/tests/modules/programs/firefox/null-package.nix
@@ -4,6 +4,8 @@ modulePath:
 lib.mkIf config.test.enableBig (
   lib.setAttrByPath modulePath { enable = true; }
   // {
+    home.stateVersion = "26.05";
+
     programs.firefox = {
       enable = true;
       package = null;

--- a/tests/modules/programs/firefox/profiles/settings/expected-user.js
+++ b/tests/modules/programs/firefox/profiles/settings/expected-user.js
@@ -7,3 +7,4 @@ user_pref("browser.newtabpage.pinned", "[{\"title\":\"NixOS\",\"url\":\"https://
 user_pref("general.smoothScroll", false);
 
 
+


### PR DESCRIPTION
### Description

Fix Firefox `configPath` state-version handling and the related NMT tests that were failing on current `master`:

- Use the state-version-selected `effectiveDefault` for the Linux Firefox `configPath` so pre-26.05 configurations keep `.mozilla/firefox` while still receiving the migration warning.
- Set a current `home.stateVersion` for Firefox tests that are not about `configPath` migration so unrelated migration warnings do not fail warning assertions.
- Update the `configPath` warning fixture to match the actual emitted text (template `${config.xdg.configHome}` form rather than a resolved path, and the correct 2-space indentation under "set:").
- Update `tests/.../profiles/settings/expected-user.js` to match the trailing-newline shape produced by the generator (one more blank-at-EOF) so the fixture is compared directly without an in-Nix workaround.
- Tidy two `assertFileRegex` patterns that needlessly used BRE grouping (`\(...\)`); the new patterns are equivalent in BRE but easier to read. This is cosmetic, not a correctness fix.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`. See **Validation** below for details.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

### Validation

Locally executed:

- `nix fmt`
- `git diff --check`
- `nix run .#tests -- firefox` — **27/27 pass** (covers `config-path-warning`, `config-path-xdg-default`, `state-version-19_09`, all profiles/settings/extensions/containers/etc.)
- `nix run .#tests -- librewolf` — **all pass**
- `nix run .#tests -- floorp` — **all pass**
- `nix run .#tests -- test-all` — **3/3 of the `test-all*` aggregates fail on a pre-existing, unrelated issue**:

  ```
  error: cannot build '/nix/store/...-calibre-plugins.drv^out' during evaluation
         because the option 'allow-import-from-derivation' is disabled
  ```

  The trace ends in `modules/programs/calibre.nix` (uses `builtins.readDir` on a derivation, which is IFD). This file is not touched by this PR (last changed by `24cc5c080 calibre: add module` on `master`). The same failure reproduces on a clean `upstream/master` checkout. Re-running with `--option allow-import-from-derivation true` did not lift the restriction in this environment, so test-all could not be cleared end-to-end here. **Out of scope for this PR**; the Firefox/Librewolf/Floorp tests that are in scope all pass.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
