### PR TITLE
github-copilot-cli: add lsp server support

### DIFF
--- a/modules/misc/news/2026/05/2026-05-01_17-00-00.nix
+++ b/modules/misc/news/2026/05/2026-05-01_17-00-00.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+{
+  time = "2026-05-01T17:00:00+00:00";
+  condition = config.programs.github-copilot-cli.enable;
+  message = ''
+    The `programs.github-copilot-cli.lspServers` option has been added.
+
+    This option manages the `lsp-config.json` file under `COPILOT_HOME`,
+    allowing GitHub Copilot CLI to start configured language servers for code
+    intelligence features.
+  '';
+}

--- a/modules/programs/github-copilot-cli.nix
+++ b/modules/programs/github-copilot-cli.nix
@@ -74,7 +74,8 @@ in
       example = literalExpression ''"''${config.xdg.configHome}/copilot"'';
       description = ''
         Directory holding Copilot CLI configuration files such as
-        {file}`config.json`, {file}`mcp-config.json`, and
+        {file}`config.json`, {file}`mcp-config.json`,
+        {file}`lsp-config.json`, and
         {file}`copilot-instructions.md`.
 
         Defaults to `''${config.xdg.configHome}/copilot` when
@@ -201,6 +202,55 @@ in
       '';
     };
 
+    lspServers = mkOption {
+      type = lib.types.attrsOf jsonFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          typescript = {
+            command = "typescript-language-server";
+            args = [ "--stdio" ];
+            fileExtensions = {
+              ".ts" = "typescript";
+              ".tsx" = "typescriptreact";
+              ".js" = "javascript";
+              ".jsx" = "javascriptreact";
+            };
+          };
+          python = {
+            command = lib.getExe' pkgs.pyright "pyright-langserver";
+            args = [ "--stdio" ];
+            fileExtensions = {
+              ".py" = "python";
+              ".pyw" = "python";
+              ".pyi" = "python";
+            };
+          };
+        }
+      '';
+      description = ''
+        LSP (Language Server Protocol) server configurations written to
+        {file}`lsp-config.json` inside
+        {option}`programs.github-copilot-cli.configDir`.
+
+        Each attribute defines a server entry under `lspServers` in the config
+        file. Supported fields include:
+        - `command` — command used to start the LSP server
+        - `args` — arguments passed to the command
+        - `fileExtensions` — map of file extensions to language IDs
+        - `env` — environment variables for the server process
+        - `rootUri` — server root directory relative to the Git root
+        - `initializationOptions` — custom startup options
+        - `requestTimeoutMs` — request timeout in milliseconds
+
+        Language server packages are not installed automatically. Add them to
+        {option}`home.packages` when needed.
+
+        See <https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-lsp-servers>
+        for the documentation.
+      '';
+    };
+
     agents = mkOption {
       type = lib.types.either (lib.types.attrsOf (
         lib.types.oneOf [
@@ -321,6 +371,12 @@ in
       "${cfg.configDir}/mcp-config.json" = mkIf (mergedMcpServers != { }) {
         source = jsonFormat.generate "github-copilot-cli-mcp-config.json" {
           mcpServers = mergedMcpServers;
+        };
+      };
+
+      "${cfg.configDir}/lsp-config.json" = mkIf (cfg.lspServers != { }) {
+        source = jsonFormat.generate "github-copilot-cli-lsp-config.json" {
+          inherit (cfg) lspServers;
         };
       };
 

--- a/tests/modules/programs/github-copilot-cli/default.nix
+++ b/tests/modules/programs/github-copilot-cli/default.nix
@@ -1,6 +1,7 @@
 {
   github-copilot-cli-config = ./config.nix;
   github-copilot-cli-directories = ./directories.nix;
+  github-copilot-cli-lsp = ./lsp.nix;
   github-copilot-cli-mcp = ./mcp.nix;
   github-copilot-cli-mcp-integration = ./mcp-integration.nix;
   github-copilot-cli-path-not-directory = ./path-not-directory.nix;

--- a/tests/modules/programs/github-copilot-cli/expected-lsp-config.json
+++ b/tests/modules/programs/github-copilot-cli/expected-lsp-config.json
@@ -1,0 +1,32 @@
+{
+  "lspServers": {
+    "python": {
+      "args": [
+        "--stdio"
+      ],
+      "command": "pyright-langserver",
+      "env": {
+        "PYTHONPATH": "${PYTHONPATH:-}"
+      },
+      "fileExtensions": {
+        ".py": "python",
+        ".pyi": "python",
+        ".pyw": "python"
+      },
+      "requestTimeoutMs": 120000,
+      "rootUri": "backend"
+    },
+    "typescript": {
+      "args": [
+        "--stdio"
+      ],
+      "command": "typescript-language-server",
+      "fileExtensions": {
+        ".js": "javascript",
+        ".jsx": "javascriptreact",
+        ".ts": "typescript",
+        ".tsx": "typescriptreact"
+      }
+    }
+  }
+}

--- a/tests/modules/programs/github-copilot-cli/lsp.nix
+++ b/tests/modules/programs/github-copilot-cli/lsp.nix
@@ -1,0 +1,38 @@
+{
+  programs.github-copilot-cli = {
+    enable = true;
+    lspServers = {
+      typescript = {
+        command = "typescript-language-server";
+        args = [ "--stdio" ];
+        fileExtensions = {
+          ".ts" = "typescript";
+          ".tsx" = "typescriptreact";
+          ".js" = "javascript";
+          ".jsx" = "javascriptreact";
+        };
+      };
+      python = {
+        command = "pyright-langserver";
+        args = [ "--stdio" ];
+        fileExtensions = {
+          ".py" = "python";
+          ".pyw" = "python";
+          ".pyi" = "python";
+        };
+        env = {
+          PYTHONPATH = "\${PYTHONPATH:-}";
+        };
+        rootUri = "backend";
+        requestTimeoutMs = 120000;
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.copilot/lsp-config.json
+    assertFileContent home-files/.copilot/lsp-config.json ${./expected-lsp-config.json}
+    assertPathNotExists home-files/.copilot/config.json
+    assertPathNotExists home-files/.copilot/mcp-config.json
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
