### PR TITLE
thunderbird: map account auth methods; default office365 to oauth2; policies support

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -412,6 +412,7 @@ let
             "gmail.com"
             "mailbox.org"
             "migadu.com"
+            "outlook.office365.com-ews"
             "outlook.office365.com"
             "plain"
             "posteo.de"
@@ -620,6 +621,17 @@ let
               enable = true;
               useStartTls = true;
             };
+          };
+        })
+
+        (mkIf (config.flavor == "outlook.office365.com-ews") {
+          userName = mkDefault config.address;
+
+          ews = {
+            host = "outlook.office365.com";
+            serviceDescriptionURL = "https://outlook.office365.com/EWS/Exchange.asmx";
+            authentication = "xoauth2";
+            tls.enable = true;
           };
         })
 

--- a/modules/misc/news/2026/04/2026-04-28_16-05-29.nix
+++ b/modules/misc/news/2026/04/2026-04-28_16-05-29.nix
@@ -1,0 +1,18 @@
+{ config, ... }:
+{
+  time = "2026-04-28T16:05:29+00:00";
+  condition = config.programs.thunderbird.enable;
+  message = ''
+    The `programs.thunderbird.languagePacks` option has been added to install
+    and activate Thunderbird language packs.
+
+    The `programs.thunderbird.policies` option has also been added to configure
+    Thunderbird enterprise policies. These policies can install Thunderbird
+    add-ons through `ExtensionSettings` and configure other supported application
+    behavior.
+
+    Thunderbird now supports accounts configured with
+    `accounts.email.accounts.<name>.ews`, including the
+    `outlook.office365.com-ews` flavor for Office365 Exchange accounts.
+  '';
+}

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -649,12 +649,18 @@ in
           { config, ... }:
           {
             config.thunderbird = {
-              settings = lib.mkIf (config.flavor == "gmail.com") (id: {
-                "mail.smtpserver.smtp_${id}.authMethod" = mkOptionDefault 10; # 10 = OAuth2
-                "mail.server.server_${id}.authMethod" = mkOptionDefault 10; # 10 = OAuth2
-                "mail.server.server_${id}.socketType" = mkOptionDefault 3; # SSL/TLS
-                "mail.server.server_${id}.is_gmail" = mkOptionDefault true; # handle labels, trash, etc
-              });
+              settings = lib.mkIf (config.flavor == "gmail.com" || config.flavor == "outlook.office365.com") (
+                id:
+                lib.optionalAttrs (config.smtp != null && config.smtp.authentication == null) {
+                  "mail.smtpserver.smtp_${id}.authMethod" = mkOptionDefault 10; # 10 = OAuth2
+                }
+                // lib.optionalAttrs (config.imap != null && config.imap.authentication == null) {
+                  "mail.server.server_${id}.authMethod" = mkOptionDefault 10; # 10 = OAuth2
+                }
+                // lib.optionalAttrs (config.flavor == "gmail.com") {
+                  "mail.server.server_${id}.is_gmail" = mkOptionDefault true; # handle labels, trash, etc
+                }
+              );
             };
             options.thunderbird = {
               enable = lib.mkEnableOption "the Thunderbird mail client for this account";

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -87,6 +87,49 @@ let
         if (builtins.isString address) then address else (address.address + address.realName)
       ));
 
+  thunderbirdAuthMethods = {
+    anonymous = 1;
+    clear = 3;
+    cram_md5 = 4;
+    digest_md5 = 4;
+    gssapi = 5;
+    login = 3;
+    ntlm = 6;
+    plain = 3;
+    xoauth2 = 10;
+  };
+
+  toThunderbirdAuthMethod =
+    authentication: if authentication == null then 3 else thunderbirdAuthMethods.${authentication} or 3;
+
+  authMethodWarning =
+    name: authentication:
+    lib.optional (authentication != null && !builtins.hasAttr authentication thunderbirdAuthMethods) ''
+      ${moduleName}: accounts.email.accounts.${name} uses authentication method
+      '${authentication}', which Thunderbird does not support directly. Falling back
+      to password-based authentication.
+    '';
+
+  unsupportedAuthMethodWarnings =
+    account:
+    let
+      aliasWarnings =
+        alias:
+        lib.optionals (builtins.isAttrs alias && alias.smtp != null && alias.smtp != account.smtp) (
+          authMethodWarning "${account.name}.aliases.${alias.address}.smtp" alias.smtp.authentication
+        );
+    in
+    lib.optionals (account.imap != null) (
+      authMethodWarning "${account.name}.imap" account.imap.authentication
+    )
+    ++ lib.optionals (account.smtp != null) (
+      authMethodWarning "${account.name}.smtp" account.smtp.authentication
+    )
+    ++ lib.optionals (account.ews != null) (
+      authMethodWarning "${account.name}.ews" account.ews.authentication
+    )
+    ++ lib.concatMap aliasWarnings account.aliases;
+
   toThunderbirdIdentity =
     account: address:
     # For backwards compatibility, the primary address reuses the account ID.
