### PR TITLE
wayle: improved auto install dependencies behaviour

### DIFF
--- a/modules/services/wayle.nix
+++ b/modules/services/wayle.nix
@@ -88,6 +88,10 @@ in
         wallpaper.engine-enabled = false;
         styling.theme-provider = "wayle";
       } cfg.settings;
+
+      # Determine if wayle is being configured via nix, or if the user will be
+      # using wayle's builtin settings dialog.
+      nix_configured = cfg.settings != { };
     in
     {
       assertions = [
@@ -96,19 +100,28 @@ in
 
       home.packages = (
         [ cfg.package ]
-        # Install the appropriate theme-provider, if set.
-        ++ (lists.optional (
-          cfg.autoInstallDependencies
-          && elem settings_with_fallbacks.styling.theme-provider [
-            "matugen"
-            "wallust"
-            "pywal"
-          ]
-        ) pkgs.${settings_with_fallbacks.styling.theme-provider})
+        # Install dependencies.
+        ++ (lists.optionals (cfg.autoInstallDependencies) (
+          # If wayle is not being configured in via nix, install all dependencies.
+          if (!nix_configured) then
+            with pkgs;
+            [
+              matugen
+              wallust
+              pywal
+            ]
+          # Otherwise, only install the appropriate theme-provider, if set.
+          else
+            (lists.optional (elem settings_with_fallbacks.styling.theme-provider [
+              "matugen"
+              "wallust"
+              "pywal"
+            ]) pkgs.${settings_with_fallbacks.styling.theme-provider})
+        ))
       );
 
       # Main config file.
-      xdg.configFile."wayle/config.toml" = mkIf (cfg.settings != { }) {
+      xdg.configFile."wayle/config.toml" = mkIf nix_configured {
         source = tomlFormat.generate "wayle-config" cfg.settings;
       };
 
@@ -134,7 +147,7 @@ in
 
       # Wallpaper-engine dependency.
       services.awww.enable = mkIf (
-        cfg.autoInstallDependencies && settings_with_fallbacks.wallpaper.engine-enabled
+        cfg.autoInstallDependencies && (settings_with_fallbacks.wallpaper.engine-enabled || !nix_configured)
       ) (lib.mkDefault true);
     }
   );

--- a/tests/modules/services/wayle/basic-config.nix
+++ b/tests/modules/services/wayle/basic-config.nix
@@ -1,4 +1,7 @@
-{ config, ... }:
+{ config, pkgs, ... }:
+let
+  inherit ((import ./lib.nix { inherit config pkgs; }).asserts) awwwInstalled packageInstalled;
+in
 {
   services.wayle = {
     enable = true;
@@ -43,4 +46,11 @@
       "home-files/.config/wayle/config.toml" \
       ${./basic-config.toml}
   '';
+
+  assertions = [
+    (awwwInstalled false)
+    (packageInstalled "matugen" false)
+    (packageInstalled "wallust" false)
+    (packageInstalled "pywal" false)
+  ];
 }

--- a/tests/modules/services/wayle/default.nix
+++ b/tests/modules/services/wayle/default.nix
@@ -2,4 +2,8 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   wayle-basic-config = ./basic-config.nix;
+  wayle-non-nix-configured = ./non-nix-configured.nix;
+  wayle-non-nix-configured-and-no-deps = ./non-nix-configured-and-no-deps.nix;
+  wayle-nix-configured-theme-provider = ./nix-configured-theme-provider.nix;
+  wayle-nix-configured-theme-provider-and-no-deps = ./nix-configured-theme-provider-and-no-deps.nix;
 }

--- a/tests/modules/services/wayle/lib.nix
+++ b/tests/modules/services/wayle/lib.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, ... }:
+{
+  asserts = {
+    awwwInstalled = state: {
+      assertion = config.services.awww.enable == state;
+      message = "Expected service awww to be ${if state then "enabled" else "disabled"}.";
+    };
+    packageInstalled = packageName: state: {
+      assertion = (builtins.elem pkgs.${packageName} config.home.packages) == state;
+      message = "Expected the ${packageName} package to ${if state then "" else "not"} be installed.";
+    };
+  };
+}

