### PR TITLE
ssh: allow explicit "no" for identitiesOnly in matchBlocks

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -410,7 +410,9 @@ let
       ++ optional (cf.forwardAgent != null) "  ForwardAgent ${lib.hm.booleans.yesNo cf.forwardAgent}"
       ++ optional cf.forwardX11 "  ForwardX11 yes"
       ++ optional cf.forwardX11Trusted "  ForwardX11Trusted yes"
-      ++ optional (cf.identitiesOnly != null) "  IdentitiesOnly ${lib.hm.booleans.yesNo cf.identitiesOnly}"
+      ++ optional (
+        cf.identitiesOnly != null
+      ) "  IdentitiesOnly ${lib.hm.booleans.yesNo cf.identitiesOnly}"
       ++ optional (cf.user != null) "  User ${cf.user}"
       ++ optional (cf.hostname != null) "  HostName ${cf.hostname}"
       ++ optional (cf.addressFamily != null) "  AddressFamily ${cf.addressFamily}"

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -135,8 +135,8 @@ let
       };
 
       identitiesOnly = mkOption {
-        type = types.bool;
-        default = false;
+        type = types.nullOr types.bool;
+        default = null;
         description = ''
           Specifies that ssh should only use the authentication
           identity explicitly configured in the
@@ -410,7 +410,7 @@ let
       ++ optional (cf.forwardAgent != null) "  ForwardAgent ${lib.hm.booleans.yesNo cf.forwardAgent}"
       ++ optional cf.forwardX11 "  ForwardX11 yes"
       ++ optional cf.forwardX11Trusted "  ForwardX11Trusted yes"
-      ++ optional cf.identitiesOnly "  IdentitiesOnly yes"
+      ++ optional (cf.identitiesOnly != null) "  IdentitiesOnly ${lib.hm.booleans.yesNo cf.identitiesOnly}"
       ++ optional (cf.user != null) "  User ${cf.user}"
       ++ optional (cf.hostname != null) "  HostName ${cf.hostname}"
       ++ optional (cf.addressFamily != null) "  AddressFamily ${cf.addressFamily}"


### PR DESCRIPTION
### Description

This addresses the issue raised with `identitiesOnly` per #9288 and allows an explicit "no" option, without changing the current default behaviour of not set.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)


---
result for exiting 21 ssh tests, unchanged default behavior as expected.
```
--- Summary ---
✅ All 21 tests passed!
```