### PR TITLE
exwm: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -211,6 +211,12 @@
     github = "fpob";
     githubId = 6289078;
   };
+  garklein = {
+    name = "Garklein";
+    email = "garklein97@gmail.com";
+    github = "garklein";
+    githubId = 63201615;
+  };
   gauthsvenkat = {
     email = "gauthsvenkat+home-manager@gmail.com";
     github = "gauthsvenkat";

--- a/modules/misc/news/2026/05/2026-05-15_09-37-08.nix
+++ b/modules/misc/news/2026/05/2026-05-15_09-37-08.nix
@@ -1,0 +1,8 @@
+{
+  time = "2026-05-15T13:37:08+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `xsession.windowManager.exwm`. This
+    provides configuration for the Emacs X Window Manager.
+  '';
+}

--- a/modules/services/window-managers/default.nix
+++ b/modules/services/window-managers/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./awesome.nix
     ./bspwm
+    ./exwm.nix
     ./fluxbox.nix
     ./herbstluftwm.nix
     ./hyprland.nix

--- a/modules/services/window-managers/exwm.nix
+++ b/modules/services/window-managers/exwm.nix
@@ -1,0 +1,62 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  meta.maintainers = [ lib.hm.maintainers.garklein ];
+
+  options = {
+    xsession.windowManager.exwm = {
+      enable = lib.mkEnableOption "exwm";
+
+      loadScript = lib.mkOption {
+        default = "(require 'exwm)";
+        type = lib.types.lines;
+        example = ''
+          (require 'exwm)
+          (exwm-enable)
+        '';
+        description = ''
+          Emacs lisp code to be run after loading the user's init
+          file.
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs "emacs" {
+        example = [ "emacs-gtk" ];
+      };
+
+      extraPackages = lib.mkOption {
+        type = lib.types.functionTo (lib.types.listOf lib.types.package);
+        default = _epkgs: [ ];
+        defaultText = lib.literalExpression "epkgs: []";
+        example = lib.literalExpression ''
+          epkgs: [
+            epkgs.emms
+            epkgs.magit
+            epkgs.proof-general
+          ]
+        '';
+        description = ''
+          Extra packages available to Emacs. The value must be a
+          function which receives the attrset defined in
+          {var}`emacs.pkgs` as the sole argument.
+        '';
+      };
+    };
+  };
+
+  config =
+    let
+      cfg = config.xsession.windowManager.exwm;
+      exwm-emacs = cfg.package.pkgs.withPackages (epkgs: cfg.extraPackages epkgs ++ [ epkgs.exwm ]);
+    in
+    lib.mkIf cfg.enable {
+      home.packages = [ exwm-emacs ];
+      xsession.windowManager.command = ''
+        ${exwm-emacs}/bin/emacs -l ${pkgs.writeText "emacs-exwm-load" "${cfg.loadScript}"}
+      '';
+    };
+}


### PR DESCRIPTION
### Description

This adds the EXWM window manager. I adapted the EXWM service from nixos.

I didn't add any tests because this module doesn't write any files.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
