### PR TITLE
tailscale-systray: make theme configurable

### DIFF
--- a/modules/services/tailscale-systray.nix
+++ b/modules/services/tailscale-systray.nix
@@ -15,6 +15,20 @@ in
     enable = lib.mkEnableOption "Official Tailscale systray application for Linux";
 
     package = lib.mkPackageOption pkgs "tailscale" { };
+
+    theme = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.enum [
+          "dark"
+          "dark:nobg"
+          "light"
+          "light:nobg"
+        ]
+      );
+      default = null;
+      example = "dark:nobg";
+      description = "Color theme to use for the Tailscale icon.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -24,6 +38,12 @@ in
         assertion = lib.versionAtLeast cfg.package.version "1.88.1";
         message = ''
           Tailscale systray is available since version 1.88.1
+        '';
+      }
+      {
+        assertion = cfg.theme != null -> lib.versionAtLeast cfg.package.version "1.98";
+        message = ''
+          Tailscale systray supports themes since version 1.98
         '';
       }
     ];
@@ -41,7 +61,12 @@ in
       Install = {
         WantedBy = [ "graphical-session.target" ];
       };
-      Service.ExecStart = "${lib.getExe cfg.package} systray";
+      Service.ExecStart = lib.concatStringsSep " " (
+        [
+          "${lib.getExe cfg.package} systray"
+        ]
+        ++ lib.optional (cfg.theme != null) "--theme ${cfg.theme}"
+      );
     };
   };
 }

--- a/tests/modules/services/tailscale-systray/default.nix
+++ b/tests/modules/services/tailscale-systray/default.nix
@@ -2,4 +2,5 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   tailscale-systray-basic = ./basic.nix;
+  tailscale-systray-theme = ./theme.nix;
 }

--- a/tests/modules/services/tailscale-systray/theme.nix
+++ b/tests/modules/services/tailscale-systray/theme.nix
@@ -1,0 +1,19 @@
+{ config, ... }:
+{
+  services.tailscale-systray = {
+    enable = true;
+    theme = "dark:nobg";
+    package = config.lib.test.mkStubPackage {
+      name = "tailscale";
+      version = "1.98.1";
+      outPath = "@tailscale@";
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/tailscale-systray.service
+    assertFileExists $serviceFile
+    assertFileRegex $serviceFile \
+      '^ExecStart=@tailscale@/bin/tailscale systray --theme dark:nobg$'
+  '';
+}


### PR DESCRIPTION
### Description

Tailscale 1.98 adds a `--theme` flag to `tailscale systray`. This change adds a home-manager option for it.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

`nix run .#tests -- tailscale-systray` passes. `nix run .#tests -- test-all` is still running (not sure how long this is expected to take...)

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
