### PR TITLE
podman: quote Quadlet labels with spaces

### DIFF
--- a/modules/services/podman/linux/podman-lib.nix
+++ b/modules/services/podman/linux/podman-lib.nix
@@ -15,17 +15,28 @@ let
   normalizeKeyValue =
     k: v:
     let
+      mkValueString = lib.generators.mkValueStringDefault { };
+      quoteIfSpaced =
+        s: if lib.match ".*[[:space:]].*" s == null then s else ''"${lib.escape [ "\\" "\"" ] s}"'';
+
+      normalizeAttrValue =
+        name: value:
+        lib.optionalString (value != null) (
+          if builtins.isAttrs value then
+            normalizeKeyValue name value
+          else
+            quoteIfSpaced "${name}=${mkValueString value}"
+        );
+
       v' =
-        if builtins.isBool v then
-          (if v then "true" else "false")
-        else if builtins.isAttrs v then
+        if builtins.isAttrs v then
           (concatStringsSep ''
 
-            ${k}='' (mapAttrsToList normalizeKeyValue v))
+            ${k}='' (mapAttrsToList normalizeAttrValue v))
         else
-          toString v;
+          mkValueString v;
     in
-    if isNull v then "" else "${k}=${v'}";
+    lib.optionalString (v != null) "${k}=${v'}";
 
   primitiveAttrs = with types; attrsOf (either primitive (listOf primitive));
   primitiveList = with types; listOf primitive;

--- a/tests/modules/services/podman/linux/container-expected.service
+++ b/tests/modules/services/podman/linux/container-expected.service
@@ -14,6 +14,7 @@ Environment=VAL_B=2
 Environment=VAL_C=false
 Image=docker.io/alpine:latest
 Label=nix.home-manager.managed=true
+Label="traefik.rule=Host(`example.com`) && PathPrefix(`/api`)"
 Network=mynet
 NetworkAlias=test-alias-1
 NetworkAlias=test-alias-2
@@ -38,7 +39,7 @@ Delegate=yes
 Type=notify
 NotifyAccess=all
 SyslogIdentifier=%N
-ExecStart=/nix/store/00000000000000000000000000000000-podman/bin/podman run --name my-container --replace --rm --cgroups=split --entrypoint=/sleep.sh --network-alias test-alias-1 --network-alias test-alias-2 --read-only-tmpfs --network mynet --sdnotify=conmon -d --device /dev/null:/dev/null -v /tmp:/tmp --label io.containers.autoupdate=registry --publish 8080:80 --env VAL_A=A --env VAL_B=2 --env VAL_C=false --label nix.home-manager.managed=true --security-opt=no-new-privileges docker.io/alpine:latest
+ExecStart=/nix/store/00000000000000000000000000000000-podman/bin/podman run --name my-container --replace --rm --cgroups=split --entrypoint=/sleep.sh --network-alias test-alias-1 --network-alias test-alias-2 --read-only-tmpfs --network mynet --sdnotify=conmon -d --device /dev/null:/dev/null -v /tmp:/tmp --label io.containers.autoupdate=registry --publish 8080:80 --env VAL_A=A --env VAL_B=2 --env VAL_C=false --label nix.home-manager.managed=true --label "traefik.rule=Host(`example.com`)\x20&&\x20PathPrefix(`/api`)" --security-opt=no-new-privileges docker.io/alpine:latest
 
 [Unit]
 Wants=podman-user-wait-network-online.service

--- a/tests/modules/services/podman/linux/container.nix
+++ b/tests/modules/services/podman/linux/container.nix
@@ -27,6 +27,9 @@
             Unit.Before = "fake.target";
           };
           image = "docker.io/alpine:latest";
+          labels = {
+            "traefik.rule" = "Host(`example.com`) && PathPrefix(`/api`)";
+          };
           # Should not generate Requires/After for network because there is no
           # services.podman.networks.mynet.
           network = "mynet";


### PR DESCRIPTION
Quote generated Quadlet key-value entries when attrset-backed values contain whitespace, preserving the value as a single systemd/Quadlet field.

Without quoting, label values such as Traefik rules are split by podman-system-generator into multiple invalid --label arguments.

Extend the container NMT fixture with a label containing spaces and assert the generated service preserves it as one label.

closes #9276

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
