### PR TITLE
podman: ensure openssh is available in PATH for machine initialization

### DIFF
--- a/modules/services/podman/darwin.nix
+++ b/modules/services/podman/darwin.nix
@@ -198,6 +198,20 @@ in
         };
       };
     };
+
+    extraPackages = mkOption {
+      type = types.listOf types.package;
+      default = with pkgs; [
+        openssh
+      ];
+      defaultText = lib.literalExpression "[ pkgs.openssh ]";
+      example = lib.literalExpression ''
+        with pkgs; [ openssh hello ];
+      '';
+      description = ''
+        Extra packages added to {env}`PATH` when creating Podman machines.
+      '';
+    };
   };
 
   config =
@@ -263,7 +277,14 @@ in
               '';
           in
           lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-            PATH="${cfg.package}/bin:$PATH"
+            PATH="${
+              lib.makeBinPath (
+                [
+                  cfg.package
+                ]
+                ++ cfg.extraPackages
+              )
+            }:$PATH"
 
             ${concatStringsSep "\n" (lib.mapAttrsToList mkMachineInitScript allMachines)}
 


### PR DESCRIPTION


### Description

`podman machine init` requires `ssh-keygen` to generate keys, but `openssh` may not be available in the system `PATH` by default. This change ensures `openssh` is available before attempting to create podman machines.

Resolves #9325

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
