### PR TITLE
github-copilot-cli: add context, agents, and skills 

### DIFF
--- a/modules/misc/news/2026/05/2026-05-01_16-15-00.nix
+++ b/modules/misc/news/2026/05/2026-05-01_16-15-00.nix
@@ -1,0 +1,13 @@
+{ config, ... }:
+{
+  time = "2026-05-01T16:15:00+00:00";
+  condition = config.programs.github-copilot-cli.enable;
+  message = ''
+    The `programs.github-copilot-cli.context`, `programs.github-copilot-cli.agents`,
+    and `programs.github-copilot-cli.skills` options have been added.
+
+    `context` manages `copilot-instructions.md` under `COPILOT_HOME`, while
+    `agents` and `skills` let you define custom Copilot CLI agents and skills
+    from inline definitions or managed directories.
+  '';
+}

--- a/modules/programs/github-copilot-cli.nix
+++ b/modules/programs/github-copilot-cli.nix
@@ -19,6 +19,11 @@ let
 
   upstreamConfigDir = "${config.home.homeDirectory}/.copilot";
 
+  isStorePathString =
+    content: builtins.isString content && lib.hasPrefix "${builtins.storeDir}/" content;
+
+  isPathLikeContent = content: lib.isPath content || isStorePathString content;
+
   transformSingleServer =
     _name: server:
     let
@@ -69,7 +74,8 @@ in
       example = literalExpression ''"''${config.xdg.configHome}/copilot"'';
       description = ''
         Directory holding Copilot CLI configuration files such as
-        {file}`config.json` and {file}`mcp-config.json`.
+        {file}`config.json`, {file}`mcp-config.json`, and
+        {file}`copilot-instructions.md`.
 
         Defaults to `''${config.xdg.configHome}/copilot` when
         {option}`home.preferXdgDirectories` is enabled and to `~/.copilot`
@@ -136,6 +142,28 @@ in
       '';
     };
 
+    context = mkOption {
+      type = lib.types.either lib.types.lines lib.types.path;
+      default = "";
+      example = literalExpression ''
+        '''
+          Review the current workspace before making edits.
+          Prefer actionable findings over general commentary.
+        '''
+      '';
+      description = ''
+        Global instructions for GitHub Copilot CLI.
+
+        The value is either:
+        - Inline content as a string
+        - A path to a file containing the content
+
+        The configured content is written to
+        {file}`copilot-instructions.md` inside
+        {option}`programs.github-copilot-cli.configDir`.
+      '';
+    };
+
     mcpServers = mkOption {
       type = lib.types.attrsOf jsonFormat.type;
       default = { };
@@ -172,9 +200,111 @@ in
         for the documentation.
       '';
     };
+
+    agents = mkOption {
+      type = lib.types.either (lib.types.attrsOf (
+        lib.types.oneOf [
+          lib.types.lines
+          lib.types.path
+          lib.types.str
+        ]
+      )) lib.types.path;
+      default = { };
+      example = literalExpression ''
+        {
+          code-reviewer = '''
+            ---
+            description: High signal code review for logic, security, and test gaps.
+            tools: ["*"]
+            ---
+
+            Review the current changes and report only actionable findings.
+          ''';
+          documentation = ./agents/documentation.agent.md;
+        }
+      '';
+      description = ''
+        Custom agents for GitHub Copilot CLI.
+
+        This option can either be:
+        - An attribute set defining agents
+        - A path to a directory containing multiple agent files
+
+        If an attribute set is used, the attribute name becomes the agent
+        filename, and the value is either:
+        - Inline content as a string (creates
+          {file}`''${configDir}/agents/<name>.agent.md`)
+        - A path to a file (creates
+          {file}`''${configDir}/agents/<name>.agent.md`)
+
+        If a path is used, it is expected to contain agent files. The directory
+        is symlinked to {file}`''${configDir}/agents/`.
+
+        See <https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference#custom-agents-reference>
+        for the documentation.
+      '';
+    };
+
+    skills = mkOption {
+      type = lib.types.either (lib.types.attrsOf (
+        lib.types.oneOf [
+          lib.types.lines
+          lib.types.path
+          lib.types.str
+        ]
+      )) lib.types.path;
+      default = { };
+      example = literalExpression ''
+        {
+          data-analysis = ./skills/data-analysis;
+          release-notes = '''
+            ---
+            name: release-notes
+            description: Draft release notes from commits and pull requests.
+            ---
+
+            Summarize user-visible changes and call out migrations.
+          ''';
+        }
+      '';
+      description = ''
+        Custom skills for GitHub Copilot CLI.
+
+        This option can be either:
+        - An attribute set defining skills
+        - A path to a directory containing skill folders
+
+        If an attribute set is used, the attribute name becomes the skill
+        directory name, and the value is either:
+        - Inline content as a string (creates
+          {file}`''${configDir}/skills/<name>/SKILL.md`)
+        - A path to a file (creates
+          {file}`''${configDir}/skills/<name>/SKILL.md`)
+        - A path to a directory (symlinks
+          {file}`''${configDir}/skills/<name>/` to that directory)
+
+        If a path is used, it is expected to contain one folder per skill name,
+        each containing a {file}`SKILL.md`. The directory is symlinked to
+        {file}`''${configDir}/skills/`.
+
+        See <https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference#skills-reference>
+        for the documentation.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !isPathLikeContent cfg.agents || lib.pathIsDirectory cfg.agents;
+        message = "`programs.github-copilot-cli.agents` must be a directory when set to a path";
+      }
+      {
+        assertion = !isPathLikeContent cfg.skills || lib.pathIsDirectory cfg.skills;
+        message = "`programs.github-copilot-cli.skills` must be a directory when set to a path";
+      }
+    ];
+
     home.packages = mkIf (cfg.package != null) [ cfg.package ];
 
     home.file = {
@@ -193,7 +323,47 @@ in
           mcpServers = mergedMcpServers;
         };
       };
