### PR TITLE
Yazi Plugins

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -17,6 +17,46 @@ let
 
   cfg = config.programs.yazi;
   tomlFormat = pkgs.formats.toml { };
+
+  pluginSubmodule = types.submodule {
+    options = {
+      package = mkOption {
+        type =
+          with types;
+          oneOf [
+            path
+            package
+          ];
+        description = ''
+          Package or path for the plugin.
+          Will be linked to
+          {file}`$XDG_CONFIG_HOME/yazi/plugins/<name>.yazi`.
+        '';
+      };
+      setup = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          When {var}`true`, generates a
+          {command}`require("{name}"):setup({...})` call in
+          {file}`$XDG_CONFIG_HOME/yazi/init.lua`.
+        '';
+      };
+      settings = mkOption {
+        type = types.attrs;
+        default = { };
+        description = ''
+          Attribute set passed to the plugin's
+          {command}`setup()` as a Lua table (via
+          {command}`lib.generators.toLua`). Values created with
+          {command}`lib.generators.mkLuaInline` are rendered as raw Lua expressions.
+          Only used when {option}`setup` is {var}`true`.
+          When empty, {command}`setup()` is called with no
+          arguments.
+        '';
+      };
+    };
+  };
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -189,23 +229,53 @@ in
     plugins = mkOption {
       type =
         with types;
-        attrsOf (oneOf [
-          path
-          package
-        ]);
+        attrsOf (
+          coercedTo
+            (oneOf [
+              path
+              package
+            ])
+            (pkg: {
+              package = pkg;
+              setup = false;
+              settings = { };
+            })
+            pluginSubmodule
+        );
       default = { };
       description = ''
         Lua plugins.
-        Values should be a package or path containing an `init.lua` file.
-        Will be linked to {file}`$XDG_CONFIG_HOME/yazi/plugins/<name>.yazi`.
+        Values can be a package or path (linked as-is), or an attribute set
+        with {option}`package`, {option}`setup`, and {option}`settings`.
+
+        Plugins with {option}`setup` set to {var}`true` generate a
+        {command}`require("{name}"):setup({...})` call in
+        {file}`$XDG_CONFIG_HOME/yazi/init.lua`, written before any
+        {option}`initLua` content.
 
         See <https://yazi-rs.github.io/docs/plugins/overview>
         for documentation.
       '';
       example = literalExpression ''
         {
-          foo = ./foo;
-          bar = pkgs.bar;
+          # package only, no setup call
+          foo = pkgs.foo;
+
+          # empty setup call: require("bar"):setup()
+          bar = {
+            package = pkgs.bar;
+            setup = true;
+          };
+
+          # setup call with settings
+          baz = {
+            package = pkgs.baz;
+            setup = true;
+            settings = {
+              part_separator = { open = ""; close = ""; };
+              tab_width = 20;
+            };
+          };
         }
       '';
     };
@@ -310,22 +380,34 @@ in
       "yazi/vfs.toml" = mkIf (cfg.vfs != { }) {
         source = tomlFormat.generate "yazi-vfs" cfg.vfs;
       };
-      "yazi/init.lua" = mkIf (cfg.initLua != null) (
-        if builtins.isPath cfg.initLua then
-          {
-            source = cfg.initLua;
-          }
-        else
-          {
-            text = cfg.initLua;
-          }
-      );
+      "yazi/init.lua" =
+        mkIf (lib.any (v: v.setup) (builtins.attrValues cfg.plugins) || cfg.initLua != null)
+          (
+            if lib.any (v: v.setup) (builtins.attrValues cfg.plugins) then
+              {
+                text =
+                  (lib.concatMapStringsSep "\n" (
+                    { name, value }:
+                    if value.settings == { } then
+                      "require(${lib.generators.toLua { } name}):setup()"
+                    else
+                      "require(${lib.generators.toLua { } name}):setup(${lib.generators.toLua { } value.settings})"
+                  ) (lib.attrsToList (lib.filterAttrs (_n: v: v.setup) cfg.plugins)))
+                  + optionalString (cfg.initLua != null) (
+                    "\n" + (if builtins.isPath cfg.initLua then builtins.readFile cfg.initLua else cfg.initLua)
+                  );
+              }
+            else if builtins.isPath cfg.initLua then
+              { source = cfg.initLua; }
+            else
+              { text = cfg.initLua; }
+          );
     }
     // (lib.mapAttrs' (
       name: value: lib.nameValuePair "yazi/flavors/${name}.yazi" { source = value; }
     ) cfg.flavors)
     // (lib.mapAttrs' (
