### PR TITLE
worktrunk: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -115,6 +115,12 @@
     github = "ckgxrg-salt";
     githubId = 165614491;
   };
+  conao3 = {
+    name = "conao3";
+    email = "conao3@gmail.com";
+    github = "conao3";
+    githubId = 4703128;
+  };
   d-dervishi = {
     email = "david.dervishi@epfl.ch";
     github = "d-dervishi";

--- a/modules/misc/news/2026/05/2026-05-04_16-48-26.nix
+++ b/modules/misc/news/2026/05/2026-05-04_16-48-26.nix
@@ -1,0 +1,9 @@
+{
+  time = "2026-05-04T16:48:26+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.worktrunk'.
+
+    worktrunk is a git worktree manager for parallel AI agent workflows.
+  '';
+}

--- a/modules/programs/worktrunk.nix
+++ b/modules/programs/worktrunk.nix
@@ -1,0 +1,54 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.worktrunk;
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ conao3 ];
+
+  options.programs.worktrunk = {
+    enable = lib.mkEnableOption "worktrunk, a git worktree manager for parallel AI agent workflows";
+
+    package = lib.mkPackageOption pkgs "worktrunk" { };
+
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
+
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
+
+    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
+
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs.bash.initExtra = lib.mkIf cfg.enableBashIntegration ''
+      eval "$(${lib.getExe cfg.package} config shell init bash)"
+    '';
+
+    programs.zsh.initContent = lib.mkIf cfg.enableZshIntegration (
+      lib.mkOrder 851 ''
+        eval "$(${lib.getExe cfg.package} config shell init zsh)"
+      ''
+    );
+
+    programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+      ${lib.getExe cfg.package} config shell init fish | source
+    '';
+
+    programs.nushell = lib.mkIf cfg.enableNushellIntegration {
+      extraConfig = ''
+        source ${
+          pkgs.runCommand "worktrunk-nushell-config.nu" { } ''
+            ${lib.getExe cfg.package} config shell init nu >> "$out"
+          ''
+        }
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/worktrunk/bash.nix
+++ b/tests/modules/programs/worktrunk/bash.nix
@@ -1,0 +1,12 @@
+{
+  programs = {
+    worktrunk.enable = true;
+    bash.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileRegex home-files/.bashrc \
+      'eval "\$(@worktrunk@/bin/wt config shell init bash)"'
+  '';
+}

--- a/tests/modules/programs/worktrunk/default.nix
+++ b/tests/modules/programs/worktrunk/default.nix
@@ -1,0 +1,6 @@
+{
+  worktrunk-bash = ./bash.nix;
+  worktrunk-zsh = ./zsh.nix;
+  worktrunk-fish = ./fish.nix;
+  worktrunk-nushell = ./nushell.nix;
+}

--- a/tests/modules/programs/worktrunk/fish.nix
+++ b/tests/modules/programs/worktrunk/fish.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  lib,
+  realPkgs,
+  ...
+}:
+
+lib.mkIf config.test.enableBig {
+  programs = {
+    worktrunk.enable = true;
+    fish.enable = true;
+  };
+
+  nixpkgs.overlays = [ (_self: _super: { inherit (realPkgs) worktrunk; }) ];
+
+  nmt.script = ''
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileRegex home-files/.config/fish/config.fish \
+      '/nix/store/.*worktrunk.*/bin/wt config shell init fish \| source'
+  '';
+}

--- a/tests/modules/programs/worktrunk/nushell.nix
+++ b/tests/modules/programs/worktrunk/nushell.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  pkgs,
+  realPkgs,
+  config,
+  ...
+}:
+
+{
+  programs = {
+    worktrunk.enable = true;
+    nushell.enable = true;
+  };
+
+  _module.args.pkgs = lib.mkForce realPkgs;
+
+  nmt.script =
+    let
+      configDir =
+        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+          "home-files/Library/Application Support/nushell"
+        else
+          "home-files/.config/nushell";
+    in
+    ''
+      assertFileExists "${configDir}/config.nu"
+      assertFileRegex "${configDir}/config.nu" \
+        'source /nix/store/[^/]*-worktrunk-nushell-config.nu'
+    '';
+}

--- a/tests/modules/programs/worktrunk/zsh.nix
+++ b/tests/modules/programs/worktrunk/zsh.nix
@@ -1,0 +1,12 @@
+{
+  programs = {
+    worktrunk.enable = true;
+    zsh.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+    assertFileRegex home-files/.zshrc \
+      'eval "\$(@worktrunk@/bin/wt config shell init zsh)"'
+  '';
+}


### PR DESCRIPTION

### Description

Adds a new `programs.worktrunk` module for [worktrunk](https://github.com/max-sixty/worktrunk), a git worktree manager for parallel AI agent workflows.

The module follows the same shape as `programs.zoxide`: it installs the package and wires the shell integration produced by `wt config shell init <shell>` into bash, zsh, fish, and nushell. PowerShell is not covered yet.

Tested locally with the per-shell tests:

```
nix-build tests -A build.worktrunk-bash
nix-build tests -A build.worktrunk-zsh
nix-build tests -A build.worktrunk-fish
nix-build tests -A build.worktrunk-nushell
```

All four pass.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

  Could not be run successfully on master at the time of this PR because evaluation aborts on `programs.acd-cli` (`adc-cli has been removed as it was unmaintained`), which is unrelated to this change.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)