### PR TITLE
vscode: create globalStorage directory for profiles

### DIFF
--- a/modules/programs/vscode/mkVscodeModule.nix
+++ b/modules/programs/vscode/mkVscodeModule.nix
@@ -386,6 +386,13 @@ in
               userDataProfiles=$(jq ".userDataProfiles += $(echo $file_write | jq -R 'split("...") | map({ name: ., location: . })')" "$file")
               echo $userDataProfiles > "$file"
             fi
+
+            # Create globalStorage for profiles, if it doesn't exist.
+            # Required to store state.vscdb file.
+            # VSCode doesn't create this folder itself.
+            for profile in "''${profiles[@]}"; do
+              mkdir -p "${userDir}/profiles/$profile/globalStorage"
+            done
           '';
         in
         modifyGlobalStorage.outPath

--- a/modules/programs/vscode/mkVscodeModule.nix
+++ b/modules/programs/vscode/mkVscodeModule.nix
@@ -391,7 +391,7 @@ in
             # Required to store state.vscdb file.
             # VSCode doesn't create this folder itself.
             for profile in "''${profiles[@]}"; do
-              mkdir -p "${userDir}/profiles/$profile/globalStorage"
+              run mkdir -p "${userDir}/profiles/$profile/globalStorage"
             done
           '';
         in


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Fixes #7094 

Creating a globalStorage directory for all profiles means that the `state.vscdb` is persisted. This file contains UI state, among other things.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
