### PR TITLE
rofi: change configPath type to nonEmptyStr

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -265,7 +265,7 @@ in
     configPath = mkOption {
       default = "${config.xdg.configHome}/rofi/config.rasi";
       defaultText = "$XDG_CONFIG_HOME/rofi/config.rasi";
-      type = types.str;
+      type = types.nonEmptyStr;
       description = "Path where to put generated configuration file.";
     };
 


### PR DESCRIPTION
### Description

After [files: add assertion to check for empty target paths by taehoonsong · Pull Request #9133 · nix-community/home-manager](https://github.com/nix-community/home-manager/pull/9133) you can't set `configPath` to an empty string (by accident or on purpose), updated home-manager and took a long time to find out why I was getting this error:

<details>

```
error:
       … while calling the 'head' builtin
         at «github:nixos/nixpkgs/549bd84d6279f9852cae6225e372cc67fb91a4c1?narHash=sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9%2BhrDTkDU%3D»/lib/attrsets.nix:1712:13:
         1711|           if length values == 1 || pred here (elemAt values 1) (head values) then
         1712|             head values
             |             ^
         1713|           else

       … while evaluating the attribute 'value'
         at «github:nixos/nixpkgs/549bd84d6279f9852cae6225e372cc67fb91a4c1?narHash=sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9%2BhrDTkDU%3D»/lib/modules.nix:1166:7:
         1165|     // {
         1166|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1167|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `system.build.toplevel':

       … while evaluating definitions from `/nix/store/h9wn92hv33sizprch7fcp16lfs1k3w5j-source/nixos/modules/system/activation/top-level.nix':

       … while evaluating the option `home-manager.users.neuromante.home.file."".target':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: A definition for option `home-manager.users.neuromante.home.file."".target' is not of type `non-empty string'. Definition values:
       - In `/nix/store/vmxg5ap0n317jw0xjw8imyw3lc28f9in-source/modules/files.nix': ""
```
</details>

### Checklist

I think this is trivial enough, but let me know if not and I will follow the checklist, thanks