### PR TITLE
rofi: fix nested extraConfig rendering

### DIFF
--- a/modules/misc/news/2026/04/2026-04-20_13-53-30.nix
+++ b/modules/misc/news/2026/04/2026-04-20_13-53-30.nix
@@ -3,11 +3,6 @@
   time = "2026-04-20T13:53:30+00:00";
   condition = config.programs.rofi.enable;
   message = ''
-    The `programs.rofi.extraConfig` option now supports nested attrsets for
-    top-level Rasi sections such as `filebrowser { ... }` and
-    `run,drun { ... }`.
-
-    Flat `extraConfig` entries continue to be written inside the
-    `configuration { ... }` block.
+    The `programs.rofi.extraConfig` option now supports nested attribute sets.
   '';
 }

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -38,18 +38,24 @@ let
     }:
     name: value: "${name}${sep}${mkValueString value}${end}";
 
+  isSection = value: isAttrs value && (value._type or "") != "literal";
+
+  toRasiKeyValue =
+    attrs:
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (
+        name: value:
+        if isSection value then
+          "${name} {\n${toRasiKeyValue (filterAttrs (_: v: v != null) value)}\n}"
+        else
+          mkKeyValue { } name value
+      ) (filterAttrs (_: v: v != null) attrs)
+    );
+
   mkRasiSection =
     name: value:
-    if isAttrs value then
-      let
-        toRasiKeyValue = lib.generators.toKeyValue { mkKeyValue = mkKeyValue { }; };
-        # Remove null values so the resulting config does not have empty lines
-        configStr = toRasiKeyValue (filterAttrs (_: v: v != null) value);
-      in
-      ''
-        ${name} {
-        ${configStr}}
-      ''
+    if isSection value then
+      "${name} {\n${toRasiKeyValue value}\n}\n"
     else
       (mkKeyValue {
         sep = " ";
@@ -137,11 +143,6 @@ let
       cfg.theme;
 
   modes = map (mode: if isString mode then mode else "${mode.name}:${mode.path}") cfg.modes;
-
-  # Flat entries belong in `configuration { ... }`, while nested attrsets map
-  # to top-level Rasi sections such as `filebrowser { ... }`.
-  configurationExtraConfig = filterAttrs (_: v: !isAttrs v) cfg.extraConfig;
-  sectionExtraConfig = filterAttrs (_: isAttrs) cfg.extraConfig;
 in
 {
   meta.maintainers = [ ];
@@ -356,26 +357,24 @@ in
     home.packages = [ cfg.finalPackage ];
 
     home.file."${cfg.configPath}".text =
-      toRasi (
-        {
-          configuration = (
-            {
-              inherit (cfg)
-                cycle
-                font
-                terminal
-                xoffset
-                yoffset
-                ;
-              location = (lib.getAttr cfg.location locationsMap);
-            }
-            // lib.optionalAttrs (modes != [ ]) { inherit modes; }
-            // configurationExtraConfig
-          );
-        }
-        // sectionExtraConfig
-        # @theme must go after configuration but attrs are output in alphabetical order ('@' first)
-      )
+      toRasi {
+        configuration = (
+          {
+            inherit (cfg)
+              cycle
+              font
+              terminal
+              xoffset
+              yoffset
+              ;
+            location = (lib.getAttr cfg.location locationsMap);
+          }
+          // lib.optionalAttrs (modes != [ ]) { inherit modes; }
+          // cfg.extraConfig
+        );
+      }
+      # @theme must go after configuration but attrs are output in alphabetical order ('@' first)
+
       + (lib.optionalString (themeName != null) (toRasi {
         "@theme" = themeName;
       }));

--- a/tests/modules/programs/rofi/valid-config-expected.rasi
+++ b/tests/modules/programs/rofi/valid-config-expected.rasi
@@ -1,21 +1,22 @@
 configuration {
 cycle: false;
-font: "Droid Sans Mono 14";
-kb-primary-paste: "Control+V,Shift+Insert";
-kb-secondary-paste: "Control+v,Insert";
-location: 0;
-modes: [ "drun","emoji","ssh","foo:bar" ];
-terminal: "/some/path";
-xoffset: 0;
-yoffset: 0;
+drun {
+display-name: "";
 }
-
 filebrowser {
 directories-first: true;
 directory: "$HOME";
 sorting-method: "name";
 }
-
+font: "Droid Sans Mono 14";
+kb-primary-paste: "Control+V,Shift+Insert";
+kb-secondary-paste: "Control+v,Insert";
+location: 0;
+modes: [ "drun","emoji","ssh","foo:bar" ];
 run,drun {
 display-name: "open:";
+}
+terminal: "/some/path";
+xoffset: 0;
+yoffset: 0;
 }

--- a/tests/modules/programs/rofi/valid-config.nix
+++ b/tests/modules/programs/rofi/valid-config.nix
@@ -21,6 +21,9 @@
     extraConfig = {
       kb-primary-paste = "Control+V,Shift+Insert";
       kb-secondary-paste = "Control+v,Insert";
+      drun = {
+        display-name = "";
+      };
       "run,drun" = {
         display-name = "open:";
       };


### PR DESCRIPTION
### Description
Related https://github.com/nix-community/home-manager/issues/4783#issuecomment-4319980905
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