--- a/tests/modules/services/wayle/nix-configured-theme-provider-and-no-deps.nix
+++ b/tests/modules/services/wayle/nix-configured-theme-provider-and-no-deps.nix
@@ -1,0 +1,27 @@
+{ config, pkgs, ... }:
+let
+  inherit ((import ./lib.nix { inherit config pkgs; }).asserts) awwwInstalled packageInstalled;
+in
+{
+  services.wayle = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "wayle"; };
+    settings = {
+      styling.theme-provider = "matugen";
+    };
+    autoInstallDependencies = false;
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      "home-files/.config/wayle/config.toml" \
+      ${./nix-configured-theme-provider-config.toml}
+  '';
+
+  assertions = [
+    (awwwInstalled false)
+    (packageInstalled "matugen" false)
+    (packageInstalled "wallust" false)
+    (packageInstalled "pywal" false)
+  ];
+}

--- a/tests/modules/services/wayle/nix-configured-theme-provider-config.toml
+++ b/tests/modules/services/wayle/nix-configured-theme-provider-config.toml
@@ -1,0 +1,2 @@
+[styling]
+theme-provider = "matugen"

--- a/tests/modules/services/wayle/nix-configured-theme-provider.nix
+++ b/tests/modules/services/wayle/nix-configured-theme-provider.nix
@@ -1,0 +1,26 @@
+{ config, pkgs, ... }:
+let
+  inherit ((import ./lib.nix { inherit config pkgs; }).asserts) awwwInstalled packageInstalled;
+in
+{
+  services.wayle = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "wayle"; };
+    settings = {
+      styling.theme-provider = "matugen";
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      "home-files/.config/wayle/config.toml" \
+      ${./nix-configured-theme-provider-config.toml}
+  '';
+
+  assertions = [
+    (awwwInstalled false)
+    (packageInstalled "matugen" true)
+    (packageInstalled "wallust" false)
+    (packageInstalled "pywal" false)
+  ];
+}

--- a/tests/modules/services/wayle/non-nix-configured-and-no-deps.nix
+++ b/tests/modules/services/wayle/non-nix-configured-and-no-deps.nix
@@ -1,0 +1,27 @@
+{ config, pkgs, ... }:
+let
+  inherit ((import ./lib.nix { inherit config pkgs; }).asserts) awwwInstalled packageInstalled;
+in
+{
+  services.wayle = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "wayle"; };
+    settings = { };
+    autoInstallDependencies = false;
+  };
+
+  # When services.wayle.settings = {}, we expect that no config file is
+  # created.
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/wayle/config.toml"
+  '';
+
+  # When services.wayle.autoInstallDependencies = false, we expect that none of
+  # wayles dependencies are installed.
+  assertions = [
+    (awwwInstalled false)
+    (packageInstalled "matugen" false)
+    (packageInstalled "wallust" false)
+    (packageInstalled "pywal" false)
+  ];
+}

--- a/tests/modules/services/wayle/non-nix-configured.nix
+++ b/tests/modules/services/wayle/non-nix-configured.nix
@@ -1,0 +1,26 @@
+{ config, pkgs, ... }:
+let
+  inherit ((import ./lib.nix { inherit config pkgs; }).asserts) awwwInstalled packageInstalled;
+in
+{
+  services.wayle = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "wayle"; };
+    settings = { };
+  };
+
+  # When services.wayle.settings = {}, we expect that no config file is
+  # created.
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/wayle/config.toml"
+  '';
+
+  # When services.wayle.settings = {}, we expect that all of wayle's
+  # dependencies are installed.
+  assertions = [
+    (awwwInstalled true)
+    (packageInstalled "matugen" true)
+    (packageInstalled "wallust" true)
+    (packageInstalled "pywal" true)
+  ];
+}


### PR DESCRIPTION
### Description

Changed the behaviour of how the wayle module automatically installs wayle's dependencies. 

If the settings option is set to empty, then all of wayle's dependencies are installed. This allows users who wish to configure wayle via wayle's built-in settings dialog to do so without worrying about the extra dependencies. If any configuration is set via the `services.wayle.settings` option, then only the required dependencies will be installed, like before. The `services.wayle.autoInstallDependencies` option still works like before, and (when set to false) can be used to not install any dependencies, regardless of the state of `services.wayle.settings`.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
  - [x] Code tested through `nix run .#tests -- wayle`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
