### PR TITLE
ssh-tpm-agent: pass SSH_ASKPASS to service when set

### DIFF
--- a/modules/services/ssh-tpm-agent.nix
+++ b/modules/services/ssh-tpm-agent.nix
@@ -89,7 +89,12 @@ in
             After = [ "ssh-tpm-agent.socket" ];
           };
           Service = {
-            Environment = "SSH_TPM_AUTH_SOCK=%t/ssh-tpm-agent.sock";
+            Environment = [
+              "SSH_TPM_AUTH_SOCK=%t/ssh-tpm-agent.sock"
+            ]
+            ++ lib.optional (
+              config.home.sessionVariables ? SSH_ASKPASS
+            ) "SSH_ASKPASS=${config.home.sessionVariables.SSH_ASKPASS}";
             ExecStart =
               let
                 inherit (config.services) ssh-agent;

--- a/tests/modules/services/ssh-tpm-agent/default.nix
+++ b/tests/modules/services/ssh-tpm-agent/default.nix
@@ -3,6 +3,7 @@
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   ssh-tpm-agent-as-ssh-agent-proxy = ./as-ssh-agent-proxy.nix;
   ssh-tpm-agent-extra-args = ./extra-args.nix;
+  ssh-tpm-agent-ssh-askpass = ./ssh-askpass.nix;
   ssh-tpm-agent-sshAuthSock = ./ssh-auth-sock.nix;
   ssh-tpm-agent-standalone = ./standalone.nix;
 }

--- a/tests/modules/services/ssh-tpm-agent/ssh-askpass.nix
+++ b/tests/modules/services/ssh-tpm-agent/ssh-askpass.nix
@@ -1,0 +1,31 @@
+{ config, ... }:
+
+{
+  home.sessionVariables.SSH_ASKPASS = "/run/current-system/sw/bin/ssh-askpass";
+
+  services.ssh-tpm-agent = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@ssh-tpm-agent@"; };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/ssh-tpm-agent.service
+
+    assertFileExists $serviceFile
+
+    assertFileContent $serviceFile ${builtins.toFile "expected-service" ''
+      [Service]
+      Environment=SSH_TPM_AUTH_SOCK=%t/ssh-tpm-agent.sock
+      Environment=SSH_ASKPASS=/run/current-system/sw/bin/ssh-askpass
+      ExecStart=@ssh-tpm-agent@/bin/dummy
+      SuccessExitStatus=2
+      Type=simple
+
+      [Unit]
+      After=ssh-tpm-agent.socket
+      Description=ssh-tpm-agent service
+      Documentation=https://github.com/Foxboron/ssh-tpm-agent
+      Requires=ssh-tpm-agent.socket
+    ''}
+  '';
+}


### PR DESCRIPTION
### Description

There have been too many cases where I didnt realize why my ssh-agent wasn't working because it was not inherting my SSH_ASKPASS env var, this makes it implicitly inherit it when available.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
