### PR TITLE
syncthing: fix the application of allProxy

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -853,7 +853,7 @@ in
               3
               4
             ];
-            Environment = lib.mkIf (cfg.allProxy != null) { all_proxy = cfg.allProxy; };
+            Environment = lib.mkIf (cfg.allProxy != null) "all_proxy=${cfg.allProxy}";
 
             # Sandboxing.
             LockPersonality = true;


### PR DESCRIPTION
`systemd.user.services.<name>.Service.Environment` should be of type `(list of string) or string convertible to it` according to its definition, but the module set it to an attribute set.

### Description

Changed the value of `systemd.user.services.syncthing.Service.Environment` from `{ all_proxy = ... }` to `"all_proxy=..."`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
