### PR TITLE
quickshell: don't throw error when package is null

### DIFF
--- a/modules/programs/quickshell.nix
+++ b/modules/programs/quickshell.nix
@@ -63,9 +63,13 @@ in
             assertion = !(builtins.any (name: lib.hasInfix "/" name) (builtins.attrNames cfg.configs));
             message = "The names of configs in `programs.quickshell.configs` must not contain slashes.";
           }
+          {
+            assertion = cfg.systemd.enable -> cfg.package != null;
+            message = "`programs.quickshell.systemd.enable` cannot be true when `programs.quickshell.package` is null";
+          }
         ];
 
-        home.packages = [ cfg.package ];
+        home.packages = lib.optionals (cfg.package != null) [ cfg.package ];
 
       }
       (lib.mkIf cfg.systemd.enable {


### PR DESCRIPTION
### Description

`programs.quickshell.package` is marked as nullable, but it will throw an error if set to null. This commit adds the necessary checks to allow setting the package to null.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```