### PR TITLE
chromium: add Microsoft Edge

### DIFF
--- a/modules/misc/news/2026/05/2026-05-07_15-57-46.nix
+++ b/modules/misc/news/2026/05/2026-05-07_15-57-46.nix
@@ -1,0 +1,17 @@
+_: {
+  time = "2026-05-07T15:57:46+00:00";
+  condition = true;
+  message = ''
+    A new option is available: `programs.microsoft-edge`.
+
+    Microsoft Edge is now supported by the Chromium-based browser module,
+    sharing the same `commandLineArgs`, `extensions`, `dictionaries` and
+    `nativeMessagingHosts` interface.
+
+    Note: the `microsoft-edge` package in nixpkgs is only available on
+    `x86_64-linux`. On macOS, install Edge through other means (e.g. the
+    official `.pkg` installer) and set
+    `programs.microsoft-edge.package = null` to manage configuration files
+    only, or supply a custom darwin-compatible package.
+  '';
+}

--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -16,6 +16,7 @@ let
     google-chrome-dev = "Google Chrome Dev";
     brave = "Brave Browser";
     vivaldi = "Vivaldi Browser";
+    microsoft-edge = "Microsoft Edge";
   };
 
   plasmaSupportedBrowsers = [
@@ -233,6 +234,7 @@ let
         google-chrome-beta = "Google/Chrome Beta";
         google-chrome-dev = "Google/Chrome Dev";
         brave = "BraveSoftware/Brave-Browser";
+        microsoft-edge = "Microsoft Edge";
       };
 
       linuxDirs = {


### PR DESCRIPTION
### Description

Adds `programs.microsoft-edge` to the Chromium-based browser module
(`modules/programs/chromium.nix`). It exposes the same
`commandLineArgs`, `extensions`, `dictionaries` and
`nativeMessagingHosts` interface as the other supported browsers, and
writes config files under:

- Linux: `\$XDG_CONFIG_HOME/microsoft-edge/`
- macOS: `~/Library/Application Support/Microsoft Edge/`

**Note on macOS:** the `microsoft-edge` package in nixpkgs is
`x86_64-linux` only. macOS users must either set
`programs.microsoft-edge.package = null` (to manage config files only,
with Edge installed via the official `.pkg` installer or similar) or
supply a custom darwin-compatible package.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

      Verified via `nix flake check` and a manual launch of the
      wrapped `microsoft-edge` binary using the activation package
      output (extension JSON correctly placed at
      `\$XDG_CONFIG_HOME/microsoft-edge/External Extensions/<id>.json`,
      `commandLineArgs` baked into the wrapper).

- [ ] Test cases updated/added.

      The existing `chromium.nix` module has no test cases; this PR
      keeps the same posture.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

- If this PR adds a new module
  - This PR adds a new browser to the existing `chromium` module
    rather than introducing a new module file, so the new-module
    checkboxes do not apply. A news entry is included for visibility.

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry.