### PR TITLE
brush: Added programs.brush

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -133,6 +133,12 @@
     github = "danjujan";
     githubId = 44864658;
   };
+  deephack1982 = {
+    name = "Mark Dickie";
+    email = "mark.dickie@hey.com";
+    github = "deephack1982";
+    githubId = 6213936;
+  };
   Dines97 = {
     name = "Denis Kaynar";
     email = "19364873+Dines97@users.noreply.github.com";

--- a/modules/misc/news/2026/05/2026-05-04_13-45-17.nix
+++ b/modules/misc/news/2026/05/2026-05-04_13-45-17.nix
@@ -1,0 +1,12 @@
+{ config, pkgs, ... }:
+{
+  time = "2026-05-04T11:45:17+00:00";
+  # condition = pkgs.stdenv.hostPlatform.isLinux;
+  # condition = config.programs.neovim.enable;
+  condition = true;
+  # if behavior changed, explain how to restore previous behavior.
+  message = ''
+    A new module is available: 'programs.brush'. This module is configured for bash
+    compatibility and so will make use of existing bash dot files by default.
+  '';
+}

--- a/modules/programs/brush.nix
+++ b/modules/programs/brush.nix
@@ -1,0 +1,286 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    optionalAttrs
+    types
+    ;
+
+  cfg = config.programs.brush;
+
+  writeBashScript =
+    name: text:
+    pkgs.writeTextFile {
+      inherit name text;
+      checkPhase = ''
+        ${pkgs.stdenv.shellDryRun} "$target"
+      '';
+    };
+
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.deephack1982 ];
+
+  options = {
+    programs.brush = {
+      enable = lib.mkEnableOption "bash/POSIX-compatible shell implemented in Rust";
+
+      package = lib.mkPackageOption pkgs "brush" {
+        nullable = true;
+        default = "brush";
+      };
+
+      enableCompletion = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable Bash completion for all interactive Brush shells.
+
+          Note, if you use NixOS or nix-darwin and do not have Bash completion
+          enabled in the system configuration, then make sure to add
+
+          ```nix
+            environment.pathsToLink = [ "/share/bash-completion" ];
+          ```
+
+          to your system configuration to get completion for system packages.
+          Note, the legacy {file}`/etc/bash_completion.d` path is
+          not supported by Home Manager.
+        '';
+      };
+
+      historySize = mkOption {
+        type = types.nullOr types.int;
+        default = 10000;
+        description = "Number of history lines to keep in memory.";
+      };
+
+      historyFile = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Location of the brush history file.";
+      };
+
+      historyFileSize = mkOption {
+        type = types.nullOr types.int;
+        default = 100000;
+        description = "Number of history lines to keep on file.";
+      };
+
+      historyControl = mkOption {
+        type = types.listOf (
+          types.enum [
+            "erasedups"
+            "ignoredups"
+            "ignorespace"
+            "ignoreboth"
+          ]
+        );
+        default = [ ];
+        description = "Controlling how commands are saved on the history list.";
+      };
+
+      historyIgnore = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [
+          "ls"
+          "cd"
+          "exit"
+        ];
+        description = "List of commands that should not be saved to the history list.";
+      };
+
+      shellOptions = mkOption {
+        type = types.listOf types.str;
+        default = [
+          # Append to history file rather than replacing it.
+          "histappend"
+
+          # Extended globbing.
+          "extglob"
+          "globstar"
+
+          # Warn if closing shell with running jobs.
+          "checkjobs"
+        ];
+        example = [
+          "extglob"
+          "-cdspell"
+        ];
+        description = ''
+          Shell options to set. Prefix an option with
+          "`-`" to unset.
+        '';
+      };
+
+      sessionVariables = mkOption {
+        default = { };
+        type =
+          with types;
+          lazyAttrsOf (
+            nullOr (oneOf [
+              str
+              path
+              int
+              float
+              bool
+            ])
+          );
+        example = {
+          MAILCHECK = 30;
+        };
+        description = ''
+          Environment variables that will be set for the Brush session.
+
+          Setting a value to `null` will skip setting the variable at all, which
+          may be useful when overriding.
+        '';
+      };
+
+      shellAliases = mkOption {
+        default = { };
+        type = types.attrsOf types.str;
+        example = lib.literalExpression ''
+          {
+            ll = "ls -l";
+            ".." = "cd ..";
+          }
+        '';
+        description = ''
+          An attribute set that maps aliases (the top level attribute names in
+          this option) to command strings or directly to build outputs.
+        '';
+      };
+
+      profileExtra = mkOption {
+        default = "";
+        type = types.lines;
+        description = ''
+          Extra commands that should be run when initializing a login
+          shell.
+        '';
+      };
+
+      initExtra = mkOption {
+        default = "";
+        type = types.lines;
+        description = ''
+          Extra commands that should be run when initializing an
+          interactive shell.
+        '';
+      };
+
+      rcExtra = mkOption {
+        default = "";
+        type = types.lines;
+        description = ''
+          Extra commands that should be placed in {file}`~/.bashrc`.
+          Note that these commands will be run even in non-interactive shells.
+        '';
+      };
+
+      logoutExtra = mkOption {
+        default = "";
+        type = types.lines;
+        description = ''
+          Extra commands that should be run when logging out of an
+          interactive shell.
+        '';
+      };
+    };
+  };
+
+  config =
+    let
+      aliasesStr = lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (k: v: "alias -- ${k}=${lib.escapeShellArg v}") cfg.shellAliases
+      );
+
+      shoptsStr =
+        let
+          switch = v: if lib.hasPrefix "-" v then "-u" else "-s";
+        in
+        lib.concatStringsSep "\n" (map (v: "shopt ${switch v} ${lib.removePrefix "-" v}") cfg.shellOptions);
+
+      sessionVarsStr = config.lib.shell.exportAll cfg.sessionVariables;
+
+      historyControlStr = (
+        lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (n: v: "${n}=${v}") (
+            optionalAttrs (cfg.historyFileSize != null) {
+              HISTFILESIZE = toString cfg.historyFileSize;
+            }
+            // optionalAttrs (cfg.historySize != null) {
+              HISTSIZE = toString cfg.historySize;
+            }
+            // optionalAttrs (cfg.historyFile != null) {
+              HISTFILE = ''"${cfg.historyFile}"'';
+            }
+            // optionalAttrs (cfg.historyControl != [ ]) {
+              HISTCONTROL = lib.concatStringsSep ":" cfg.historyControl;
+            }
+            // optionalAttrs (cfg.historyIgnore != [ ]) {
+              HISTIGNORE = lib.escapeShellArg (lib.concatStringsSep ":" cfg.historyIgnore);
+            }
+          )
+          ++ lib.optional (cfg.historyFile != null) ''mkdir -p "$(dirname "$HISTFILE")"''
+        )
+      );
+    in
+    mkIf cfg.enable {
+      home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+      home.file.".bash_profile".source = writeBashScript "bash_profile" ''
+        # include .profile if it exists
+        [[ -f ~/.profile ]] && . ~/.profile
+
+        # include .bashrc if it exists
+        [[ -f ~/.bashrc ]] && . ~/.bashrc
+      '';
+
+      # If completion is enabled then make sure it is sourced very early. This
+      # is to avoid problems if any other initialization code attempts to set up
+      # completion.
+      programs.brush.initExtra = mkIf cfg.enableCompletion (
+        lib.mkOrder 100 ''
+          if [[ ! -v BASH_COMPLETION_VERSINFO ]]; then
+            . "${pkgs.bash-completion}/etc/profile.d/bash_completion.sh"
+          fi
+        ''
+      );
+
+      home.file.".profile".source = writeBashScript "profile" ''
+        . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
+
+        ${sessionVarsStr}
+
+        ${cfg.profileExtra}
+      '';
+
+      home.file.".bashrc".source = writeBashScript "bashrc" ''
+        ${cfg.rcExtra}
+
+        # Commands that should be applied only for interactive shells.
+        [[ $- == *i* ]] || return
+
+        ${historyControlStr}
+
+        ${shoptsStr}
+
+        ${aliasesStr}
+
+        ${cfg.initExtra}
+      '';
+
+      home.file.".bash_logout" = mkIf (cfg.logoutExtra != "") {
+        source = writeBashScript "bash_logout" cfg.logoutExtra;
+      };
+    };
+}


### PR DESCRIPTION
### Description

<!--

Added programs.brush as a drop in compatible replacement for bash. As such it is making use of existing bash dotfiles.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
