### PR TITLE
rclone: make module compatible to darwin

### DIFF
--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -92,7 +92,12 @@ let
         Type =
           if !isMount && !(builtins.elem sidecar.protocol serveProtocolNotifies) then "simple" else "notify";
         Environment =
-          (lib.optional isMount "PATH=/run/wrappers/bin")
+          # PATH is set explicitly so fusermount/fusermount3 is found on both
+          # NixOS (/run/wrappers/bin) and standalone home-manager hosts running
+          # other Linux distros (where the FUSE setuid helper lives in standard
+          # /usr or /sbin paths). Setting Environment=PATH= replaces systemd's
+          # inherited PATH, so we must enumerate the non-NixOS locations too.
+          (lib.optional isMount "PATH=/run/wrappers/bin:/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
           ++ lib.optional (sidecar.logLevel != null) "RCLONE_LOG_LEVEL=${sidecar.logLevel}";
         SuccessExitStatus = "143";
 

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -126,6 +126,61 @@ let
       ) "default.target";
     };
 
+  # Builder for a per-sidecar launchd agent. Returns the value half
+  # of a `nameValuePair` (the agent attrs).
+  mkLaunchdSidecar =
+    {
+      sidecarType,
+      remoteName,
+      sidecar,
+      sidecarPath,
+      isMount,
+      cmdName,
+    }:
+    let
+      label = "rclone-${cmdName}:${replaceIllegalChars sidecarPath}@${remoteName}";
+      runAtLoad = if isMount then sidecar.autoMount else sidecar.autoStart;
+      rcloneArgs =
+        [
+          (lib.getExe cfg.package)
+          cmdName
+        ]
+        ++ (lib.cli.toCommandLineGNU { } sidecar.options)
+        ++ (
+          if isMount then
+            [
+              "${remoteName}:${sidecarPath}"
+              sidecar.mountPoint
+            ]
+          else
+            [
+              sidecar.protocol
+              "${remoteName}:${sidecarPath}"
+            ]
+        );
+    in
+    {
+      enable = true;
+      config = {
+        ProgramArguments =
+          [ (lib.getExe rcloneSidecarWrapper) ]
+          ++ (lib.optionals isMount [
+            "--mkdir"
+            sidecar.mountPoint
+          ])
+          ++ rcloneArgs;
+        RunAtLoad = runAtLoad;
+        KeepAlive = {
+          SuccessfulExit = false;
+          Crashed = true;
+        };
+        StandardOutPath = "${config.home.homeDirectory}/Library/Logs/rclone/${label}.log";
+        StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/rclone/${label}.err.log";
+        EnvironmentVariables =
+          if sidecar.logLevel != null then { RCLONE_LOG_LEVEL = sidecar.logLevel; } else null;
+      };
+    };
+
   # Iterate cfg.remotes × remote.${sidecarType}, applying the supplied
   # value builder. Produces an attrset keyed by service name.
   mkRcloneSidecars =
@@ -184,6 +239,11 @@ let
         fi
         sleep 1
       done
+
+      if [ "''${1:-}" = "--mkdir" ]; then
+        mkdir -p "$2"
+        shift 2
+      fi
 
       exec "$@"
     '';
@@ -568,6 +628,8 @@ in
       ];
       launchd.agents = lib.mkMerge [
         mkLaunchdConfigService
+        (mkRcloneSidecars "mounts" mkLaunchdSidecar)
+        (mkRcloneSidecars "serve" mkLaunchdSidecar)
       ];
     };
 }

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -69,80 +69,95 @@ let
     };
   };
 
