### PR TITLE
[Backport 25.11] wayle: add module

### DIFF
--- a/modules/misc/news/2026/03/2026-03-19_20-34-29.nix
+++ b/modules/misc/news/2026/03/2026-03-19_20-34-29.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+{
+  time = "2026-03-20T02:34:29+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'services.wayle'.
+
+    Wayle is a fast, configurable desktop environment shell for Wayland
+    compositors. Built in Rust with Relm4 and focused on performance,
+    modularity, and a great user experience. A successor to HyprPanel without
+    the pain or dependency on Hyprland.
+  '';
+}

--- a/modules/services/wayle.nix
+++ b/modules/services/wayle.nix
@@ -1,0 +1,140 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (builtins) elem;
+  inherit (lib.attrsets) recursiveUpdate;
+  inherit (lib) lists getExe';
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkEnableOption mkOption mkPackageOption;
+
+  cfg = config.services.wayle;
+
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    perchun
+  ];
+
+  options.services.wayle = {
+    enable = mkEnableOption "wayle shell";
+    package = mkPackageOption pkgs "wayle" { };
+
+    autoInstallDependencies = mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whether to automatically install soft dependencies used by wayle that
+        will be required based on your config.
+      '';
+    };
+
+    settings = mkOption {
+      inherit (tomlFormat) type;
+      description = ''
+        Standard configuration options for wayle.
+      '';
+
+      default = { };
+
+      example = {
+        styling = {
+          theme-provider = "wayle";
+
+          palette = {
+            bg = "#16161e";
+            fg = "#c0caf5";
+            primary = "#7aa2f7";
+          };
+        };
+
+        bar = {
+          scale = 1;
+          location = "top";
+          rounding = "sm";
+
+          layout = [
+            {
+              monitor = "*";
+              left = [ "clock" ];
+              center = [ "media" ];
+              right = [ "battery" ];
+            }
+          ];
+        };
+
+        modules.clock = {
+          format = "%H:%M";
+          icon-show = true;
+          label-show = true;
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (
+    let
+      # Define default settings.
+      # This is not used to generate the config.toml file for wayle, only for
+      # internal module configuration that require (possibly user unset)
+      # default settings. These are the same defaults wayle uses.
+      settings_with_fallbacks = recursiveUpdate {
+        wallpaper.engine-enabled = false;
+        styling.theme-provider = "wayle";
+      } cfg.settings;
+    in
+    {
+      assertions = [
+        (lib.hm.assertions.assertPlatform "services.wayle" pkgs lib.platforms.linux)
+      ];
+
+      home.packages = (
+        [ cfg.package ]
+        # Install the appropriate theme-provider, if set.
+        ++ (lists.optional (
+          cfg.autoInstallDependencies
+          && elem settings_with_fallbacks.styling.theme-provider [
+            "matugen"
+            "wallust"
+            "pywal"
+          ]
+        ) pkgs.${settings_with_fallbacks.styling.theme-provider})
+      );
+
+      # Main config file.
+      xdg.configFile."wayle/config.toml" = mkIf (cfg.settings != { }) {
+        source = tomlFormat.generate "wayle-config" cfg.settings;
+      };
+
+      # Systemd service for main wayle shell.
+      systemd.user.services.wayle = {
+        Unit = {
+          Description = ''
+            Wayland Elements - A compositor agnostic shell with extensive customization
+          '';
+          Documentation = "https://github.com/wayle-rs/wayle";
+          PartOf = [ config.wayland.systemd.target ];
+          After = [ config.wayland.systemd.target ];
+          ConditionEnvironment = "WAYLAND_DISPLAY";
+        };
+        Service = {
+          ExecStart = "${getExe' cfg.package "wayle"} shell";
+          Restart = "on-failure";
+        };
+        Install = {
+          WantedBy = [ config.wayland.systemd.target ];
+        };
+      };
+
+      # Wallpaper-engine dependency.
+      services.swww.enable = mkIf (
+        cfg.autoInstallDependencies && settings_with_fallbacks.wallpaper.engine-enabled
+      ) (lib.mkDefault true);
+    }
+  );
+}

--- a/tests/modules/services/wayle/basic-config.nix
+++ b/tests/modules/services/wayle/basic-config.nix
@@ -1,0 +1,44 @@
+{ config, ... }:
+{
+  services.wayle = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "wayle"; };
+
+    settings = {
+      styling = {
+        theme-provider = "wayle";
+
+        palette = {
+          bg = "#16161e";
+          fg = "#c0caf5";
+          primary = "#7aa2f7";
+        };
+      };
+
+      bar = {
+        scale = 1;
+        location = "top";
+        rounding = "sm";
+
+        layout = {
+          monitor = "*";
+          left = [ "clock" ];
+          center = [ "media" ];
+          right = [ "battery" ];
+        };
+      };
+
+      modules.clock = {
+        format = "%H:%M";
+        icon-show = true;
+        label-show = true;
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      "home-files/.config/wayle/config.toml" \
+      ${./basic-config.toml}
+  '';
+}

--- a/tests/modules/services/wayle/basic-config.toml
+++ b/tests/modules/services/wayle/basic-config.toml
@@ -1,0 +1,23 @@
+[bar]
+location = "top"
+rounding = "sm"
+scale = 1
+
+[bar.layout]
+center = ["media"]
+left = ["clock"]
+monitor = "*"
+right = ["battery"]
+
+[modules.clock]
+format = "%H:%M"
+icon-show = true
+label-show = true
+
+[styling]
+theme-provider = "wayle"
+
+[styling.palette]
+bg = "#16161e"
+fg = "#c0caf5"
+primary = "#7aa2f7"

--- a/tests/modules/services/wayle/default.nix
+++ b/tests/modules/services/wayle/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  wayle-basic-config = ./basic-config.nix;
+}


### PR DESCRIPTION
Backport of https://github.com/nix-community/home-manager/pull/8998 and https://github.com/nix-community/home-manager/pull/9164

Nixpkgs backport: https://github.com/NixOS/nixpkgs/pull/514137

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
