### PR TITLE
kanshi: Remove myself from the maintainers

### DIFF
--- a/all-maintainers.nix
+++ b/all-maintainers.nix
@@ -1840,13 +1840,6 @@
     name = "Viktor Titov";
     source = "nixpkgs";
   };
-  nurelin = {
-    email = "nurelin@users.noreply.github.com";
-    github = "nurelin";
-    githubId = 5276274;
-    name = "nurelin";
-    source = "home-manager";
-  };
   nyarly = {
     email = "nyarly@gmail.com";
     github = "nyarly";

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -434,12 +434,6 @@
     github = "NitroSniper";
     githubId = 44097331;
   };
-  nurelin = {
-    name = "nurelin";
-    email = "nurelin@users.noreply.github.com";
-    github = "nurelin";
-    githubId = 5276274;
-  };
   ojsef39 = {
     name = "Josef Hofer";
     email = "josef.hofer@1und1.de";

--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -221,7 +221,7 @@ let
 in
 {
 
-  meta.maintainers = [ lib.hm.maintainers.nurelin ];
+  meta.maintainers = [ ];
 
   options.services.kanshi = {
     enable = lib.mkEnableOption "kanshi, a Wayland daemon that automatically configures outputs";


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
I do not use kanshi anymore and thus cannot meaningfully test changes.

Since it is my only maintained module, also remove myself from the maintainer lists.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