-      name: value: lib.nameValuePair "yazi/plugins/${name}.yazi" { source = value; }
+      name: value: lib.nameValuePair "yazi/plugins/${name}.yazi" { source = value.package; }
     ) cfg.plugins);
 
     warnings = lib.filter (s: s != "") (

--- a/tests/modules/programs/yazi/configurations-expected.lua
+++ b/tests/modules/programs/yazi/configurations-expected.lua
@@ -1,0 +1,8 @@
+require("dual-pane"):setup()
+require("yatline"):setup({
+  ["section_separator"] = {
+    ["close"] = "",
+    ["open"] = ""
+  },
+  ["tab_width"] = 20
+})

--- a/tests/modules/programs/yazi/configurations-with-init-lua-expected.lua
+++ b/tests/modules/programs/yazi/configurations-with-init-lua-expected.lua
@@ -1,0 +1,4 @@
+require("dual-pane"):setup()
+require("zoxide"):setup {
+  update_db = true,
+}

--- a/tests/modules/programs/yazi/configurations-with-init-lua.nix
+++ b/tests/modules/programs/yazi/configurations-with-init-lua.nix
@@ -1,0 +1,19 @@
+{
+  programs.yazi = {
+    enable = true;
+
+    plugins = {
+      dual-pane = {
+        package = ./plugin;
+        setup = true;
+      };
+    };
+
+    initLua = builtins.readFile ./init.lua;
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/yazi/init.lua \
+      ${./configurations-with-init-lua-expected.lua}
+  '';
+}

--- a/tests/modules/programs/yazi/configurations-with-path-init-lua.nix
+++ b/tests/modules/programs/yazi/configurations-with-path-init-lua.nix
@@ -1,0 +1,19 @@
+{
+  programs.yazi = {
+    enable = true;
+
+    plugins = {
+      dual-pane = {
+        package = ./plugin;
+        setup = true;
+      };
+    };
+
+    initLua = ./init.lua;
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/yazi/init.lua \
+      ${./configurations-with-init-lua-expected.lua}
+  '';
+}

--- a/tests/modules/programs/yazi/configurations.nix
+++ b/tests/modules/programs/yazi/configurations.nix
@@ -1,0 +1,28 @@
+{
+  programs.yazi = {
+    enable = true;
+
+    plugins = {
+      dual-pane = {
+        package = ./plugin;
+        setup = true;
+      };
+      yatline = {
+        package = ./plugin;
+        setup = true;
+        settings = {
+          section_separator = {
+            open = "";
+            close = "";
+          };
+          tab_width = 20;
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/yazi/init.lua \
+      ${./configurations-expected.lua}
+  '';
+}

--- a/tests/modules/programs/yazi/default.nix
+++ b/tests/modules/programs/yazi/default.nix
@@ -1,7 +1,10 @@
 {
   yazi-settings = ./settings.nix;
   yazi-init-lua-string = ./init-lua-string.nix;
+  yazi-configurations-with-init-lua = ./configurations-with-init-lua.nix;
+  yazi-configurations-with-path-init-lua = ./configurations-with-path-init-lua.nix;
   yazi-bash-integration-enabled = ./bash-integration-enabled.nix;
+  yazi-configurations = ./configurations.nix;
   yazi-zsh-integration-enabled = ./zsh-integration-enabled.nix;
   yazi-fish-integration-enabled = ./fish-integration-enabled.nix;
   yazi-nushell-integration-enabled = ./nushell-integration-enabled.nix;


### PR DESCRIPTION
### Description
- Yazi plugins are a huge part of Yazi! But we don't need a whole nixvim thing. 
- This would really simplify my Yazi configuration!
- Looks really nice and sweet and clean

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

-x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
