### PR TITLE
discord: account for different config locations

### DIFF
--- a/modules/programs/discord.nix
+++ b/modules/programs/discord.nix
@@ -16,6 +16,15 @@ in
   options.programs.discord = {
     enable = lib.mkEnableOption "Discord, the chat platform";
     package = lib.mkPackageOption pkgs "discord" { nullable = true; };
+    configName = lib.mkOption {
+      type = lib.types.str;
+      default = "discord";
+      example = "discordptb";
+      description = ''
+        Name of the subdirectory where {file}`settings.json` is linked under.
+        For example discord-canary uses `discordcanary`.
+      '';
+    };
     settings = lib.mkOption {
       description = ''
         Configuration for Discord.
@@ -62,7 +71,7 @@ in
     in
     {
       home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
-      home.file."${configDir}/discord/settings.json".source =
+      home.file."${configDir}/${cfg.configName}/settings.json".source =
         jsonFormat.generate "discord-settings" cfg.settings;
     }
   );

--- a/tests/modules/programs/discord/default.nix
+++ b/tests/modules/programs/discord/default.nix
@@ -1,3 +1,4 @@
 {
   discord-basic-configuration = ./basic-configuration.nix;
+  discord-non-default-config-dir = ./non-default-config-dir.nix;
 }

--- a/tests/modules/programs/discord/non-default-config-dir.nix
+++ b/tests/modules/programs/discord/non-default-config-dir.nix
@@ -1,0 +1,24 @@
+{ pkgs, ... }:
+{
+  config = {
+    programs.discord = {
+      enable = true;
+      configName = "discordcanary";
+      settings.DANGEROUS_ENABLE_DEVTOOLS_ONLY_ENABLE_IF_YOU_KNOW_WHAT_YOURE_DOING = true;
+    };
+
+    nmt.script =
+      let
+        configDir =
+          if pkgs.stdenv.hostPlatform.isLinux then
+            "home-files/.config/discordcanary"
+          else
+            "home-files/Library/Application Support/discordcanary";
+      in
+      ''
+        assertFileExists "${configDir}/settings.json"
+        assertFileContent "${configDir}/settings.json" \
+          ${./basic-settings.json}
+      '';
+  };
+}


### PR DESCRIPTION
### Description
Different discord branches use different config locations, but home-manager uses `${configDir}/discord` unconditionally. This fixes that issue based on `cfg.package`.


I can only test on linux, so I don't know if they name it differently on Mac.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
