### PR TITLE
Fix minor CI lints found by actionlint

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -24,7 +24,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          COUNT=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' | grep '^modules/' | wc -l || echo 0)
+          COUNT=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' | grep -c '^modules/' || echo 0)
           echo "Found $COUNT changed module files."
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/tag-maintainers.yml
+++ b/.github/workflows/tag-maintainers.yml
@@ -42,12 +42,12 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          CHANGED_FILES=$(gh pr diff $PR_NUMBER --name-only | grep '^modules/' | grep -v '^modules/\(po\|.*\/news\)/' || true)
+          CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only | grep '^modules/' | grep -v '^modules/\(po\|.*\/news\)/' || true)
           echo "Changed files:"
           echo "$CHANGED_FILES"
-          echo "changed_files<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$CHANGED_FILES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Extract Maintainers
         id: extract-maintainers
         env:
@@ -58,7 +58,7 @@ jobs:
           MAINTAINERS=$(lib/python/extract-maintainers.py \
             --changed-files "$CHANGED_FILES" \
             --pr-author "$PR_AUTHOR")
-          echo "maintainers=$MAINTAINERS" >> $GITHUB_OUTPUT
+          echo "maintainers=$MAINTAINERS" >> "$GITHUB_OUTPUT"
           echo "Found maintainers: $MAINTAINERS"
       - name: Manage Reviewers
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,37 +92,37 @@ jobs:
         if: github.event_name == 'pull_request'
         shell: bash
         run: |
-          echo "### Test Job Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "A summary of tasks triggered by file changes in this PR:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Test Job Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "A summary of tasks triggered by file changes in this PR:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "${{ needs.changes.outputs.docs }}" == "true" ]]; then
-            echo "- ✅ **Docs Build:** Triggered" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ **Docs Build:** Triggered" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- ☑️ **Docs Build:** Skipped (no relevant files changed)" >> $GITHUB_STEP_SUMMARY
+            echo "- ☑️ **Docs Build:** Skipped (no relevant files changed)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           if [[ "${{ needs.changes.outputs.format }}" == "true" ]]; then
-            echo "- ✅ **Format Check:** Triggered" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ **Format Check:** Triggered" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- ☑️ **Format Check:** Skipped (no relevant files changed)" >> $GITHUB_STEP_SUMMARY
+            echo "- ☑️ **Format Check:** Skipped (no relevant files changed)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           if [[ "${{ needs.changes.outputs.parse }}" == "true" ]]; then
-            echo "- ✅ **Nix Parse (nix + Lix):** Triggered" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ **Nix Parse (nix + Lix):** Triggered" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- ☑️ **Nix Parse (nix + Lix):** Skipped (no relevant files changed)" >> $GITHUB_STEP_SUMMARY
+            echo "- ☑️ **Nix Parse (nix + Lix):** Skipped (no relevant files changed)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           if [[ "${{ needs.changes.outputs.hm }}" == "true" ]]; then
-            echo "- ✅ **Home Manager Tests:** Triggered" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ **Home Manager Tests:** Triggered" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- ☑️ **Home Manager Tests:** Skipped (no relevant files changed)" >> $GITHUB_STEP_SUMMARY
+            echo "- ☑️ **Home Manager Tests:** Skipped (no relevant files changed)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           if [[ "${{ needs.changes.outputs.tests }}" == "true" ]]; then
-            echo "- ✅ **General Tests:** Triggered" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ **General Tests:** Triggered" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- ☑️ **General Tests:** Skipped (no relevant files changed)" >> $GITHUB_STEP_SUMMARY
+            echo "- ☑️ **General Tests:** Skipped (no relevant files changed)" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/update-maintainers.yml
+++ b/.github/workflows/update-maintainers.yml
@@ -184,7 +184,7 @@ jobs:
           if [[ -n "$info" ]]; then
             echo "PR info:"
             echo "$info"
-            echo "$info" >> $GITHUB_OUTPUT
+            echo "$info" >> "$GITHUB_OUTPUT"
           else
             echo "No PR is currently open"
           fi
@@ -266,21 +266,21 @@ jobs:
                 echo "✅ Successfully updated PR with new changes."
                 echo "$changes"
                 echo "🔗 PR URL: $pr_url"
-                echo "### ✅ PR Updated" >> $GITHUB_STEP_SUMMARY
-                echo "[$pr_url]($pr_url)" >> $GITHUB_STEP_SUMMARY
+                echo "### ✅ PR Updated" >> "$GITHUB_STEP_SUMMARY"
+                echo "[$pr_url]($pr_url)" >> "$GITHUB_STEP_SUMMARY"
               elif [[ -n "$pr_url" ]]; then
                 echo "✅ Successfully created PR with maintainer updates."
                 echo "$changes"
                 echo "🔗 PR URL: $pr_url"
-                echo "### ✅ PR Created" >> $GITHUB_STEP_SUMMARY
-                echo "[$pr_url]($pr_url)" >> $GITHUB_STEP_SUMMARY
+                echo "### ✅ PR Created" >> "$GITHUB_STEP_SUMMARY"
+                echo "[$pr_url]($pr_url)" >> "$GITHUB_STEP_SUMMARY"
               else
                 echo "❌ Failed to create or update pull request."
-                echo "### ❌ PR Operation Failed" >> $GITHUB_STEP_SUMMARY
-                echo "A pull request was intended but the URL was not captured. Please check the logs." >> $GITHUB_STEP_SUMMARY
+                echo "### ❌ PR Operation Failed" >> "$GITHUB_STEP_SUMMARY"
+                echo "A pull request was intended but the URL was not captured. Please check the logs." >> "$GITHUB_STEP_SUMMARY"
               fi
           else
             echo "ℹ️ No changes detected - maintainers list is up to date."
-            echo "### ℹ️ No Changes" >> $GITHUB_STEP_SUMMARY
-            echo "The maintainers list is up-to-date. No PR was created." >> $GITHUB_STEP_SUMMARY
+            echo "### ℹ️ No Changes" >> "$GITHUB_STEP_SUMMARY"
+            echo "The maintainers list is up-to-date. No PR was created." >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
### Description

This fixes a few minor CI lints reported by [actionlint](https://github.com/rhysd/actionlint).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```