### PR TITLE
hyprland: update documentation links

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -32,7 +32,7 @@ in
 
     (lib.mkRemovedOptionModule # \
       [ "wayland" "windowManager" "hyprland" "xwayland" "hidpi" ]
-      "HiDPI patches are deprecated. Refer to https://wiki.hypr.land/Configuring/XWayland"
+      "HiDPI patches are deprecated. Refer to <https://wiki.hypr.land/Configuring/Advanced-and-Cool/XWayland>"
     )
 
     (lib.mkRemovedOptionModule # \
@@ -230,7 +230,7 @@ in
       description = ''
         Attribute set of Hyprland submaps.
 
-        See <https://wiki.hypr.land/Configuring/Binds#submaps> to learn about submaps
+        See <https://wiki.hypr.land/Configuring/Basics/Binds/#submaps> to learn about submaps
       '';
       default = { };
       type = lib.types.attrsOf (


### PR DESCRIPTION
### Description

I updated 2 links that were leading to 404 errors due to a structure change in the Hyprland wiki. See commit https://github.com/hyprwm/hyprland-wiki/commit/e99eac80a63d68e050623af2f69629f9423befdb.patch for the refactor and location of the 2 changed pages.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.