### PR TITLE
delta: configure as pager for git blame

### DIFF
--- a/modules/programs/delta.nix
+++ b/modules/programs/delta.nix
@@ -61,8 +61,8 @@ in
         Whether to enable git integration for delta.
 
         When enabled, delta will be configured as git's pager for
-        {command}`diff`, {command}`log`, and {command}`show`, and as git's diff
-        filter for interactive staging.
+        {command}`blame`, {command}`diff`, {command}`log`, and {command}`show`,
+        and as git's diff filter for interactive staging.
       '';
     };
 
@@ -129,8 +129,8 @@ in
           let
             deltaCommand = lib.getExe cfg.package;
           in
-          lib.hm.git.diffPagerConfig deltaCommand
-          // {
+          lib.recursiveUpdate (lib.hm.git.diffPagerConfig deltaCommand) {
+            pager.blame = deltaCommand;
             interactive.diffFilter = "${deltaCommand} --color-only";
             delta = cfg.options;
           };

--- a/tests/modules/programs/delta/delta-with-git-integration.nix
+++ b/tests/modules/programs/delta/delta-with-git-integration.nix
@@ -18,6 +18,7 @@
   nmt.script = ''
     assertFileExists home-files/.config/git/config
     assertFileContains home-files/.config/git/config '[pager]'
+    assertFileRegex home-files/.config/git/config 'blame = .*/bin/delta'
     assertFileRegex home-files/.config/git/config 'diff = .*/bin/delta'
     assertFileRegex home-files/.config/git/config 'log = .*/bin/delta'
     assertFileRegex home-files/.config/git/config 'show = .*/bin/delta'


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

`programs.delta.enableGitIntegration` sets `pager.blame = "delta"` in git config.

This fixes a regression caused by https://github.com/nix-community/home-manager/pull/9032. `delta` supports acting as a pager for `git blame`[^1]

[^1]: https://dandavison.github.io/delta/git-blame.html

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
