### PR TITLE
wiremix: add module

### DIFF
--- a/modules/misc/news/2026/05/2026-05-01_13-04-41.nix
+++ b/modules/misc/news/2026/05/2026-05-01_13-04-41.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+{
+  time = "2026-05-01T11:04:41+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'programs.wiremix'.
+  '';
+}

--- a/modules/programs/wiremix.nix
+++ b/modules/programs/wiremix.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.wiremix;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.maintainers; [ kybe236 ];
+
+  options.programs.wiremix = {
+    enable = lib.mkEnableOption "wiremix";
+
+    package = lib.mkPackageOption pkgs "wiremix" { nullable = true; };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule { freeformType = tomlFormat.type; };
+      default = { };
+      example = {
+        mouse = false;
+        max_volume_percent = 100.0;
+      };
+      description = ''
+        Wiremix configuration.
+        See <https://github.com/tsowell/wiremix#configuration> and <https://github.com/tsowell/wiremix/blob/main/wiremix.toml> for options.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."wiremix/wiremix.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "wiremix-config.toml" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/wiremix/default.nix
+++ b/tests/modules/programs/wiremix/default.nix
@@ -1,0 +1,4 @@
+{
+  wiremix-example-settings = ./example-settings.nix;
+  wiremix-empty-settings = ./empty-settings.nix;
+}

--- a/tests/modules/programs/wiremix/empty-settings.nix
+++ b/tests/modules/programs/wiremix/empty-settings.nix
@@ -1,0 +1,7 @@
+{
+  programs.wiremix.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/wiremix
+  '';
+}

--- a/tests/modules/programs/wiremix/example-settings-expected.toml
+++ b/tests/modules/programs/wiremix/example-settings-expected.toml
@@ -1,0 +1,9 @@
+fps = 75.0
+mouse = false
+tabs = ["playback", "output", "input", "configuration"]
+
+[char_sets.extracompat]
+dropdown_selector = ">>"
+
+[theme.default.selector]
+fg = "LightCyan"

--- a/tests/modules/programs/wiremix/example-settings.nix
+++ b/tests/modules/programs/wiremix/example-settings.nix
@@ -1,0 +1,24 @@
+{
+  programs.wiremix = {
+    enable = true;
+    settings = {
+      fps = 75.0;
+      mouse = false;
+
+      tabs = [
+        "playback"
+        "output"
+        "input"
+        "configuration"
+      ];
+
+      theme.default.selector.fg = "LightCyan";
+      char_sets.extracompat.dropdown_selector = ">>";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/wiremix/wiremix.toml
+    assertFileContent home-files/.config/wiremix/wiremix.toml ${./example-settings-expected.toml}
+  '';
+}


### PR DESCRIPTION
### Description

Add a new module `programs.wiremix` for [Wiremix](https://github.com/tsowell/wiremix)

Also is the list fixed to the commit shown here?
https://github.com/nix-community/home-manager/blob/899c08a15beae5da51a5cecd6b2b994777a948da/modules/lib/maintainers.nix#L7
If so i would need to add myself to the hm list. but i wasn't sure weather it is updated or not.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [X] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
