### PR TITLE
direnv: avoid duplicate fish hook

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -128,7 +128,9 @@ in
           # Using `mkAfter` to make it more likely to appear after other
           # manipulations of the prompt.
           mkAfter ''
-            ${getExe cfg.package} hook fish | source
+            if not functions -q __direnv_export_eval
+              ${getExe cfg.package} hook fish | source
+            end
           ''
         );
 

--- a/tests/modules/programs/direnv/basic-config.nix
+++ b/tests/modules/programs/direnv/basic-config.nix
@@ -87,7 +87,10 @@ in
       assertFileRegex home-files/.zshrc \
         'eval.*direnv hook zsh'
 
-      # Test fish integration (enabled by default)
+      # Test fish integration includes a guard so the hook is a no-op when
+      # direnv's Fish vendor conf file has already been loaded.
+      assertFileRegex home-files/.config/fish/config.fish \
+        'functions -q __direnv_export_eval'
       assertFileRegex home-files/.config/fish/config.fish \
         'direnv hook fish.*source'
 


### PR DESCRIPTION
## Summary

- Keep the existing `programs.direnv.enableFishIntegration` default behavior
- Guard the generated Fish hook so it is a no-op when direnv's vendor config already loaded the hook
- Update the direnv test to assert the Fish hook guard is generated

## Rationale

When `programs.direnv.enable = true`, the direnv package is added to the user profile. Upstream direnv installs a Fish vendor configuration file that runs `direnv hook fish | source`, so Home Manager can end up running the same hook twice.

Relevant upstream direnv code:

- The install target writes `share/fish/vendor_conf.d/direnv.fish`: https://github.com/direnv/direnv/blob/b00e451f547f39be7ab836d969054114a465a0f9/GNUmakefile#L176-L177
- `direnv hook fish` generates the Fish event functions: https://github.com/direnv/direnv/blob/b00e451f547f39be7ab836d969054114a465a0f9/internal/cmd/shell_fish.go#L13-L40

This keeps Home Manager's usual shell integration defaults intact while avoiding duplicate Fish hook initialization when the vendor config has already been sourced.
