### PR TITLE
foot and wlsunset: fix systemd dependencies

### DIFF
--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -77,6 +77,7 @@ in
           Documentation = "man:foot(1)";
           PartOf = [ cfg.server.systemdTarget ];
           After = [ cfg.server.systemdTarget ];
+          ConditionEnvironment = "WAYLAND_DISPLAY";
         };
 
         Service = {

--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -16,7 +16,23 @@ in
 
     package = lib.mkPackageOption pkgs "foot" { };
 
-    server.enable = lib.mkEnableOption "Foot terminal server";
+    server = {
+      enable = lib.mkEnableOption "Foot terminal server";
+
+      systemdTarget = lib.mkOption {
+        type = lib.types.str;
+        default = config.wayland.systemd.target;
+        defaultText = lib.literalExpression "config.wayland.systemd.target";
+        example = "sway-session.target";
+        description = ''
+          The systemd target that will automatically start the Foot server service.
+
+          When setting this value to `"sway-session.target"`,
+          make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+          otherwise the service may never be started.
+        '';
+      };
+    };
 
     settings = lib.mkOption {
       inherit (iniFormat) type;
@@ -59,8 +75,8 @@ in
         Unit = {
           Description = "Fast, lightweight and minimalistic Wayland terminal emulator.";
           Documentation = "man:foot(1)";
-          PartOf = [ "graphical-session.target" ];
-          After = [ "graphical-session.target" ];
+          PartOf = [ cfg.server.systemdTarget ];
+          After = [ cfg.server.systemdTarget ];
         };
 
         Service = {
@@ -70,7 +86,7 @@ in
         };
 
         Install = {
-          WantedBy = [ "graphical-session.target" ];
+          WantedBy = [ cfg.server.systemdTarget ];
         };
       };
     };

--- a/modules/services/wlsunset.nix
+++ b/modules/services/wlsunset.nix
@@ -131,6 +131,7 @@ in
         Description = "Day/night gamma adjustments for Wayland compositors.";
         After = [ cfg.systemdTarget ];
         PartOf = [ cfg.systemdTarget ];
+        ConditionEnvironment = "WAYLAND_DISPLAY";
       };
 
       Service = {

--- a/tests/modules/programs/foot/systemd-user-service-expected.service
+++ b/tests/modules/programs/foot/systemd-user-service-expected.service
@@ -8,6 +8,7 @@ Restart=on-failure
 
 [Unit]
 After=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
 Description=Fast, lightweight and minimalistic Wayland terminal emulator.
 Documentation=man:foot(1)
 PartOf=graphical-session.target

--- a/tests/modules/services/wlsunset/wlsunset-service-expected.service
+++ b/tests/modules/services/wlsunset/wlsunset-service-expected.service
@@ -6,5 +6,6 @@ ExecStart=@wlsunset@/bin/wlsunset -L128.8 -T6000 -g0.6 -l12.3 -t3500
 
 [Unit]
 After=test.target
+ConditionEnvironment=WAYLAND_DISPLAY
 Description=Day/night gamma adjustments for Wayland compositors.
 PartOf=test.target


### PR DESCRIPTION
### Description

In the spirit of #6253:

- Adds `programs.foot.server.systemdTarget` to replace hard-coded `graphical-session.target` dependency.
- Adds `ConditionEnvironment=WAYLAND_DISPLAY` to foot and wlsunset.

This ensures that with `wayland.systemd.target = "sway-session.target"`, these services actually get started.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- ~~If this PR adds a new module~~