### PR TITLE
ssh-tpm-agent: add extraArgs option

### DIFF
--- a/modules/services/ssh-tpm-agent.nix
+++ b/modules/services/ssh-tpm-agent.nix
@@ -33,6 +33,16 @@ in
       description = "Path of the directory to look for TPM sealed keys in, defaults to $HOME/.ssh if unset";
       default = null;
     };
+
+    extraArgs = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      example = [
+        "--no-cache"
+        "-d"
+      ];
+      description = "Extra arguments to be passed to the ssh-tpm-agent executable.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -86,7 +96,8 @@ in
               in
               (lib.getExe cfg.package)
               + lib.optionalString (cfg.keyDir != null) " --key-dir ${cfg.keyDir}"
-              + lib.optionalString ssh-agent.enable " -A %t/${ssh-agent.socket}";
+              + lib.optionalString ssh-agent.enable " -A %t/${ssh-agent.socket}"
+              + lib.optionalString (cfg.extraArgs != [ ]) " ${lib.escapeShellArgs cfg.extraArgs}";
             SuccessExitStatus = 2;
             Type = "simple";
           };

--- a/tests/modules/services/ssh-tpm-agent/default.nix
+++ b/tests/modules/services/ssh-tpm-agent/default.nix
@@ -2,6 +2,7 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   ssh-tpm-agent-as-ssh-agent-proxy = ./as-ssh-agent-proxy.nix;
+  ssh-tpm-agent-extra-args = ./extra-args.nix;
   ssh-tpm-agent-sshAuthSock = ./ssh-auth-sock.nix;
   ssh-tpm-agent-standalone = ./standalone.nix;
 }

--- a/tests/modules/services/ssh-tpm-agent/extra-args.nix
+++ b/tests/modules/services/ssh-tpm-agent/extra-args.nix
@@ -1,0 +1,48 @@
+{ config, ... }:
+
+{
+  services.ssh-tpm-agent = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@ssh-tpm-agent@"; };
+    extraArgs = [
+      "--no-cache"
+      "-d"
+    ];
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/ssh-tpm-agent.service
+    socketFile=home-files/.config/systemd/user/ssh-tpm-agent.socket
+
+    assertFileExists $serviceFile
+    assertFileExists $socketFile
+
+    assertFileContent $serviceFile ${builtins.toFile "expected-service" ''
+      [Service]
+      Environment=SSH_TPM_AUTH_SOCK=%t/ssh-tpm-agent.sock
+      ExecStart=@ssh-tpm-agent@/bin/dummy --no-cache -d
+      SuccessExitStatus=2
+      Type=simple
+
+      [Unit]
+      After=ssh-tpm-agent.socket
+      Description=ssh-tpm-agent service
+      Documentation=https://github.com/Foxboron/ssh-tpm-agent
+      Requires=ssh-tpm-agent.socket
+    ''}
+
+    assertFileContent $socketFile ${builtins.toFile "expected-socket" ''
+      [Install]
+      WantedBy=sockets.target
+
+      [Socket]
+      ListenStream=%t/ssh-tpm-agent.sock
+      Service=ssh-tpm-agent.service
+      SocketMode=0600
+
+      [Unit]
+      Description=SSH TPM agent socket
+      Documentation=https://github.com/Foxboron/ssh-tpm-agent
+    ''}
+  '';
+}


### PR DESCRIPTION
### Description

Add `extraArgs` option to `services.ssh-tpm-agent`, following the pattern used by other services (e.g. `services.clipman`), so users can pass additional flags to the agent.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
