### PR TITLE
codex: add remote control service

### DIFF
--- a/modules/programs/codex.nix
+++ b/modules/programs/codex.nix
@@ -183,6 +183,18 @@ in
     remoteControl = {
       enable = lib.mkEnableOption "the Codex remote-control app-server systemd user service";
 
+      package = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = cfg.package;
+        defaultText = lib.literalExpression "config.programs.codex.package";
+        description = ''
+          Codex package to use for the remote-control service.
+
+          This defaults to {option}`programs.codex.package`, but can be
+          overridden when the service should run a different Codex build.
+        '';
+      };
+
       codexHome = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
         default = null;
@@ -300,6 +312,7 @@ in
         ]
         ++ remoteControlCfg.extraPackages
       );
+      remoteControlPackage = remoteControlCfg.package;
       remoteControlEnvironment = {
         CODEX_HOME = codexHome;
         PATH = remoteControlPath;
@@ -386,8 +399,8 @@ in
           message = "`programs.codex.remoteControl.enable` is only supported on Linux";
         }
         {
-          assertion = !remoteControlCfg.enable || cfg.package != null;
-          message = "`programs.codex.remoteControl.enable` requires `programs.codex.package` to be set";
+          assertion = !remoteControlCfg.enable || remoteControlPackage != null;
+          message = "`programs.codex.remoteControl.enable` requires `programs.codex.remoteControl.package` to be set";
         }
       ];
 
@@ -415,7 +428,7 @@ in
       };
 
       systemd.user.services.codex-remote-control =
-        mkIf (remoteControlCfg.enable && cfg.package != null && pkgs.stdenv.hostPlatform.isLinux)
+        mkIf (remoteControlCfg.enable && remoteControlPackage != null && pkgs.stdenv.hostPlatform.isLinux)
           {
             Unit = {
               Description = "Codex remote-control app-server";
@@ -426,7 +439,7 @@ in
               Environment = remoteControlEnvironmentList;
               ExecStart = lib.escapeShellArgs (
                 [
-                  (lib.getExe cfg.package)
+                  (lib.getExe remoteControlPackage)
                   "app-server"
                   "--remote-control"
                   "--listen"

--- a/modules/programs/codex.nix
+++ b/modules/programs/codex.nix
@@ -217,7 +217,7 @@ in
           {command}`codex app-server --listen`.
 
           The default disables local transports and exposes only the outbound
-          remote-control websocket. Set this to {literal}`unix://` if local
+          remote-control websocket. Set this to `unix://` if local
           tools should also be able to connect through the Codex app-server
           control socket.
         '';

--- a/modules/programs/codex.nix
+++ b/modules/programs/codex.nix
@@ -8,6 +8,7 @@ let
   inherit (lib) mkIf;
 
   cfg = config.programs.codex;
+  remoteControlCfg = cfg.remoteControl;
 
   tomlFormat = pkgs.formats.toml { };
   yamlFormat = pkgs.formats.yaml { };
@@ -178,6 +179,105 @@ in
         }
       '';
     };
+
+    remoteControl = {
+      enable = lib.mkEnableOption "the Codex remote-control app-server systemd user service";
+
+      codexHome = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "\${config.home.homeDirectory}/.codex";
+        description = ''
+          Value for the {env}`CODEX_HOME` environment variable used by the
+          remote-control service.
+
+          If unset, this follows the same Codex home directory managed by this
+          module.
+        '';
+      };
+
+      listen = lib.mkOption {
+        type = lib.types.str;
+        default = "off";
+        example = "unix://";
+        description = ''
+          Local app-server transport endpoint passed to
+          {command}`codex app-server --listen`.
+
+          The default disables local transports and exposes only the outbound
+          remote-control websocket. Set this to {literal}`unix://` if local
+          tools should also be able to connect through the Codex app-server
+          control socket.
+        '';
+      };
+
+      target = lib.mkOption {
+        type = lib.types.str;
+        default = "default.target";
+        description = ''
+          Systemd user target that starts the Codex remote-control service.
+        '';
+      };
+
+      environment = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.nullOr (
+            lib.types.oneOf [
+              lib.types.bool
+              lib.types.int
+              lib.types.str
+            ]
+          )
+        );
+        default = { };
+        description = ''
+          Environment variables to set for the Codex remote-control service.
+
+          Sensitive values should be provided through
+          [](#opt-programs.codex.remoteControl.environmentFile), since values
+          configured here are visible in the Nix store and systemd unit.
+        '';
+        example = lib.literalExpression ''
+          {
+            RUST_LOG = "codex_app_server=info";
+          }
+        '';
+      };
+
+      environmentFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/run/secrets/codex-remote-control.env";
+        description = ''
+          Additional environment file as defined in {manpage}`systemd.exec(5)`.
+
+          This can be used for machine-local settings that should not be
+          written into the generated systemd unit.
+        '';
+      };
+
+      extraPackages = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = [ ];
+        example = lib.literalExpression "with pkgs; [ gitMinimal nix openssh ]";
+        description = ''
+          Extra packages to add to {env}`PATH` for commands launched by Codex.
+
+          The service also includes the Home Manager profile in {env}`PATH`.
+        '';
+      };
+
+      extraArgs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [
+          "--analytics-default-enabled"
+        ];
+        description = ''
+          Additional arguments passed to {command}`codex app-server`.
+        '';
+      };
+    };
   };
 
   config =
