### PR TITLE
programs.depot-tools: add module

### DIFF
--- a/modules/programs/depot-tools.nix
+++ b/modules/programs/depot-tools.nix
@@ -1,0 +1,172 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.depot-tools;
+
+  isUsingSecretProvisioner = name: config ? "${name}" && config."${name}".secrets != { };
+
+  envVarNameRegex = "[A-Za-z_][A-Za-z0-9_]*";
+
+  shellEnvFile = "${config.xdg.configHome}/depot-tools/environment";
+
+  renderEnvironmentLine = name: value: ''
+    value=${lib.escapeShellArg value}
+    printf -v quoted '%q' "$value"
+    printf 'export ${name}=%s\n' "$quoted"
+  '';
+
+  renderSecretLine = name: path: ''
+    secret_file=${lib.escapeShellArg path}
+    if [[ ! -r "$secret_file" ]]; then
+      echo "Secret file for ${name} is not readable: $secret_file" >&2
+      exit 1
+    fi
+    value="$(cat "$secret_file")"
+    printf -v quoted '%q' "$value"
+    printf 'export ${name}=%s\n' "$quoted"
+  '';
+
+  environmentScript = pkgs.writeShellApplication {
+    name = "depot-tools-environment";
+    runtimeInputs = [ pkgs.coreutils ];
+    text = ''
+      set -euo pipefail
+
+      env_file="${shellEnvFile}"
+      install -d -m 700 "$(dirname "$env_file")"
+      tmp_file="$(mktemp "$env_file.tmp.XXXXXX")"
+      trap 'rm -f "$tmp_file"' EXIT
+
+      umask 077
+      {
+      ${lib.concatStringsSep "\n" (lib.mapAttrsToList renderEnvironmentLine cfg.environment)}
+      ${lib.concatStringsSep "\n" (lib.mapAttrsToList renderSecretLine cfg.environmentSecretFiles)}
+      } > "$tmp_file"
+
+      install -m 600 "$tmp_file" "$env_file"
+    '';
+  };
+
+in
+{
+  meta.maintainers = with lib.maintainers; [ caniko ];
+
+  options.programs.depot-tools = {
+    enable = lib.mkEnableOption "Chromium depot_tools";
+
+    package = lib.mkPackageOption pkgs "depot-tools" { };
+
+    environment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = {
+        DEPOT_TOOLS_METRICS = "0";
+      };
+      description = ''
+        Non-secret environment variables to expose to depot_tools commands.
+      '';
+    };
+
+    environmentSecretFiles = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          GIT_COOKIES_PATH = config.age.secrets.chromium-git-cookies.path;
+          LUCI_CONTEXT = config.age.secrets.luci-context.path;
+        }
+      '';
+      description = ''
+        Environment variables whose values are read from files at service run time.
+
+        This is suitable for secrets managed by agenix, sops-nix, or another
+        provisioner that writes files outside the Nix store.
+      '';
+    };
+
+    requiresUnit = lib.mkOption {
+      type = with lib.types; nullOr str;
+      default =
+        lib.foldlAttrs
+          (
+            acc: prov: svc:
+            if isUsingSecretProvisioner prov then svc else acc
+          )
+          null
+          {
+            "sops" = "sops-nix.service";
+            "age" = "agenix.service";
+          };
+      example = "agenix.service";
+      description = ''
+        Systemd user service that must complete before depot_tools secret
+        environment variables are rendered.
+
+        This is inferred automatically for agenix and sops-nix users.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions =
+          lib.mapAttrsToList (name: _value: {
+            assertion = builtins.match envVarNameRegex name != null;
+            message = "programs.depot-tools.environment contains invalid environment variable name: ${name}";
+          }) cfg.environment
+          ++ lib.mapAttrsToList (name: _value: {
+            assertion = builtins.match envVarNameRegex name != null;
+            message = "programs.depot-tools.environmentSecretFiles contains invalid environment variable name: ${name}";
+          }) cfg.environmentSecretFiles
+          ++ [
+            {
+              assertion = cfg.environmentSecretFiles == { } || pkgs.stdenv.hostPlatform.isLinux;
+              message = "programs.depot-tools.environmentSecretFiles currently requires systemd user services, which are only available on Linux.";
+            }
+          ];
+
+        home.packages = [ cfg.package ];
+        home.sessionVariables = cfg.environment;
+      }
+
+      (lib.mkIf (cfg.environmentSecretFiles != { }) {
+        systemd.user.services.depot-tools-environment = {
+          Unit = lib.mkMerge [
+            {
+              Description = "Render depot_tools environment";
+            }
+            (lib.optionalAttrs (cfg.requiresUnit != null) {
+              Requires = [ cfg.requiresUnit ];
+              After = [ cfg.requiresUnit ];
+            })
+          ];
+
+          Service = {
+            Type = "oneshot";
+            ExecStart = lib.getExe environmentScript;
+          };
+
+          Install.WantedBy = [ "default.target" ];
+        };
+
+        programs.bash.initExtra = lib.mkAfter ''
+          if [ -r "${shellEnvFile}" ]; then
+            . "${shellEnvFile}"
+          fi
+        '';
+
+        programs.zsh.initContent = lib.mkAfter ''
+          if [ -r "${shellEnvFile}" ]; then
+            . "${shellEnvFile}"
+          fi
+        '';
+      })
+    ]
+  );
+}

