### PR TITLE
eww: remove shell integration

### DIFF
--- a/modules/programs/eww.nix
+++ b/modules/programs/eww.nix
@@ -12,6 +12,22 @@ in
 {
   meta.maintainers = [ lib.hm.maintainers.mainrs ];
 
+  imports =
+    map
+      (
+        shell:
+        lib.mkRemovedOptionModule [
+          "programs"
+          "eww"
+          "enable${shell}Integration"
+        ] "This option is no longer necessary. Shell completions are now installed with eww by nixpkgs."
+      )
+      [
+        "Bash"
+        "Zsh"
+        "Fish"
+      ];
+
   options.programs.eww = {
     enable = lib.mkEnableOption "eww";
 
@@ -26,38 +42,10 @@ in
         {file}`$XDG_CONFIG_HOME/eww`.
       '';
     };
-
-    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
-
-    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
-
-    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
-  config =
-    let
-      ewwCmd = lib.getExe cfg.package;
-    in
-    mkIf cfg.enable {
-      home.packages = [ cfg.package ];
-      xdg = mkIf (cfg.configDir != null) { configFile."eww".source = cfg.configDir; };
-
-      programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-        if [[ $TERM != "dumb" ]]; then
-          eval "$(${ewwCmd} shell-completions --shell bash)"
-        fi
-      '';
-
-      programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
-        if [[ $TERM != "dumb" ]]; then
-          eval "$(${ewwCmd} shell-completions --shell zsh)"
-        fi
-      '';
-
-      programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-        if test "$TERM" != "dumb"
-          eval "$(${ewwCmd} shell-completions --shell fish)"
-        end
-      '';
-    };
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    xdg = mkIf (cfg.configDir != null) { configFile."eww".source = cfg.configDir; };
+  };
 }


### PR DESCRIPTION
### Description

Removes shell integration from the eww module. It was only used to source completions on shell startup, but shell completions have been installed with eww by nixpkgs since December 2024 (https://github.com/NixOS/nixpkgs/commit/cc419ccaefba3540224c84a322449bbefe8b3c01).

I didn't generate a news entry because I'm not sure if this is considered breaking. Please let me know if I should do that.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
