### PR TITLE
gtklock: Add module

### DIFF
--- a/modules/misc/news/2026/05/2026-05-10-14_14_28.nix
+++ b/modules/misc/news/2026/05/2026-05-10-14_14_28.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+{
+  time = "2026-05-05T14:14:28+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'programs.gtklock'.
+
+    Gtklock is GTK-based lockscreen for Wayland, based on gtkgreet.
+  '';
+}

--- a/modules/programs/gtklock.nix
+++ b/modules/programs/gtklock.nix
@@ -1,0 +1,144 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.gtklock;
+
+  settingsFormat = pkgs.formats.ini {
+    listToValue = builtins.concatStringsSep ";";
+  };
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.olmokramer ];
+
+  options.programs.gtklock = {
+    enable = lib.mkEnableOption "gtklock";
+
+    package = lib.mkPackageOption pkgs "gtklock" { };
+
+    settings = lib.mkOption {
+      inherit (settingsFormat) type;
+      default = { };
+      description = ''
+        Gtklock settings. See <https://github.com/jovanlanik/gtklock/wiki#config>
+        for supported values.
+      '';
+      example = {
+        idle-hide = true;
+        idle-timeout = 60;
+        start-hidden = true;
+      };
+    };
+
+    modulePackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = ''
+        List of packages containing extra modules to load. All `.so` files in
+        the package's `lib/gtklock` directory will be included in the
+        configuration.
+      '';
+      example = lib.literalExpression ''
+        [
+          pkgs.gtklock-playerctl-module
+          pkgs.gtklock-virtkb-module
+        ]
+      '';
+    };
+
+    style = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = ''
+        CSS to add to the stylesheet. See
+        <https://github.com/jovanlanik/gtklock/wiki#styling>
+        for more information.
+      '';
+      example = lib.literalExpression ''
+        '''
+          window {
+            background-color: red;
+            color: white;
+          }
+        '''
+      '';
+    };
+
+    background = {
+      path = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          Path to a background image to use. By default the image is centered
+          and stretched to fill the entire screen.
+        '';
+        example = lib.literalExpression ''
+          ./background.jpg
+        '';
+      };
+
+      mode = lib.mkOption {
+        type = lib.types.str;
+        default = "center/cover";
+        description = ''
+          Extra properties to add to the `background` shorthand CSS rule. See
+          <https://docs.gtk.org/gtk3/css-properties.html#background-properties>
+          for details.
+        '';
+        example = "center/50% repeat";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.gtklock" pkgs lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    programs.gtklock = {
+      style =
+        let
+          inherit (cfg.background) path mode;
+        in
+        lib.mkIf (path != null) (
+          lib.mkAfter ''
+            window {
+              background: url("file://${cfg.background.path}") ${mode};
+            }
+          ''
+        );
+
+      settings = lib.mkMerge [
+        (lib.mkIf (cfg.modulePackages != [ ]) {
+          main.modules =
+            let
+              isSoFile = fileName: fileType: fileType == "regular" && lib.hasSuffix ".so" fileName;
+
+              getSoFiles =
+                pkg:
+                let
+                  moduleDir = "${pkg}/lib/gtklock";
+                  allFiles = builtins.readDir moduleDir;
+                  soFiles = lib.filterAttrs isSoFile allFiles;
+                in
+                lib.mapAttrsToList (name: _: "${moduleDir}/${name}") soFiles;
+            in
+            lib.concatMap getSoFiles cfg.modulePackages;
+        })
+
+        (lib.mkIf (lib.trim cfg.style != "") {
+          main.style = "${pkgs.writeText "gtklock-style.css" cfg.style}";
+        })
+      ];
+    };
+
+    xdg.configFile = lib.mkIf (cfg.settings != { }) {
+      "gtklock/config.ini".source = settingsFormat.generate "gtklock-config.ini" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/gtklock/default.nix
+++ b/tests/modules/programs/gtklock/default.nix
@@ -1,0 +1,6 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  gtklock-config = ./gtklock-config.nix;
+  gtklock-empty-config = ./gtklock-empty-config.nix;
+}

--- a/tests/modules/programs/gtklock/gtklock-config.nix
+++ b/tests/modules/programs/gtklock/gtklock-config.nix
@@ -1,0 +1,31 @@
+{ pkgs, ... }:
+{
+  programs.gtklock = {
+    enable = true;
+    settings.main = {
+      idle-hide = true;
+      idle-timeout = 60;
+      start-hidden = true;
+    };
+    modulePackages = [
+      (pkgs.writeTextDir "lib/gtklock/module_1.so" "")
+      (pkgs.runCommand "gtklock-module" { } ''
+        mkdir -p $out/lib/gtklock
+        touch $out/lib/gtklock/module_2.so
+        touch $out/lib/gtklock/module_3.so
+        touch $out/lib/gtklock/readme.txt
+      '')
+    ];
+    background.path = builtins.toFile "background.jpg" "";
+  };
+
+  nmt.script = ''
+    configPath=home-files/.config/gtklock/config.ini
+    configFile=$(normalizeStorePaths "$configPath")
+    assertFileContent "$configFile" ${./gtklock-expected-config.ini}
+
+    stylePath=$(grep '^style=' "$TESTED/home-files/.config/gtklock/config.ini" | sed 's/^style=//')
+    styleFile=$(normalizeStorePaths "$stylePath")
+    assertFileContent "$styleFile" ${./gtklock-expected-style.css}
+  '';
+}

--- a/tests/modules/programs/gtklock/gtklock-empty-config.nix
+++ b/tests/modules/programs/gtklock/gtklock-empty-config.nix
@@ -1,0 +1,7 @@
+_: {
+  programs.gtklock.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/gtklock/config.ini
+  '';
+}

--- a/tests/modules/programs/gtklock/gtklock-expected-config.ini
+++ b/tests/modules/programs/gtklock/gtklock-expected-config.ini
@@ -1,0 +1,6 @@
+[main]
+idle-hide=true
+idle-timeout=60
+modules=/nix/store/00000000000000000000000000000000-module_1.so/lib/gtklock/module_1.so;/nix/store/00000000000000000000000000000000-gtklock-module/lib/gtklock/module_2.so;/nix/store/00000000000000000000000000000000-gtklock-module/lib/gtklock/module_3.so
+start-hidden=true
+style=/nix/store/00000000000000000000000000000000-gtklock-style.css

--- a/tests/modules/programs/gtklock/gtklock-expected-style.css
+++ b/tests/modules/programs/gtklock/gtklock-expected-style.css
@@ -1,0 +1,3 @@
+window {
+  background: url("file:///nix/store/00000000000000000000000000000000-background.jpg") center/cover;
+}


### PR DESCRIPTION
### Description

Adds a module to configure [gtklock]. A couple of options are exposed
to simplify configuration such as a background image and plugins
(modules).

[gtklock]: https://github.com/jovanlanik/gtklock

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