@@ -128,7 +171,7 @@ let
       addressIsString = builtins.isString address;
     in
     optionalAttrs (!addressIsString && address.smtp != null) {
-      "mail.smtpserver.smtp_${id}.authMethod" = 3;
+      "mail.smtpserver.smtp_${id}.authMethod" = toThunderbirdAuthMethod address.smtp.authentication;
       "mail.smtpserver.smtp_${id}.hostname" = address.smtp.host;
       "mail.smtpserver.smtp_${id}.port" = if (address.smtp.port != null) then address.smtp.port else 587;
       "mail.smtpserver.smtp_${id}.try_ssl" =
@@ -173,8 +216,11 @@ let
       "mail.server.server_${id}.type" = "imap";
       "mail.server.server_${id}.userName" = account.userName;
     }
+    // optionalAttrs (account.imap != null && account.imap.authentication != null) {
+      "mail.server.server_${id}.authMethod" = toThunderbirdAuthMethod account.imap.authentication;
+    }
     // optionalAttrs (account.smtp != null) {
-      "mail.smtpserver.smtp_${id}.authMethod" = 3;
+      "mail.smtpserver.smtp_${id}.authMethod" = toThunderbirdAuthMethod account.smtp.authentication;
       "mail.smtpserver.smtp_${id}.hostname" = account.smtp.host;
       "mail.smtpserver.smtp_${id}.port" = if (account.smtp.port != null) then account.smtp.port else 587;
       "mail.smtpserver.smtp_${id}.try_ssl" =
@@ -188,7 +234,7 @@ let
     }
     // optionalAttrs (account.ews != null) {
       "mail.smtpserver.ews_${id}.type" = "ews";
-      "mail.outgoingserver.ews_${id}.auth_method" = 3;
+      "mail.outgoingserver.ews_${id}.auth_method" = toThunderbirdAuthMethod account.ews.authentication;
       "mail.outgoingserver.ews_${id}.ews_url" = account.ews.serviceDescriptionURL;
       "mail.outgoingserver.ews_${id}.key" = "ews_${id}";
       "mail.outgoingserver.ews_${id}.username" = account.userName;
@@ -209,6 +255,9 @@ let
           3;
       "mail.server.server_${id}.type" = "ews";
       "mail.server.server_${id}.userName" = account.userName;
+    }
+    // optionalAttrs (account.ews != null && account.ews.authentication != null) {
+      "mail.server.server_${id}.authMethod" = toThunderbirdAuthMethod account.ews.authentication;
     }
     // builtins.foldl' (a: b: a // b) { } (map (address: toThunderbirdSMTP account address) addresses)
     // optionalAttrs (account.smtp != null && account.primary) {
@@ -951,12 +1000,14 @@ in
       )
     ];
 
-    warnings = lib.optionals (!cfg.darwinSetupWarning) [
-      ''
-        Using programs.thunderbird.darwinSetupWarning is deprecated and will be
-        removed in the future. Thunderbird is now supported on Darwin.
-      ''
-    ];
+    warnings =
+      lib.optionals (!cfg.darwinSetupWarning) [
+        ''
+          Using programs.thunderbird.darwinSetupWarning is deprecated and will be
+          removed in the future. Thunderbird is now supported on Darwin.
+        ''
+      ]
+      ++ lib.flatten (map unsupportedAuthMethodWarnings enabledEmailAccounts);
 
     home.packages = [
       cfg.package

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -24,7 +24,9 @@ let
 
   cfg = config.programs.thunderbird;
 
-  thunderbirdJson = types.attrsOf (pkgs.formats.json { }).type // {
+  jsonFormat = pkgs.formats.json { };
+
+  thunderbirdJson = types.attrsOf jsonFormat.type // {
     description = "Thunderbird preference (int, bool, string, and also attrs, list, float as a JSON string)";
   };
 
