### PR TITLE
nix-search-tv: add keybindings and actions

### DIFF
--- a/modules/programs/nix-search-tv.nix
+++ b/modules/programs/nix-search-tv.nix
@@ -70,7 +70,9 @@ in
 
     programs.television.channels.nix-search-tv = lib.mkIf cfg.enableTelevisionIntegration (
       let
-        path = lib.getExe cfg.package;
+        nix-search-tv-path = if cfg.package != null then lib.getExe cfg.package else "nix-search-tv";
+        keybinding_modifier = if pkgs.stdenv.isDarwin then "alt" else "ctrl";
+        opener = if pkgs.stdenv.isDarwin then "open" else "xdg-open";
       in
       {
         metadata = {
@@ -78,15 +80,34 @@ in
           description = "Search nix options and packages";
         };
 
-        source.command = "${path} print";
-        preview.command = ''${path} preview "{}"'';
+        source.command = "${nix-search-tv-path} print";
+        preview.command = ''${nix-search-tv-path} preview "{}"'';
+
+        keybindings = {
+          "${keybinding_modifier}-r" = "actions:run";
+          "${keybinding_modifier}-i" = "actions:shell";
+          "${keybinding_modifier}-s" = "actions:source";
+          "${keybinding_modifier}-o" = "actions:homepage";
+        };
 
         actions.run = {
+          description = "Run the package";
           command = ''nix run {replace:s/\/ /#/g}'';
-          mode = "fork";
+          mode = "execute";
         };
         actions.shell = {
+          description = "Enter new nix shell with this package";
           command = ''nix shell {replace:s/\/ /#/g}'';
+          mode = "execute";
+        };
+        actions.source = {
+          description = "Open link to source code";
+          command = "${nix-search-tv-path} source '{}' | xargs ${opener}";
+          mode = "execute";
+        };
+        actions.homepage = {
+          description = "Open link to homepage";
+          command = "${nix-search-tv-path} homepage '{}' | xargs ${opener}";
           mode = "execute";
         };
       }

--- a/tests/modules/programs/nix-search-tv/television.nix
+++ b/tests/modules/programs/nix-search-tv/television.nix
@@ -4,27 +4,50 @@
 
   programs.nix-search-tv.enable = true;
 
-  nmt.script = ''
-    assertFileExists home-files/.config/television/cable/nix-search-tv.toml
-    assertFileContent home-files/.config/television/cable/nix-search-tv.toml \
-      ${pkgs.writeText "settings-expected" ''
-        [actions.run]
-        command = "nix run {replace:s/\\/ /#/g}"
-        mode = "fork"
+  nmt.script =
+    let
+      keybinding_modifier = if pkgs.stdenv.isDarwin then "alt" else "ctrl";
+      opener = if pkgs.stdenv.isDarwin then "open" else "xdg-open";
+    in
+    ''
+      assertFileExists home-files/.config/television/cable/nix-search-tv.toml
+      assertFileContent home-files/.config/television/cable/nix-search-tv.toml \
+        ${pkgs.writeText "settings-expected" ''
+          [actions.homepage]
+          command = "${lib.getExe pkgs.nix-search-tv} homepage '{}' | xargs ${opener}"
+          description = "Open link to homepage"
+          mode = "execute"
 
-        [actions.shell]
-        command = "nix shell {replace:s/\\/ /#/g}"
-        mode = "execute"
+          [actions.run]
+          command = "nix run {replace:s/\\/ /#/g}"
+          description = "Run the package"
+          mode = "execute"
 
-        [metadata]
-        description = "Search nix options and packages"
-        name = "nix-search-tv"
+          [actions.shell]
+          command = "nix shell {replace:s/\\/ /#/g}"
+          description = "Enter new nix shell with this package"
+          mode = "execute"
 
-        [preview]
-        command = "${lib.getExe pkgs.nix-search-tv} preview \"{}\""
+          [actions.source]
+          command = "${lib.getExe pkgs.nix-search-tv} source '{}' | xargs ${opener}"
+          description = "Open link to source code"
+          mode = "execute"
 
-        [source]
-        command = "${lib.getExe pkgs.nix-search-tv} print"
-      ''}
-  '';
+          [keybindings]
+          ${keybinding_modifier}-i = "actions:shell"
+          ${keybinding_modifier}-o = "actions:homepage"
+          ${keybinding_modifier}-r = "actions:run"
+          ${keybinding_modifier}-s = "actions:source"
+
+          [metadata]
+          description = "Search nix options and packages"
+          name = "nix-search-tv"
+
+          [preview]
+          command = "${lib.getExe pkgs.nix-search-tv} preview \"{}\""
+
+          [source]
+          command = "${lib.getExe pkgs.nix-search-tv} print"
+        ''}
+    '';
 }


### PR DESCRIPTION
Use the same keybindings as nix-search-tv's author used here: https://github.com/3timeslazy/nix-search-tv/blob/main/nixpkgs.sh#L26

### Description

Add more actions to the television integration of nix-search-tv
Copied from the original repo: https://github.com/3timeslazy/nix-search-tv/blob/main/nixpkgs.sh#L26

For the mode of the `run` action, I feel like it is more useful to have `execute` than `fork`:
 - Using `execute` on the htop package launch it
 - Using `fork` does nothing useful

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Tested with `nix run .#tests -- television nix-search-tv` 
    `nix run .#tests -- test-all` ran for more than 20 minutes, with low CPU usage. I terminated it
    What is the expected run time approximately ?

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
