### PR TITLE
thunderbird: html signature support; add msg filter rules description

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -80,6 +80,18 @@ let
         default = "none";
         description = "Method to communicate the signature.";
       };
+
+      htmlFormat = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether Thunderbird should interpret {option}`text` as an HTML signature.
+
+          This maps to Thunderbird's `mail.identity.id_*.htmlSigFormat`
+          preference. The signature content itself is still written through
+          `mail.identity.id_*.htmlSigText`.
+        '';
+      };
     };
   };
 

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -688,7 +688,15 @@ in
                       };
                       type = mkOption {
                         type = str;
-                        description = "Type for this filter.";
+                        description = ''
+                          Thunderbird filter type bitmask written as the
+                          `type="..."` field in `msgFilterRules.dat`.
+
+                          Thunderbird does not publish a stable table for this
+                          bitmask. To reuse an existing value, inspect the
+                          account's `msgFilterRules.dat` file and copy the
+                          `type="..."` field from a comparable filter.
+                        '';
                       };
                       action = mkOption {
                         type = str;
@@ -732,8 +740,16 @@ in
                   ]
                 '';
                 description = ''
-                  List of message filters to add to this Thunderbird account
-                  configuration.
+                  List of message filters to add to this Thunderbird account configuration.
+
+                  Home Manager writes these to Thunderbird's per-account
+                  `msgFilterRules.dat` file under the profile mail server
+                  directory, for example `ImapMail/<server>/msgFilterRules.dat`.
+
+                  Thunderbird does not publish a stable reference for all fields
+                  in this file. To migrate existing filters, inspect an existing
+                  `msgFilterRules.dat` file and translate each filter block into
+                  this option.
                 '';
               };
             };

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -102,6 +102,9 @@ let
       "mail.identity.id_${id}.htmlSigText" =
         if identity.signature.showSignature == "none" then "" else identity.signature.text;
     }
+    // optionalAttrs identity.signature.htmlFormat {
+      "mail.identity.id_${id}.htmlSigFormat" = true;
+    }
     // optionalAttrs (identity.gpg != null) {
       "mail.identity.id_${id}.attachPgpKey" = false;
       "mail.identity.id_${id}.autoEncryptDrafts" = true;

--- a/tests/modules/programs/thunderbird/thunderbird-expected-first-darwin.js
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-first-darwin.js
@@ -36,6 +36,7 @@ user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ec
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.e2etechpref", 0);
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.encryptionpolicy", 0);
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.fullName", "H. M. Test");
+user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.htmlSigFormat", true);
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.htmlSigText", "signature");
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.is_gnupg_key_id", true);
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.last_entered_external_gnupg_key_id", "ABC");
@@ -71,6 +72,7 @@ user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.e2etechpref", 0);
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.encryptionpolicy", 0);
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.fullName", "H. M. Test");
+user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.htmlSigFormat", true);
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.htmlSigText", "signature");
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.is_gnupg_key_id", true);
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.last_entered_external_gnupg_key_id", "ABC");

--- a/tests/modules/programs/thunderbird/thunderbird-expected-first-linux.js
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-first-linux.js
@@ -36,6 +36,7 @@ user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ec
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.e2etechpref", 0);
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.encryptionpolicy", 0);
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.fullName", "H. M. Test");
+user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.htmlSigFormat", true);
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.htmlSigText", "signature");
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.is_gnupg_key_id", true);
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.last_entered_external_gnupg_key_id", "ABC");
@@ -71,6 +72,7 @@ user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.e2etechpref", 0);
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.encryptionpolicy", 0);
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.fullName", "H. M. Test");
+user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.htmlSigFormat", true);
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.htmlSigText", "signature");
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.is_gnupg_key_id", true);
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.last_entered_external_gnupg_key_id", "ABC");

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -59,6 +59,7 @@
       smtp.port = 456;
 
       signature = {
+        htmlFormat = true;
         text = "signature";
         showSignature = "append";
       };


### PR DESCRIPTION
### Description

Closes #8628
Closes #7868

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
