### PR TITLE
programs/docker-cli: add file-backed registry credentials

### DIFF
--- a/modules/programs/docker-cli.nix
+++ b/modules/programs/docker-cli.nix
@@ -6,14 +6,61 @@
 }:
 let
   inherit (lib)
-    mkIf
     mkEnableOption
+    mkIf
     mkOption
     ;
 
   cfg = config.programs.docker-cli;
 
   jsonFormat = pkgs.formats.json { };
+
+  hasRegistryCredentials = cfg.registryCredentials != { };
+
+  configFile = "${config.home.homeDirectory}/${cfg.configDir}/config.json";
+
+  baseConfigFile = jsonFormat.generate "docker-cli-config.json" cfg.settings;
+
+  registryCredentialsScript = ''
+    set -euo pipefail
+    PATH=${
+      lib.makeBinPath [
+        pkgs.coreutils
+        pkgs.jq
+      ]
+    }''${PATH:+:}$PATH
+
+    configFile=${lib.escapeShellArg configFile}
+    mkdir -p "$(dirname "$configFile")"
+    install -m 0600 ${baseConfigFile} "$configFile"
+  ''
+  + lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (
+      registry: registryCfg:
+      let
+        passwordFile = lib.escapeShellArg registryCfg.passwordFile;
+        username = lib.escapeShellArg registryCfg.username;
+        registryArg = lib.escapeShellArg registry;
+      in
+      ''
+        if [ ! -f ${passwordFile} ]; then
+          echo "Docker registry password file not found for ${registry}: ${registryCfg.passwordFile}" >&2
+          exit 1
+        fi
+
+        password=$(cat ${passwordFile})
+        auth=$(printf '%s:%s' ${username} "$password" | base64 --wrap=0)
+        tmpFile=$(mktemp)
+        jq \
+          --arg registry ${registryArg} \
+          --arg auth "$auth" \
+          '.auths[$registry] = { auth: $auth }' \
+          "$configFile" > "$tmpFile"
+        install -m 0600 "$tmpFile" "$configFile"
+        rm -f "$tmpFile"
+      ''
+    ) cfg.registryCredentials
+  );
 in
 {
   meta.maintainers = [
@@ -92,6 +139,46 @@ in
         <https://docs.docker.com/reference/cli/docker/#docker-cli-configuration-file-configjson-properties
       '';
     };
+
+    registryCredentials = mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options = {
+            username = mkOption {
+              type = lib.types.str;
+              description = "Username for the registry.";
+            };
+
+            passwordFile = mkOption {
+              type = lib.types.str;
+              description = ''
+                Path to a file containing the registry password or token.
+
+                The file is read during activation and its contents are written
+                to the Docker CLI configuration as a base64-encoded auth entry.
+              '';
+            };
+          };
+        }
+      );
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "https://index.docker.io/v1/" = {
+            username = "my-user";
+            passwordFile = config.age.secrets.docker-hub-token.path;
+          };
+        }
+      '';
+      description = ''
+        Registry credentials to write to the Docker CLI configuration.
+
+        Attribute names are registry URLs, for example
+        `https://index.docker.io/v1/` for Docker Hub. This option writes
+        file-backed credentials directly to `config.json` and does not use a
+        credential helper or credential store.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -100,23 +187,28 @@ in
         DOCKER_CONFIG = "${config.home.homeDirectory}/${cfg.configDir}";
       };
 
-      file = {
-        "${cfg.configDir}/config.json" = {
-          source = jsonFormat.generate "config.json" cfg.settings;
-        };
-      }
-      // lib.mapAttrs' (
-        _n: ctx:
-        let
-          path = "${cfg.configDir}/contexts/meta/${builtins.hashString "sha256" ctx.Name}/meta.json";
-        in
-        {
-          name = path;
-          value = {
-            source = jsonFormat.generate "config.json" ctx;
+      file =
+        lib.optionalAttrs (!hasRegistryCredentials) {
+          "${cfg.configDir}/config.json" = {
+            source = jsonFormat.generate "config.json" cfg.settings;
           };
         }
-      ) cfg.contexts;
+        // lib.mapAttrs' (
+          _n: ctx:
+          let
+            path = "${cfg.configDir}/contexts/meta/${builtins.hashString "sha256" ctx.Name}/meta.json";
+          in
+          {
+            name = path;
+            value = {
+              source = jsonFormat.generate "config.json" ctx;
+            };
+          }
+        ) cfg.contexts;
     };
+
+    home.activation.dockerCliRegistryCredentials = mkIf hasRegistryCredentials (
+      lib.hm.dag.entryAfter [ "writeBoundary" ] registryCredentialsScript
+    );
   };
 }

--- a/tests/modules/programs/docker-cli/default.nix
+++ b/tests/modules/programs/docker-cli/default.nix
@@ -2,4 +2,5 @@
   docker-cli = ./example-config.nix;
   docker-cli-empty-config = ./empty-config.nix;
   docker-cli-contexts = ./example-contexts.nix;
+  docker-cli-registry-credentials = ./registry-credentials.nix;
 }

--- a/tests/modules/programs/docker-cli/registry-credentials.json
+++ b/tests/modules/programs/docker-cli/registry-credentials.json
@@ -1,0 +1,12 @@
+{
+  "proxies": {
+    "default": {
+      "httpProxy": "http://proxy.example.org:3128"
+    }
+  },
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "Y2FuaWtvOnMzY3IzdA=="
+    }
+  }
+}

--- a/tests/modules/programs/docker-cli/registry-credentials.nix
+++ b/tests/modules/programs/docker-cli/registry-credentials.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+  programs.docker-cli = {
+    enable = true;
+
+    configDir = ".docker2";
+
+    settings.proxies.default.httpProxy = "http://proxy.example.org:3128";
+
+    registryCredentials."https://index.docker.io/v1/" = {
+      username = "caniko";
+      passwordFile = "/@TMPDIR@/docker-token";
+    };
+  };
+
+  nmt.script =
+    let
+      cfgDocker = config.programs.docker-cli;
+      activationScript = pkgs.writeScript "activation" config.home.activation.dockerCliRegistryCredentials.data;
+      configTestPath = "$HOME/${cfgDocker.configDir}/config.json";
+    in
+    ''
+      export HOME=$TMPDIR/hm-user
+      echo -n s3cr3t > $TMPDIR/docker-token
+
+      assertPathNotExists home-files/${cfgDocker.configDir}/config.json
+
+      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+      chmod +x $TMPDIR/activate
+      $TMPDIR/activate
+
+      assertFileExists ${configTestPath}
+      assertFileContent ${configTestPath} \
+        ${./registry-credentials.json}
+
+      $TMPDIR/activate
+      assertFileContent ${configTestPath} \
+        ${./registry-credentials.json}
+    '';
+}


### PR DESCRIPTION
## Description

Add `programs.docker-cli.registryCredentials`, allowing users to populate Docker CLI registry auth entries from file-backed secrets during Home Manager activation.

This supports headless or non-graphical environments where Docker credential stores such as `secretservice` are unavailable, while still keeping the secret value out of the Nix store. The option reads each configured `passwordFile` at activation time and writes the corresponding base64 `auth` entry to `config.json` with mode `0600`.

When registry credentials are configured, `config.json` is activation-managed instead of a store symlink so the secret-derived auth entry can be written at switch time. Existing `settings` are preserved as the base config.

## Checklist

- [x] Added a test for file-backed registry credentials
- [x] Ran `nix run .#tests -- docker-cli-registry-credentials`
- [x] Ran `nix run .#tests -- docker-cli`
