### PR TITLE
mako: allow null package

### DIFF
--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -99,7 +99,7 @@ in
 
   options.services.mako = {
     enable = mkEnableOption "mako";
-    package = mkPackageOption pkgs "mako" { };
+    package = mkPackageOption pkgs "mako" { nullable = true; };
     settings = mkOption {
       type = lib.types.attrsOf (
         lib.types.oneOf [
@@ -151,12 +151,16 @@ in
       (lib.hm.assertions.assertPlatform "services.mako" pkgs lib.platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.optionals (cfg.package != null) [ cfg.package ];
 
-    dbus.packages = [ cfg.package ];
+    dbus.packages = lib.optionals (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."mako/config" = mkIf (cfg.settings != { } || cfg.extraConfig != "") {
-      onChange = "${cfg.package}/bin/makoctl reload || true";
+      onChange =
+        let
+          makoctl = if cfg.package != null then lib.getExe' cfg.package "makoctl" else "makoctl";
+        in
+        "${makoctl} reload || true";
       text = generateConfig cfg.settings;
     };
   };


### PR DESCRIPTION
### Description

Make `services.mako.package` nullable so that mako can be installed from sources other than nixpkgs.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.