### PR TITLE
voxtype: initial module implementation

### DIFF
--- a/modules/services/voxtype.nix
+++ b/modules/services/voxtype.nix
@@ -1,0 +1,197 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    makeBinPath
+    mapAttrsToList
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    optional
+    optionals
+    optionalAttrs
+    recursiveUpdate
+    escapeShellArg
+    escapeShellArgs
+    concatMapStringsSep
+    types
+    ;
+
+  cfg = config.services.voxtype;
+  toml = pkgs.formats.toml { };
+  # Voxtype requires these whenever a config file exists.
+  settings = recursiveUpdate {
+    hotkey = { };
+    audio = {
+      device = "default";
+      sample_rate = 16000;
+      max_duration_secs = 60;
+    };
+    output = {
+      mode = "type";
+      fallback_to_clipboard = true;
+    };
+  } cfg.settings;
+
+in
+{
+  meta.maintainers = [ lib.maintainers.marijanp ];
+
+  options.services.voxtype = {
+    enable = mkEnableOption "Voxtype speech-to-text daemon";
+
+    package = mkPackageOption pkgs "voxtype" {
+      example = "pkgs.voxtype-vulkan";
+    };
+
+    settings = mkOption {
+      inherit (toml) type;
+      default = { };
+      example = {
+        output = {
+          mode = "type";
+          fallback_to_clipboard = true;
+        };
+        whisper = {
+          model = "base.en";
+          language = "en";
+        };
+      };
+      description = ''
+        Voxtype configuration written to `$XDG_CONFIG_HOME/voxtype/config.toml`.
+      '';
+    };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "--verbose" ];
+      description = "Extra command-line arguments passed to `voxtype daemon`.";
+    };
+
+    environment = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = "Environment variables for the Voxtype user service.";
+    };
+
+    x11.display = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = ":0";
+      description = ''
+        X11 display name to expose to the Voxtype user service.
+      '';
+    };
+
+    wayland.display = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "wayland-1";
+      description = ''
+        Wayland display socket name to expose to the Voxtype user service.
+      '';
+    };
+
+    loadModels = mkOption {
+      type = types.listOf types.str;
+      apply = builtins.filter (model: model != "");
+      default = [ ];
+      example = [ "base.en" ];
+      description = ''
+        Downloads the listed models with `voxtype setup --download` before starting
+        the daemon.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [
+      cfg.package
+    ]
+    ++ optionals (cfg.x11.display != null) [ pkgs.xclip ]
+    ++ optionals (cfg.wayland.display != null) [
+      pkgs.wl-clipboard
+      pkgs.wtype
+    ];
+
+    xdg.configFile."voxtype/config.toml" = mkIf (cfg.settings != { }) {
+      source = toml.generate "voxtype-config.toml" settings;
+    };
+
+    systemd.user.services.voxtype = {
+      Unit = {
+        Description = "Voxtype speech-to-text daemon";
+        PartOf = [ "default.target" ];
+      }
+      // optionalAttrs (cfg.loadModels != [ ]) {
+        Wants = [ "voxtype-model-loader.service" ];
+        After = [ "voxtype-model-loader.service" ];
+      };
+
+      Service =
+        let
+          runtimePath = makeBinPath (
+            [ pkgs.which ]
+            ++ optionals (cfg.x11.display != null) [ pkgs.xclip ]
+            ++ optionals (cfg.wayland.display != null) [
+              pkgs.wl-clipboard
+              pkgs.wtype
+            ]
+          );
+        in
+        {
+          Type = "exec";
+          ExecStart = "${getExe cfg.package} daemon ${escapeShellArgs cfg.extraArgs}";
+          Restart = "on-failure";
+          RestartSec = "5s";
+          Environment = [
+            "PATH=${runtimePath}"
+            "XDG_RUNTIME_DIR=%t"
+          ]
+          ++ optional (cfg.x11.display != null) "DISPLAY=${cfg.x11.display}"
+          ++ optional (cfg.wayland.display != null) "WAYLAND_DISPLAY=${cfg.wayland.display}"
+          ++ mapAttrsToList (name: value: "${name}=${value}") cfg.environment;
+        };
+
+      Install.WantedBy = [ "default.target" ];
+    };
+
+    systemd.user.services.voxtype-model-loader = mkIf (cfg.loadModels != [ ]) {
+      Unit = {
+        Description = "Download Voxtype models";
+        Before = [ "voxtype.service" ];
+        Wants = [ "network-online.target" ];
+        After = [ "network-online.target" ];
+      };
+
+      Service =
+        let
+          modelLoaderScript = pkgs.writeShellScript "voxtype-model-loader" ''
+            set -euo pipefail
+            tmp="$(${pkgs.coreutils}/bin/mktemp -d /tmp/voxtype-model-loader.XXXXXX)"
+            trap '${pkgs.coreutils}/bin/rm -rf "$tmp"' EXIT
+
+            ${concatMapStringsSep "\n" (
+              model:
+              "XDG_CONFIG_HOME=\"$tmp\" ${getExe cfg.package} setup --download --model ${escapeShellArg model} --no-post-install"
+            ) cfg.loadModels}
+          '';
+        in
+        {
+          Type = "oneshot";
+          ExecStart = modelLoaderScript;
+          Restart = "on-failure";
+          RestartSec = "30s";
+        };
+
+      Install.WantedBy = [ "default.target" ];
+    };
+  };
+}

