### PR TITLE
github-copilot-cli: fix mcp integration

### DIFF
--- a/modules/programs/github-copilot-cli.nix
+++ b/modules/programs/github-copilot-cli.nix
@@ -22,17 +22,19 @@ let
   transformSingleServer =
     _name: server:
     let
-      base = removeAttrs server [ "disabled" ];
-      withType =
-        if base ? type then
-          base
-        else if base ? url then
-          base // { type = "http"; }
-        else
-          base // { type = "local"; };
-      withTools = if withType ? tools then withType else withType // { tools = [ "*" ]; };
+      server' = removeAttrs server [ "disabled" ];
+      type = server'.type or (if server' ? url then "http" else "local");
     in
-    withTools;
+    server'
+    // {
+      inherit type;
+    }
+    // lib.optionalAttrs (type == "local") {
+      args = server'.args or [ ];
+    }
+    // lib.optionalAttrs (!(server' ? tools)) {
+      tools = [ "*" ];
+    };
 
   transformedMcpServers =
     if cfg.enableMcpIntegration && config.programs.mcp.enable && config.programs.mcp.servers != { } then

--- a/tests/modules/programs/github-copilot-cli/expected-mcp-integration-config.json
+++ b/tests/modules/programs/github-copilot-cli/expected-mcp-integration-config.json
@@ -14,6 +14,14 @@
       ],
       "type": "local"
     },
+    "fetch": {
+      "args": [],
+      "command": "mcp-server-fetch",
+      "tools": [
+        "*"
+      ],
+      "type": "local"
+    },
     "filesystem": {
       "args": [
         "-y",

--- a/tests/modules/programs/github-copilot-cli/mcp-integration.nix
+++ b/tests/modules/programs/github-copilot-cli/mcp-integration.nix
@@ -36,6 +36,9 @@
             DATABASE_URL = "postgresql://user:pass@localhost:5432/db";
           };
         };
+        fetch = {
+          command = "mcp-server-fetch";
+        };
         disabled-server = {
           command = "disabled-cmd";
           disabled = true;


### PR DESCRIPTION
MCP servers require the args in json, even if not configured.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