@@ -187,6 +287,27 @@ in
       configDir = if useXdgDirectories then "${xdgConfigHome}/codex" else ".codex";
       configFileName = if isTomlConfig then "config.toml" else "config.yaml";
       skillsDir = "${configDir}/skills";
+      codexHome =
+        if remoteControlCfg.codexHome != null then
+          remoteControlCfg.codexHome
+        else if useXdgDirectories then
+          "${config.xdg.configHome}/codex"
+        else
+          "${config.home.homeDirectory}/.codex";
+      remoteControlPath = lib.makeSearchPath "bin" (
+        [
+          config.home.profileDirectory
+        ]
+        ++ remoteControlCfg.extraPackages
+      );
+      remoteControlEnvironment = {
+        CODEX_HOME = codexHome;
+        PATH = remoteControlPath;
+      }
+      // remoteControlCfg.environment;
+      remoteControlEnvironmentList = lib.mapAttrsToList (
+        name: value: "${name}=${if lib.isBool value then lib.boolToString value else toString value}"
+      ) (lib.filterAttrs (_name: value: value != null) remoteControlEnvironment);
 
       # TODO: Remove this workaround once Codex supports symlinked SKILL.md
       # files again. Upstream only supports symlinking the containing skill
@@ -260,6 +381,14 @@ in
           );
           message = "`programs.codex.rules` attribute values must be files when set to paths";
         }
+        {
+          assertion = !remoteControlCfg.enable || pkgs.stdenv.hostPlatform.isLinux;
+          message = "`programs.codex.remoteControl.enable` is only supported on Linux";
+        }
+        {
+          assertion = !remoteControlCfg.enable || cfg.package != null;
+          message = "`programs.codex.remoteControl.enable` requires `programs.codex.package` to be set";
+        }
       ];
 
       home = {
@@ -284,5 +413,37 @@ in
           CODEX_HOME = "${config.xdg.configHome}/codex";
         };
       };
+
+      systemd.user.services.codex-remote-control =
+        mkIf (remoteControlCfg.enable && cfg.package != null && pkgs.stdenv.hostPlatform.isLinux)
+          {
+            Unit = {
+              Description = "Codex remote-control app-server";
+              After = [ "network.target" ];
+            };
+
+            Service = {
+              Environment = remoteControlEnvironmentList;
+              ExecStart = lib.escapeShellArgs (
+                [
+                  (lib.getExe cfg.package)
+                  "app-server"
+                  "--remote-control"
+                  "--listen"
+                  remoteControlCfg.listen
+                ]
+                ++ remoteControlCfg.extraArgs
+              );
+              Restart = "on-failure";
+              RestartSec = 5;
+            }
+            // lib.optionalAttrs (remoteControlCfg.environmentFile != null) {
+              EnvironmentFile = remoteControlCfg.environmentFile;
+            };
+
+            Install = {
+              WantedBy = [ remoteControlCfg.target ];
+            };
+          };
     };
 }

--- a/tests/modules/programs/codex/default.nix
+++ b/tests/modules/programs/codex/default.nix
@@ -6,6 +6,7 @@
   codex-legacy-custom-instructions = ./legacy-custom-instructions.nix;
   codex-mcp-integration = ./mcp-integration.nix;
   codex-mcp-integration-with-override = ./mcp-integration-with-override.nix;
+  codex-remote-control-service = ./remote-control-service.nix;
   codex-rules = ./rules.nix;
   codex-skills-inline = ./skills-inline.nix;
   codex-skills-inline-null-package = ./skills-inline-null-package.nix;

