### PR TITLE
chromium: address plasma integration review

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -74,27 +74,26 @@ let
         '';
       };
     }
-    // lib.optionalAttrs (lib.elem browser plasmaSupportedBrowsers) {
-      plasmaSupport = mkOption {
-        inherit visible;
-        type = types.bool;
-        default = false;
-        example = true;
-        description = "Whether to enable the 'Use QT' theme for ${name} on Linux.";
-      };
+    //
+      lib.optionalAttrs (pkgs.stdenv.hostPlatform.isLinux && lib.elem browser plasmaSupportedBrowsers)
+        {
+          plasmaSupport = mkOption {
+            inherit visible;
+            type = types.bool;
+            default = false;
+            example = true;
+            description = "Whether to enable the 'Use QT' theme for ${name} on Linux.";
+          };
 
-      plasmaBrowserIntegrationPackage = mkOption {
-        inherit visible;
-        type = types.package;
-        default = pkgs.kdePackages.plasma-browser-integration;
-        defaultText = literalExpression "pkgs.kdePackages.plasma-browser-integration";
-        example = literalExpression "pkgs.kdePackages.plasma-browser-integration";
-        description = ''
-          Package to use for the Plasma browser integration native messaging
-          host on Linux.
-        '';
-      };
-    }
+          plasmaBrowserIntegrationPackage =
+            lib.mkPackageOption pkgs.kdePackages "plasma-browser-integration" {
+              extraDescription = "Used for the native messaging host on Linux.";
+              pkgsText = "pkgs.kdePackages";
+            }
+            // {
+              inherit visible;
+            };
+        }
     // {
       dictionaries = mkOption {
         inherit visible;
@@ -269,7 +268,8 @@ let
         value.source = pkg;
       };
 
-      plasmaSupportEnabled = pkgs.stdenv.isLinux && (cfg.plasmaSupport or false);
+      plasmaSupportEnabled =
+        pkgs.stdenv.isLinux && lib.elem browser plasmaSupportedBrowsers && cfg.plasmaSupport;
 
       nativeMessagingHosts = lib.unique (
         cfg.nativeMessagingHosts ++ lib.optional plasmaSupportEnabled cfg.plasmaBrowserIntegrationPackage

--- a/tests/modules/programs/chromium/plasma-support-command-line-args.nix
+++ b/tests/modules/programs/chromium/plasma-support-command-line-args.nix
@@ -48,6 +48,18 @@ let
       "Library/Application Support/Google/Chrome/NativeMessagingHosts"
     else
       ".config/google-chrome/NativeMessagingHosts";
+
+  nativeHostAssertion =
+    if pkgs.stdenv.hostPlatform.isLinux then
+      ''
+        assertFileExists \
+          "home-files/${nativeHostsDir}/org.kde.plasma.browser_integration.json"
+      ''
+    else
+      ''
+        assertPathNotExists \
+          "home-files/${nativeHostsDir}/org.kde.plasma.browser_integration.json"
+      '';
 in
 {
   programs.google-chrome = {
@@ -57,6 +69,8 @@ in
       "--enable-logging=stderr"
       "--ignore-gpu-blocklist"
     ];
+  }
+  // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
     plasmaSupport = true;
     inherit plasmaBrowserIntegrationPackage;
   };
@@ -76,17 +90,6 @@ in
         plasmaSupport=${lib.boolToString pkgs.stdenv.hostPlatform.isLinux}
       ''}
 
-    ${
-      if pkgs.stdenv.hostPlatform.isLinux then
-        ''
-          assertFileExists \
-            "home-files/${nativeHostsDir}/org.kde.plasma.browser_integration.json"
-        ''
-      else
-        ''
-          assertPathNotExists \
-            "home-files/${nativeHostsDir}/org.kde.plasma.browser_integration.json"
-        ''
-    }
+    ${nativeHostAssertion}
   '';
 }


### PR DESCRIPTION
Hide the Plasma integration options on non-Linux platforms so the Chromium module does not need fallback access for platform-specific options.

Switch the integration package option to mkPackageOption and document the kdePackages default path with pkgsText. Also tighten the focused NMT test so Darwin does not set the Linux-only option while still asserting that no native host file is produced there.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