@@ -385,6 +387,7 @@ let
     (filter (
       a: a.thunderbird.profiles == [ ] || lib.any (p: p == profileName) a.thunderbird.profiles
     ) accounts);
+
 in
 {
   meta.maintainers = [
@@ -398,6 +401,58 @@ in
 
       package = lib.mkPackageOption pkgs "thunderbird" {
         example = "pkgs.thunderbird-91";
+      };
+
+      finalPackage = mkOption {
+        type = types.package;
+        readOnly = true;
+        description = "Resulting Thunderbird package.";
+      };
+
+      release = mkOption {
+        internal = true;
+        type = types.str;
+        description = ''
+          Upstream release version used to fetch language packs from
+          `releases.mozilla.org`.
+        '';
+      };
+
+      languagePacks = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          Thunderbird language packs to install and activate through enterprise
+          policies.
+
+          Available language codes can be found on the releases page:
+          `https://releases.mozilla.org/pub/thunderbird/releases/''${version}/linux-x86_64/xpi/`,
+          replacing `''${version}` with the version of Thunderbird you have. If
+          the version string of your Thunderbird package differs from the
+          upstream version, override the internal `release` option.
+        '';
+        example = [
+          "en-GB"
+          "de"
+        ];
+      };
+
+      policies = mkOption {
+        type = types.attrsOf jsonFormat.type;
+        default = { };
+        description = ''
+          Thunderbird enterprise policies. See the
+          [list of policies](https://thunderbird.github.io/policy-templates/).
+        '';
+        example = {
+          DisableTelemetry = true;
+          ExtensionSettings = {
+            "addoncompatibility@opto.one" = {
+              install_url = "https://addons.thunderbird.net/thunderbird/downloads/latest/addon-compatibility-check/latest.xpi";
+              installation_mode = "normal_installed";
+            };
+          };
+        };
       };
 
       profileVersion = mkOption {
@@ -944,6 +999,14 @@ in
         }
       )
 
+      {
+        assertion = cfg.policies == { } || cfg.package ? override;
+        message = ''
+          'programs.thunderbird.policies' requires 'programs.thunderbird.package'
+          to be a package that supports overriding wrapper arguments.
+        '';
+      }
+
       (
         let
           profiles = lib.catAttrs "name" profilesWithId;
@@ -1032,12 +1095,12 @@ in
       ++ lib.flatten (map unsupportedAuthMethodWarnings enabledEmailAccounts);
 
     home.packages = [
-      cfg.package
+      cfg.finalPackage
     ]
     ++ lib.optional (lib.any (p: p.withExternalGnupg) (attrValues cfg.profiles)) pkgs.gpgme;
 
     mozilla.thunderbirdNativeMessagingHosts = [
-      cfg.package # package configured native messaging hosts (entire mail app actually)
+      cfg.finalPackage # package configured native messaging hosts (entire mail app actually)
     ]
     ++ cfg.nativeMessagingHosts; # user configured native messaging hosts
 
@@ -1190,5 +1253,34 @@ in
         ))
       ) cfg.profiles)
     );
+
+    programs.thunderbird = {
+      finalPackage =
+        if cfg.policies == { } then
+          cfg.package
+        else
+          cfg.package.override (old: {
+            extraPolicies = (old.extraPolicies or { }) // cfg.policies;
+          });
+
+      release = mkOptionDefault (
+        builtins.head (lib.splitString "-" (cfg.package.version or (lib.getVersion cfg.package)))
+      );
+
+      policies = {
+        RequestedLocales = lib.mkIf (cfg.languagePacks != [ ]) (concatStringsSep "," cfg.languagePacks);
+        ExtensionSettings = lib.mkIf (cfg.languagePacks != [ ]) (
+          lib.listToAttrs (
+            map (
+              lang:
+              lib.nameValuePair "langpack-${lang}@thunderbird.mozilla.org" {
+                installation_mode = "normal_installed";
+                install_url = "https://releases.mozilla.org/pub/thunderbird/releases/${cfg.release}/linux-x86_64/xpi/${lang}.xpi";
+              }
+            ) cfg.languagePacks
+          )
+        );
+      };
+    };
   };
 }

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -162,6 +162,9 @@ let
     // optionalAttrs (identity.smtp != null) {
       "mail.identity.id_${id}.smtpServer" = "smtp_${identity.id}";
     }
