### PR TITLE
restic: unset systemd `PrivateTmp` option

### DIFF
--- a/modules/services/restic.nix
+++ b/modules/services/restic.nix
@@ -498,7 +498,6 @@ in
           RuntimeDirectory = serviceName;
           CacheDirectory = serviceName;
           CacheDirectoryMode = "0700";
-          PrivateTmp = true;
 
           Environment = mkEnvironment backup ++ [ "RESTIC_CACHE_DIR=%C/${serviceName}" ];
 

--- a/tests/integration/standalone/restic-home.nix
+++ b/tests/integration/standalone/restic-home.nix
@@ -4,6 +4,8 @@ let
   passwordCommand = "${pkgs.coreutils}/bin/cat /home/alice/password";
   paths = [ "/home/alice/files" ];
   exclude = [ "*exclude*" ];
+
+  sshKeys = import "${pkgs.path}/nixos/tests/ssh-keys.nix" pkgs;
 in
 {
   home.username = "alice";
@@ -141,6 +143,15 @@ in
           SECRET=1234
           TOKEN=123456789ABcdEF
         ''}";
+      };
+
+      sftp = {
+        inherit paths passwordFile exclude;
+        initialize = true;
+        repository = "sftp:alice@remote:/home/alice/remote-repo";
+        extraOptions = [
+          "sftp.args='-o StrictHostKeyChecking=no -i ${sshKeys.snakeOilEd25519PrivateKey}'"
+        ];
       };
     };
   };

--- a/tests/integration/standalone/restic.nix
+++ b/tests/integration/standalone/restic.nix
@@ -1,5 +1,7 @@
 { pkgs, lib, ... }:
 let
+  sshKeys = import "${pkgs.path}/nixos/tests/ssh-keys.nix" pkgs;
+
   testDir = pkgs.runCommand "test-files-to-backup" { } ''
     mkdir $out
     echo some_file > $out/some_file
@@ -20,11 +22,8 @@ let
       '';
     }
   );
-in
-{
-  name = "restic";
 
-  nodes.machine = {
+  baseMachine = {
     imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
     virtualisation.memorySize = 2048;
     users.users.alice = {
@@ -33,8 +32,23 @@ in
       password = "foobar";
       uid = 1000;
     };
+  };
+in
+{
+  name = "restic";
 
-    security.polkit.enable = true;
+  nodes = {
+    machine = {
+      imports = [ baseMachine ];
+      security.polkit.enable = true;
+    };
+    remote = {
+      imports = [ baseMachine ];
+      services.openssh.enable = true;
+      users.users.alice.openssh.authorizedKeys.keys = [
+        sshKeys.snakeOilEd25519PublicKey
+      ];
+    };
   };
 
   testScript = ''
@@ -305,6 +319,14 @@ in
       systemctl_succeed_as_alice("start restic-backups-env-file.service")
       actual = succeed_as_alice("restic-env-file ls latest")
       assert_list("restic-env-file ls latest", expectedIncluded, actual)
+
+      assert "exclude" not in actual, \
+        f"Paths containing \"*exclude*\" got backed up incorrectly. output: {actual}"
+
+    with subtest("sftp remote"):
+      systemctl_succeed_as_alice("start restic-backups-sftp.service")
+      actual = succeed_as_alice("restic-sftp ls latest")
+      assert_list("restic-sftp ls latest", expectedIncluded, actual)
 
       assert "exclude" not in actual, \
         f"Paths containing \"*exclude*\" got backed up incorrectly. output: {actual}"


### PR DESCRIPTION
This option works with the NixOS version of the module as host services have different user namespace permissions to user services. Programs like ssh get confused when certain config files aren't owned by root.

#9106

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
