### PR TITLE
zsh: guard session variables under nounset

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -657,7 +657,7 @@ in
       destination = "/etc/profile.d/hm-session-vars.sh";
       text = ''
         # Only source this once.
-        if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
+        if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
         export __HM_SESS_VARS_SOURCED=1
 
         ${config.lib.shell.exportAll cfg.sessionVariables}

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -486,7 +486,7 @@ in
             . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
 
             # Only source this once
-            if [[ -z "$__HM_ZSH_SESS_VARS_SOURCED" ]]; then
+            if [[ -z "''${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
               export __HM_ZSH_SESS_VARS_SOURCED=1
               ${envVarsStr}
             fi

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -6,7 +6,7 @@ let
 
   linuxExpected = ''
     # Only source this once.
-    if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
+    if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
     export __HM_SESS_VARS_SOURCED=1
 
     export IS_EMPTY=""
@@ -25,7 +25,7 @@ let
 
   darwinExpected = ''
     # Only source this once.
-    if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
+    if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
     export __HM_SESS_VARS_SOURCED=1
 
     export IS_EMPTY=""

--- a/tests/modules/programs/zsh/session-variables.zshenv
+++ b/tests/modules/programs/zsh/session-variables.zshenv
@@ -2,7 +2,7 @@
 . "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
 
 # Only source this once
-if [[ -z "$__HM_ZSH_SESS_VARS_SOURCED" ]]; then
+if [[ -z "${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
   export __HM_ZSH_SESS_VARS_SOURCED=1
   export IS_EMPTY=""
   export IS_FALSE=false


### PR DESCRIPTION
Use parameter expansion with a default value when checking Home Manager's session-variable sentinels.

Users with zsh NO_UNSET or shell nounset enabled were seeing parameter-not-set errors before the generated session variables had a chance to export the sentinel variables.

Update the home session-variable and zsh fixtures to cover the generated guards.

closes #9311 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