-    };
+
+      "${cfg.configDir}/copilot-instructions.md" =
+        if isPathLikeContent cfg.context then
+          { source = cfg.context; }
+        else
+          mkIf (cfg.context != "") {
+            text = cfg.context;
+          };
+
+      "${cfg.configDir}/agents" = mkIf (isPathLikeContent cfg.agents) {
+        source = cfg.agents;
+        recursive = true;
+      };
+
+      "${cfg.configDir}/skills" = mkIf (isPathLikeContent cfg.skills) {
+        source = cfg.skills;
+        recursive = true;
+      };
+    }
+    // lib.optionalAttrs (builtins.isAttrs cfg.agents) (
+      lib.mapAttrs' (
+        name: content:
+        lib.nameValuePair "${cfg.configDir}/agents/${name}.agent.md" (
+          if isPathLikeContent content then { source = content; } else { text = content; }
+        )
+      ) cfg.agents
+    )
+    // lib.optionalAttrs (builtins.isAttrs cfg.skills) (
+      lib.mapAttrs' (
+        name: content:
+        if isPathLikeContent content && lib.pathIsDirectory content then
+          lib.nameValuePair "${cfg.configDir}/skills/${name}" {
+            source = content;
+            recursive = true;
+          }
+        else
+          lib.nameValuePair "${cfg.configDir}/skills/${name}/SKILL.md" (
+            if isPathLikeContent content then { source = content; } else { text = content; }
+          )
+      ) cfg.skills
+    );
 
     home.sessionVariables = mkIf (cfg.configDir != upstreamConfigDir) {
       COPILOT_HOME = cfg.configDir;

--- a/tests/modules/programs/github-copilot-cli/agents/code-reviewer.agent.md
+++ b/tests/modules/programs/github-copilot-cli/agents/code-reviewer.agent.md
@@ -1,0 +1,6 @@
+---
+description: Review changes for correctness and missing tests.
+tools: ["*"]
+---
+
+Prioritize concrete, reproducible findings.

--- a/tests/modules/programs/github-copilot-cli/agents/documentation.agent.md
+++ b/tests/modules/programs/github-copilot-cli/agents/documentation.agent.md
@@ -1,0 +1,6 @@
+---
+description: Write concise, accurate user-facing documentation updates.
+tools: ["*"]
+---
+
+Focus on examples, migrations, and operator-facing impact.

--- a/tests/modules/programs/github-copilot-cli/config.nix
+++ b/tests/modules/programs/github-copilot-cli/config.nix
@@ -1,3 +1,37 @@
+{ pkgs, ... }:
+let
+  inlineAgent = ''
+    ---
+    description: Review staged changes for bugs and test gaps.
+    tools: ["*"]
+    ---
+
+    Report only actionable findings.
+  '';
+  storeAgentSrc = pkgs.writeText "code-reviewer.agent.md" ''
+    ---
+    description: Review changes for bugs and missing tests.
+    tools: ["*"]
+    ---
+
+    Report actionable findings only.
+  '';
+  inlineSkill = ''
+    ---
+    name: inline-skill
+    description: Inline skill fixture for Copilot CLI tests.
+    ---
+
+    Use this skill when validating inline skill materialization.
+  '';
+  inlineContext = ''
+    Review the repository before making changes.
+    Report only actionable findings.
+  '';
+  storeSkillSrc = pkgs.writeTextDir "skills/external-skill/SKILL.md" ''
+    # External Skill
+  '';
+in
 {
   programs.github-copilot-cli = {
     enable = true;
@@ -6,11 +40,65 @@
       theme = "dark";
       trusted_folders = [ "/home/user/projects" ];
     };
+    context = inlineContext;
+    agents = {
+      inline-reviewer = inlineAgent;
+      path-reviewer = ./agents/documentation.agent.md;
+      store-reviewer = "${storeAgentSrc}";
+    };
+    skills = {
+      inline-skill = inlineSkill;
+      path-skill = ./test-skill.md;
+      dir-skill = ./skills/data-analysis;
+      store-skill = "${storeSkillSrc}/skills/external-skill";
+    };
   };
 
   nmt.script = ''
     assertFileExists home-files/.copilot/config.json
     assertFileContent home-files/.copilot/config.json ${./expected-config.json}
+
+    assertFileExists home-files/.copilot/copilot-instructions.md
+    assertFileContent home-files/.copilot/copilot-instructions.md \
+      ${builtins.toFile "expected-copilot-instructions.md" inlineContext}
+
+    assertFileExists home-files/.copilot/agents/inline-reviewer.agent.md
+    assertFileContent home-files/.copilot/agents/inline-reviewer.agent.md \
+      ${builtins.toFile "expected-inline-reviewer.agent.md" inlineAgent}
+
+    assertFileExists home-files/.copilot/agents/path-reviewer.agent.md
+    assertLinkExists home-files/.copilot/agents/path-reviewer.agent.md
+    assertFileContent home-files/.copilot/agents/path-reviewer.agent.md \
+      ${./agents/documentation.agent.md}
+
+    assertFileExists home-files/.copilot/agents/store-reviewer.agent.md
+    assertLinkExists home-files/.copilot/agents/store-reviewer.agent.md
+    assertFileContent home-files/.copilot/agents/store-reviewer.agent.md \
+      ${storeAgentSrc}
+
+    assertFileExists home-files/.copilot/skills/inline-skill/SKILL.md
+    assertFileContent home-files/.copilot/skills/inline-skill/SKILL.md \
+      ${builtins.toFile "expected-inline-skill.md" inlineSkill}
+
+    assertFileExists home-files/.copilot/skills/path-skill/SKILL.md
+    assertLinkExists home-files/.copilot/skills/path-skill/SKILL.md
+    assertFileContent home-files/.copilot/skills/path-skill/SKILL.md \
+      ${./test-skill.md}
+
+    assertFileExists home-files/.copilot/skills/dir-skill/SKILL.md
+    assertFileExists home-files/.copilot/skills/dir-skill/notes.txt
+    assertLinkExists home-files/.copilot/skills/dir-skill/SKILL.md
+    assertLinkExists home-files/.copilot/skills/dir-skill/notes.txt
+    assertFileContent home-files/.copilot/skills/dir-skill/SKILL.md \
+      ${./skills/data-analysis/SKILL.md}
+    assertFileContent home-files/.copilot/skills/dir-skill/notes.txt \
+      ${./skills/data-analysis/notes.txt}
+
+    assertFileExists home-files/.copilot/skills/store-skill/SKILL.md
+    assertLinkExists home-files/.copilot/skills/store-skill/SKILL.md
+    assertFileContent home-files/.copilot/skills/store-skill/SKILL.md \
+      "${storeSkillSrc}/skills/external-skill/SKILL.md"
+
     assertPathNotExists home-files/.copilot/mcp-config.json
     assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh 'COPILOT_HOME'
   '';

--- a/tests/modules/programs/github-copilot-cli/context.md
+++ b/tests/modules/programs/github-copilot-cli/context.md
@@ -1,0 +1,2 @@
+Review the current workspace before editing files.
+Prefer concrete recommendations and minimal churn.

--- a/tests/modules/programs/github-copilot-cli/default.nix
+++ b/tests/modules/programs/github-copilot-cli/default.nix
@@ -1,6 +1,10 @@
 {
   github-copilot-cli-config = ./config.nix;
+  github-copilot-cli-directories = ./directories.nix;
   github-copilot-cli-mcp = ./mcp.nix;
   github-copilot-cli-mcp-integration = ./mcp-integration.nix;
+  github-copilot-cli-path-not-directory = ./path-not-directory.nix;
+  github-copilot-cli-store-path-dir = ./store-path-dir.nix;
+  github-copilot-cli-store-path-not-directory = ./store-path-not-directory.nix;
   github-copilot-cli-xdg-config-dir = ./xdg-config-dir.nix;
 }

--- a/tests/modules/programs/github-copilot-cli/directories.nix
+++ b/tests/modules/programs/github-copilot-cli/directories.nix
@@ -1,0 +1,37 @@
+{
+  programs.github-copilot-cli = {
+    enable = true;
+    agents = ./agents;
+    skills = ./skills;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.copilot/agents/code-reviewer.agent.md
+    assertLinkExists home-files/.copilot/agents/code-reviewer.agent.md
+    assertFileContent home-files/.copilot/agents/code-reviewer.agent.md \
+      ${./agents/code-reviewer.agent.md}
+
+    assertFileExists home-files/.copilot/agents/documentation.agent.md
+    assertLinkExists home-files/.copilot/agents/documentation.agent.md
+    assertFileContent home-files/.copilot/agents/documentation.agent.md \
+      ${./agents/documentation.agent.md}
+
+    assertFileExists home-files/.copilot/skills/data-analysis/SKILL.md
+    assertFileExists home-files/.copilot/skills/data-analysis/notes.txt
+    assertLinkExists home-files/.copilot/skills/data-analysis/SKILL.md
+    assertLinkExists home-files/.copilot/skills/data-analysis/notes.txt
+    assertFileContent home-files/.copilot/skills/data-analysis/SKILL.md \
+      ${./skills/data-analysis/SKILL.md}
+    assertFileContent home-files/.copilot/skills/data-analysis/notes.txt \
+      ${./skills/data-analysis/notes.txt}
+
+    assertFileExists home-files/.copilot/skills/release-notes/SKILL.md
+    assertFileExists home-files/.copilot/skills/release-notes/checklist.md
+    assertLinkExists home-files/.copilot/skills/release-notes/SKILL.md
+    assertLinkExists home-files/.copilot/skills/release-notes/checklist.md
+    assertFileContent home-files/.copilot/skills/release-notes/SKILL.md \
+      ${./skills/release-notes/SKILL.md}
+    assertFileContent home-files/.copilot/skills/release-notes/checklist.md \
+      ${./skills/release-notes/checklist.md}
+  '';
+}

--- a/tests/modules/programs/github-copilot-cli/path-not-directory.nix
+++ b/tests/modules/programs/github-copilot-cli/path-not-directory.nix
@@ -1,0 +1,12 @@
+{
+  programs.github-copilot-cli = {
+    enable = true;
+    agents = ./agents/code-reviewer.agent.md;
+    skills = ./skills/data-analysis/SKILL.md;
+  };
+
+  test.asserts.assertions.expected = [
+    "`programs.github-copilot-cli.agents` must be a directory when set to a path"
+    "`programs.github-copilot-cli.skills` must be a directory when set to a path"
+  ];
+}

--- a/tests/modules/programs/github-copilot-cli/skills/data-analysis/SKILL.md
+++ b/tests/modules/programs/github-copilot-cli/skills/data-analysis/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: data-analysis
+description: Summarize structured outputs and highlight regressions.
+---
+
+Use this skill when a task depends on reading tabular or machine-generated data.

--- a/tests/modules/programs/github-copilot-cli/skills/data-analysis/notes.txt
+++ b/tests/modules/programs/github-copilot-cli/skills/data-analysis/notes.txt
@@ -1,0 +1,1 @@
+Supplementary notes for the data-analysis skill fixture.

--- a/tests/modules/programs/github-copilot-cli/skills/release-notes/SKILL.md
+++ b/tests/modules/programs/github-copilot-cli/skills/release-notes/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: release-notes
+description: Draft release notes from commits and merged pull requests.
+---
+
+Summarize user-visible changes and call out upgrades or migration notes.

--- a/tests/modules/programs/github-copilot-cli/skills/release-notes/checklist.md
+++ b/tests/modules/programs/github-copilot-cli/skills/release-notes/checklist.md
@@ -1,0 +1,5 @@
+# Release Notes Checklist
+
+- Group changes by user impact.
+- Call out migrations.
+- Link follow-up issues when relevant.

--- a/tests/modules/programs/github-copilot-cli/store-path-dir.nix
+++ b/tests/modules/programs/github-copilot-cli/store-path-dir.nix
@@ -1,0 +1,39 @@
+{ pkgs, ... }:
+let
+  src = pkgs.writeTextDir "agents/code-reviewer.agent.md" ''
+    ---
+    description: Review changes from a store-path directory fixture.
+    tools: ["*"]
+    ---
+
+    Focus on correctness and missing coverage.
+  '';
+
+  skillsSrc = pkgs.writeTextDir "skills/external-skill/SKILL.md" ''
+    ---
+    name: external-skill
+    description: Store-path directory fixture.
+    ---
+
+    Exercise top-level store-path directory handling.
+  '';
+in
+{
+  programs.github-copilot-cli = {
+    enable = true;
+    agents = "${src}/agents";
+    skills = "${skillsSrc}/skills";
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.copilot/agents/code-reviewer.agent.md
+    assertLinkExists home-files/.copilot/agents/code-reviewer.agent.md
+    assertFileContent home-files/.copilot/agents/code-reviewer.agent.md \
+      "${src}/agents/code-reviewer.agent.md"
+
+    assertFileExists home-files/.copilot/skills/external-skill/SKILL.md
+    assertLinkExists home-files/.copilot/skills/external-skill/SKILL.md
+    assertFileContent home-files/.copilot/skills/external-skill/SKILL.md \
+      "${skillsSrc}/skills/external-skill/SKILL.md"
+  '';
+}

--- a/tests/modules/programs/github-copilot-cli/store-path-not-directory.nix
+++ b/tests/modules/programs/github-copilot-cli/store-path-not-directory.nix
@@ -1,0 +1,28 @@
+{ pkgs, ... }:
+let
+  agentFile = pkgs.writeText "code-reviewer.agent.md" ''
+    ---
+    description: Invalid top-level agent file fixture.
+    tools: ["*"]
+    ---
+  '';
+
+  skillFile = pkgs.writeText "SKILL.md" ''
+    ---
+    name: invalid-top-level-skill
+    description: Invalid top-level skill file fixture.
+    ---
+  '';
+in
+{
+  programs.github-copilot-cli = {
+    enable = true;
+    agents = "${agentFile}";
+    skills = "${skillFile}";
+  };
+
+  test.asserts.assertions.expected = [
+    "`programs.github-copilot-cli.agents` must be a directory when set to a path"
+    "`programs.github-copilot-cli.skills` must be a directory when set to a path"
+  ];
+}

--- a/tests/modules/programs/github-copilot-cli/test-skill.md
+++ b/tests/modules/programs/github-copilot-cli/test-skill.md
@@ -1,0 +1,6 @@
+---
+name: test-skill
+description: File-backed skill fixture.
+---
+
+This skill is defined by a standalone markdown file.

--- a/tests/modules/programs/github-copilot-cli/xdg-config-dir.nix
+++ b/tests/modules/programs/github-copilot-cli/xdg-config-dir.nix
@@ -2,6 +2,7 @@
   home.preferXdgDirectories = true;
   programs.github-copilot-cli = {
     enable = true;
+    context = ./context.md;
     settings = {
       model = "claude-sonnet-4-5";
       theme = "dark";
@@ -12,7 +13,12 @@
   nmt.script = ''
     assertFileExists home-files/.config/copilot/config.json
     assertFileContent home-files/.config/copilot/config.json ${./expected-config.json}
+    assertFileExists home-files/.config/copilot/copilot-instructions.md
+    assertLinkExists home-files/.config/copilot/copilot-instructions.md
+    assertFileContent home-files/.config/copilot/copilot-instructions.md \
+      ${./context.md}
     assertPathNotExists home-files/.copilot/config.json
+    assertPathNotExists home-files/.copilot/copilot-instructions.md
     assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
       'export COPILOT_HOME="/home/hm-user/.config/copilot"'
   '';


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