-  # creates a sidecar user service. returns an attrset of systemd services
+  # Builder for a per-sidecar systemd user unit. Returns the value half
+  # of a `nameValuePair` (the unit attrs).
+  mkSystemdSidecar =
+    {
+      sidecarType,
+      remoteName,
+      sidecar,
+      sidecarPath,
+      isMount,
+      cmdName,
+    }:
+    {
+      Unit = {
+        Description = "Rclone ${
+          if isMount then "FUSE daemon" else "protocol serving"
+        } for ${remoteName}:${sidecarPath}";
+        Requires = [ "rclone-config.service" ];
+        After = [ "rclone-config.service" ];
+      };
+
+      Service = {
+        Type =
+          if sidecarType == "serve" && !(builtins.elem sidecar.protocol serveProtocolNotifies) then
+            "simple"
+          else
+            "notify";
+        Environment =
+          (lib.optional (sidecarType == "mounts") "PATH=/run/wrappers/bin")
+          ++ lib.optional (sidecar.logLevel != null) "RCLONE_LOG_LEVEL=${sidecar.logLevel}";
+        SuccessExitStatus = "143";
+
+        ExecStartPre = lib.mkIf isMount "${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg sidecar.mountPoint}";
+        ExecStart = lib.concatStringsSep " " (
+          [ "${lib.getExe cfg.package} ${cmdName}" ]
+          ++ (
+            if isMount then
+              [
+                (lib.cli.toCommandLineShellGNU { } sidecar.options)
+                (lib.escapeShellArg "${remoteName}:${sidecarPath}")
+                (lib.escapeShellArg sidecar.mountPoint)
+              ]
+            else
+              [
+                (lib.escapeShellArg sidecar.protocol)
+                (lib.cli.toCommandLineShellGNU { } sidecar.options)
+                (lib.escapeShellArg "${remoteName}:${sidecarPath}")
+              ]
+          )
+        );
+        Restart = "on-failure";
+      };
+
+      Install.WantedBy = lib.optional (
+        if isMount then sidecar.autoMount else sidecar.autoStart
+      ) "default.target";
+    };
+
+  # Iterate cfg.remotes × remote.${sidecarType}, applying the supplied
+  # value builder. Produces an attrset keyed by service name.
   mkRcloneSidecars =
-    # type of the sidecar, either "mounts" or "serve" corresponding to options
-    sidecarType:
+    sidecarType: mkValue:
     lib.listToAttrs (
       lib.concatMap (
-        _remote: # remote name + remote config
+        _remote:
         let
           remoteName = _remote.name;
           remote = _remote.value;
         in
         lib.concatMap (
-          _sidecar: # sidecar path + sidecar config
+          _sidecar:
           let
-            # a sidecar is either a mount or a protocol-serve
             sidecarPath = _sidecar.name;
             sidecar = _sidecar.value;
-
-            # there are currently only 2 types mount/serve - this may need changed in the future
             isMount = sidecarType == "mounts";
-            # name of the rclone command to use - also used in service name
             cmdName = if isMount then "mount" else "serve";
           in
           lib.optional sidecar.enable (
-            lib.nameValuePair "rclone-${cmdName}:${replaceIllegalChars sidecarPath}@${remoteName}" {
-              Unit = {
-                Description = "Rclone ${
-                  if isMount then "FUSE daemon" else "protocol serving"
-                } for ${remoteName}:${sidecarPath}";
-                Requires = [ "rclone-config.service" ];
-                After = [ "rclone-config.service" ];
-              };
-
-              Service = {
-                Type =
-                  # all services can be Type=notify except for serve protocols that don't notify
-                  if sidecarType == "serve" && !(builtins.elem sidecar.protocol serveProtocolNotifies) then
-                    "simple"
-                  else
-                    "notify";
-                Environment =
-                  # fusermount/fusermount3
-                  (lib.optional (sidecarType == "mounts") "PATH=/run/wrappers/bin")
-                  ++ lib.optional (sidecar.logLevel != null) "RCLONE_LOG_LEVEL=${sidecar.logLevel}";
-                # rclone exits with code 143 when stopped properly
-                SuccessExitStatus = "143";
-
-                ExecStartPre = lib.mkIf isMount "${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg sidecar.mountPoint}";
-                ExecStart = lib.concatStringsSep " " (
-                  [ "${lib.getExe cfg.package} ${cmdName}" ] # rclone [command]
-                  ++ (
-                    if isMount then
-                      # https://rclone.org/commands/rclone_mount/
-                      [
-                        (lib.cli.toCommandLineShellGNU { } sidecar.options) # [opts]
-                        (lib.escapeShellArg "${remoteName}:${sidecarPath}") # <remote>
-                        (lib.escapeShellArg sidecar.mountPoint) # <mountpoint>
-                      ]
-                    else
-                      # https://rclone.org/commands/rclone_serve/
-                      [
-                        (lib.escapeShellArg sidecar.protocol) # <protocol>
-                        (lib.cli.toCommandLineShellGNU { } sidecar.options) # [opts]
-                        (lib.escapeShellArg "${remoteName}:${sidecarPath}") # <remote>
-                      ]
-                  )
-                );
-                Restart = "on-failure";
-              };
-
-              Install.WantedBy = lib.optional (
-                if isMount then sidecar.autoMount else sidecar.autoStart
-              ) "default.target";
-            }
+            lib.nameValuePair "rclone-${cmdName}:${replaceIllegalChars sidecarPath}@${remoteName}" (
+              mkValue {
+                inherit
+                  sidecarType
+                  remoteName
+                  sidecar
+                  sidecarPath
+                  isMount
+                  cmdName
+                  ;
+              }
+            )
           )
         ) (lib.attrsToList (remote.${sidecarType} or { }))
       ) (lib.attrsToList cfg.remotes)
