### PR TITLE
git: avoid implicit signing config

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -454,7 +454,7 @@ in
       (mkIf (cfg.signing != { }) {
         programs.git = {
           signing = {
-            format = mkOptionDefault signingFormatStateVersionDefault.default;
+            format = mkOptionDefault signingFormatStateVersionDefault.effectiveDefault;
             signer =
               let
                 defaultSigners = {

--- a/tests/modules/programs/git/default.nix
+++ b/tests/modules/programs/git/default.nix
@@ -7,6 +7,7 @@
   git-without-signing-key-id = ./git-without-signing-key-id.nix;
   git-without-signing-key-id-current = ./git-without-signing-key-id-current.nix;
   git-without-signing = ./git-without-signing.nix;
+  git-without-signing-legacy = ./git-without-signing-legacy.nix;
   git-with-hooks = ./git-with-hooks.nix;
   git-with-lfs = ./git-with-lfs.nix;
   git-with-maintenance = ./git-with-maintenance.nix;

--- a/tests/modules/programs/git/git-without-signing-legacy.conf
+++ b/tests/modules/programs/git/git-without-signing-legacy.conf
@@ -1,0 +1,9 @@
+[gpg]
+	format = "openpgp"
+
+[gpg "openpgp"]
+	program = "@gnupg@/bin/gpg"
+
+[user]
+	email = "user@example.org"
+	name = "John Doe"

--- a/tests/modules/programs/git/git-without-signing-legacy.nix
+++ b/tests/modules/programs/git/git-without-signing-legacy.nix
@@ -1,0 +1,20 @@
+{
+  programs.git = {
+    enable = true;
+    settings = {
+      user = {
+        name = "John Doe";
+        email = "user@example.org";
+      };
+    };
+  };
+
+  home.stateVersion = "24.05";
+
+  test.asserts.evalWarnings.expected = [ ];
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContent home-files/.config/git/config ${./git-without-signing-legacy.conf}
+  '';
+}


### PR DESCRIPTION
Fixes #6630

Similar bug to another module where we accidentally used `.default` instead of `effectiveDefault`

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
