### PR TITLE
tests: buildbot tests enableBig

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,8 +63,7 @@
             # Create chunked test packages for better CI parallelization
             tests = import ./tests {
               inherit pkgs;
-              # Disable big tests since this is only used for CI
-              enableBig = false;
+              enableBig = true;
             };
             allTests = lib.attrNames tests.build;
             # Remove 'all' from the test list as it's a meta-package

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -283,10 +283,13 @@ in
       internal = true;
       type = types.str;
       default =
-        lib.toUpper (lib.substring 0 1 cfg.wrappedPackageName)
-        + lib.toLower (
-          lib.substring 1 ((lib.stringLength cfg.wrappedPackageName) - 1) cfg.wrappedPackageName
-        );
+        if platforms.darwin ? "appName" then
+          platforms.darwin.appName
+        else
+          lib.toUpper (lib.substring 0 1 cfg.wrappedPackageName)
+          + lib.toLower (
+            lib.substring 1 ((lib.stringLength cfg.wrappedPackageName) - 1) cfg.wrappedPackageName
+          );
       description = "Name of browser app on Darwin.";
     };
 

--- a/modules/programs/floorp.nix
+++ b/modules/programs/floorp.nix
@@ -23,6 +23,7 @@ in
         configPath = ".floorp";
       };
       platforms.darwin = {
+        appName = "Floorp";
         configPath = "Library/Application Support/Floorp";
       };
     })

--- a/tests/modules/programs/firefox/common.nix
+++ b/tests/modules/programs/firefox/common.nix
@@ -1,11 +1,22 @@
-name:
+{ lib, name }:
+let
+  withDefaultStateVersion = module: {
+    imports = [ module ];
+
+    # Stronger than the global test default, but weaker than any test-local
+    # stateVersion assignment.
+    home.stateVersion = lib.mkOverride 900 "26.05";
+  };
+in
 builtins.mapAttrs
   (
     _test: module:
-    import module [
-      "programs"
-      name
-    ]
+    withDefaultStateVersion (
+      import module [
+        "programs"
+        name
+      ]
+    )
   )
   {
     "${name}-deprecated-native-messenger" = ./deprecated-native-messenger.nix;

--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -1,3 +1,4 @@
+{ lib, ... }:
 {
   "firefox-config-path-explicit-legacy" = ./config-path-explicit-legacy.nix;
   "firefox-config-path-explicit-xdg" = ./config-path-explicit-xdg.nix;
@@ -5,6 +6,6 @@
   "firefox-config-path-warning" = ./config-path-warning.nix;
   "firefox-multiple-derivatives" = ./multiple-derivatives.nix;
 }
-// (import ./firefox.nix)
-// (import ./floorp.nix)
-// (import ./librewolf.nix)
+// (import ./firefox.nix { inherit lib; })
+// (import ./floorp.nix { inherit lib; })
+// (import ./librewolf.nix { inherit lib; })

--- a/tests/modules/programs/firefox/final-package.nix
+++ b/tests/modules/programs/firefox/final-package.nix
@@ -22,8 +22,6 @@ lib.mkIf config.test.enableBig (
     }
   )
   // {
-    home.stateVersion = "19.09";
-
     _module.args.pkgs = lib.mkForce realPkgs;
 
     nmt.script = ''

--- a/tests/modules/programs/firefox/firefox.nix
+++ b/tests/modules/programs/firefox/firefox.nix
@@ -1,1 +1,5 @@
-import ./common.nix "firefox"
+{ lib, ... }:
+import ./common.nix {
+  inherit lib;
+  name = "firefox";
+}

--- a/tests/modules/programs/firefox/floorp.nix
+++ b/tests/modules/programs/firefox/floorp.nix
@@ -1,1 +1,5 @@
-import ./common.nix "floorp"
+{ lib, ... }:
+import ./common.nix {
+  inherit lib;
+  name = "floorp";
+}

--- a/tests/modules/programs/firefox/librewolf.nix
+++ b/tests/modules/programs/firefox/librewolf.nix
@@ -1,1 +1,5 @@
-import ./common.nix "librewolf"
+{ lib, ... }:
+import ./common.nix {
+  inherit lib;
+  name = "librewolf";
+}

