### PR TITLE
wallust: fix config location on darwin

### DIFF
--- a/modules/programs/wallust.nix
+++ b/modules/programs/wallust.nix
@@ -42,12 +42,14 @@ in
   config = mkIf cfg.enable {
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-    xdg.configFile."wallust/wallust.toml" = mkIf (cfg.settings != { } && !pkgs.stdenv.isDarwin) {
-      source = tomlFormat.generate "wallust.toml" cfg.settings;
-    };
+    xdg.configFile."wallust/wallust.toml" =
+      mkIf (cfg.settings != { } && !pkgs.stdenv.hostPlatform.isDarwin)
+        {
+          source = tomlFormat.generate "wallust.toml" cfg.settings;
+        };
 
     home.file."Library/Application Support/wallust/wallust.toml" =
-      mkIf (cfg.settings != { } && pkgs.stdenv.isDarwin)
+      mkIf (cfg.settings != { } && pkgs.stdenv.hostPlatform.isDarwin)
         {
           source = tomlFormat.generate "wallust.toml" cfg.settings;
         };

--- a/modules/programs/wallust.nix
+++ b/modules/programs/wallust.nix
@@ -42,8 +42,14 @@ in
   config = mkIf cfg.enable {
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-    xdg.configFile."wallust/wallust.toml" = mkIf (cfg.settings != { }) {
+    xdg.configFile."wallust/wallust.toml" = mkIf (cfg.settings != { } && !pkgs.stdenv.isDarwin) {
       source = tomlFormat.generate "wallust.toml" cfg.settings;
     };
+
+    home.file."Library/Application Support/wallust/wallust.toml" =
+      mkIf (cfg.settings != { } && pkgs.stdenv.isDarwin)
+        {
+          source = tomlFormat.generate "wallust.toml" cfg.settings;
+        };
   };
 }

--- a/tests/modules/programs/wallust/wallust.nix
+++ b/tests/modules/programs/wallust/wallust.nix
@@ -1,4 +1,8 @@
 {
+  pkgs,
+  ...
+}:
+{
   home.enableNixpkgsReleaseCheck = false;
   programs.wallust = {
     enable = true;
@@ -9,8 +13,16 @@
     };
   };
 
-  nmt.script = ''
-    assertFileExists home-files/.config/wallust/wallust.toml
-    assertFileContent home-files/.config/wallust/wallust.toml ${./expected.toml}
-  '';
+  nmt.script =
+    let
+      path =
+        if pkgs.stdenv.isDarwin then
+          "home-files/Library/Application Support/wallust/wallust.toml"
+        else
+          "home-files/.config/wallust/wallust.toml";
+    in
+    ''
+      assertFileExists '${path}'
+      assertFileContent '${path}' ${./expected.toml}
+    '';
 }

--- a/tests/modules/programs/wallust/wallust.nix
+++ b/tests/modules/programs/wallust/wallust.nix
@@ -16,7 +16,7 @@
   nmt.script =
     let
       path =
-        if pkgs.stdenv.isDarwin then
+        if pkgs.stdenv.hostPlatform.isDarwin then
           "home-files/Library/Application Support/wallust/wallust.toml"
         else
           "home-files/.config/wallust/wallust.toml";


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This fixes the path of the `wallust` config file to be under `Library/Application Support/wallust` when on Darwin, instead of assuming it always falls under the `XDG_CONFIG_HOME` (for whatever reason the owner of the Rust `dirs` package refuses to allow XDG on macOS, since it's non-standard)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
