### PR TITLE
lakectl: init module

### DIFF
--- a/modules/misc/news/2026/04/2026-04-22_17-27-11.nix
+++ b/modules/misc/news/2026/04/2026-04-22_17-27-11.nix
@@ -1,0 +1,9 @@
+{
+  time = "2026-04-22T17:27:11+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.lakectl'. lakectl is the
+    official command-line interface for lakeFS, an open-source
+    platform that provides Git-like version control for data lakes.
+  '';
+}

--- a/modules/programs/lakectl.nix
+++ b/modules/programs/lakectl.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    mkPackageOption
+    ;
+
+  cfg = config.programs.lakectl;
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = with lib.maintainers; [ philocalyst ];
+
+  options.programs.lakectl = {
+    enable = mkEnableOption "lakectl";
+
+    package = mkPackageOption pkgs "lakectl" { nullable = true; };
+
+    settings = mkOption {
+      inherit (yamlFormat) type;
+      default = { };
+      example = {
+        credentials = {
+          access_key_id = "AKIAIOSFODNN7EXAMPLE";
+          secret_access_key = "secret";
+        };
+        server.endpoint_url = "http://127.0.0.1:8000";
+      };
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/lakectl/config.yaml`.
+
+        `lakectl` normally reads {file}`~/.lakectl.yaml`, so this module also sets
+        `LAKECTL_CONFIG_FILE` to the XDG path.
+
+        See <https://docs.lakefs.io/latest/reference/cli/#lakectl-configuration>
+        for the full list of options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf (cfg.package != null) {
+      home.packages = [ cfg.package ];
+    })
+    (mkIf (cfg.settings != { }) (mkMerge [
+      (mkIf config.home.preferXdgDirectories {
+        home.sessionVariables.LAKECTL_CONFIG_FILE = "${config.xdg.configHome}/lakectl/config.yaml";
+        xdg.configFile."lakectl/config.yaml".source =
+          yamlFormat.generate "lakectl-config.yaml" cfg.settings;
+      })
+      (mkIf (!config.home.preferXdgDirectories) {
+        home.file.".lakectl.yaml".source = yamlFormat.generate "lakectl-config.yaml" cfg.settings;
+      })
+    ]))
+  ]);
+}

--- a/modules/services/lakectl-backup.nix
+++ b/modules/services/lakectl-backup.nix
@@ -1,0 +1,192 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.lakectl-backup;
+  inherit (lib)
+    getExe
+    mkEnableOption
+    mkIf
+    optionalString
+    escapeShellArgs
+    escapeShellArg
+    mapAttrs'
+    mkOption
+    concatMapStringsSep
+    mkPackageOption
+    nameValuePair
+    optionalAttrs
+    mapAttrsToList
+    types
+    ;
+in
+{
+  meta.maintainers = [ lib.maintainers.philocalyst ];
+
+  options.services.lakectl-backup = {
+    enable = mkEnableOption "lakectl backup service";
+
+    package = mkPackageOption pkgs "lakectl" { };
+
+    backups = mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          options = {
+            paths = mkOption {
+              type = types.listOf types.str;
+              description = "List of local files or directories to back up.";
+              example = [
+                "~/Documents"
+                "/etc/config"
+              ];
+            };
+
+            repository = mkOption {
+              type = types.str;
+              description = "Name of the lakeFS repository.";
+              example = "my-data";
+            };
+
+            branch = mkOption {
+              type = types.str;
+              default = "main";
+              description = "Target branch in lakeFS.";
+            };
+
+            prefix = mkOption {
+              type = types.str;
+              default = "";
+              description = "Prefix in lakeFS where the files will be uploaded.";
+            };
+
+            calendar = mkOption {
+              type = types.str;
+              default = "daily";
+              description = ''
+                The schedule for the backup.
+
+                On Linux, this is a string as defined by {manpage}`systemd.time(7)`.
+
+                ${lib.hm.darwin.intervalDocumentation}
+              '';
+            };
+
+            commitMessage = mkOption {
+              type = types.str;
+              default = "Automated backup [$(date)]";
+              description = "Commit message for the backup.";
+            };
+
+            extraArgs = mkOption {
+              type = types.listOf types.str;
+              default = [ ];
+              description = "Extra arguments for {command}`lakectl fs upload`.";
+            };
+
+            environmentFile = mkOption {
+              type = types.nullOr types.path;
+              default = null;
+              description = ''
+                Path to a file containing environment variables (e.g., credentials).
+                On Linux, this is passed to {option}`EnvironmentFile`.
+                On Darwin and in the wrapper, this file is sourced.
+              '';
+            };
+          };
+        }
+      );
+      default = { };
+      description = "Backup configurations.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mapAttrsToList (
+      name: backup:
+      pkgs.writeShellScriptBin "lakectl-backup-${name}" ''
+        set -e
+        ${optionalString (
+          backup.environmentFile != null
+        ) "source ${escapeShellArg (toString backup.environmentFile)}"}
+
+        echo "Starting lakectl backup for ${name}..."
+        ${concatMapStringsSep "\n" (path: ''
+          echo "Uploading ${path}..."
+          ${escapeShellArgs (
+            [
+              (getExe cfg.package)
+              "fs"
+              "upload"
+              "--recursive"
+            ]
+            ++ backup.extraArgs
+            ++ [
+              path
+              "lakefs://${backup.repository}/${backup.branch}/${backup.prefix}"
+            ]
+          )}
+        '') backup.paths}
+
+        echo "Committing changes..."
+        ${escapeShellArgs [
+          (getExe cfg.package)
+          "commit"
+          "lakefs://${backup.repository}/${backup.branch}"
+          "-m"
+          backup.commitMessage
+        ]}
+
+        echo "Backup ${name} completed successfully."
+      ''
+    ) cfg.backups;
+
+    systemd.user.services = mapAttrs' (
+      name: backup:
+      nameValuePair "lakectl-backup-${name}" {
+        Unit.Description = "lakectl backup - ${name}";
+        Service = {
+          Type = "oneshot";
+          ExecStart = "${config.home.profileDirectory}/bin/lakectl-backup-${name}";
+        }
+        // optionalAttrs (backup.environmentFile != null) {
+          EnvironmentFile = toString backup.environmentFile;
+        };
+      }
+    ) cfg.backups;
+
+    systemd.user.timers = mapAttrs' (
+      name: backup:
+      nameValuePair "lakectl-backup-${name}" {
+        Unit.Description = "Timer for lakectl backup - ${name}";
+        Timer = {
+          OnCalendar = backup.calendar;
+          Persistent = true;
+        };
+        Install.WantedBy = [ "timers.target" ];
+      }
+    ) cfg.backups;
+
+    launchd.agents = mapAttrs' (
+      name: backup:
+      nameValuePair "lakectl-backup-${name}" {
+        enable = true;
+        config = {
+          ProgramArguments = [ "${config.home.profileDirectory}/bin/lakectl-backup-${name}" ];
+          StartCalendarInterval = lib.hm.darwin.mkCalendarInterval backup.calendar;
+          ProcessType = "Background";
+          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/lakectl-backup/${name}.log";
+          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/lakectl-backup/${name}.err";
+        };
+      }
+    ) cfg.backups;
+
+    assertions = mapAttrsToList (
+      name: backup:
+      lib.hm.darwin.assertInterval "services.lakectl-backup.backups.${name}.calendar" backup.calendar pkgs
+    ) cfg.backups;
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -93,6 +93,7 @@ let
     "kitty"
     "kubecolor"
     "kubeswitch"
+    "lakectl"
     "lapce"
     "lazydocker"
     "lazygit"

--- a/tests/modules/programs/lakectl/config.yaml
+++ b/tests/modules/programs/lakectl/config.yaml
@@ -1,0 +1,5 @@
+credentials:
+  access_key_id: AKIAIOSFODNN7EXAMPLE
+  secret_access_key: secret
+server:
+  endpoint_url: http://127.0.0.1:8000

--- a/tests/modules/programs/lakectl/default.nix
+++ b/tests/modules/programs/lakectl/default.nix
@@ -1,0 +1,4 @@
+{
+  lakectl-settings = ./settings.nix;
+  lakectl-settings-non-xdg = ./settings-non-xdg.nix;
+}

--- a/tests/modules/programs/lakectl/settings-non-xdg.nix
+++ b/tests/modules/programs/lakectl/settings-non-xdg.nix
@@ -1,0 +1,23 @@
+_: {
+  home.preferXdgDirectories = false;
+  programs.lakectl = {
+    enable = true;
+    settings = {
+      credentials = {
+        access_key_id = "AKIAIOSFODNN7EXAMPLE";
+        secret_access_key = "secret";
+      };
+      server.endpoint_url = "http://127.0.0.1:8000";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.lakectl.yaml
+    assertFileContent home-files/.lakectl.yaml \
+      ${./config.yaml}
+
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'LAKECTL_CONFIG_FILE'
+  '';
+}

--- a/tests/modules/programs/lakectl/settings.nix
+++ b/tests/modules/programs/lakectl/settings.nix
@@ -1,0 +1,24 @@
+{ config, ... }:
+{
+  home.preferXdgDirectories = true;
+  programs.lakectl = {
+    enable = true;
+    settings = {
+      credentials = {
+        access_key_id = "AKIAIOSFODNN7EXAMPLE";
+        secret_access_key = "secret";
+      };
+      server.endpoint_url = "http://127.0.0.1:8000";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/lakectl/config.yaml
+    assertFileContent home-files/.config/lakectl/config.yaml \
+      ${./config.yaml}
+
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+      'export LAKECTL_CONFIG_FILE="${config.xdg.configHome}/lakectl/config.yaml"'
+  '';
+}

--- a/tests/modules/services/lakectl-backup/default.nix
+++ b/tests/modules/services/lakectl-backup/default.nix
@@ -1,0 +1,42 @@
+_:
+
+{
+  lakectl-backup =
+    { config, ... }:
+    {
+      config = {
+        home.stateVersion = "24.11";
+
+        services.lakectl-backup = {
+          enable = true;
+          package = config.lib.test.mkStubPackage {
+            name = "lakectl";
+            buildScript = "mkdir -p $out/bin; touch $out/bin/lakectl; chmod +x $out/bin/lakectl";
+          };
+          backups.my-test = {
+            paths = [ "/tmp/testpath" ];
+            repository = "test-repo";
+            branch = "main";
+            calendar = "hourly";
+            commitMessage = "Test commit";
+          };
+        };
+
+        nmt.script = ''
+          wrapperFile=$(normalizeStorePaths home-path/bin/lakectl-backup-my-test)
+          assertFileExists "$wrapperFile"
+
+          assertFileRegex "$wrapperFile" "echo \"Starting lakectl backup for my-test...\""
+          assertFileRegex "$wrapperFile" "echo \"Uploading /tmp/testpath...\""
+          assertFileRegex "$wrapperFile" "fs.*upload.*--recursive.*/tmp/testpath.*lakefs://test-repo/main/"
+          assertFileRegex "$wrapperFile" "commit.*lakefs://test-repo/main.*-m.*Test commit"
+          if [[ -d "$TESTED/LaunchAgents" ]]; then
+            assertFileExists "$TESTED/LaunchAgents/org.nix-community.home.lakectl-backup-my-test.plist"
+          else
+            assertFileExists "$TESTED/home-files/.config/systemd/user/lakectl-backup-my-test.service"
+            assertFileExists "$TESTED/home-files/.config/systemd/user/timers.target.wants/lakectl-backup-my-test.timer"
+          fi
+        '';
+      };
+    };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

- This brings lakefs clients to home-manager!
- What I'm most excited for is using this in the context of backups :)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