--- a/tests/modules/programs/depot-tools/basic.nix
+++ b/tests/modules/programs/depot-tools/basic.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 
 {
   programs.depot-tools = {
@@ -9,7 +9,6 @@
   test.stubs.depot-tools = { };
 
   nmt.script = ''
-    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
-      'DEPOT_TOOLS_METRICS="0"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh 'DEPOT_TOOLS_METRICS="0"'
   '';
 }

--- a/tests/modules/programs/depot-tools/basic.nix
+++ b/tests/modules/programs/depot-tools/basic.nix
@@ -1,0 +1,15 @@
+{ ... }:
+
+{
+  programs.depot-tools = {
+    enable = true;
+    environment.DEPOT_TOOLS_METRICS = "0";
+  };
+
+  test.stubs.depot-tools = { };
+
+  nmt.script = ''
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'DEPOT_TOOLS_METRICS="0"'
+  '';
+}

--- a/tests/modules/programs/depot-tools/default.nix
+++ b/tests/modules/programs/depot-tools/default.nix
@@ -1,0 +1,4 @@
+{
+  depot-tools-basic = ./basic.nix;
+  depot-tools-secrets = ./secrets.nix;
+}

--- a/tests/modules/programs/depot-tools/secrets.nix
+++ b/tests/modules/programs/depot-tools/secrets.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 
@@ -33,6 +34,10 @@
       chromium-git-cookies.path = "/run/agenix/chromium-git-cookies";
       luci-context.path = "/run/agenix/luci-context";
     };
+
+    test.asserts.assertions.expected = lib.optionals (!pkgs.stdenv.hostPlatform.isLinux) [
+      "programs.depot-tools.environmentSecretFiles currently requires systemd user services, which are only available on Linux."
+    ];
 
     test.stubs.depot-tools = { };
 

--- a/tests/modules/programs/depot-tools/secrets.nix
+++ b/tests/modules/programs/depot-tools/secrets.nix
@@ -41,7 +41,7 @@
 
     test.stubs.depot-tools = { };
 
-    nmt.script = ''
+    nmt.script = lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
       service=home-files/.config/systemd/user/depot-tools-environment.service
 
       assertFileExists "$service"

--- a/tests/modules/programs/depot-tools/secrets.nix
+++ b/tests/modules/programs/depot-tools/secrets.nix
@@ -1,0 +1,54 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+{
+  options.age.secrets = lib.mkOption {
+    type = lib.types.attrsOf (
+      lib.types.submodule {
+        options.path = lib.mkOption {
+          type = lib.types.str;
+        };
+      }
+    );
+    default = { };
+  };
+
+  config = {
+    programs.bash.enable = true;
+    programs.zsh.enable = true;
+
+    programs.depot-tools = {
+      enable = true;
+      environment.DEPOT_TOOLS_METRICS = "0";
+      environmentSecretFiles = {
+        GIT_COOKIES_PATH = config.age.secrets.chromium-git-cookies.path;
+        LUCI_CONTEXT = config.age.secrets.luci-context.path;
+      };
+    };
+
+    age.secrets = {
+      chromium-git-cookies.path = "/run/agenix/chromium-git-cookies";
+      luci-context.path = "/run/agenix/luci-context";
+    };
+
+    test.stubs.depot-tools = { };
+
+    nmt.script = ''
+      service=home-files/.config/systemd/user/depot-tools-environment.service
+
+      assertFileExists "$service"
+      assertFileRegex "$service" 'After=agenix.service'
+      assertFileRegex "$service" 'Requires=agenix.service'
+      assertFileRegex "$service" 'ExecStart=.*/bin/depot-tools-environment'
+
+      assertFileExists home-files/.bashrc
+      assertFileRegex home-files/.bashrc '.*/depot-tools/environment'
+
+      assertFileExists home-files/.zshrc
+      assertFileRegex home-files/.zshrc '.*/depot-tools/environment'
+    '';
+  };
+}


### PR DESCRIPTION
Adds a `programs.depot-tools` Home Manager module for installing Chromium depot_tools and rendering optional secret-backed environment variables through a user service.

This remains draft because it depends on `pkgs.depot-tools` from NixOS/nixpkgs#515028 landing in nixpkgs.

Validated locally:

- `nix-build tests -A build.depot-tools-basic`
- `nix-build tests -A build.depot-tools-secrets`

CI status on the latest head:

- GitHub Actions Linux/macOS tests passed
- buildbot nix-eval and nix-build passed