### PR TITLE
{home-environment,bash,zsh}: support ignoring null sessionVariables

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -266,12 +266,14 @@ in
       default = { };
       type =
         with types;
-        lazyAttrsOf (oneOf [
-          str
-          path
-          int
-          float
-        ]);
+        lazyAttrsOf (
+          nullOr (oneOf [
+            str
+            path
+            int
+            float
+          ])
+        );
       example = {
         EDITOR = "emacs";
         GS_OPTIONS = "-sPAPERSIZE=a4";
@@ -307,6 +309,9 @@ in
           BAR = "''${config.home.sessionVariables.FOO} World!";
         };
         ```
+
+        Setting a value to `null` will skip setting the variable at all, which
+        may be useful when overriding.
       '';
     };
 

--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -69,7 +69,9 @@ in
   # Given an attribute set containing shell variable names and their
   # assignment, this function produces a string containing an export
   # statement for each set entry.
-  exportAll = vars: lib.concatStringsSep "\n" (lib.mapAttrsToList export vars);
+  exportAll =
+    vars:
+    lib.concatStringsSep "\n" (lib.mapAttrsToList export (lib.filterAttrs (_k: v: v != null) vars));
 
   # Formats a list of items for shell array content with intelligent width optimization.
   # IMPORTANT: This formats the CONTENTS of an array (what goes inside parentheses),

--- a/modules/lib/zsh.nix
+++ b/modules/lib/zsh.nix
@@ -38,5 +38,7 @@ rec {
     let
       separator = if indent == "" then "\n" else "\n" + indent;
     in
-    lib.concatStringsSep separator (lib.mapAttrsToList export vars);
+    lib.concatStringsSep separator (
+      lib.mapAttrsToList export (lib.filterAttrs (_k: v: v != null) vars)
+    );
 }

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -137,8 +137,9 @@ in
           with types;
           lazyAttrsOf (oneOf [
             str
-            int
             path
+            int
+            float
           ]);
         example = {
           MAILCHECK = 30;

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -135,17 +135,22 @@ in
         default = { };
         type =
           with types;
-          lazyAttrsOf (oneOf [
-            str
-            path
-            int
-            float
-          ]);
+          lazyAttrsOf (
+            nullOr (oneOf [
+              str
+              path
+              int
+              float
+            ])
+          );
         example = {
           MAILCHECK = 30;
         };
         description = ''
           Environment variables that will be set for the Bash session.
+
+          Setting a value to `null` will skip setting the variable at all, which
+          may be useful when overriding.
         '';
       };
 

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -249,16 +249,23 @@ in
           default = { };
           type =
             with types;
-            lazyAttrsOf (oneOf [
-              str
-              path
-              int
-              float
-            ]);
+            lazyAttrsOf (
+              nullOr (oneOf [
+                str
+                path
+                int
+                float
+              ])
+            );
           example = {
             MAILCHECK = 30;
           };
-          description = "Environment variables that will be set for zsh session.";
+          description = ''
+            Environment variables that will be set for zsh session.
+
+            Setting a value to `null` will skip setting the variable at all, which
+            may be useful when overriding.
+          '';
         };
 
         initContent = mkOption {

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -247,7 +247,14 @@ in
 
         sessionVariables = mkOption {
           default = { };
-          type = types.attrs;
+          type =
+            with types;
+            lazyAttrsOf (oneOf [
+              str
+              path
+              int
+              float
+            ]);
           example = {
             MAILCHECK = 30;
           };

--- a/tests/modules/home-environment/session-variables-expected.txt
+++ b/tests/modules/home-environment/session-variables-expected.txt
@@ -1,9 +1,0 @@
-# Only source this once.
-if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
-export __HM_SESS_VARS_SOURCED=1
-@exportLocaleVar@
-export V1="v1"
-export V2="v2-v1"
-export XDG_CACHE_HOME="/home/hm-user/.cache"
-export XDG_CONFIG_HOME="/home/hm-user/.config"
-export XDG_DATA_HOME="/home/hm-user/.local/share"

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -9,6 +9,7 @@ let
     if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
     export __HM_SESS_VARS_SOURCED=1
 
+    export IS_EMPTY=""
     export LOCALE_ARCHIVE_2_27="${config.i18n.glibcLocales}/lib/locale/locale-archive"
     export V1="v1"
     export V2="v2-v1"
@@ -25,6 +26,7 @@ let
     if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
     export __HM_SESS_VARS_SOURCED=1
 
+    export IS_EMPTY=""
     export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:$TERMINFO_DIRS''${TERMINFO_DIRS:+:}/usr/share/terminfo"
     export V1="v1"
     export V2="v2-v1"
@@ -45,6 +47,8 @@ in
   home.sessionVariables = {
     V1 = "v1";
     V2 = "v2-${config.home.sessionVariables.V1}";
+    IS_EMPTY = "";
+    IS_NULL = null;
   };
 
   nmt.script = ''

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -8,6 +8,8 @@
     sessionVariables = {
       V1 = "v1";
       V2 = "v2-${config.programs.bash.sessionVariables.V1}";
+      IS_EMPTY = "";
+      IS_NULL = null;
     };
   };
 
@@ -18,6 +20,7 @@
       ${builtins.toFile "session-variables-expected" ''
         . "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
 
+        export IS_EMPTY=""
         export V1="v1"
         export V2="v2-v1"
 

--- a/tests/modules/programs/zsh/session-variables.nix
+++ b/tests/modules/programs/zsh/session-variables.nix
@@ -8,6 +8,8 @@
       PATH = "$HOME/bin:$PATH";
       V1 = "v1";
       V2 = "v2-${config.programs.zsh.sessionVariables.V1}";
+      IS_EMPTY = "";
+      IS_NULL = null;
     };
   };
 

--- a/tests/modules/programs/zsh/session-variables.zshenv
+++ b/tests/modules/programs/zsh/session-variables.zshenv
@@ -4,6 +4,7 @@
 # Only source this once
 if [[ -z "$__HM_ZSH_SESS_VARS_SOURCED" ]]; then
   export __HM_ZSH_SESS_VARS_SOURCED=1
+  export IS_EMPTY=""
   export PATH="$HOME/bin:$PATH"
   export V1="v1"
   export V2="v2-v1"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

I ran `nix run .#tests -- session-variables`, running with `test-all` seemed to hang.

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