--- a/tests/modules/services/voxtype/basic-configuration.nix
+++ b/tests/modules/services/voxtype/basic-configuration.nix
@@ -1,0 +1,35 @@
+{ config, ... }:
+{
+  services.voxtype = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@voxtype@"; };
+    wayland.display = "wayland-1";
+    extraArgs = [ "--verbose" ];
+    environment.VOXTYPE_TEST_ENV = "1";
+    settings = {
+      output = {
+        mode = "type";
+        fallback_to_clipboard = true;
+      };
+      whisper = {
+        model = "base.en";
+        language = "en";
+      };
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/voxtype.service
+    configFile=home-files/.config/voxtype/config.toml
+
+    assertFileExists "$serviceFile"
+    assertFileExists "$configFile"
+
+    assertFileRegex "$serviceFile" 'ExecStart=@voxtype@/bin/dummy daemon --verbose'
+    assertFileRegex "$serviceFile" 'Environment=PATH=.*/bin'
+    assertFileRegex "$serviceFile" 'Environment=WAYLAND_DISPLAY=wayland-1'
+    assertFileRegex "$serviceFile" 'Environment=VOXTYPE_TEST_ENV=1'
+
+    assertFileContent "$configFile" ${./expected-config.toml}
+  '';
+}

--- a/tests/modules/services/voxtype/default.nix
+++ b/tests/modules/services/voxtype/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  voxtype-basic-configuration = ./basic-configuration.nix;
+}

--- a/tests/modules/services/voxtype/expected-config.toml
+++ b/tests/modules/services/voxtype/expected-config.toml
@@ -1,0 +1,14 @@
+[audio]
+device = "default"
+max_duration_secs = 60
+sample_rate = 16000
+
+[hotkey]
+
+[output]
+fallback_to_clipboard = true
+mode = "type"
+
+[whisper]
+language = "en"
+model = "base.en"


### PR DESCRIPTION
### Description

Generic module implementation for voxtype a wayland/X text-to-speech daemon using whisper. E.g. this allows one to press scroll-lock and speak. the spoken text will be transcribed wherever the cursor is, or it falls back to the clipboard.
I was not able to test this with X yet.
```
{
    services.voxtype = {
      enable = true;
      package = pkgs.voxtype-vulkan;

      wayland.display = "wayland-1";

      loadModels = [ "base.en" ];

      settings = {
        whisper = {
          model = "base.en";
          language = "en";
        };
        output = {
          mode = "type";
          fallback_to_clipboard = true;
        };
      };
    };
  }
  ```

CC: may be interesting to package contributor and reviewers from https://github.com/NixOS/nixpkgs/pull/491124
### Checklist
@DarthPJB
<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef). - Does not exist anymore in that shape?

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](a)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