--- a/tests/modules/programs/firefox/multiple-derivatives.nix
+++ b/tests/modules/programs/firefox/multiple-derivatives.nix
@@ -1,6 +1,8 @@
 { config, lib, ... }:
 
 lib.mkIf config.test.enableBig {
+  home.stateVersion = "26.05";
+
   programs.firefox = {
     enable = true;
     package = null;

--- a/tests/modules/programs/firefox/policies.nix
+++ b/tests/modules/programs/firefox/policies.nix
@@ -16,10 +16,7 @@ in
   imports = [ firefoxMockOverlay ];
 
   config = lib.mkIf config.test.enableBig (
-    {
-      home.stateVersion = "23.05";
-    }
-    // lib.setAttrByPath modulePath {
+    lib.setAttrByPath modulePath {
       enable = true;
       configPath = lib.mkIf pkgs.stdenv.hostPlatform.isLinux ".mozilla/firefox";
       policies = {
@@ -40,9 +37,17 @@ in
             else
               "${cfg.finalPackage}/lib/${cfg.finalPackage.unwrapped.libName or cfg.wrappedPackageName}";
           config_file = "${libDir}/distribution/policies.json";
+          config_file_browser = "${libDir}/browser/distribution/policies.json";
         in
         ''
           jq=${lib.getExe pkgs.jq}
+          if [[ -f "${config_file}" ]]; then
+            config_file="${config_file}"
+          elif [[ -f "${config_file_browser}" ]]; then
+            config_file="${config_file_browser}"
+          else
+            fail "Expected ${libDir}/distribution/policies.json to exist but it was not found."
+          fi
 
           assertFileExists "${config_file}"
 

--- a/tests/modules/programs/firefox/profiles/bookmarks/default.nix
+++ b/tests/modules/programs/firefox/profiles/bookmarks/default.nix
@@ -18,11 +18,7 @@ in
   imports = [ firefoxMockOverlay ];
 
   config = lib.mkIf config.test.enableBig (
-    {
-      # Required for bookmark policy to get set
-      home.stateVersion = "19.09";
-    }
-    // lib.setAttrByPath modulePath {
+    lib.setAttrByPath modulePath {
       enable = true;
       configPath = lib.mkIf pkgs.stdenv.hostPlatform.isLinux ".mozilla/firefox";
       profiles.bookmarks = {
@@ -95,8 +91,17 @@ in
             else
               "${cfg.finalPackage}/lib/${cfg.finalPackage.unwrapped.libName or cfg.wrappedPackageName}";
           config_file = "${libDir}/distribution/policies.json";
+          config_file_browser = "${libDir}/browser/distribution/policies.json";
         in
         ''
+          if [[ -f "${config_file}" ]]; then
+            config_file="${config_file}"
+          elif [[ -f "${config_file_browser}" ]]; then
+            config_file="${config_file_browser}"
+          else
+            fail "Expected ${libDir}/distribution/policies.json to exist but it was not found."
+          fi
+
           assertFileExists "${config_file}"
 
           noDefaultBookmarks_actual_value="$(${lib.getExe pkgs.jq} ".policies.NoDefaultBookmarks" ${config_file})"

--- a/tests/modules/programs/firefox/profiles/overwrite/default.nix
+++ b/tests/modules/programs/firefox/profiles/overwrite/default.nix
@@ -46,7 +46,7 @@ in
         in
         ''
           assertFileRegex \
-            "home-path/${binPath}/${cfg.wrappedPackageName}" \
+            "home-path/${binPath}/${cfg.finalPackage.meta.mainProgram}" \
             MOZ_APP_LAUNCHER
 
           assertDirectoryExists "home-files/${cfg.profilesPath}/basic"

--- a/tests/modules/programs/firefox/profiles/settings/default.nix
+++ b/tests/modules/programs/firefox/profiles/settings/default.nix
@@ -48,7 +48,7 @@ in
         in
         ''
           assertFileRegex \
-            "home-path/${binPath}/${cfg.wrappedPackageName}" \
+            "home-path/${binPath}/${cfg.finalPackage.meta.mainProgram}" \
             MOZ_APP_LAUNCHER
 
           assertDirectoryExists "home-files/${cfg.profilesPath}/basic"

--- a/tests/modules/programs/firefox/profiles/userchrome/default.nix
+++ b/tests/modules/programs/firefox/profiles/userchrome/default.nix
@@ -44,7 +44,7 @@ in
         in
         ''
           assertFileRegex \
-            "home-path/${binPath}/${cfg.wrappedPackageName}" \
+            "home-path/${binPath}/${cfg.finalPackage.meta.mainProgram}" \
             MOZ_APP_LAUNCHER
 
           assertDirectoryExists "home-files/${cfg.profilesPath}/basic"

--- a/tests/modules/programs/firefox/setup-firefox-mock-overlay.nix
+++ b/tests/modules/programs/firefox/setup-firefox-mock-overlay.nix
@@ -25,7 +25,7 @@ in
           binaryName = cfg.wrappedPackageName;
           gtk3 = null;
           meta.description = "I pretend to be ${cfg.name}";
-          meta.mainProgram = lib.toLower cfg.name;
+          meta.mainProgram = cfg.wrappedPackageName;
         };
         outPath = null;
         buildScript =

--- a/tests/modules/programs/neovim/plugin-config.expected
+++ b/tests/modules/programs/neovim/plugin-config.expected
@@ -1,7 +1,7 @@
 package.path = "/nix/store/00000000000000000000000000000000-luajit/share/lua/5.1/?.lua;/nix/store/00000000000000000000000000000000-luajit/share/lua/5.1/?/init.lua".. ";" .. package.path
 package.cpath = "/nix/store/00000000000000000000000000000000-luajit/lib/lua/5.1/?.so".. ";" .. package.cpath
 
-vim.g.loaded_node_provider=0;vim.g.loaded_perl_provider=0;vim.g.loaded_ruby_provider=0;vim.g.python3_host_prog='/nix/store/00000000000000000000000000000000-nvim-host-python3/bin/nvim-python3'
+vim.g.loaded_node_provider=0;vim.g.loaded_perl_provider=0;vim.g.loaded_ruby_provider=0;vim.g.loaded_python3_provider=0
 vim.cmd.source "/nix/store/00000000000000000000000000000000-init.vim"
 
 vim.g.Unicode_data_directory="/nix/store/00000000000000000000000000000000-vimplugin-unicode.vim/autoload/unicode"

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -7,6 +7,8 @@
 }:
 
 lib.mkIf config.test.enableBig {
+  home.stateVersion = "26.05";
+
   programs.neovim = {
     enable = true;
     extraConfig = ''
@@ -17,6 +19,7 @@ lib.mkIf config.test.enableBig {
       {
         plugin = vim-commentary;
         # testing viml config
+        type = "viml";
         config = ''
           let g:hmPlugins='HM_PLUGINS_CONFIG'
         '';


### PR DESCRIPTION
Keep missing test failures due to them not being included in CI. Now that we have a buildbot nix store, there's little reason to not include them in our CI.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