@@ -504,8 +519,8 @@ in
       home.packages = [ cfg.package ];
       systemd.user.services = lib.mkMerge [
         rcloneConfigService
-        (mkRcloneSidecars "mounts")
-        (mkRcloneSidecars "serve")
+        (mkRcloneSidecars "mounts" mkSystemdSidecar)
+        (mkRcloneSidecars "serve" mkSystemdSidecar)
       ];
     };
 }

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -48,7 +48,14 @@ let
       default = { };
       apply = lib.mergeAttrs {
         vfs-cache-mode = "full";
-        cache-dir = "%C/rclone";
+        # On Linux the unit runs under systemd, so keep the %C specifier:
+        # it is expanded at unit-start time to the live $XDG_CACHE_HOME
+        # (falling back to ~/.cache), preserving the pre-Darwin behavior
+        # even for users who set XDG_CACHE_HOME outside Home Manager.
+        # launchd has no equivalent specifier, so Darwin must use the
+        # Home Manager-evaluated path.
+        cache-dir =
+          if pkgs.stdenv.hostPlatform.isLinux then "%C/rclone" else "${config.xdg.cacheHome}/rclone";
       };
       description = ''
         An attribute set of option values passed to the command.

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -163,6 +163,32 @@ let
       ) (lib.attrsToList cfg.remotes)
     );
 
