### PR TITLE
firefox: fix legacy configPath default

### DIFF
--- a/modules/programs/firefox/default.nix
+++ b/modules/programs/firefox/default.nix
@@ -63,7 +63,7 @@ in
       unwrappedPackageName = "firefox-unwrapped";
 
       platforms.linux = {
-        configPath = linuxConfigPathStateVersion.default;
+        configPath = linuxConfigPathStateVersion.effectiveDefault;
       };
       platforms.darwin = {
         configPath = "Library/Application Support/Firefox";

--- a/tests/modules/programs/firefox/config-path-explicit-legacy.nix
+++ b/tests/modules/programs/firefox/config-path-explicit-legacy.nix
@@ -14,21 +14,26 @@ in
   imports = [ firefoxMockOverlay ];
 
   config = lib.mkIf (config.test.enableBig && !pkgs.stdenv.hostPlatform.isDarwin) {
-    home.stateVersion = "26.05";
-    xdg.configHome = "/home/hm-user/.config-custom";
+    home.stateVersion = "25.11";
 
     programs.firefox = {
       enable = true;
+      configPath = ".mozilla/firefox";
       profiles.test.settings."general.smoothScroll" = false;
+    };
+
+    test.asserts.warnings = {
+      enable = true;
+      expected = [ ];
     };
 
     nmt.script = ''
       assertFileRegex \
-        home-files/.config-custom/mozilla/firefox/test/user.js \
+        home-files/.mozilla/firefox/test/user.js \
         'user_pref("general\.smoothScroll", false);'
 
       assertPathNotExists \
-        home-files/.mozilla/firefox/test/user.js
+        home-files/.config/mozilla/firefox/test/user.js
     '';
   };
 }

--- a/tests/modules/programs/firefox/config-path-explicit-xdg.nix
+++ b/tests/modules/programs/firefox/config-path-explicit-xdg.nix
@@ -14,12 +14,18 @@ in
   imports = [ firefoxMockOverlay ];
 
   config = lib.mkIf (config.test.enableBig && !pkgs.stdenv.hostPlatform.isDarwin) {
-    home.stateVersion = "26.05";
+    home.stateVersion = "25.11";
     xdg.configHome = "/home/hm-user/.config-custom";
 
     programs.firefox = {
       enable = true;
+      configPath = "${config.xdg.configHome}/mozilla/firefox";
       profiles.test.settings."general.smoothScroll" = false;
+    };
+
+    test.asserts.warnings = {
+      enable = true;
+      expected = [ ];
     };
 
     nmt.script = ''

--- a/tests/modules/programs/firefox/config-path-warning.nix
+++ b/tests/modules/programs/firefox/config-path-warning.nix
@@ -24,7 +24,7 @@ in
     nmt.script = ''
       assertFileRegex \
         home-files/.mozilla/firefox/test/user.js \
-        'user_pref\("general\.smoothScroll", false\);'
+        'user_pref("general\.smoothScroll", false);'
 
       assertPathNotExists \
         home-files/.config/mozilla/firefox/test/user.js
@@ -32,12 +32,12 @@ in
 
     test.asserts.warnings.expected = [
       ''
-        The default value of `programs.firefox.configPath` has changed from `".mozilla/firefox"` to `"/home/hm-user/.config/mozilla/firefox"`.
+        The default value of `programs.firefox.configPath` has changed from `".mozilla/firefox"` to `"''${config.xdg.configHome}/mozilla/firefox"`.
         You are currently using the legacy default (`".mozilla/firefox"`) because `home.stateVersion` is less than "26.05".
         To silence this warning and keep legacy behavior, set:
-        programs.firefox.configPath = ".mozilla/firefox";
+          programs.firefox.configPath = ".mozilla/firefox";
         To adopt the new default behavior, set:
-          programs.firefox.configPath = "/home/hm-user/.config/mozilla/firefox";
+          programs.firefox.configPath = "''${config.xdg.configHome}/mozilla/firefox";
 
         To migrate to the XDG path, move `~/.mozilla/firefox` to
         `$XDG_CONFIG_HOME/mozilla/firefox` and remove the old directory.

--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -1,4 +1,6 @@
 {
+  "firefox-config-path-explicit-legacy" = ./config-path-explicit-legacy.nix;
+  "firefox-config-path-explicit-xdg" = ./config-path-explicit-xdg.nix;
   "firefox-config-path-xdg-default" = ./config-path-xdg-default.nix;
   "firefox-config-path-warning" = ./config-path-warning.nix;
   "firefox-multiple-derivatives" = ./multiple-derivatives.nix;


### PR DESCRIPTION
The deferred state-version warning helper keeps .default on the current branch so warnings can be emitted from config. Firefox passed that .default through as the Linux configPath default, which made home.stateVersion < 26.05 still use the XDG path.

Use effectiveDefault for the platform default so legacy state versions keep .mozilla/firefox, while preserving the warning. Adjust the config-path tests to cover explicit legacy and XDG paths.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
