### PR TITLE
wrtag: init module

### DIFF
--- a/modules/misc/news/2026/07/2026-07-05_00-00-00.nix
+++ b/modules/misc/news/2026/07/2026-07-05_00-00-00.nix
@@ -1,0 +1,14 @@
+{ config, ... }:
+{
+  time = "2026-07-05T00:00:00+00:00";
+  condition = config.programs.wrtag.enable;
+  message = ''
+    A new module is available: `programs.wrtag`.
+
+    wrtag is a music tagging and organisation tool based on MusicBrainz.
+
+    Configuration is written in flagconf format and supports stackable
+    options such as `addon`, `keep-file`, and `notification-uri`. The
+    module respects `home.preferXdgDirectories` on macOS.
+  '';
+}

--- a/modules/programs/wrtag.nix
+++ b/modules/programs/wrtag.nix
@@ -1,0 +1,69 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.wrtag;
+
+  # flagconf uses "key value" spacing and duplicate keys for lists
+  flagconfFormat = pkgs.formats.keyValue {
+    listsAsDuplicateKeys = true;
+    mkKeyValue = lib.generators.mkKeyValueDefault { } " ";
+  };
+
+in
+{
+  meta.maintainers = [ lib.maintainers.philocalyst ];
+
+  options.programs.wrtag = {
+    enable = lib.mkEnableOption "wrtag, a music tagging and organisation tool based on MusicBrainz";
+
+    package = lib.mkPackageOption pkgs "wrtag" { nullable = true; };
+
+    settings = lib.mkOption {
+      inherit (flagconfFormat) type;
+      default = { };
+      description = ''
+        Configuration written in flagconf format (`key value` per line).
+
+        Stackable options such as `addon`, `keep-file`, and `notification-uri`
+        accept a list; each element becomes its own line with the same key.
+
+        See <https://github.com/sentriz/wrtag#global-configuration> for
+        available options.
+
+        And <https://github.com/sentriz/wrtag#config-file> for default locations
+      '';
+      example = lib.literalExpression ''
+        {
+          path-format = "/music/{{ artists .Release.Artists | join \"; \" | safepath }}/({{ .Release.ReleaseGroup.FirstReleaseDate.Year }}) {{ .Release.Title | safepath }}/{{ pad0 2 .Track.Position }} {{ .Track.Title | safepath }}{{ .Ext }}";
+          addon = [ "replaygain" "lyrics lrclib genius" ];
+          log-level = "debug";
+          cover-upgrade = true;
+        }
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    let
+      useXdg = !pkgs.stdenv.hostPlatform.isDarwin || config.home.preferXdgDirectories;
+      hasSettings = cfg.settings != { };
+      configFile = flagconfFormat.generate "wrtag-config" cfg.settings;
+    in
+    {
+      home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+      xdg.configFile."wrtag/config" = lib.mkIf (hasSettings && useXdg) {
+        source = configFile;
+      };
+
+      home.file."Library/Application Support/wrtag/config" = lib.mkIf (hasSettings && !useXdg) {
+        source = configFile;
+      };
+    }
+  );
+}

--- a/tests/modules/programs/wrtag/addons.conf
+++ b/tests/modules/programs/wrtag/addons.conf
@@ -1,0 +1,4 @@
+addon replaygain
+addon lyrics lrclib genius
+log-level info
+mb-rate-limit 2s

--- a/tests/modules/programs/wrtag/addons.nix
+++ b/tests/modules/programs/wrtag/addons.nix
@@ -1,0 +1,34 @@
+{ pkgs, ... }:
+
+{
+  config = {
+    home.enableNixpkgsReleaseCheck = false;
+
+    programs.wrtag = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy-wrtag" "";
+      settings = {
+        addon = [
+          "replaygain"
+          "lyrics lrclib genius"
+        ];
+        log-level = "info";
+        mb-rate-limit = "2s";
+      };
+    };
+
+    nmt.script =
+      let
+        configFile =
+          if pkgs.stdenv.hostPlatform.isDarwin then
+            "home-files/Library/Application Support/wrtag/config"
+          else
+            "home-files/.config/wrtag/config";
+      in
+      ''
+        assertFileExists "${configFile}"
+        assertFileContent "${configFile}" \
+            ${./addons.conf}
+      '';
+  };
+}

--- a/tests/modules/programs/wrtag/default.nix
+++ b/tests/modules/programs/wrtag/default.nix
@@ -1,0 +1,6 @@
+_: {
+  wrtag-empty = ./empty.nix;
+  wrtag-settings = ./settings.nix;
+  wrtag-addons = ./addons.nix;
+  wrtag-prefer-xdg = ./prefer-xdg.nix;
+}

--- a/tests/modules/programs/wrtag/empty.nix
+++ b/tests/modules/programs/wrtag/empty.nix
@@ -1,0 +1,24 @@
+{ pkgs, ... }:
+
+{
+  config = {
+    home.enableNixpkgsReleaseCheck = false;
+
+    programs.wrtag = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy-wrtag" "";
+    };
+
+    nmt.script =
+      let
+        configFile =
+          if pkgs.stdenv.hostPlatform.isDarwin then
+            "home-files/Library/Application Support/wrtag/config"
+          else
+            "home-files/.config/wrtag/config";
+      in
+      ''
+        assertPathNotExists "${configFile}"
+      '';
+  };
+}

--- a/tests/modules/programs/wrtag/prefer-xdg.nix
+++ b/tests/modules/programs/wrtag/prefer-xdg.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+
+{
+  config = {
+    home.enableNixpkgsReleaseCheck = false;
+    home.preferXdgDirectories = true;
+
+    programs.wrtag = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy-wrtag" "";
+      settings = {
+        path-format = "/music/library";
+        log-level = "debug";
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists "home-files/.config/wrtag/config"
+      assertPathNotExists "home-files/Library/Application Support/wrtag/config"
+    '';
+  };
+}

--- a/tests/modules/programs/wrtag/settings.conf
+++ b/tests/modules/programs/wrtag/settings.conf
@@ -1,0 +1,3 @@
+cover-upgrade true
+log-level debug
+path-format /music/library

--- a/tests/modules/programs/wrtag/settings.nix
+++ b/tests/modules/programs/wrtag/settings.nix
@@ -1,0 +1,31 @@
+{ pkgs, ... }:
+
+{
+  config = {
+    home.enableNixpkgsReleaseCheck = false;
+
+    programs.wrtag = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy-wrtag" "";
+      settings = {
+        cover-upgrade = true;
+        log-level = "debug";
+        path-format = "/music/library";
+      };
+    };
+
+    nmt.script =
+      let
+        configFile =
+          if pkgs.stdenv.hostPlatform.isDarwin then
+            "home-files/Library/Application Support/wrtag/config"
+          else
+            "home-files/.config/wrtag/config";
+      in
+      ''
+        assertFileExists "${configFile}"
+        assertFileContent "${configFile}" \
+            ${./settings.conf}
+      '';
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
