### PR TITLE
wayle: improved unit tests

### DIFF
--- a/modules/services/wayle.nix
+++ b/modules/services/wayle.nix
@@ -88,6 +88,10 @@ in
         wallpaper.engine-enabled = false;
         styling.theme-provider = "wayle";
       } cfg.settings;
+
+      # Determine if wayle is being configured via nix, or if the user will be
+      # using wayle's builtin settings dialog.
+      nix_configured = cfg.settings != { };
     in
     {
       assertions = [
@@ -96,7 +100,7 @@ in
 
       home.packages = (
         [ cfg.package ]
-        # Install the appropriate theme-provider, if set.
+        # Install only the dependencies wayle needs based on the nix configuration.
         ++ (lists.optional (
           cfg.autoInstallDependencies
           && elem settings_with_fallbacks.styling.theme-provider [
@@ -108,7 +112,7 @@ in
       );
 
       # Main config file.
-      xdg.configFile."wayle/config.toml" = mkIf (cfg.settings != { }) {
+      xdg.configFile."wayle/config.toml" = mkIf nix_configured {
         source = tomlFormat.generate "wayle-config" cfg.settings;
       };
 

--- a/tests/modules/services/wayle/basic-config.nix
+++ b/tests/modules/services/wayle/basic-config.nix
@@ -1,4 +1,8 @@
-{ config, ... }:
+{ config, pkgs, ... }:
+let
+  wayleTestLib = import ./lib.nix { inherit config pkgs; };
+  inherit (wayleTestLib.asserts) awwwInstalled packageInstalled;
+in
 {
   services.wayle = {
     enable = true;
@@ -43,4 +47,11 @@
       "home-files/.config/wayle/config.toml" \
       ${./basic-config.toml}
   '';
+
+  assertions = [
+    (awwwInstalled false)
+    (packageInstalled "matugen" false)
+    (packageInstalled "wallust" false)
+    (packageInstalled "pywal" false)
+  ];
 }

--- a/tests/modules/services/wayle/default.nix
+++ b/tests/modules/services/wayle/default.nix
@@ -2,4 +2,8 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   wayle-basic-config = ./basic-config.nix;
+  wayle-non-nix-configured = ./non-nix-configured.nix;
+  wayle-non-nix-configured-and-no-deps = ./non-nix-configured-and-no-deps.nix;
+  wayle-nix-configured-theme-provider = ./nix-configured-theme-provider.nix;
+  wayle-nix-configured-theme-provider-and-no-deps = ./nix-configured-theme-provider-and-no-deps.nix;
 }

--- a/tests/modules/services/wayle/lib.nix
+++ b/tests/modules/services/wayle/lib.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, ... }:
+{
+  asserts = {
+    awwwInstalled = state: {
+      assertion = config.services.awww.enable == state;
+      message = "Expected service awww to be ${if state then "enabled" else "disabled"}.";
+    };
+    packageInstalled = packageName: state: {
+      assertion = (builtins.elem pkgs.${packageName} config.home.packages) == state;
+      message = "Expected the ${packageName} package to ${if state then "" else "not"} be installed.";
+    };
+  };
+}

--- a/tests/modules/services/wayle/nix-configured-theme-provider-and-no-deps.nix
+++ b/tests/modules/services/wayle/nix-configured-theme-provider-and-no-deps.nix
@@ -1,0 +1,28 @@
+{ config, pkgs, ... }:
+let
+  wayleTestLib = import ./lib.nix { inherit config pkgs; };
+  inherit (wayleTestLib.asserts) awwwInstalled packageInstalled;
+in
+{
+  services.wayle = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "wayle"; };
+    settings = {
+      styling.theme-provider = "matugen";
+    };
+    autoInstallDependencies = false;
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      "home-files/.config/wayle/config.toml" \
+      ${./nix-configured-theme-provider-config.toml}
+  '';
+
+  assertions = [
+    (awwwInstalled false)
+    (packageInstalled "matugen" false)
+    (packageInstalled "wallust" false)
+    (packageInstalled "pywal" false)
+  ];
+}

--- a/tests/modules/services/wayle/nix-configured-theme-provider-config.toml
+++ b/tests/modules/services/wayle/nix-configured-theme-provider-config.toml
@@ -1,0 +1,2 @@
+[styling]
+theme-provider = "matugen"

--- a/tests/modules/services/wayle/nix-configured-theme-provider.nix
+++ b/tests/modules/services/wayle/nix-configured-theme-provider.nix
@@ -1,0 +1,27 @@
+{ config, pkgs, ... }:
+let
+  wayleTestLib = import ./lib.nix { inherit config pkgs; };
+  inherit (wayleTestLib.asserts) awwwInstalled packageInstalled;
+in
+{
+  services.wayle = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "wayle"; };
+    settings = {
+      styling.theme-provider = "matugen";
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      "home-files/.config/wayle/config.toml" \
+      ${./nix-configured-theme-provider-config.toml}
+  '';
+
+  assertions = [
+    (awwwInstalled false)
+    (packageInstalled "matugen" true)
+    (packageInstalled "wallust" false)
+    (packageInstalled "pywal" false)
+  ];
+}

--- a/tests/modules/services/wayle/non-nix-configured-and-no-deps.nix
+++ b/tests/modules/services/wayle/non-nix-configured-and-no-deps.nix
@@ -1,0 +1,28 @@
+{ config, pkgs, ... }:
+let
+  wayleTestLib = import ./lib.nix { inherit config pkgs; };
+  inherit (wayleTestLib.asserts) awwwInstalled packageInstalled;
+in
+{
+  services.wayle = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "wayle"; };
+    settings = { };
+    autoInstallDependencies = false;
+  };
+
+  # When services.wayle.settings = {}, we expect that no config file is
+  # created.
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/wayle/config.toml"
+  '';
+
+  # When services.wayle.autoInstallDependencies = false, we expect that none of
+  # wayles dependencies are installed.
+  assertions = [
+    (awwwInstalled false)
+    (packageInstalled "matugen" false)
+    (packageInstalled "wallust" false)
+    (packageInstalled "pywal" false)
+  ];
+}

--- a/tests/modules/services/wayle/non-nix-configured.nix
+++ b/tests/modules/services/wayle/non-nix-configured.nix
@@ -1,0 +1,23 @@
+{ config, pkgs, ... }:
+let
+  wayleTestLib = import ./lib.nix { inherit config pkgs; };
+  inherit (wayleTestLib.asserts) awwwInstalled packageInstalled;
+in
+{
+  services.wayle = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "wayle"; };
+    settings = { };
+  };
+
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/wayle/config.toml"
+  '';
+
+  assertions = [
+    (awwwInstalled false)
+    (packageInstalled "matugen" false)
+    (packageInstalled "wallust" false)
+    (packageInstalled "pywal" false)
+  ];
+}


### PR DESCRIPTION
### Description

Added more detailed unit tests for testing dependency auto-installation for wayle.

This is just the improved test components from #9198.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
  - [x] Code tested through `nix run .#tests -- wayle`

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
