### PR TITLE
rclone: rename remote directory to fix failing tests

### DIFF
--- a/tests/integration/standalone/rclone/serve.nix
+++ b/tests/integration/standalone/rclone/serve.nix
@@ -20,7 +20,7 @@ let
             known_hosts = "${sshKeys.snakeOilEd25519PublicKey}";
           };
           serve = {
-            "/home/alice/files" = {
+            "/home/alice/sftp-files" = {
               enable = true;
               protocol = "http";
               options.addr = "localhost:8080";
@@ -57,9 +57,9 @@ in
     with subtest("Serve a remote over HTTP (sftp)"):
       # create files on remote
       succeed_as_alice(
-        "mkdir /home/alice/files",
-        "touch /home/alice/files/other_file",
-        "echo serving > /home/alice/files/test.txt",
+        "mkdir /home/alice/sftp-files",
+        "touch /home/alice/sftp-files/other_file",
+        "echo serving > /home/alice/sftp-files/test.txt",
         box=remote
       )
 


### PR DESCRIPTION
The `/home/alice/files` directory is already used by the mount subtest.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