+    // optionalAttrs (identity.smtp == null && account.ews != null) {
+      "mail.identity.id_${id}.smtpServer" = "ews_${account.id}";
+    }
     // account.thunderbird.perIdentitySettings id;
 
   toThunderbirdSMTP =
@@ -235,6 +238,7 @@ let
     // optionalAttrs (account.ews != null) {
       "mail.smtpserver.ews_${id}.type" = "ews";
       "mail.outgoingserver.ews_${id}.auth_method" = toThunderbirdAuthMethod account.ews.authentication;
+      "mail.outgoingserver.ews_${id}.description" = account.name;
       "mail.outgoingserver.ews_${id}.ews_url" = account.ews.serviceDescriptionURL;
       "mail.outgoingserver.ews_${id}.key" = "ews_${id}";
       "mail.outgoingserver.ews_${id}.username" = account.userName;
@@ -262,6 +266,9 @@ let
     // builtins.foldl' (a: b: a // b) { } (map (address: toThunderbirdSMTP account address) addresses)
     // optionalAttrs (account.smtp != null && account.primary) {
       "mail.smtp.defaultserver" = "smtp_${id}";
+    }
+    // optionalAttrs (account.smtp == null && account.ews != null && account.primary) {
+      "mail.smtp.defaultserver" = "ews_${id}";
     }
     // builtins.foldl' (a: b: a // b) { } (
       map (address: toThunderbirdIdentity account address) addresses
