### PR TITLE
elephant: add module; walker: add elephant integration

### DIFF
--- a/modules/misc/news/2026/05/2026-05-18_02-52-12.nix
+++ b/modules/misc/news/2026/05/2026-05-18_02-52-12.nix
@@ -1,0 +1,14 @@
+{ config, ... }:
+
+{
+  time = "2026-05-18T02:52:12+00:00";
+  condition = config.services.elephant.enable;
+  message = ''
+    A new service is available: 'services.elephant'.
+
+    Elephant is a data provider service for application launchers such as
+    Walker. The module can install Elephant, generate
+    `~/.config/elephant/config.toml`, and run Elephant as a systemd user
+    service.
+  '';
+}

--- a/modules/misc/news/2026/05/2026-05-18_03-07-36.nix
+++ b/modules/misc/news/2026/05/2026-05-18_03-07-36.nix
@@ -1,0 +1,15 @@
+{ config, ... }:
+
+{
+  time = "2026-05-18T03:07:36+00:00";
+  condition = config.services.walker.enable;
+  message = ''
+    The 'services.walker' module now supports Elephant integration through
+    {option}`services.walker.enableElephantIntegration`.
+
+    When both `services.walker` and `services.elephant` are enabled, Walker's
+    systemd user service now starts after `elephant.service` and requires it.
+    Set {option}`services.walker.enableElephantIntegration` to `false` to
+    disable this service dependency.
+  '';
+}

--- a/modules/services/elephant.nix
+++ b/modules/services/elephant.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.elephant;
+
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = [ ];
+
+  options.services.elephant = {
+    enable = lib.mkEnableOption "elephant";
+
+    package = lib.mkPackageOption pkgs "elephant" {
+      example = ''
+        pkgs.elephant.override {
+          enabledProviders = [
+            "desktopapplications"
+            "runner"
+          ];
+        }
+      '';
+    };
+
+    settings = lib.mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = {
+        providers.default = [
+          "desktopapplications"
+          "runner"
+        ];
+      };
+      description = ''
+        Configuration settings for Elephant.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.elephant" pkgs lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."elephant/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "elephant-config" cfg.settings;
+    };
+
+    systemd.user.services.elephant = {
+      Unit.Description = "Elephant - Data provider for application launchers";
+      Install.WantedBy = [ "graphical-session.target" ];
+      Service = {
+        ExecStart = lib.getExe cfg.package;
+        Restart = "on-failure";
+      };
+    };
+  };
+}

--- a/modules/services/walker.nix
+++ b/modules/services/walker.nix
@@ -22,7 +22,20 @@ in
 
   options.services.walker = {
     enable = mkEnableOption "walker";
+
     package = mkPackageOption pkgs "walker" { nullable = true; };
+
+    enableElephantIntegration = mkOption {
+      type = types.bool;
+      default = config.services.elephant.enable;
+      defaultText = lib.literalExpression "config.services.elephant.enable";
+      example = true;
+      description = ''
+        Whether to make Walker's systemd service depend on
+        {option}`services.elephant`.
+      '';
+    };
+
     settings = mkOption {
       inherit (tomlFormat) type;
       default = { };
@@ -95,12 +108,18 @@ in
         }
       ];
 
-      home.packages = mkIf (cfg.package != null) [ cfg.package ];
+      home.packages = lib.optional (cfg.package != null) cfg.package;
       xdg.configFile."walker/config.toml" = mkIf (cfg.settings != { }) {
         source = tomlFormat.generate "walker-config" cfg.settings;
       };
       systemd.user.services.walker = mkIf (cfg.systemd.enable && cfg.package != null) {
-        Unit.Description = "Walker - Application Runner";
+        Unit = {
+          Description = "Walker - Application Runner";
+        }
+        // lib.optionalAttrs cfg.enableElephantIntegration {
+          After = [ "elephant.service" ];
+          Requires = [ "elephant.service" ];
+        };
         Install.WantedBy = [ "graphical-session.target" ];
         Service = {
           ExecStart = "${lib.getExe cfg.package} --gapplication-service";

--- a/tests/modules/services/elephant/config.toml
+++ b/tests/modules/services/elephant/config.toml
@@ -1,0 +1,3 @@
+[providers]
+default = ["desktopapplications", "runner"]
+max_results = 50

--- a/tests/modules/services/elephant/default.nix
+++ b/tests/modules/services/elephant/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  elephant-example-config = ./example-config.nix;
+}

--- a/tests/modules/services/elephant/elephant.service
+++ b/tests/modules/services/elephant/elephant.service
@@ -1,0 +1,9 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@elephant@/bin/elephant
+Restart=on-failure
+
+[Unit]
+Description=Elephant - Data provider for application launchers

--- a/tests/modules/services/elephant/example-config.nix
+++ b/tests/modules/services/elephant/example-config.nix
@@ -1,0 +1,25 @@
+{
+  services.elephant = {
+    enable = true;
+    settings = {
+      providers = {
+        default = [
+          "desktopapplications"
+          "runner"
+        ];
+        max_results = 50;
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/elephant/config.toml
+    assertFileExists home-files/.config/systemd/user/elephant.service
+
+    assertFileContent home-files/.config/elephant/config.toml \
+    ${./config.toml}
+
+    assertFileContent home-files/.config/systemd/user/elephant.service \
+    ${./elephant.service}
+  '';
+}

--- a/tests/modules/services/walker/example-config.nix
+++ b/tests/modules/services/walker/example-config.nix
@@ -3,9 +3,12 @@ let
   layout_xml = builtins.readFile ./item_dmenu.xml;
 in
 {
+  services.elephant.enable = true;
+
   services.walker = {
     enable = true;
     systemd.enable = true;
+    enableElephantIntegration = true;
     settings = {
       app_launch_prefix = "";
       terminal_title_flag = "";
@@ -49,5 +52,9 @@ in
 
     assertFileContent home-files/.config/walker/themes/mytheme/style.css \
     ${./mytheme.css}
+
+    walkerService=home-files/.config/systemd/user/walker.service
+
+    assertFileContent $walkerService ${./walker.service}
   '';
 }

--- a/tests/modules/services/walker/walker.service
+++ b/tests/modules/services/walker/walker.service
@@ -1,0 +1,11 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@walker@/bin/walker --gapplication-service
+Restart=on-failure
+
+[Unit]
+After=elephant.service
+Description=Walker - Application Runner
+Requires=elephant.service


### PR DESCRIPTION
Walker 2.x relies on Elephant for launcher data. Add a dedicated `services.elephant` module for configuring Elephant itself, including package installation, provider packages, config generation, and a systemd user service.

Add `services.walker.enableElephantIntegration` to order Walker after `elephant.service` and add a systemd `Requires=` dependency when enabled. The integration defaults to `services.elephant.enable`, while still allowing users to depend on an externally managed `elephant.service`.

Closes #9305

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
