### PR TITLE
vdirsyncer: add preDeletionHook

### DIFF
--- a/modules/programs/vdirsyncer/accounts.nix
+++ b/modules/programs/vdirsyncer/accounts.nix
@@ -188,6 +188,16 @@ in
       '';
     };
 
+    preDeletionHook = mkOption {
+      type = types.nullOr types.lines;
+      default = null;
+      description = ''
+        Command to call before each item deletion.
+        The command will be called with the path of the file that will
+        be deleted.
+      '';
+    };
+
     ## Options for google storages
 
     tokenFile = mkOption {

--- a/modules/programs/vdirsyncer/default.nix
+++ b/modules/programs/vdirsyncer/default.nix
@@ -41,6 +41,13 @@ let
             (pkgs.writeShellScriptBin "post-hook" a.vdirsyncer.postHook + "/bin/post-hook")
           else
             null;
+        preDeletionHook =
+          if a.vdirsyncer.preDeletionHook != null then
+            (
+              pkgs.writeShellScriptBin "pre-deletion-hook" a.vdirsyncer.preDeletionHook + "/bin/pre-deletion-hook"
+            )
+          else
+            null;
       }
     );
 
@@ -91,6 +98,8 @@ let
       ''encoding = "${v}"''
     else if (n == "postHook") then
       ''post_hook = "${v}"''
+    else if (n == "preDeletionHook") then
+      ''pre_deletion_hook = "${v}"''
     else if (n == "url") then
       ''url = "${v}"''
     else if (n == "urlCommand") then
@@ -183,7 +192,6 @@ let
       mapAttrsToList (n: v: "[storage ${n}_remote]" + "\n" + attrsString v) remoteStorages
     )}
   '';
-
 in
 {
   imports = [
@@ -213,7 +221,6 @@ in
   config = lib.mkIf cfg.enable {
     assertions =
       let
-
         mutuallyExclusiveOptions = [
           [
             "url"
@@ -275,6 +282,7 @@ in
               "fileExt"
               "encoding"
               "postHook"
+              "preDeletionHook"
             ]
           else if (t == "singlefile") then
             [ "encoding" ]
@@ -303,7 +311,7 @@ in
               a: _v':
               [
                 {
-                  assertion = (lib.elem a allowed);
+                  assertion = lib.elem a allowed;
                   message = ''
                     Storage ${n} is of type ${v.type}. Option
                     ${a} is not allowed for this type.
@@ -345,7 +353,6 @@ in
         storageAssertions =
           lib.flatten (mapAttrsToList assertStorage localStorages)
           ++ lib.flatten (mapAttrsToList assertStorage remoteStorages);
-
       in
       storageAssertions;
     home.packages = [ cfg.package ];


### PR DESCRIPTION
### Description

This PR adds support for `preDeletionHook` in Home Manager's vdirsyncer module so users can run a command before local item deletions. This mirrors existing `postHook` behavior and closes a feature gap for deletion workflows.

Reference: [docs](https://vdirsyncer.pimutils.org/en/stable/config.html#local)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.
- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
