### PR TITLE
launchd: use bootout --wait to wait for the service to stop

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -145,7 +145,7 @@ in
 
               verboseEcho "Stopping agent '$domain/$agentName'..."
               local bootout_output
-              bootout_output=$(run /bin/launchctl bootout "$domain/$agentName" 2>&1) || {
+              bootout_output=$(run /bin/launchctl bootout --wait "$domain/$agentName" 2>&1) || {
                 # Only show warning if it's not the common "No such process" error
                 if [[ "$bootout_output" != *"No such process"* ]]; then
                   warnEcho "Failed to stop agent '$domain/$agentName': $bootout_output"
@@ -153,9 +153,6 @@ in
                   verboseEcho "Agent '$domain/$agentName' was not running"
                 fi
               }
-
-              # Give the system a moment to fully unload the agent
-              sleep 1
             }
 
             installAndBootstrapAgent() {


### PR DESCRIPTION
### Description

Fixes #8829.

Some services like colima don't finish stopping within 1 second causing an error in bootstrap:
```
Failed to start agent 'gui/501/org.nix-community.home.colima-default' with I/O error (code 5)
This typically happens when the agent wasn't unloaded before attempting to bootstrap the new agent.
```

Uses bootout --wait to make the operation synchronous.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