+  # Darwin-only: wraps each rclone mount/serve invocation, polling for
+  # rclone.conf before exec'ing. Substitutes for systemd's
+  # `After=rclone-config.service` ordering. Has no consumers on Linux.
+  rcloneSidecarWrapper = pkgs.writeShellApplication {
+    name = "rclone-sidecar-wrapper";
+
+    runtimeInputs = [
+      pkgs.coreutils
+    ];
+
+    text = ''
+      configPath="${config.xdg.configHome}/rclone/rclone.conf"
+      deadline=$(( $(date +%s) + 300 ))
+
+      while [ ! -f "$configPath" ]; do
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+          echo "Timeout waiting for $configPath" >&2
+          exit 1
+        fi
+        sleep 1
+      done
+
+      exec "$@"
+    '';
+  };
+
 in
 {
   meta.maintainers = with lib.maintainers; [ jess ];

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -376,6 +376,11 @@ in
                   rclone documentation <https://rclone.org/commands/rclone_mount/> — we create
                   a key-value pair like this:
                   `"path/to/files/on/remote" = { ... }`.
+
+                  On macOS, FUSE mounts additionally require macFUSE
+                  (<https://osxfuse.github.io/>) to be installed and its system extension
+                  approved. Home Manager does not install macFUSE; rclone will surface
+                  a runtime error if it is missing.
                 '';
                 example = lib.literalExpression ''
                   {
@@ -513,6 +518,11 @@ in
           When using sops-nix or agenix, this value is set automatically to
           sops-nix.service or agenix.service, respectively. Set this manually if you
           use a different secret provisioner.
+
+          Ignored on macOS, since launchd has no equivalent ordering primitive.
+          The config-install agent retries on failure (KeepAlive.Crashed), so it
+          will succeed on a subsequent attempt once the secret-provisioner agent
+          has materialized the secret files.
         '';
       };
     };

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -73,7 +73,6 @@ let
   # of a `nameValuePair` (the unit attrs).
   mkSystemdSidecar =
     {
-      sidecarType,
       remoteName,
       sidecar,
       sidecarPath,
@@ -91,12 +90,9 @@ let
 
       Service = {
         Type =
-          if sidecarType == "serve" && !(builtins.elem sidecar.protocol serveProtocolNotifies) then
-            "simple"
-          else
-            "notify";
+          if !isMount && !(builtins.elem sidecar.protocol serveProtocolNotifies) then "simple" else "notify";
         Environment =
-          (lib.optional (sidecarType == "mounts") "PATH=/run/wrappers/bin")
+          (lib.optional isMount "PATH=/run/wrappers/bin")
           ++ lib.optional (sidecar.logLevel != null) "RCLONE_LOG_LEVEL=${sidecar.logLevel}";
         SuccessExitStatus = "143";
 
@@ -130,7 +126,6 @@ let
   # of a `nameValuePair` (the agent attrs).
   mkLaunchdSidecar =
     {
-      sidecarType,
       remoteName,
       sidecar,
       sidecarPath,
@@ -203,7 +198,6 @@ let
           lib.optional sidecar.enable (
             lib.nameValuePair "rclone-${cmdName}:${replaceIllegalChars sidecarPath}@${remoteName}" (mkValue {
               inherit
-                sidecarType
                 remoteName
                 sidecar
                 sidecarPath

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -542,6 +542,22 @@ in
           Install.WantedBy = [ "default.target" ];
         };
       };
+
+      mkLaunchdConfigService = lib.mkIf (cfg.remotes != { }) {
+        rclone-config = {
+          enable = true;
+          config = {
+            ProgramArguments = [ (lib.getExe rcloneConfigScript) ];
+            RunAtLoad = true;
+            KeepAlive = {
+              SuccessfulExit = false;
+              Crashed = true;
+            };
+            StandardOutPath = "${config.home.homeDirectory}/Library/Logs/rclone/rclone-config.log";
+            StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/rclone/rclone-config.err.log";
+          };
+        };
+      };
     in
     lib.mkIf cfg.enable {
       home.packages = [ cfg.package ];
@@ -549,6 +565,9 @@ in
         mkSystemdConfigService
         (mkRcloneSidecars "mounts" mkSystemdSidecar)
         (mkRcloneSidecars "serve" mkSystemdSidecar)
+      ];
+      launchd.agents = lib.mkMerge [
+        mkLaunchdConfigService
       ];
     };
 }

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -140,35 +140,35 @@ let
     let
       label = "rclone-${cmdName}:${replaceIllegalChars sidecarPath}@${remoteName}";
       runAtLoad = if isMount then sidecar.autoMount else sidecar.autoStart;
-      rcloneArgs =
-        [
-          (lib.getExe cfg.package)
-          cmdName
-        ]
-        ++ (lib.cli.toCommandLineGNU { } sidecar.options)
-        ++ (
-          if isMount then
-            [
-              "${remoteName}:${sidecarPath}"
-              sidecar.mountPoint
-            ]
-          else
-            [
-              sidecar.protocol
-              "${remoteName}:${sidecarPath}"
-            ]
-        );
+      rcloneArgs = [
+        (lib.getExe cfg.package)
+        cmdName
+      ]
+      ++ (lib.cli.toCommandLineGNU { } sidecar.options)
+      ++ (
+        if isMount then
+          [
+            "${remoteName}:${sidecarPath}"
+            sidecar.mountPoint
+          ]
+        else
+          [
+            sidecar.protocol
+            "${remoteName}:${sidecarPath}"
+          ]
+      );
     in
     {
       enable = true;
       config = {
-        ProgramArguments =
-          [ (lib.getExe rcloneSidecarWrapper) ]
-          ++ (lib.optionals isMount [
-            "--mkdir"
-            sidecar.mountPoint
-          ])
-          ++ rcloneArgs;
+        ProgramArguments = [
+          (lib.getExe rcloneSidecarWrapper)
+        ]
+        ++ (lib.optionals isMount [
+          "--mkdir"
+          sidecar.mountPoint
+        ])
+        ++ rcloneArgs;
         RunAtLoad = runAtLoad;
         KeepAlive = {
           SuccessfulExit = false;
@@ -201,18 +201,16 @@ let
             cmdName = if isMount then "mount" else "serve";
           in
           lib.optional sidecar.enable (
-            lib.nameValuePair "rclone-${cmdName}:${replaceIllegalChars sidecarPath}@${remoteName}" (
-              mkValue {
-                inherit
-                  sidecarType
-                  remoteName
-                  sidecar
-                  sidecarPath
-                  isMount
-                  cmdName
-                  ;
-              }
-            )
+            lib.nameValuePair "rclone-${cmdName}:${replaceIllegalChars sidecarPath}@${remoteName}" (mkValue {
+              inherit
+                sidecarType
+                remoteName
+                sidecar
+                sidecarPath
+                isMount
+                cmdName
+                ;
+            })
           )
         ) (lib.attrsToList (remote.${sidecarType} or { }))
       ) (lib.attrsToList cfg.remotes)
@@ -331,9 +329,10 @@ in
                   must be provided as file paths to the secrets, which will be read at activation
                   time.
 
-                  These values are expanded in a shell context within a systemd service, so
+                  These values are expanded in a shell context within the rclone-config
+                  service (a systemd user service on Linux, a launchd agent on macOS), so
                   you can use bash features like command substitution or variable expansion
-                  (e.g. "''${XDG_RUNTIME_DIR}" as used by agenix).
+                  (e.g. "''${XDG_RUNTIME_DIR}" on Linux, as used by agenix).
                 '';
                 example = lib.literalExpression ''
                   {

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -489,17 +489,21 @@ in
 
       requiresUnit = lib.mkOption {
         type = with lib.types; nullOr str;
+        readOnly = !pkgs.stdenv.hostPlatform.isLinux;
         default =
-          lib.foldlAttrs
-            (
-              acc: prov: svc:
-              if isUsingSecretProvisioner prov then svc else acc
-            )
+          if !pkgs.stdenv.hostPlatform.isLinux then
             null
-            {
-              "sops" = "sops-nix.service";
-              "age" = "agenix.service";
-            };
+          else
+            lib.foldlAttrs
+              (
+                acc: prov: svc:
+                if isUsingSecretProvisioner prov then svc else acc
+              )
+              null
+              {
+                "sops" = "sops-nix.service";
+                "age" = "agenix.service";
+              };
         example = "agenix.service";
         description = ''
           The name of a systemd user service that must complete before the rclone
@@ -512,10 +516,11 @@ in
           sops-nix.service or agenix.service, respectively. Set this manually if you
           use a different secret provisioner.
 
-          Ignored on macOS, since launchd has no equivalent ordering primitive.
-          The config-install agent retries on failure (KeepAlive.Crashed), so it
-          will succeed on a subsequent attempt once the secret-provisioner agent
-          has materialized the secret files.
+          Read-only on non-systemd platforms (always null), since this option
+          has no equivalent ordering primitive outside systemd. On macOS, the
+          config-install launchd agent retries on failure (KeepAlive.Crashed),
+          so it will succeed on a subsequent attempt once the secret-provisioner
+          agent has materialized the secret files.
         '';
       };
     };

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -434,91 +434,93 @@ in
 
   config =
     let
-      rcloneConfigService =
-        let
-          safeConfig = lib.pipe cfg.remotes [
-            (lib.mapAttrs (_: v: v.config))
-            (iniFormat.generate "rclone.conf@pre-secrets")
+      rcloneConfigPath = "${config.xdg.configHome}/rclone/rclone.conf";
+
+      injectSecret =
+        remote:
+        lib.mapAttrsToList (secret: secretFile: ''
+          if [[ ! -r "${secretFile}" ]]; then
+            echo "Secret \"${secretFile}\" not found"
+            cleanup
+          fi
+
+          if ! ${lib.getExe cfg.package} config update \
+                 --config "$stagingPath" \
+                 ${remote.name} config_refresh_token=false \
+                 ${secret}="$(cat "${secretFile}")" \
+                 --non-interactive; then
+            echo "Failed to inject secret \"${secretFile}\""
+            cleanup
+          fi
+        '') remote.value.secrets or { };
+
+      injectAllSecrets = lib.concatMap injectSecret (lib.mapAttrsToList lib.nameValuePair cfg.remotes);
+
+      safeConfig = lib.pipe cfg.remotes [
+        (lib.mapAttrs (_: v: v.config))
+        (iniFormat.generate "rclone.conf@pre-secrets")
+      ];
+
+      rcloneConfigScript = pkgs.writeShellApplication {
+        name = "rclone-config";
+
+        runtimeInputs = [
+          pkgs.coreutils
+        ];
+
+        text = ''
+          configPath="${rcloneConfigPath}"
+          configDir="$(dirname "$configPath")"
+          install -d -m700 "$configDir"
+          stagingPath="$(mktemp "$configDir/.rclone.conf.XXXXXX")"
+
+          cleanup() {
+            echo "Failed to render config."
+            rm -f "$stagingPath"
+            exit 1
+          }
+
+          trap cleanup SIGINT
+
+          # Render and inject secrets into a staging file, then publish it
+          # atomically. The live rclone.conf only ever appears (or changes)
+          # once it is complete with secrets, so a half-rendered or
+          # secrets-less config is never observed and an existing config is
+          # left untouched on failure. This matters on Darwin, where the
+          # sidecar wrapper polls for this file in lieu of systemd ordering.
+          install -v -m600 "${safeConfig}" "$stagingPath"
+          ${lib.concatLines injectAllSecrets}
+          mv -f "$stagingPath" "$configPath"
+        '';
+      };
+
+      mkSystemdConfigService = lib.mkIf (cfg.remotes != { }) {
+        rclone-config = {
+          Unit = lib.mkMerge [
+            {
+              Description = "Install rclone configuration to ${rcloneConfigPath}";
+            }
+
+            (lib.optionalAttrs (cfg.requiresUnit != null) {
+              Requires = [ cfg.requiresUnit ];
+              After = [ cfg.requiresUnit ];
+            })
           ];
 
-          injectSecret =
-            remote:
-            lib.mapAttrsToList (secret: secretFile: ''
-              if [[ ! -r "${secretFile}" ]]; then
-                echo "Secret \"${secretFile}\" not found"
-                cleanup
-              fi
-
-              if ! ${lib.getExe cfg.package} config update \
-                     ${remote.name} config_refresh_token=false \
-                     ${secret}="$(cat "${secretFile}")" \
-                     --non-interactive; then
-                echo "Failed to inject secret \"${secretFile}\""
-                cleanup
-              fi
-            '') remote.value.secrets or { };
-
-          injectAllSecrets = lib.concatMap injectSecret (lib.mapAttrsToList lib.nameValuePair cfg.remotes);
-          rcloneConfigPath = "${config.xdg.configHome}/rclone/rclone.conf";
-        in
-        lib.mkIf (cfg.remotes != { }) {
-          rclone-config = {
-            Unit = lib.mkMerge [
-              {
-                Description = "Install rclone configuration to ${rcloneConfigPath}";
-              }
-
-              (lib.optionalAttrs (cfg.requiresUnit != null) {
-                Requires = [ cfg.requiresUnit ];
-                After = [ cfg.requiresUnit ];
-              })
-            ];
-
-            Service = {
-              Type = "oneshot";
-              ExecStart = lib.getExe (
-                pkgs.writeShellApplication {
-                  name = "rclone-config";
-
-                  runtimeInputs = [
-                    pkgs.coreutils
-                  ];
-
-                  text = ''
-                    configPath="${rcloneConfigPath}"
-                    configName="$(basename $configPath)"
-                    savedConfigPath="$(dirname $configPath)"/."$configName".orig
-
-                    cleanup() {
-                      echo "Failed to render config."
-                      if [ -f "$savedConfigPath" ]; then
-                        cp -v "$savedConfigPath" "${rcloneConfigPath}"
-                      fi
-                      exit 1
-                    }
-
-                    trap cleanup SIGINT
-
-                    if [ -f "${rcloneConfigPath}" ]; then
-                      cp -v "${rcloneConfigPath}" "$savedConfigPath"
-                    fi
-
-                    install -v -D -m600 "${safeConfig}" "${rcloneConfigPath}"
-                    ${lib.concatLines injectAllSecrets}
-                  '';
-                }
-              );
-              Restart = "on-abnormal";
-            };
-
-            Install.WantedBy = [ "default.target" ];
+          Service = {
+            Type = "oneshot";
+            ExecStart = lib.getExe rcloneConfigScript;
+            Restart = "on-abnormal";
           };
+
+          Install.WantedBy = [ "default.target" ];
         };
+      };
     in
     lib.mkIf cfg.enable {
       home.packages = [ cfg.package ];
       systemd.user.services = lib.mkMerge [
-        rcloneConfigService
+        mkSystemdConfigService
         (mkRcloneSidecars "mounts" mkSystemdSidecar)
         (mkRcloneSidecars "serve" mkSystemdSidecar)
       ];

--- a/tests/modules/programs/rclone/basic-configuration.nix
+++ b/tests/modules/programs/rclone/basic-configuration.nix
@@ -1,11 +1,22 @@
-_: {
-  programs.rclone = {
-    enable = true;
-    remotes.myremote.config.type = "local";
-  };
+{ lib, pkgs, ... }:
 
-  # make sure config service exists
-  nmt.script = ''
-    assertFileExists home-files/.config/systemd/user/rclone-config.service
-  '';
-}
+lib.mkMerge [
+  {
+    programs.rclone = {
+      enable = true;
+      remotes.myremote.config.type = "local";
+    };
+  }
+
+  (lib.mkIf pkgs.stdenv.isLinux {
+    nmt.script = ''
+      assertFileExists home-files/.config/systemd/user/rclone-config.service
+    '';
+  })
+
+  (lib.mkIf pkgs.stdenv.isDarwin {
+    nmt.script = ''
+      assertFileExists LaunchAgents/org.nix-community.home.rclone-config.plist
+    '';
+  })
+]

--- a/tests/modules/programs/rclone/default.nix
+++ b/tests/modules/programs/rclone/default.nix
@@ -1,6 +1,8 @@
 { lib, pkgs, ... }:
-lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+{
   rclone-basic-configuration = ./basic-configuration.nix;
+}
+// lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   rclone-mount-service-generation = ./mount-service-generation.nix;
   rclone-serve-service-generation = ./serve-service-generation.nix;
 }

--- a/tests/modules/programs/rclone/default.nix
+++ b/tests/modules/programs/rclone/default.nix
@@ -6,3 +6,6 @@
   rclone-mount-service-generation = ./mount-service-generation.nix;
   rclone-serve-service-generation = ./serve-service-generation.nix;
 }
+// lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+  rclone-mount-service-generation-darwin = ./mount-service-generation-darwin.nix;
+}

--- a/tests/modules/programs/rclone/default.nix
+++ b/tests/modules/programs/rclone/default.nix
@@ -8,4 +8,5 @@
 }
 // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
   rclone-mount-service-generation-darwin = ./mount-service-generation-darwin.nix;
+  rclone-serve-service-generation-darwin = ./serve-service-generation-darwin.nix;
 }

--- a/tests/modules/programs/rclone/mount-service-generation-darwin.nix
+++ b/tests/modules/programs/rclone/mount-service-generation-darwin.nix
@@ -1,0 +1,67 @@
+_: {
+  programs.rclone = {
+    enable = true;
+    remotes.sftp-remote = {
+      config = {
+        type = "sftp";
+        host = "backup-server.example.com";
+        user = "alice";
+        key_file = "/Users/alice/.ssh/id_ed25519";
+      };
+      mounts = {
+        "documents/work" = {
+          enable = true;
+          mountPoint = "/Users/alice/mounts/work-docs";
+          logLevel = "INFO";
+          options = {
+            dir-cache-time = "5000h";
+            poll-interval = "10s";
+            umask = "002";
+          };
+        };
+        "disabled-mount" = {
+          enable = false;
+          mountPoint = "/Users/alice/mounts/disabled";
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    plist="LaunchAgents/org.nix-community.home.rclone-mount:documents.work@sftp-remote.plist"
+    assertFileExists "$plist"
+
+    # rclone command line is wrapped by the launchd module in
+    # `/bin/sh -c "/bin/wait4path /nix/store && exec <args>"`,
+    # then by our rclone-sidecar-wrapper. Check for the meaningful
+    # substrings rather than the full quoted form.
+    assertFileContains "$plist" "rclone-sidecar-wrapper"
+    assertFileContains "$plist" "/bin/rclone"
+    assertFileContains "$plist" "mount"
+    assertFileContains "$plist" "&apos;--cache-dir=/home/hm-user/.cache/rclone&apos;"
+    assertFileContains "$plist" "&apos;--vfs-cache-mode=full&apos;"
+    assertFileContains "$plist" "&apos;--dir-cache-time=5000h&apos;"
+    assertFileContains "$plist" "&apos;--poll-interval=10s&apos;"
+    assertFileContains "$plist" "&apos;--umask=002&apos;"
+    assertFileContains "$plist" "sftp-remote:documents/work"
+    assertFileContains "$plist" "/Users/alice/mounts/work-docs"
+
+    # Mount sidecars pre-create the mount point via the wrapper's --mkdir flag.
+    assertFileContains "$plist" "rclone-sidecar-wrapper --mkdir"
+
+    # Lifecycle keys
+    assertFileContains "$plist" "<key>RunAtLoad</key>"
+    assertFileContains "$plist" "<key>KeepAlive</key>"
+    assertFileContains "$plist" "<key>Crashed</key>"
+
+    # Logs route under ~/Library/Logs/rclone/
+    assertFileContains "$plist" "Library/Logs/rclone"
+
+    # Log level surfaces as an environment variable
+    assertFileContains "$plist" "RCLONE_LOG_LEVEL"
+    assertFileContains "$plist" "INFO"
+
+    # Disabled mount produces no plist
+    assertPathNotExists "LaunchAgents/org.nix-community.home.rclone-mount:disabled-mount@sftp-remote.plist"
+  '';
+}

--- a/tests/modules/programs/rclone/mount-service-generation.nix
+++ b/tests/modules/programs/rclone/mount-service-generation.nix
@@ -34,7 +34,7 @@ _: {
     assertFileContains "$service" "rclone mount '--cache-dir=%C/rclone' '--dir-cache-time=5000h' '--poll-interval=10s' '--umask=002' '--vfs-cache-mode=full' sftp-remote:documents/work /home/alice/mounts/work-docs"
     assertFileContains "$service" "mkdir -p /home/alice/mounts/work-docs"
     assertFileContains "$service" "RCLONE_LOG_LEVEL=INFO"
-    assertFileContains "$service" "PATH=/run/wrappers/bin"
+    assertFileContains "$service" "PATH=/run/wrappers/bin:/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     assertFileContains "$service" "Rclone FUSE daemon for sftp-remote:documents/work"
     assertFileContains "$service" "Type=notify"
 

--- a/tests/modules/programs/rclone/serve-service-generation-darwin.nix
+++ b/tests/modules/programs/rclone/serve-service-generation-darwin.nix
@@ -1,0 +1,59 @@
+_: {
+  programs.rclone = {
+    enable = true;
+    remotes = {
+      sftp-remote = {
+        config = {
+          type = "sftp";
+          host = "backup-server.example.com";
+          user = "alice";
+          key_file = "/Users/alice/.ssh/id_ed25519";
+        };
+        serve = {
+          "documents/work" = {
+            enable = true;
+            protocol = "http";
+            logLevel = "ERROR";
+            options = {
+              addr = "127.0.0.1:8080";
+              dir-cache-time = "5000h";
+            };
+          };
+          "/games" = {
+            enable = true;
+            protocol = "ftp";
+          };
+          "disabled-serve" = {
+            enable = false;
+            protocol = "ftp";
+          };
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    # http serve
+    plist="LaunchAgents/org.nix-community.home.rclone-serve:documents.work@sftp-remote.plist"
+    assertFileExists "$plist"
+    assertFileContains "$plist" "rclone-sidecar-wrapper"
+    assertFileContains "$plist" "/bin/rclone"
+    assertFileContains "$plist" "serve"
+    assertFileContains "$plist" "http"
+    assertFileContains "$plist" "&apos;--addr=127.0.0.1:8080&apos;"
+    assertFileContains "$plist" "&apos;--cache-dir=/home/hm-user/.cache/rclone&apos;"
+    assertFileContains "$plist" "&apos;--dir-cache-time=5000h&apos;"
+    assertFileContains "$plist" "sftp-remote:documents/work"
+    assertFileContains "$plist" "RCLONE_LOG_LEVEL"
+    assertFileContains "$plist" "ERROR"
+
+    # ftp serve
+    plist2="LaunchAgents/org.nix-community.home.rclone-serve:.games@sftp-remote.plist"
+    assertFileExists "$plist2"
+    assertFileContains "$plist2" "ftp"
+    assertFileContains "$plist2" "sftp-remote:/games"
+
+    # Disabled serve produces no plist
+    assertPathNotExists "LaunchAgents/org.nix-community.home.rclone-serve:disabled-serve@sftp-remote.plist"
+  '';
+}


### PR DESCRIPTION
> [!NOTE]
> Re-opens #9271, which was inadvertently merged empty. Sorry for the inconvenience, the [pull[bot]](https://github.com/wei/pull) auto-sync app force-pushed it back to upstream. And the recorded merge contained 0 commits / 0 files.
>
> cc @ttrssreal and @ambroisie.

### Description

This PR provides the implementation of `rclone` module on darwin.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.