### PR TITLE
email: add warning to documentation of `useStartTls`

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -109,7 +109,9 @@ let
         type = types.bool;
         default = false;
         description = ''
-          Whether to use STARTTLS.
+          Whether to use STARTTLS. This is discouraged and should be avoided if
+          possible. See <https://datatracker.ietf.org/doc/html/rfc8314> for
+          more.
         '';
       };
 


### PR DESCRIPTION
### Description

Discourage use of `useStartTls`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```