### PR TITLE
email: extend `mailbox.org` config flavor

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -657,8 +657,14 @@ let
         (mkIf (config.flavor == "mailbox.org") {
           userName = mkDefault config.address;
           folders.inbox = mkDefault "INBOX";
-          imap.host = "imap.mailbox.org";
-          smtp.host = "smtp.mailbox.org";
+          imap = {
+            host = "imap.mailbox.org";
+            port = 993;
+          };
+          smtp = {
+            host = "smtp.mailbox.org";
+            port = 465;
+          };
         })
 
         (mkIf (config.flavor == "migadu.com") {


### PR DESCRIPTION
### Description

Add IMAP and SMTP ports. See
<https://kb.mailbox.org/en/private/e-mail/e-mail-configuration>.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```