### PR TITLE
kvantum: enable when style.name is kvantum

### DIFF
--- a/modules/misc/qt/kvantum.nix
+++ b/modules/misc/qt/kvantum.nix
@@ -10,7 +10,6 @@ let
     concatMapStringsSep
     generators
     literalExpression
-    mkEnableOption
     mkIf
     mkOption
     types
@@ -31,7 +30,12 @@ in
 
 {
   options.qt.kvantum = {
-    enable = mkEnableOption "Kvantum configuration";
+    enable = mkOption {
+      type = types.bool;
+      default = (config.qt.style.name == "kvantum");
+      defaultText = ''config.qt.style.name == "kvantum"'';
+      description = "Kvantum configuration";
+    };
 
     settings = mkOption {
       type = types.submodule {
@@ -127,9 +131,17 @@ in
         };
       };
 
-      "Kvantum/kvantum.kvconfig" = mkIf (cfg.settings != { }) {
-        source = kvconfigFormat.generate "kvantum-config" cfg.settings;
-      };
+      "Kvantum/kvantum.kvconfig" =
+        mkIf
+          (
+            cfg.settings != {
+              Applications = { };
+              General.theme = null;
+            }
+          )
+          {
+            source = kvconfigFormat.generate "kvantum-config" cfg.settings;
+          };
     };
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