@@ -1163,7 +1170,10 @@ in
         in
         (builtins.listToAttrs (
           map (a: {
-            name = "${thunderbirdProfilesPath}/${name}/ImapMail/${a.id}/msgFilterRules.dat";
+            name =
+              "${thunderbirdProfilesPath}/${name}/"
+              + (if a.ews != null then "Mail" else "ImapMail")
+              + "/${a.id}/msgFilterRules.dat";
             value = {
               text = mkFilterListToIni a.thunderbird.messageFilters;
             };

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -540,7 +540,16 @@ in
                   type = types.bool;
                   default = false;
                   example = true;
-                  description = "Allow using external GPG keys with GPGME.";
+                  description = ''
+                    Allow Thunderbird to use external GnuPG secret keys through
+                    GPGME, as used by its documented smartcard and external-key
+                    workflow.
+
+                    This installs `gpgme` and sets
+                    `mail.openpgp.allow_external_gnupg`. Public keys and key
+                    acceptance settings still live in Thunderbird's internal
+                    OpenPGP key manager.
+                  '';
                 };
 
                 userChrome = mkOption {

--- a/tests/modules/programs/thunderbird/default.nix
+++ b/tests/modules/programs/thunderbird/default.nix
@@ -2,6 +2,7 @@
   thunderbird = ./thunderbird.nix;
   thunderbird-auth-methods = ./thunderbird-auth-methods.nix;
   thunderbird-auth-warning = ./thunderbird-auth-warning.nix;
+  thunderbird-office365 = ./thunderbird-office365.nix;
   thunderbird-with-firefox = ./thunderbird-with-firefox.nix;
   thunderbird-native-messaging-host = ./thunderbird-native-messaging-host.nix;
 }

--- a/tests/modules/programs/thunderbird/default.nix
+++ b/tests/modules/programs/thunderbird/default.nix
@@ -3,6 +3,7 @@
   thunderbird-auth-methods = ./thunderbird-auth-methods.nix;
   thunderbird-auth-warning = ./thunderbird-auth-warning.nix;
   thunderbird-office365 = ./thunderbird-office365.nix;
+  thunderbird-exchange = ./thunderbird-exchange.nix;
   thunderbird-with-firefox = ./thunderbird-with-firefox.nix;
   thunderbird-native-messaging-host = ./thunderbird-native-messaging-host.nix;
 }

--- a/tests/modules/programs/thunderbird/default.nix
+++ b/tests/modules/programs/thunderbird/default.nix
@@ -1,5 +1,7 @@
 {
   thunderbird = ./thunderbird.nix;
+  thunderbird-auth-methods = ./thunderbird-auth-methods.nix;
+  thunderbird-auth-warning = ./thunderbird-auth-warning.nix;
   thunderbird-with-firefox = ./thunderbird-with-firefox.nix;
   thunderbird-native-messaging-host = ./thunderbird-native-messaging-host.nix;
 }

--- a/tests/modules/programs/thunderbird/default.nix
+++ b/tests/modules/programs/thunderbird/default.nix
@@ -6,4 +6,5 @@
   thunderbird-exchange = ./thunderbird-exchange.nix;
   thunderbird-with-firefox = ./thunderbird-with-firefox.nix;
   thunderbird-native-messaging-host = ./thunderbird-native-messaging-host.nix;
+  thunderbird-policies = ./thunderbird-policies.nix;
 }

--- a/tests/modules/programs/thunderbird/thunderbird-auth-methods.nix
+++ b/tests/modules/programs/thunderbird/thunderbird-auth-methods.nix
@@ -1,0 +1,94 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  anonymousAccountId = builtins.hashString "sha256" "anonymous@example.com";
+  digestAccountId = builtins.hashString "sha256" "digest@example.com";
+  gssapiAccountId = builtins.hashString "sha256" "gssapi@example.com";
+  mixedAccountId = builtins.hashString "sha256" "mixed@example.com";
+  aliasSmtpId = builtins.hashString "sha256" "alias@example.comAlias";
+
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+  profilesDir = if isDarwin then "Library/Thunderbird/Profiles" else ".thunderbird";
+  userJs = "home-files/${profilesDir}/default/user.js";
+in
+{
+  accounts.email.accounts = {
+    "anonymous@example.com" = {
+      address = "anonymous@example.com";
+      imap = {
+        host = "imap-anonymous.example.com";
+        authentication = "anonymous";
+      };
+      primary = true;
+      realName = "Anonymous";
+      thunderbird.enable = true;
+    };
+
+    "digest@example.com" = {
+      address = "digest@example.com";
+      imap = {
+        host = "imap-digest.example.com";
+        authentication = "digest_md5";
+      };
+      realName = "Digest";
+      thunderbird.enable = true;
+    };
+
+    "gssapi@example.com" = {
+      address = "gssapi@example.com";
+      ews = {
+        host = "ews-gssapi.example.com";
+        serviceDescriptionURL = "https://ews-gssapi.example.com/EWS/Exchange.asmx";
+        authentication = "gssapi";
+      };
+      realName = "GSSAPI";
+      thunderbird.enable = true;
+    };
+
+    "mixed@example.com" = {
+      address = "mixed@example.com";
+      aliases = [
+        {
+          address = "alias@example.com";
+          realName = "Alias";
+          smtp = {
+            host = "smtp-alias.example.com";
+            authentication = "xoauth2";
+          };
+        }
+      ];
+      imap = {
+        host = "imap-mixed.example.com";
+        authentication = "ntlm";
+      };
+      realName = "Mixed";
+      smtp = {
+        host = "smtp-mixed.example.com";
+        authentication = "clear";
+      };
+      thunderbird.enable = true;
+    };
+  };
+
+  programs.thunderbird = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "thunderbird";
+    };
+
+    profiles.default.isDefault = true;
+  };
+
+  nmt.script = ''
+    assertFileContains ${userJs} 'user_pref("mail.server.server_${anonymousAccountId}.authMethod", 1);'
+    assertFileContains ${userJs} 'user_pref("mail.server.server_${digestAccountId}.authMethod", 4);'
+    assertFileContains ${userJs} 'user_pref("mail.server.server_${gssapiAccountId}.authMethod", 5);'
+    assertFileContains ${userJs} 'user_pref("mail.outgoingserver.ews_${gssapiAccountId}.auth_method", 5);'
+    assertFileContains ${userJs} 'user_pref("mail.server.server_${mixedAccountId}.authMethod", 6);'
+    assertFileContains ${userJs} 'user_pref("mail.smtpserver.smtp_${mixedAccountId}.authMethod", 3);'
+    assertFileContains ${userJs} 'user_pref("mail.smtpserver.smtp_${aliasSmtpId}.authMethod", 10);'
+  '';
+}

