### PR TITLE
exo: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -151,6 +151,12 @@
     github = "dsoverlord";
     githubId = 78819443;
   };
+  dsqr = {
+    name = "Dave Dennis";
+    email = "me@dsqr.dev";
+    github = "0xdsqr";
+    githubId = 99584622;
+  };
   dwagenk = {
     email = "dwagenk@mailbox.org";
     github = "dwagenk";

--- a/modules/misc/news/2026/04/2026-04-28_03-00-36.nix
+++ b/modules/misc/news/2026/04/2026-04-28_03-00-36.nix
@@ -1,0 +1,10 @@
+{
+  time = "2026-04-28T03:00:36+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'services.exo'.
+
+    exo connects devices into a local AI cluster and provides a dashboard
+    and API server for interacting with local models.
+  '';
+}

--- a/modules/services/exo.nix
+++ b/modules/services/exo.nix
@@ -1,0 +1,75 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.exo;
+in
+{
+  meta.maintainers = [ lib.maintainers.dsqr ];
+
+  options.services.exo = {
+    enable = lib.mkEnableOption "exo local AI cluster node";
+
+    package = lib.mkPackageOption pkgs "exo" { };
+
+    environmentVariables = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = {
+        EXO_LIBP2P_NAMESPACE = "home-cluster";
+        EXO_OFFLINE = "true";
+      };
+      description = ''
+        Environment variables for the exo service.
+
+        See <https://github.com/exo-explore/exo#environment-variables>
+        for supported environment variables.
+      '';
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "--no-worker" ];
+      description = ''
+        Extra command-line arguments passed to {command}`exo`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    systemd.user.services.exo = {
+      Unit = {
+        Description = "exo local AI cluster node";
+        After = [ "network.target" ];
+      };
+
+      Service = {
+        ExecStart = lib.escapeShellArgs ([ (lib.getExe cfg.package) ] ++ cfg.extraArgs);
+        Environment = lib.mapAttrsToList (name: value: "${name}=${value}") cfg.environmentVariables;
+        Restart = "on-failure";
+      };
+
+      Install.WantedBy = [ "default.target" ];
+    };
+
+    launchd.agents.exo = {
+      enable = true;
+      config = {
+        ProgramArguments = [ (lib.getExe cfg.package) ] ++ cfg.extraArgs;
+        EnvironmentVariables = cfg.environmentVariables;
+        KeepAlive = {
+          Crashed = true;
+          SuccessfulExit = false;
+        };
+        ProcessType = "Background";
+        RunAtLoad = true;
+      };
+    };
+  };
+}

--- a/tests/modules/services/exo/default.nix
+++ b/tests/modules/services/exo/default.nix
@@ -1,0 +1,3 @@
+{
+  exo-service = ./service.nix;
+}

--- a/tests/modules/services/exo/service.nix
+++ b/tests/modules/services/exo/service.nix
@@ -1,0 +1,39 @@
+{ config, pkgs, ... }:
+{
+  services.exo = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "exo";
+      outPath = "@exo@";
+    };
+    environmentVariables = {
+      EXO_LIBP2P_NAMESPACE = "hm-test";
+      EXO_OFFLINE = "true";
+    };
+    extraArgs = [ "--no-worker" ];
+  };
+
+  nmt.script =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      ''
+        plistFile=LaunchAgents/org.nix-community.home.exo.plist
+
+        assertFileExists "$plistFile"
+        assertFileRegex "$plistFile" '<key>EXO_LIBP2P_NAMESPACE</key>'
+        assertFileRegex "$plistFile" '<string>hm-test</string>'
+        assertFileRegex "$plistFile" '<key>EXO_OFFLINE</key>'
+        assertFileRegex "$plistFile" '<string>true</string>'
+        assertFileRegex "$plistFile" '<string>/bin/wait4path /nix/store &amp;&amp; exec @exo@/bin/exo --no-worker</string>'
+      ''
+    else
+      ''
+        serviceFile=home-files/.config/systemd/user/exo.service
+
+        assertFileExists "$serviceFile"
+        assertFileRegex "$serviceFile" 'After=network\.target'
+        assertFileRegex "$serviceFile" 'Environment=EXO_LIBP2P_NAMESPACE=hm-test'
+        assertFileRegex "$serviceFile" 'Environment=EXO_OFFLINE=true'
+        assertFileRegex "$serviceFile" 'ExecStart=@exo@/bin/exo --no-worker'
+        assertFileRegex "$serviceFile" 'Restart=on-failure'
+      '';
+}


### PR DESCRIPTION
## Description

Add a new `services.exo` module for running exo as a Home Manager managed user service.

exo connects devices into a local AI cluster and provides a dashboard/API server for interacting with local models. This module keeps the initial option surface intentionally small and follows the existing local LLM service pattern used by modules like `services.ollama`.

The module supports:

- `services.exo.enable`
- `services.exo.package`
- `services.exo.environmentVariables`
- `services.exo.extraArgs`

When enabled, the module:

- installs the selected exo package
- creates a Linux `systemd.user.services.exo` service
- creates a macOS `launchd.agents.exo` agent
- allows common upstream configuration through environment variables such as `EXO_LIBP2P_NAMESPACE`, `EXO_OFFLINE`, and model directory variables
- allows command-line flags such as `--no-worker` through `extraArgs`

## Rationale

exo is packaged in nixpkgs, but Home Manager currently has no module for running it as a managed user service.

A service module fits better than a program-only module because exo runs a long-lived dashboard/API process. The implementation mirrors existing Home Manager service patterns instead of adding exo-specific abstractions.

## Tests

- `nix fmt modules/services/exo.nix tests/modules/services/exo/default.nix tests/modules/services/exo/service.nix modules/misc/news/2026/04/2026-04-28_03-00-36.nix modules/lib/maintainers.nix`
- `nix run .#tests -- exo`
- `nix run .#tests -- test-news-validation`

I also evaluated the Linux service configuration shape from macOS, but could not build the `x86_64-linux` test derivation locally from this `aarch64-darwin` machine.