### PR TITLE
codex: keep managed skills under CODEX_HOME

### DIFF
--- a/modules/programs/codex.nix
+++ b/modules/programs/codex.nix
@@ -14,7 +14,6 @@ let
 
   packageVersion = if cfg.package != null then lib.getVersion cfg.package else "0.94.0";
   isTomlConfig = lib.versionAtLeast packageVersion "0.2.0";
-  isAgentsSkillsSupported = lib.versionAtLeast packageVersion "0.94.0";
   settingsFormat = if isTomlConfig then tomlFormat else yamlFormat;
 in
 {
@@ -125,9 +124,10 @@ in
         {file}`<skills-dir>/` itself as a normal directory so unmanaged
         skills can coexist.
 
-        The skills target directory depends on Codex version:
-        - {file}`~/.agents/skills` for Codex >= 0.94.0
-        - {file}`~/.codex/skills` for older versions
+        Home Manager manages skills under {file}`CODEX_HOME/skills`
+        (typically {file}`~/.codex/skills`, or
+        {file}`~/.config/codex/skills` when
+        {option}`home.preferXdgDirectories` is enabled).
       '';
       example = lib.literalExpression ''
         {
@@ -186,7 +186,7 @@ in
       xdgConfigHome = lib.removePrefix config.home.homeDirectory config.xdg.configHome;
       configDir = if useXdgDirectories then "${xdgConfigHome}/codex" else ".codex";
       configFileName = if isTomlConfig then "config.toml" else "config.yaml";
-      skillsDir = if isAgentsSkillsSupported then ".agents/skills" else "${configDir}/skills";
+      skillsDir = "${configDir}/skills";
 
       # TODO: Remove this workaround once Codex supports symlinked SKILL.md
       # files again. Upstream only supports symlinking the containing skill

--- a/tests/modules/programs/codex/skills-dir.nix
+++ b/tests/modules/programs/codex/skills-dir.nix
@@ -13,15 +13,15 @@ in
   };
 
   nmt.script = ''
-    if [[ -L home-files/.agents/skills ]]; then
-      fail "Expected home-files/.agents/skills to remain a normal directory so unmanaged skills can coexist."
+    if [[ -L home-files/.codex/skills ]]; then
+      fail "Expected home-files/.codex/skills to remain a normal directory so unmanaged skills can coexist."
     fi
-    assertLinkExists home-files/.agents/skills/skill-one
-    assertFileExists home-files/.agents/skills/skill-one/SKILL.md
-    if [[ -L home-files/.agents/skills/skill-one/SKILL.md ]]; then
-      fail "Expected home-files/.agents/skills/skill-one/SKILL.md to be a regular file inside a symlinked skill directory."
+    assertLinkExists home-files/.codex/skills/skill-one
+    assertFileExists home-files/.codex/skills/skill-one/SKILL.md
+    if [[ -L home-files/.codex/skills/skill-one/SKILL.md ]]; then
+      fail "Expected home-files/.codex/skills/skill-one/SKILL.md to be a regular file inside a symlinked skill directory."
     fi
-    assertFileContent home-files/.agents/skills/skill-one/SKILL.md \
+    assertFileContent home-files/.codex/skills/skill-one/SKILL.md \
       ${./skills-dir/skill-one/SKILL.md}
   '';
 }

--- a/tests/modules/programs/codex/skills-inline-null-package.nix
+++ b/tests/modules/programs/codex/skills-inline-null-package.nix
@@ -10,12 +10,12 @@
   };
 
   nmt.script = ''
-    assertLinkExists home-files/.agents/skills/inline-skill
-    assertFileExists home-files/.agents/skills/inline-skill/SKILL.md
-    if [[ -L home-files/.agents/skills/inline-skill/SKILL.md ]]; then
-      fail "Expected home-files/.agents/skills/inline-skill/SKILL.md to be a regular file inside a symlinked skill directory."
+    assertLinkExists home-files/.codex/skills/inline-skill
+    assertFileExists home-files/.codex/skills/inline-skill/SKILL.md
+    if [[ -L home-files/.codex/skills/inline-skill/SKILL.md ]]; then
+      fail "Expected home-files/.codex/skills/inline-skill/SKILL.md to be a regular file inside a symlinked skill directory."
     fi
-    assertFileContent home-files/.agents/skills/inline-skill/SKILL.md \
+    assertFileContent home-files/.codex/skills/inline-skill/SKILL.md \
       ${builtins.toFile "expected-inline-skill.md" ''
         # Inline Skill
       ''}

--- a/tests/modules/programs/codex/skills-inline.nix
+++ b/tests/modules/programs/codex/skills-inline.nix
@@ -27,29 +27,29 @@ in
   };
 
   nmt.script = ''