--- a/tests/modules/programs/thunderbird/thunderbird-auth-warning.nix
+++ b/tests/modules/programs/thunderbird/thunderbird-auth-warning.nix
@@ -1,0 +1,85 @@
+{
+  config,
+  ...
+}:
+{
+  accounts.email.accounts."hm@example.com" = {
+    address = "hm@example.com";
+    imap = {
+      host = "imap.example.com";
+      authentication = "oauthbearer";
+    };
+    primary = true;
+    realName = "Home Manager";
+    thunderbird.enable = true;
+  };
+
+  accounts.email.accounts."exchange@example.com" = {
+    address = "exchange@example.com";
+    ews = {
+      host = "ews.example.com";
+      serviceDescriptionURL = "https://ews.example.com/EWS/Exchange.asmx";
+      authentication = "oauthbearer";
+    };
+    realName = "Exchange Account";
+    thunderbird.enable = true;
+  };
+
+  accounts.email.accounts."smtp@example.com" = {
+    address = "smtp@example.com";
+    aliases = [
+      {
+        address = "inherited-alias@example.com";
+        realName = "Inherited Alias";
+      }
+      {
+        address = "overridden-alias@example.com";
+        realName = "Overridden Alias";
+        smtp = {
+          host = "smtp-alias.example.com";
+          authentication = "oauthbearer";
+        };
+      }
+    ];
+    imap.host = "imap-smtp.example.com";
+    realName = "SMTP Account";
+    smtp = {
+      host = "smtp.example.com";
+      authentication = "oauthbearer";
+    };
+    thunderbird.enable = true;
+  };
+
+  programs.thunderbird = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "thunderbird";
+    };
+
+    profiles.default.isDefault = true;
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      programs.thunderbird: accounts.email.accounts.exchange@example.com.ews uses authentication method
+      'oauthbearer', which Thunderbird does not support directly. Falling back
+      to password-based authentication.
+    ''
+    ''
+      programs.thunderbird: accounts.email.accounts.hm@example.com.imap uses authentication method
+      'oauthbearer', which Thunderbird does not support directly. Falling back
+      to password-based authentication.
+    ''
+    ''
+      programs.thunderbird: accounts.email.accounts.smtp@example.com.smtp uses authentication method
+      'oauthbearer', which Thunderbird does not support directly. Falling back
+      to password-based authentication.
+    ''
+    ''
+      programs.thunderbird: accounts.email.accounts.smtp@example.com.aliases.overridden-alias@example.com.smtp uses authentication method
+      'oauthbearer', which Thunderbird does not support directly. Falling back
+      to password-based authentication.
+    ''
+  ];
+  test.asserts.warnings.enable = true;
+}

