### PR TITLE
fish: fix handler function sourcing

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -421,7 +421,7 @@ let
         "onSignal"
         "onEvent"
       ];
-      isHandler = _name: def: isAttrs def && builtins.any (attr: builtins.hasAttr attr def) handlerAttrs;
+      isHandler = _name: def: isAttrs def && builtins.any (attr: def.${attr} != null) handlerAttrs;
       handlerFunctions = lib.filterAttrs isHandler cfg.functions;
       sourceFunction = name: _def: "source ${config.xdg.configHome}/fish/functions/${name}.fish";
     in

--- a/tests/modules/programs/fish/source-handlers.nix
+++ b/tests/modules/programs/fish/source-handlers.nix
@@ -5,6 +5,10 @@
 
       functions = {
         normal-function = "";
+        function-with-args = {
+          argumentNames = [ "test" ];
+          body = "";
+        };
         event-handler = {
           body = "";
           onEvent = "test";
@@ -36,6 +40,7 @@
       assertFileContains home-files/.config/fish/config.fish "source /home/hm-user/.config/fish/functions/signal-handler.fish"
       assertFileContains home-files/.config/fish/config.fish "source /home/hm-user/.config/fish/functions/process-handler.fish"
       assertFileNotRegex home-files/.config/fish/config.fish "source /home/hm-user/.config/fish/functions/normal-function.fish"
+      assertFileNotRegex home-files/.config/fish/config.fish "source /home/hm-user/.config/fish/functions/function-with-args.fish"
     '';
   };
 }


### PR DESCRIPTION
### Description

Currently, fish functions defined as an attrset are sourced within config.fish regardless of whether the function is a handler. Here's an example anyone should be able to replicate.

In your home-manager config:
```nix
programs.fish.functions = {
  not_a_handler = {
    description = "I am not a handler function";
    argumentNames = [ "something_interesting" ];
    body = ''
      echo $something_interesting
    '';
  };

  is_a_handler = {
    description = "I am a handler function";
    onVariable = "test_dummy";
    body = ''
      echo "test_dummy was set!"
    '';
  };
};
```

In the generated config.fish:
```fish
# Source handler functions
source /home/Sun/.config/fish/functions/is_a_handler.fish
source /home/Sun/.config/fish/functions/not_a_handler.fish
```

This occurs because the filter for handler functions checks if the function _has_ any handler attribute. If a fish function is defined as an attrset without specifying any handler attributes (such as with `not_a_handler` above), it'll have all handler attributes defined as null.

This commit changes the filter for handler functions to check if the function has any handler attribute _that is not null_. With this change and the above home-manager config, the generated config.fish correctly sources `is_a_handler` and not `not_a_handler`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
