### PR TITLE
rofi: allow list values in extraConfig

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -102,7 +102,9 @@ let
   # Either a `section { foo: "bar"; }` or a `@import/@theme "some-text"`
   configType = with types; either sectionType str;
 
-  extraConfigType = with types; attrsOf (either sectionType configValueType);
+  extraConfigType =
+    with types;
+    attrsOf (either sectionType (either configValueType (listOf configValueType)));
 
   rasiLiteral =
     types.submodule {

--- a/tests/modules/programs/rofi/valid-config-expected.rasi
+++ b/tests/modules/programs/rofi/valid-config-expected.rasi
@@ -1,4 +1,5 @@
 configuration {
+combi-modes: [ "window","drun" ];
 cycle: false;
 drun {
 display-name: "";
@@ -13,6 +14,7 @@ kb-primary-paste: "Control+V,Shift+Insert";
 kb-secondary-paste: "Control+v,Insert";
 location: 0;
 modes: [ "drun","emoji","ssh","foo:bar" ];
+modi: [ "run","drun","window","ssh" ];
 run,drun {
 display-name: "open:";
 }

--- a/tests/modules/programs/rofi/valid-config.nix
+++ b/tests/modules/programs/rofi/valid-config.nix
@@ -19,8 +19,18 @@
       }
     ];
     extraConfig = {
+      combi-modes = [
+        "window"
+        "drun"
+      ];
       kb-primary-paste = "Control+V,Shift+Insert";
       kb-secondary-paste = "Control+v,Insert";
+      modi = [
+        "run"
+        "drun"
+        "window"
+        "ssh"
+      ];
       drun = {
         display-name = "";
       };


### PR DESCRIPTION
### Description
Related https://github.com/nix-community/home-manager/pull/9147#issuecomment-4330635553
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
