### PR TITLE
generic-linux-gpu: don't pass kernel

### DIFF
--- a/modules/targets/generic-linux/gpu/default.nix
+++ b/modules/targets/generic-linux/gpu/default.nix
@@ -101,7 +101,6 @@
         }).override
           {
             libsOnly = true;
-            kernel = null;
           };
 
       setupPackage = cfg.packages.callPackage ./setup {


### PR DESCRIPTION
### Description

i use home-manager with `nixpkgs` input override on `nixpkgs-unstable`, and today after an update my configuration broke: it doesn't even evaluate.

[this commit](https://github.com/NixOS/nixpkgs/commit/c7dfcad894b8b44ae78950b7bb6a7867267d4a05#diff-14b54ff5255020d55946030106ffa0c927ddb97b8688deea69e6d4c5925fc2f4L44) removed the kernel argument in nvidia-x11 drivers, so the evaluation errors: `function 'anonymous lambda' called with unexpected argument 'kernel'`.

this commit removes the override of this argument (it was set to `null` anyway), which fixes the problem. however, `nixpkgs` version in home-manager flake doesn't include this commit yet, so i am marking this PR as a draft.

there is probably a way to pass this argument as `null` if it's present and skip otherwise, but i don't know how to implement that. also this override probably just can be removed, because the `kernel` is null by default (even in home-manager's `nixpkgs` input), but i assume there was a reason for that.

i wanted to open this pull request ASAP even in this state, because there are no reports of this in issues/prs. users of `targets.genericLinux.gpu.nvidia` module can either do this patch manually or temporarily use my fork.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