--- a/tests/modules/programs/thunderbird/thunderbird-exchange.nix
+++ b/tests/modules/programs/thunderbird/thunderbird-exchange.nix
@@ -1,0 +1,76 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  accountId = builtins.hashString "sha256" "work@example.com";
+  customAccountId = builtins.hashString "sha256" "custom@example.com";
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+  profilesDir = if isDarwin then "Library/Thunderbird/Profiles" else ".thunderbird";
+  userJs = "home-files/${profilesDir}/default/user.js";
+in
+{
+  accounts.email.accounts."work@example.com" = {
+    address = "work@example.com";
+    flavor = "outlook.office365.com-ews";
+    primary = true;
+    realName = "Home Manager";
+    thunderbird.enable = true;
+  };
+
+  accounts.email.accounts."custom@example.com" = {
+    address = "custom@example.com";
+    ews = {
+      host = "ews.example.com";
+      serviceDescriptionURL = "https://ews.example.com/EWS/Exchange.asmx";
+      authentication = "ntlm";
+    };
+    realName = "Custom Exchange";
+    thunderbird = {
+      enable = true;
+      messageFilters = [
+        {
+          name = "Custom";
+          type = "17";
+          action = "Mark read";
+          condition = "ALL";
+        }
+      ];
+    };
+  };
+
+  programs.thunderbird = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "thunderbird";
+    };
+
+    profiles.default.isDefault = true;
+  };
+
+  nmt.script = ''
+    assertFileContains ${userJs} 'user_pref("mail.account.account_${accountId}.server", "server_${accountId}");'
+    assertFileContains ${userJs} 'user_pref("mail.smtp.defaultserver", "ews_${accountId}");'
+    assertFileContains ${userJs} 'user_pref("mail.identity.id_${accountId}.smtpServer", "ews_${accountId}");'
+    assertFileContains ${userJs} 'user_pref("mail.outgoingserver.ews_${accountId}.auth_method", 10);'
+    assertFileContains ${userJs} 'user_pref("mail.outgoingserver.ews_${accountId}.ews_url", "https://outlook.office365.com/EWS/Exchange.asmx");'
+    assertFileContains ${userJs} 'user_pref("mail.server.server_${accountId}.authMethod", 10);'
+    assertFileContains ${userJs} 'user_pref("mail.server.server_${accountId}.type", "ews");'
+    assertFileContains ${userJs} 'user_pref("mail.outgoingserver.ews_${customAccountId}.auth_method", 6);'
+    assertFileContains ${userJs} 'user_pref("mail.outgoingserver.ews_${customAccountId}.ews_url", "https://ews.example.com/EWS/Exchange.asmx");'
+    assertFileContains ${userJs} 'user_pref("mail.server.server_${customAccountId}.hostname", "ews.example.com");'
+    assertFileExists home-files/${profilesDir}/default/Mail/${customAccountId}/msgFilterRules.dat
+    assertFileContent \
+      home-files/${profilesDir}/default/Mail/${customAccountId}/msgFilterRules.dat \
+      ${pkgs.writeText "thunderbird-ews-expected-msgFilterRules.dat" ''
+        version="9"
+        logging="no"
+        name="Custom"
+        enabled="yes"
+        type="17"
+        action="Mark read"
+        condition="ALL"
+      ''}
+  '';
+}

--- a/tests/modules/programs/thunderbird/thunderbird-native-messaging-host.nix
+++ b/tests/modules/programs/thunderbird/thunderbird-native-messaging-host.nix
@@ -9,9 +9,30 @@ let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
   nativeHostsDir =
     if isDarwin then "Library/Mozilla/NativeMessagingHosts" else ".mozilla/native-messaging-hosts";
+  thunderbirdPackage = config.lib.test.mkStubPackage {
+    name = "thunderbird";
+    extraAttrs = {
+      override =
+        f:
+        let
+          overrides = f { extraPolicies = { }; };
+        in
+        (config.lib.test.mkStubPackage {
+          name = "thunderbird-with-native-host";
+          buildScript = ''
+            mkdir -p "$out/lib/mozilla/native-messaging-hosts"
+            echo wrapped > "$out/lib/mozilla/native-messaging-hosts/com.example.thunderbird-wrapped.json"
+          '';
+        })
+        // {
+          inherit (overrides) extraPolicies;
+        };
+    };
+  };
 in
 lib.recursiveUpdate (import ./thunderbird.nix { inherit config lib pkgs; }) {
   programs.thunderbird = {
+    package = thunderbirdPackage;
     nativeMessagingHosts = [
       (config.lib.test.mkStubPackage {
         name = "browserpass";
@@ -21,9 +42,11 @@ lib.recursiveUpdate (import ./thunderbird.nix { inherit config lib pkgs; }) {
         '';
       })
     ];
+    policies.DisableTelemetry = true;
   };
 
   nmt.script = ''
     assertFileExists home-files/${nativeHostsDir}/com.github.browserpass.native.json
+    assertFileExists home-files/${nativeHostsDir}/com.example.thunderbird-wrapped.json
   '';
 }

--- a/tests/modules/programs/thunderbird/thunderbird-office365.nix
+++ b/tests/modules/programs/thunderbird/thunderbird-office365.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  defaultAccountId = builtins.hashString "sha256" "default@example.com";
+  overriddenAccountId = builtins.hashString "sha256" "overridden@example.com";
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+  profilesDir = if isDarwin then "Library/Thunderbird/Profiles" else ".thunderbird";
+  userJs = "home-files/${profilesDir}/default/user.js";
+in
+{
+  accounts.email.accounts."default@example.com" = {
+    address = "default@example.com";
+    flavor = "outlook.office365.com";
+    primary = true;
+    realName = "Default Office365";
+    thunderbird.enable = true;
+  };
+
+  accounts.email.accounts."overridden@example.com" = {
+    address = "overridden@example.com";
+    flavor = "outlook.office365.com";
+    realName = "Overridden Office365";
+    imap.authentication = "ntlm";
+    smtp.authentication = "clear";
+    thunderbird.enable = true;
+  };
+
+  programs.thunderbird = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "thunderbird";
+    };
+
+    profiles.default.isDefault = true;
+  };
+
+  nmt.script = ''
+    assertFileContains ${userJs} 'user_pref("mail.server.server_${defaultAccountId}.authMethod", 10);'
+    assertFileContains ${userJs} 'user_pref("mail.smtpserver.smtp_${defaultAccountId}.authMethod", 10);'
+    assertFileContains ${userJs} 'user_pref("mail.server.server_${defaultAccountId}.socketType", 3);'
+
+    assertFileContains ${userJs} 'user_pref("mail.server.server_${overriddenAccountId}.authMethod", 6);'
+    assertFileContains ${userJs} 'user_pref("mail.smtpserver.smtp_${overriddenAccountId}.authMethod", 3);'
+  '';
+}

