### PR TITLE
shell: support boolean sessionVariables

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -272,6 +272,7 @@ in
             path
             int
             float
+            bool
           ])
         );
       example = {

--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -23,7 +23,12 @@ let
     };
 
   # Produces a Bourne shell like variable export statement.
-  export = n: v: ''export ${n}="${toString v}"'';
+  export =
+    n: v:
+    let
+      value = if builtins.isBool v then lib.boolToString v else toString v;
+    in
+    ''export ${n}="${value}"'';
 
   # Wrap a list of strings to a given line width.
   # Packs as many items as possible per line without exceeding maxWidth.

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -141,6 +141,7 @@ in
               path
               int
               float
+              bool
             ])
           );
         example = {

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -255,6 +255,7 @@ in
                 path
                 int
                 float
+                bool
               ])
             );
           example = {

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -10,6 +10,8 @@ let
     export __HM_SESS_VARS_SOURCED=1
 
     export IS_EMPTY=""
+    export IS_FALSE="false"
+    export IS_TRUE="true"
     export LOCALE_ARCHIVE_2_27="${config.i18n.glibcLocales}/lib/locale/locale-archive"
     export V1="v1"
     export V2="v2-v1"
@@ -27,6 +29,8 @@ let
     export __HM_SESS_VARS_SOURCED=1
 
     export IS_EMPTY=""
+    export IS_FALSE="false"
+    export IS_TRUE="true"
     export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:$TERMINFO_DIRS''${TERMINFO_DIRS:+:}/usr/share/terminfo"
     export V1="v1"
     export V2="v2-v1"
@@ -49,6 +53,8 @@ in
     V2 = "v2-${config.home.sessionVariables.V1}";
     IS_EMPTY = "";
     IS_NULL = null;
+    IS_TRUE = true;
+    IS_FALSE = false;
   };
 
   nmt.script = ''

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -10,6 +10,8 @@
       V2 = "v2-${config.programs.bash.sessionVariables.V1}";
       IS_EMPTY = "";
       IS_NULL = null;
+      IS_TRUE = true;
+      IS_FALSE = false;
     };
   };
 
@@ -21,6 +23,8 @@
         . "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
 
         export IS_EMPTY=""
+        export IS_FALSE="false"
+        export IS_TRUE="true"
         export V1="v1"
         export V2="v2-v1"
 

--- a/tests/modules/programs/zsh/session-variables.nix
+++ b/tests/modules/programs/zsh/session-variables.nix
@@ -10,6 +10,8 @@
       V2 = "v2-${config.programs.zsh.sessionVariables.V1}";
       IS_EMPTY = "";
       IS_NULL = null;
+      IS_FALSE = false;
+      IS_TRUE = true;
     };
   };
 

--- a/tests/modules/programs/zsh/session-variables.zshenv
+++ b/tests/modules/programs/zsh/session-variables.zshenv
@@ -5,6 +5,8 @@
 if [[ -z "$__HM_ZSH_SESS_VARS_SOURCED" ]]; then
   export __HM_ZSH_SESS_VARS_SOURCED=1
   export IS_EMPTY=""
+  export IS_FALSE=false
+  export IS_TRUE=true
   export PATH="$HOME/bin:$PATH"
   export V1="v1"
   export V2="v2-v1"


### PR DESCRIPTION
Follow up to https://github.com/nix-community/home-manager/pull/9189

Allow boolean values in sessionVariables for Home Manager shell modules and serialize them consistently in generated session files.

- modules/lib/shell: stringify boolean values using lib.boolToString in export helper

- modules/home-environment, programs.bash, programs.zsh: include lib.types.bool in sessionVariables option type

- tests: add IS_TRUE/IS_FALSE assertions in home-environment, bash, and zsh session-variables tests

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