--- a/tests/modules/programs/codex/default.nix
+++ b/tests/modules/programs/codex/default.nix
@@ -1,3 +1,5 @@
+{ lib, pkgs, ... }:
+
 {
   codex-settings-toml = ./settings-toml.nix;
   codex-settings-toml-prefer-xdg-directories = ./settings-toml-prefer-xdg-directories.nix;
@@ -6,7 +8,6 @@
   codex-legacy-custom-instructions = ./legacy-custom-instructions.nix;
   codex-mcp-integration = ./mcp-integration.nix;
   codex-mcp-integration-with-override = ./mcp-integration-with-override.nix;
-  codex-remote-control-service = ./remote-control-service.nix;
   codex-rules = ./rules.nix;
   codex-skills-inline = ./skills-inline.nix;
   codex-skills-inline-null-package = ./skills-inline-null-package.nix;
@@ -15,4 +16,7 @@
   codex-skills-store-path = ./skills-store-path.nix;
   codex-skills-store-path-dir = ./skills-store-path-dir.nix;
   codex-skills-path-not-directory = ./skills-path-not-directory.nix;
+}
+// lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  codex-remote-control-service = ./remote-control-service.nix;
 }

--- a/tests/modules/programs/codex/remote-control-service.nix
+++ b/tests/modules/programs/codex/remote-control-service.nix
@@ -1,0 +1,30 @@
+{ config, ... }:
+let
+  codexPackage = config.lib.test.mkStubPackage {
+    name = "codex";
+  };
+in
+{
+  programs.codex = {
+    enable = true;
+    package = codexPackage;
+    remoteControl = {
+      enable = true;
+      listen = "unix://";
+      environment = {
+        RUST_LOG = "codex_app_server=info";
+      };
+      environmentFile = "/run/secrets/codex-remote-control.env";
+      extraArgs = [
+        "--analytics-default-enabled"
+      ];
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/codex-remote-control.service
+    assertFileExists "$serviceFile"
+    serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+    assertFileContent "$serviceFileNormalized" ${./remote-control-service.service}
+  '';
+}

--- a/tests/modules/programs/codex/remote-control-service.nix
+++ b/tests/modules/programs/codex/remote-control-service.nix
@@ -3,6 +3,9 @@ let
   codexPackage = config.lib.test.mkStubPackage {
     name = "codex";
   };
+  remoteControlPackage = config.lib.test.mkStubPackage {
+    name = "codex-remote-control";
+  };
 in
 {
   programs.codex = {
@@ -10,6 +13,7 @@ in
     package = codexPackage;
     remoteControl = {
       enable = true;
+      package = remoteControlPackage;
       listen = "unix://";
       environment = {
         RUST_LOG = "codex_app_server=info";

--- a/tests/modules/programs/codex/remote-control-service.service
+++ b/tests/modules/programs/codex/remote-control-service.service
@@ -6,7 +6,7 @@ Environment=CODEX_HOME=/home/hm-user/.codex
 Environment=PATH=/home/hm-user/.nix-profile/bin
 Environment=RUST_LOG=codex_app_server=info
 EnvironmentFile=/run/secrets/codex-remote-control.env
-ExecStart=/nix/store/00000000000000000000000000000000-codex/bin/codex app-server --remote-control --listen unix:// --analytics-default-enabled
+ExecStart=/nix/store/00000000000000000000000000000000-codex-remote-control/bin/codex-remote-control app-server --remote-control --listen unix:// --analytics-default-enabled
 Restart=on-failure
 RestartSec=5
 

--- a/tests/modules/programs/codex/remote-control-service.service
+++ b/tests/modules/programs/codex/remote-control-service.service
@@ -1,0 +1,15 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+Environment=CODEX_HOME=/home/hm-user/.codex
+Environment=PATH=/home/hm-user/.nix-profile/bin
+Environment=RUST_LOG=codex_app_server=info
+EnvironmentFile=/run/secrets/codex-remote-control.env
+ExecStart=/nix/store/00000000000000000000000000000000-codex/bin/codex app-server --remote-control --listen unix:// --analytics-default-enabled
+Restart=on-failure
+RestartSec=5
+
+[Unit]
+After=network.target
+Description=Codex remote-control app-server


### PR DESCRIPTION
## Summary

- add `programs.codex.remoteControl` options to manage a headless Codex app-server
- generate a Linux systemd user service running `codex app-server --remote-control --listen <value>`
- add NMT coverage for the rendered systemd unit, including `CODEX_HOME`, `PATH`, `EnvironmentFile`, and extra args

## Notes

The default `listen = "off"` keeps the service remote-control only. Users can set `listen = "unix://"` if they also want local app-server clients to connect through the Codex control socket.

This service depends on the user already having ChatGPT auth in the configured `CODEX_HOME`.

## Tests

- `nix fmt modules/programs/codex.nix tests/modules/programs/codex/default.nix tests/modules/programs/codex/remote-control-service.nix`
- `make test TEST=codex-remote-control-service`
- `make test TEST=codex-empty-settings`
- `make test TEST=codex-settings-toml-prefer-xdg-directories`
- `git diff --check`