--- a/tests/modules/programs/thunderbird/thunderbird-policies.nix
+++ b/tests/modules/programs/thunderbird/thunderbird-policies.nix
@@ -1,0 +1,77 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  thunderbirdPackage = config.lib.test.mkStubPackage {
+    name = "thunderbird";
+    version = "140.0.2";
+    extraAttrs = {
+      override =
+        f:
+        let
+          overrides = f {
+            extraPolicies = {
+              DisableAppUpdate = true;
+            };
+          };
+          policiesJson = pkgs.writeText "policies.json" (
+            builtins.toJSON {
+              policies = overrides.extraPolicies;
+            }
+          );
+        in
+        (pkgs.runCommandLocal "thunderbird-with-policies" { } ''
+          mkdir -p "$out/lib/thunderbird/distribution"
+          cp ${policiesJson} "$out/lib/thunderbird/distribution/policies.json"
+        '')
+        // {
+          inherit (overrides) extraPolicies;
+        };
+    };
+  };
+
+  expectedPolicies = {
+    policies = {
+      DisableAppUpdate = true;
+      DisableTelemetry = true;
+      ExtensionSettings = {
+        "langpack-de@thunderbird.mozilla.org" = {
+          install_url = "https://releases.mozilla.org/pub/thunderbird/releases/140.0.2/linux-x86_64/xpi/de.xpi";
+          installation_mode = "normal_installed";
+        };
+        "langpack-en-GB@thunderbird.mozilla.org" = {
+          install_url = "https://releases.mozilla.org/pub/thunderbird/releases/140.0.2/linux-x86_64/xpi/en-GB.xpi";
+          installation_mode = "normal_installed";
+        };
+      };
+      RequestedLocales = "de,en-GB";
+    };
+  };
+in
+{
+  programs.thunderbird = {
+    enable = true;
+    package = thunderbirdPackage;
+
+    languagePacks = [
+      "de"
+      "en-GB"
+    ];
+
+    policies = {
+      DisableTelemetry = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists ${config.programs.thunderbird.finalPackage}/lib/thunderbird/distribution/policies.json
+    assertFileContent \
+      ${config.programs.thunderbird.finalPackage}/lib/thunderbird/distribution/policies.json \
+      ${pkgs.writeText "thunderbird-expected-policies.json" (
+        lib.generators.toJSON { } expectedPolicies
+      )}
+  '';
+}


### PR DESCRIPTION
### Description
  - map Home Manager email authentication methods to Thunderbird auth method
  values
  - default Gmail and Office365 IMAP/SMTP accounts to OAuth2 when auth is not
  explicitly set
  - support Thunderbird EWS accounts, including a new `outlook.office365.com-
  ews` flavor
  - add `programs.thunderbird.policies` for enterprise policy configuration
  - add `programs.thunderbird.languagePacks` for installing Thunderbird language
  packs
  - clarify the external GnuPG option documentation


Closes https://github.com/nix-community/home-manager/issues/5137
Closes https://github.com/nix-community/home-manager/issues/8011
Closes https://github.com/nix-community/home-manager/issues/5694
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
