### PR TITLE
yubikey-agent: fix fish shell syntax

### DIFF
--- a/modules/services/yubikey-agent.nix
+++ b/modules/services/yubikey-agent.nix
@@ -24,20 +24,34 @@ in
 
     sshAuthSock.initialization =
       let
-        socketPath =
-          if pkgs.stdenv.isDarwin then
-            "/tmp/yubikey-agent.sock"
-          else
-            "\${XDG_RUNTIME_DIR:-/run/user/$UID}/yubikey-agent/yubikey-agent.sock";
+        darwinSocket = "/tmp/yubikey-agent.sock";
+        linuxSocketSuffix = "yubikey-agent/yubikey-agent.sock";
       in
       {
-        bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
-        fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
+        bash = ''export SSH_AUTH_SOCK="${
+          if pkgs.stdenv.isDarwin then
+            darwinSocket
+          else
+            "\${XDG_RUNTIME_DIR:-/run/user/$UID}/${linuxSocketSuffix}"
+        }"'';
+
+        fish =
+          if pkgs.stdenv.isDarwin then
+            ''
+              set -x SSH_AUTH_SOCK ${darwinSocket}
+            ''
+          else
+            ''
+              set -l runtime_dir "$XDG_RUNTIME_DIR"
+              test -n "$runtime_dir"; or set runtime_dir /run/user/(id -u)
+              set -x SSH_AUTH_SOCK "$runtime_dir/${linuxSocketSuffix}"
+            '';
+
         nushell = "$env.SSH_AUTH_SOCK = ${
           if pkgs.stdenv.isDarwin then
-            "/tmp/yubikey-agent.sock"
+            darwinSocket
           else
-            ''$"($env.XDG_RUNTIME_DIR | default $"/run/user/(id -u)")/yubikey-agent/yubikey-agent.sock"''
+            ''$"($env.XDG_RUNTIME_DIR? | default $"/run/user/(id -u)")/${linuxSocketSuffix}"''
         }";
       };
 


### PR DESCRIPTION
### Description

This unbreaks the fish shell integration of the yubikey-agent module.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