-    if [[ -L home-files/.agents/skills ]]; then
-      fail "Expected home-files/.agents/skills to remain a normal directory so unmanaged skills can coexist."
+    if [[ -L home-files/.codex/skills ]]; then
+      fail "Expected home-files/.codex/skills to remain a normal directory so unmanaged skills can coexist."
     fi
-    assertLinkExists home-files/.agents/skills/inline-skill
-    assertFileExists home-files/.agents/skills/inline-skill/SKILL.md
-    if [[ -L home-files/.agents/skills/inline-skill/SKILL.md ]]; then
-      fail "Expected home-files/.agents/skills/inline-skill/SKILL.md to be a regular file inside a symlinked skill directory."
+    assertLinkExists home-files/.codex/skills/inline-skill
+    assertFileExists home-files/.codex/skills/inline-skill/SKILL.md
+    if [[ -L home-files/.codex/skills/inline-skill/SKILL.md ]]; then
+      fail "Expected home-files/.codex/skills/inline-skill/SKILL.md to be a regular file inside a symlinked skill directory."
     fi
-    assertFileContent home-files/.agents/skills/inline-skill/SKILL.md \
+    assertFileContent home-files/.codex/skills/inline-skill/SKILL.md \
       ${builtins.toFile "expected-inline-skill.md" inlineSkill}
-    assertLinkExists home-files/.agents/skills/file-skill
-    assertFileExists home-files/.agents/skills/file-skill/SKILL.md
-    if [[ -L home-files/.agents/skills/file-skill/SKILL.md ]]; then
-      fail "Expected home-files/.agents/skills/file-skill/SKILL.md to be a regular file inside a symlinked skill directory."
+    assertLinkExists home-files/.codex/skills/file-skill
+    assertFileExists home-files/.codex/skills/file-skill/SKILL.md
+    if [[ -L home-files/.codex/skills/file-skill/SKILL.md ]]; then
+      fail "Expected home-files/.codex/skills/file-skill/SKILL.md to be a regular file inside a symlinked skill directory."
     fi
-    assertFileContent home-files/.agents/skills/file-skill/SKILL.md \
+    assertFileContent home-files/.codex/skills/file-skill/SKILL.md \
       ${./skill-file.md}
-    assertLinkExists home-files/.agents/skills/dir-skill
-    assertFileExists home-files/.agents/skills/dir-skill/SKILL.md
-    if [[ -L home-files/.agents/skills/dir-skill/SKILL.md ]]; then
-      fail "Expected home-files/.agents/skills/dir-skill/SKILL.md to be a regular file inside a symlinked skill directory."
+    assertLinkExists home-files/.codex/skills/dir-skill
+    assertFileExists home-files/.codex/skills/dir-skill/SKILL.md
+    if [[ -L home-files/.codex/skills/dir-skill/SKILL.md ]]; then
+      fail "Expected home-files/.codex/skills/dir-skill/SKILL.md to be a regular file inside a symlinked skill directory."
     fi
-    assertFileContent home-files/.agents/skills/dir-skill/SKILL.md \
+    assertFileContent home-files/.codex/skills/dir-skill/SKILL.md \
       ${./skills-dir/skill-one/SKILL.md}
   '';
 }

--- a/tests/modules/programs/codex/skills-store-path.nix
+++ b/tests/modules/programs/codex/skills-store-path.nix
@@ -21,14 +21,14 @@ in
   };
 
   nmt.script = ''
-    assertLinkExists home-files/.agents/skills/dir-skill
-    assertFileExists home-files/.agents/skills/dir-skill/SKILL.md
-    assertFileContent home-files/.agents/skills/dir-skill/SKILL.md \
+    assertLinkExists home-files/.codex/skills/dir-skill
+    assertFileExists home-files/.codex/skills/dir-skill/SKILL.md
+    assertFileContent home-files/.codex/skills/dir-skill/SKILL.md \
       "${src}/skills/external-skill/SKILL.md"
 
-    assertLinkExists home-files/.agents/skills/file-skill
-    assertFileExists home-files/.agents/skills/file-skill/SKILL.md
-    assertFileContent home-files/.agents/skills/file-skill/SKILL.md \
+    assertLinkExists home-files/.codex/skills/file-skill
+    assertFileExists home-files/.codex/skills/file-skill/SKILL.md
+    assertFileContent home-files/.codex/skills/file-skill/SKILL.md \
       "${src}/skills/external-skill/SKILL.md"
   '';
 }


### PR DESCRIPTION
Codex still loads skills from $CODEX_HOME/skills, so the module should keep managing skills there instead of switching to .agents/skills.

This keeps the module aligned with current Codex behavior and avoids coupling generic agents state to the Codex module.

Essentially reverts https://github.com/nix-community/home-manager/pull/8823 since it was not required and I'd like to separate `~/.agents` management from harness specific management that causes consumers of multiple harness modules to have to create conditional logic depending on whether the harness reads from the agents spec directory. 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
