### PR TITLE
fish: don't set man.generateCaches default = true if man.package == null

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -681,7 +681,7 @@ in
         in
         {
           # Support completion for `man` by building a cache for `apropos`.
-          programs.man.generateCaches = lib.mkDefault true;
+          programs.man.generateCaches = lib.mkIf (config.programs.man.package != null) (lib.mkDefault true);
 
           xdg.dataFile."fish/home-manager/generated_completions".source =
             let

--- a/tests/modules/programs/fish/default.nix
+++ b/tests/modules/programs/fish/default.nix
@@ -7,6 +7,7 @@
   fish-source-handlers = ./source-handlers.nix;
   fish-plugins = ./plugins.nix;
   fish-manpage = ./manpage.nix;
+  fish-no-man-cache-without-man-package = ./no-man-cache-without-man-package.nix;
   fish-binds = ./binds.nix;
   fish-session-variables = ./session-variables.nix;
 }

--- a/tests/modules/programs/fish/no-man-cache-without-man-package.nix
+++ b/tests/modules/programs/fish/no-man-cache-without-man-package.nix
@@ -1,0 +1,12 @@
+{
+  config = {
+    home.stateVersion = "26.05";
+
+    programs.man.package = null;
+    programs.fish.enable = true;
+
+    nmt.script = ''
+      assertPathNotExists home-files/.manpath
+    '';
+  };
+}


### PR DESCRIPTION
### Description
I'm getting `trace: warning: programs.man.generateCaches has no effect when programs.man.package is null` everytime I do home-manager switch with this change. Since setting this to true if package is null is a no-op, avoid setting this value at all when that is the case.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
