### PR TITLE
treewide: remove network-online.target

### DIFF
--- a/modules/services/colima.nix
+++ b/modules/services/colima.nix
@@ -312,8 +312,6 @@ in
         lib.nameValuePair "colima-${name}" {
           Unit = {
             Description = "Colima container runtime (${name} profile)";
-            After = [ "network-online.target" ];
-            Wants = [ "network-online.target" ];
           };
           Service = {
             ExecStart = ''

--- a/modules/services/pantalaimon.nix
+++ b/modules/services/pantalaimon.nix
@@ -58,7 +58,6 @@ in
       pantalaimon = {
         Unit = {
           Description = "Pantalaimon - E2EE aware proxy daemon for matrix clients";
-          After = [ "network-online.target" ];
         };
 
         Service = {

--- a/modules/services/pimsync.nix
+++ b/modules/services/pimsync.nix
@@ -41,7 +41,6 @@ in
     systemd.user.services.pimsync = {
       Unit = {
         Description = "pimsync calendar and contacts synchronization";
-        PartOf = [ "network-online.target" ];
       };
       Install.WantedBy = [ "default.target" ];
       Service = {

--- a/modules/services/podman/linux/services.nix
+++ b/modules/services/podman/linux/services.nix
@@ -42,8 +42,6 @@ in
           Unit = {
             Description = "Podman auto-update service";
             Documentation = "man:podman-auto-update(1)";
-            Wants = [ "network-online.target" ];
-            After = [ "network-online.target" ];
           };
 
           Service = {

--- a/modules/services/rescrobbled.nix
+++ b/modules/services/rescrobbled.nix
@@ -56,8 +56,6 @@ in
       Unit = {
         Description = "An MPRIS scrobbler";
         Documentation = "https://github.com/InputUsername/rescrobbled";
-        Wants = [ "network-online.target" ];
-        After = [ "network-online.target" ];
       };
 
       Service.ExecStart = lib.getExe cfg.package;

--- a/modules/services/restic.nix
+++ b/modules/services/restic.nix
@@ -487,8 +487,6 @@ in
       lib.nameValuePair serviceName {
         Unit = {
           Description = "Restic backup service";
-          Wants = [ "network-online.target" ];
-          After = [ "network-online.target" ];
         };
 
         Service = {

--- a/modules/services/tldr-update.nix
+++ b/modules/services/tldr-update.nix
@@ -35,8 +35,6 @@ in
       Unit = {
         Description = "Update tldr CLI cache";
         Documentation = "https://tldr.sh/";
-        Wants = [ "network-online.target" ];
-        After = [ "network-online.target" ];
       };
 
       Service = {

--- a/modules/services/vdirsyncer.nix
+++ b/modules/services/vdirsyncer.nix
@@ -64,7 +64,6 @@ in
     systemd.user.services.vdirsyncer = {
       Unit = {
         Description = "vdirsyncer calendar&contacts synchronization";
-        PartOf = [ "network-online.target" ];
       };
 
       Service = {

--- a/tests/modules/services/colima/linux/colima-docker-cli-expected.service
+++ b/tests/modules/services/colima/linux/colima-docker-cli-expected.service
@@ -17,6 +17,4 @@ StandardError=append:/home/hm-user/.local/state/colima/default.log
 StandardOutput=append:/home/hm-user/.local/state/colima/default.log
 
 [Unit]
-After=network-online.target
 Description=Colima container runtime (default profile)
-Wants=network-online.target

--- a/tests/modules/services/colima/linux/expected-service.service
+++ b/tests/modules/services/colima/linux/expected-service.service
@@ -15,6 +15,4 @@ StandardError=append:/home/hm-user/.local/state/colima/default.log
 StandardOutput=append:/home/hm-user/.local/state/colima/default.log
 
 [Unit]
-After=network-online.target
 Description=Colima container runtime (default profile)
-Wants=network-online.target

--- a/tests/modules/services/rescrobbled/basic-config.nix
+++ b/tests/modules/services/rescrobbled/basic-config.nix
@@ -39,8 +39,6 @@
 
     assertFileExists $service
     assertFileRegex $service 'Description=An MPRIS scrobbler'
-    assertFileRegex $service 'Wants=network-online.target'
-    assertFileRegex $service 'After=network-online.target'
     assertFileRegex $service 'WantedBy=default.target'
   '';
 }

--- a/tests/modules/services/tldr-update/tldr-update.service
+++ b/tests/modules/services/tldr-update/tldr-update.service
@@ -4,7 +4,5 @@ ExecStart=@tldr@/bin/dummy --update
 Type=oneshot
 
 [Unit]
-After=network-online.target
 Description=Update tldr CLI cache
 Documentation=https://tldr.sh/
-Wants=network-online.target


### PR DESCRIPTION
### Description

In #9210 @marwing noted the change I made to add a dependency on `network-online.target` does nothing for a user unit.
I copied this configuration from another `home-manager` module.

To prevent the proliferation of this mistake I updated all units in `home-manager` to remove this do-nothing dependency.

Reference this upstream systemd issue for more details: https://github.com/systemd/systemd/issues/3312

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
