### PR TITLE
macchina: fix palette spacing config being missing

### DIFF
--- a/modules/programs/macchina/theme.nix
+++ b/modules/programs/macchina/theme.nix
@@ -30,6 +30,11 @@ let
         default = null;
         description = "Whether to show the palette.";
       };
+      spacing = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = "The amount of spacing to leave between each glyph.";
+      };
     };
   };
 


### PR DESCRIPTION
### Description

Adds the palette spacing option to the macchina theme. This is a valid option and seems to have even been forgotten by the original devs :sweat_smile: (https://github.com/Macchina-CLI/macchina/pull/363) despite it being included in one of the default themes ([Lithium](https://github.com/Macchina-CLI/macchina/blob/main/contrib/themes/Lithium.toml#L13)).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
