### PR TITLE
gimp: init module

### DIFF
--- a/modules/misc/news/2026/08/2026-08-03.nix
+++ b/modules/misc/news/2026/08/2026-08-03.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+{
+  time = "2026-08-03T19:35:00+00:00";
+  condition = config.programs.gimp.enable;
+  message = ''
+    A new module is available: {option}`programs.gimp`.
+
+    This module installs and configures the GIMP image editor, including
+    `gimprc` and `shortcutsrc` settings, controllers, and content
+    directories (brushes, patterns, scripts, plug-ins, and more).
+  '';
+}

--- a/modules/programs/gimp/config.nix
+++ b/modules/programs/gimp/config.nix
@@ -1,0 +1,148 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  gimpConfigurationModule = import ./gimprc.nix { inherit lib; };
+  shortcutConfigurationModule = import ./shortcutsrc.nix { inherit lib; };
+  controllerConfigurationModule = import ./controllerrc.nix { inherit lib; };
+  gtpModule = import ./gtp.nix { inherit lib; };
+  gplModule = import ./gpl.nix { inherit lib; };
+  gdynModule = import ./gdyn.nix { inherit lib; };
+  mybModule = import ./myb.nix { inherit lib; };
+  vbrModule = import ./vbr.nix { inherit lib; };
+
+  configuration = config.programs.gimp;
+  configurationDirectory = "GIMP/${configuration.configVersion}";
+  useXdgDirectories = !pkgs.stdenv.hostPlatform.isDarwin || config.home.preferXdgDirectories;
+
+  # Ensures raw strings become store paths, while existing paths pass through unmodified.
+  toSource =
+    name: content:
+    if lib.isPath content || lib.isStorePath content then content else pkgs.writeText name content;
+
+  # Like toSource, but automatically applies a rendering function to structured attrsets.
+  toRenderedSource =
+    renderFunction: name: value:
+    if lib.isPath value || lib.isStorePath value then
+      value
+    else
+      pkgs.writeText name (if builtins.isString value then value else renderFunction value);
+
+  # Helper to generate Home Manager file mappings for unrendered paths/strings
+  renderContent =
+    basePath: configurationSet:
+    lib.mapAttrs' (
+      name: value: lib.nameValuePair "${basePath}/${name}" { source = toSource name value; }
+    ) configurationSet;
+
+  # Helper to generate Home Manager file mappings for resources requiring structural rendering
+  renderResource =
+    basePath: renderFunction: configurationSet:
+    lib.mapAttrs' (
+      name: value:
+      lib.nameValuePair "${basePath}/${name}" { source = toRenderedSource renderFunction name value; }
+    ) configurationSet;
+
+  majorVersion = lib.versions.major configuration.configVersion;
+
+  fontsMap =
+    if builtins.isAttrs configuration.fonts then
+      configuration.fonts
+    else
+      let
+        fontBasenames = map (
+          f: builtins.unsafeDiscardStringContext (baseNameOf (toString f))
+        ) configuration.fonts;
+        uniqueBasenames = lib.unique fontBasenames;
+      in
+      assert lib.assertMsg (lib.length fontBasenames == lib.length uniqueBasenames)
+        "programs.gimp.fonts: list contains duplicate font filenames (${lib.concatStringsSep ", " fontBasenames})";
+      lib.listToAttrs (
+        map (
+          font: lib.nameValuePair (builtins.unsafeDiscardStringContext (baseNameOf (toString font))) font
+        ) configuration.fonts
+      );
+
+  allConfigurationFiles =
+    # Standard unrendered resources (strings or paths)
+    lib.concatMapAttrs (directory: items: renderContent "${configurationDirectory}/${directory}" items)
+      {
+        inherit (configuration)
+          brushes
+          gradients
+          patterns
+          scripts
+          themes
+          icons
+          ;
+        "plug-ins" = configuration.plugins;
+      }
+
+    # Rendered structured resources
+    //
+      renderResource "${configurationDirectory}/palettes" gplModule.toPaletteFile
+        configuration.palettes
+    //
+      renderResource "${configurationDirectory}/dynamics" gdynModule.toDynamicsFile
+        configuration.dynamics
+    //
+      renderResource "${configurationDirectory}/tool-presets" gtpModule.toToolPresetFile
+        configuration.toolPresets
+    //
+      renderResource "${configurationDirectory}/brushes" vbrModule.toVbrFile
+        configuration.parametricBrushes
+    // renderContent "${configurationDirectory}/fonts" fontsMap
+
+    # Environment files (direct text assignment instead of source path)
+    // lib.mapAttrs' (
+      name: text: lib.nameValuePair "${configurationDirectory}/environ/${name}" { inherit text; }
+    ) configuration.environ
+
+    # Base configuration files (gimprc, shortcutsrc, controllerrc)
+    // lib.optionalAttrs (configuration.settings != { } || configuration.extraConfig != "") {
+      "${configurationDirectory}/gimprc".text =
+        lib.optionalString (configuration.settings != { }) (
+          gimpConfigurationModule.toGimpConfiguration configuration.settings
+        )
+        + configuration.extraConfig;
+    }
+    // lib.optionalAttrs (configuration.keyboardShortcuts != { }) {
+      "${configurationDirectory}/shortcutsrc".text =
+        shortcutConfigurationModule.toShortcutSource configuration.keyboardShortcuts;
+    }
+    // lib.optionalAttrs (configuration.controllers != { } || configuration.extraControllerrc != "") {
+      "${configurationDirectory}/controllerrc".text =
+        lib.optionalString (configuration.controllers != { }) (
+          controllerConfigurationModule.toControllerConfiguration configuration.controllers
+        )
+        + configuration.extraControllerrc;
+    };
+
+  # NOT under configurationDirectory (GIMP/<version>/...): MyPaint brushes
+  # bypass XDG preferences and GIMP versioning. GIMP's default setting for
+  # `mypaint-brush-path-writable` hard-defaults to ~/.mypaint/brushes.
+  mypaintFiles = renderResource ".mypaint/brushes" mybModule.toBrushFile configuration.mypaintBrushes;
+in
+{
+  config = lib.mkIf configuration.enable {
+    home.packages = lib.mkIf (configuration.package != null) [ configuration.package ];
+
+    home.sessionVariables = lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && useXdgDirectories) {
+      "GIMP${majorVersion}_DIRECTORY" = "${config.xdg.configHome}/${configurationDirectory}";
+    };
+
+    xdg.configFile = lib.mkIf useXdgDirectories allConfigurationFiles;
+
+    home.file =
+      lib.optionalAttrs (!useXdgDirectories) (
+        lib.mapAttrs' (
+          name: value: lib.nameValuePair "Library/Application Support/${name}" value
+        ) allConfigurationFiles
+      )
+      // mypaintFiles;
+  };
+}

--- a/modules/programs/gimp/controllerrc.nix
+++ b/modules/programs/gimp/controllerrc.nix
@@ -1,0 +1,47 @@
+{ lib }:
+
+let
+  gimprc = import ./gimprc.nix { inherit lib; };
+  inherit (gimprc) spaces renderBoolean;
+
+  renderMap =
+    event: "${spaces 8}(map ${gimprc.renderScalar event.stroke} ${gimprc.renderScalar event.action})";
+
+  renderController =
+    controllerName: controller:
+    let
+      mappingBlock =
+        if controller.events == [ ] then
+          "(mapping)"
+        else
+          "(mapping\n" + lib.concatMapStringsSep "\n" renderMap controller.events + ")";
+    in
+    "(GimpControllerInfo ${gimprc.renderScalar controllerName}\n"
+    + spaces 4
+    + "(enabled ${renderBoolean controller.enabled})\n"
+    + spaces 4
+    + "(debug-events no)\n"
+    + spaces 4
+    + "(controller ${gimprc.renderScalar controllerName})\n"
+    + spaces 4
+    + mappingBlock
+    + ")";
+
+in
+{
+  toControllerConfiguration =
+    controllers:
+    let
+      controllerBlocks = lib.mapAttrsToList renderController controllers;
+      documentLines = [
+        "# GIMP controllerrc"
+        ""
+      ]
+      ++ controllerBlocks
+      ++ [
+        ""
+        "# end of controllerrc"
+      ];
+    in
+    lib.concatStringsSep "\n" documentLines + "\n";
+}

--- a/modules/programs/gimp/default.nix
+++ b/modules/programs/gimp/default.nix
@@ -1,0 +1,56 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    literalExpression
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    types
+    ;
+in
+{
+  meta.maintainers = [ lib.maintainers.philocalyst ];
+
+  imports = [
+    ./config.nix
+    ./options/gimprc.nix
+    ./options/content.nix
+    ./options/paint.nix
+    ./options/input.nix
+    ./options/appearance.nix
+  ];
+
+  options.programs.gimp = {
+    enable = mkEnableOption "GIMP image editor";
+
+    package = mkPackageOption pkgs "gimp" { nullable = true; };
+
+    configVersion = mkOption {
+      type = types.str;
+      default =
+        if config.programs.gimp.package != null then
+          lib.versions.majorMinor config.programs.gimp.package.version
+        else
+          throw ''
+            programs.gimp.configVersion has no package to derive a default
+            from because programs.gimp.package is null .
+          '';
+      defaultText = literalExpression "lib.versions.majorMinor config.programs.gimp.package.version";
+      example = "3.2";
+      description = ''
+        Config directory version suffix used for
+        {file}`$XDG_CONFIG_HOME/GIMP/<configVersion>/`.
+
+        Automatically derived from the package version when
+        {option}`programs.gimp.package` is set (e.g. `"3.0"` for GIMP 3.0.x,
+        `"3.2"` for GIMP 3.2.x). Must be set explicitly when
+        {option}`programs.gimp.package` is `null`.
+      '';
+    };
+  };
+}

--- a/modules/programs/gimp/gdyn.nix
+++ b/modules/programs/gimp/gdyn.nix
@@ -1,0 +1,17 @@
+{ lib }:
+let
+  gimprc = import ./gimprc.nix { inherit lib; };
+
+  toDynamicsSettings = dynamics: dynamics.settings or { };
+in
+{
+  toDynamicsFile =
+    dynamics:
+    let
+      settingsBlock = toDynamicsSettings dynamics;
+    in
+    "# GIMP dynamics file\n\n"
+    + "(name ${gimprc.renderScalar dynamics.name})\n"
+    + lib.optionalString (settingsBlock != { }) ("\n" + gimprc.toGimpConfiguration settingsBlock)
+    + "\n# end of GIMP dynamics file\n";
+}

--- a/modules/programs/gimp/gimprc.nix
+++ b/modules/programs/gimp/gimprc.nix
@@ -1,0 +1,132 @@
+{ lib }:
+
+let
+  # Generates a string of empty spaces for indentation
+  spaces = length: lib.fixedWidthString length " " "";
+
+  # The 'r', 'g', 'b', and 'a' attributes map directly to the literal target
+  # property names within the GIMP schema, so they are retained as-is.
+  isColor = value: builtins.isAttrs value && value ? r && value ? g && value ? b;
+
+  # Identifies explicit bare symbols (e.g. { symbol = "cursor-mode"; })
+  isSymbol = value: builtins.isAttrs value && builtins.attrNames value == [ "symbol" ];
+
+  # Validates and extracts a bare gimprc symbol token
+  renderSymbol =
+    { symbol }:
+    if builtins.isString symbol && builtins.match "[a-zA-Z0-9_][a-zA-Z0-9._-]*" symbol != null then
+      symbol
+    else
+      throw ''
+        gimp settings: { symbol = ${builtins.toJSON symbol}; } is not a valid bare gimprc symbol (must be a non-empty string of letters, digits, '.', '_' or '-', starting with a letter/digit/underscore).
+      '';
+
+  # GIMP's gimprc scanner (gimp_scanner_parse_double) only accepts numeric
+  # G_TOKEN_FLOAT/G_TOKEN_INT tokens for colour components
+  isNormalisedColorComponent = v: (builtins.isInt v || builtins.isFloat v) && v >= 0.0 && v <= 1.0;
+
+  renderColor =
+    {
+      r,
+      g,
+      b,
+      a ? 1.0,
+      ...
+    }:
+    if
+      isNormalisedColorComponent r
+      && isNormalisedColorComponent g
+      && isNormalisedColorComponent b
+      && isNormalisedColorComponent a
+    then
+      "(color-rgba ${toString r} ${toString g} ${toString b} ${toString a})"
+    else
+      throw ''
+        gimp settings: ${
+          builtins.toJSON {
+            inherit
+              r
+              g
+              b
+              a
+              ;
+          }
+        } is not a valid GIMP colour
+        (r, g, b, and the optional a must all be numbers normalised to 0.0-1.0).
+      '';
+
+  # Renders booleans to GIMP's yes/no format
+  renderBoolean = value: if value then "yes" else "no";
+
+  # Renders basic scalar types.
+  # Plain strings are ALWAYS quoted (GParamString) since we cannot infer schema.
+  # Use { symbol = "..."; } for unquoted identifiers (GParamEnum).
+  renderScalar =
+    value:
+    if builtins.isBool value then
+      renderBoolean value
+    else if builtins.isInt value || builtins.isFloat value then
+      toString value
+    else
+      "\"${lib.escape [ "\"" "\\" ] value}\"";
+
+  # Core formatting abstraction for key-value pairings used in both top-level and nested attrs
+  renderExpression =
+    indentation: key: value:
+    "${indentation}(${key} ${renderValue indentation value})";
+
+  # Recursively resolves any GIMP configuration value
+  renderValue =
+    indentation: value:
+    if isColor value then
+      renderColor value
+    else if isSymbol value then
+      renderSymbol value
+    else if builtins.isList value then
+      lib.concatMapStringsSep " " (v: renderValue indentation v) value
+    else if builtins.isAttrs value then
+      "\n"
+      + lib.concatStringsSep "\n" (lib.mapAttrsToList (renderExpression (indentation + spaces 4)) value)
+    else
+      renderScalar value;
+
+  # Converts a Nix attribute set into a full GIMP configuration block
+  toGimpConfiguration =
+    settings: lib.concatStringsSep "\n" (lib.mapAttrsToList (renderExpression "") settings) + "\n";
+
+  # Wraps settings in the standard GIMP file header and footer strings
+  toSExpressionFile =
+    fileType: settings:
+    "# GIMP ${fileType} file\n\n${toGimpConfiguration settings}\n# end of GIMP ${fileType} file\n";
+
+  gimpValueType = lib.mkOptionType {
+    name = "gimpValue";
+    description = "a GIMP s-expression value (boolean, number, string, symbol, color, list, or nested attribute set of GIMP values)";
+    check =
+      v:
+      builtins.isBool v
+      || builtins.isInt v
+      || builtins.isFloat v
+      || builtins.isString v
+      || isSymbol v
+      || isColor v
+      || (builtins.isList v && lib.all gimpValueType.check v)
+      || (builtins.isAttrs v && lib.all gimpValueType.check (builtins.attrValues v));
+    merge = location: definitions: lib.mergeOneOption location definitions;
+  };
+in
+{
+  inherit
+    gimpValueType
+    isColor
+    isSymbol
+    renderBoolean
+    renderColor
+    renderScalar
+    renderSymbol
+    renderValue
+    spaces
+    toGimpConfiguration
+    toSExpressionFile
+    ;
+}

--- a/modules/programs/gimp/gpl.nix
+++ b/modules/programs/gimp/gpl.nix
@@ -1,0 +1,17 @@
+{ lib }:
+let
+  padInt = n: lib.fixedWidthString 3 " " (toString n);
+  renderColor =
+    color:
+    "${padInt color.r} ${padInt color.g} ${padInt color.b}"
+    + lib.optionalString (color.name != "") "\t${color.name}";
+in
+{
+  toPaletteFile =
+    palette:
+    "GIMP Palette\n"
+    + "Name: ${palette.name}\n"
+    + lib.optionalString (palette.columns != 0) "Columns: ${toString palette.columns}\n"
+    + "#\n"
+    + lib.concatMapStrings (c: renderColor c + "\n") palette.colors;
+}

--- a/modules/programs/gimp/gtp.nix
+++ b/modules/programs/gimp/gtp.nix
@@ -1,0 +1,37 @@
+{ lib }:
+let
+  sexp = import ./gimprc.nix { inherit lib; };
+
+  renderToolOptions =
+    class: options:
+    if class == null && options == { } then
+      ""
+    else if class == null && options != { } then
+      throw "gimp toolPresets: toolOptions requires toolOptionsClass to be specified."
+    else if options == { } then
+      "(tool-options \"${class}\")\n"
+    else
+      let
+        renderPair = key: value: "    (${key} ${sexp.renderValue "    " value})";
+      in
+      "(tool-options \"${class}\"\n"
+      + lib.concatStringsSep "\n" (lib.mapAttrsToList renderPair options)
+      + ")\n";
+in
+{
+  toToolPresetFile =
+    preset:
+    "# GIMP tool preset file\n\n"
+    + lib.optionalString (preset.iconName != "") "(icon-name ${sexp.renderScalar preset.iconName})\n"
+    + "(name ${sexp.renderScalar preset.name})\n"
+    + renderToolOptions preset.toolOptionsClass preset.toolOptions
+    + "(use-fg-bg ${sexp.renderBoolean preset.useFgBg})\n"
+    + "(use-brush ${sexp.renderBoolean preset.useBrush})\n"
+    + "(use-dynamics ${sexp.renderBoolean preset.useDynamics})\n"
+    + "(use-mypaint-brush ${sexp.renderBoolean preset.useMypaintBrush})\n"
+    + "(use-gradient ${sexp.renderBoolean preset.useGradient})\n"
+    + "(use-pattern ${sexp.renderBoolean preset.usePattern})\n"
+    + "(use-palette ${sexp.renderBoolean preset.usePalette})\n"
+    + "(use-font ${sexp.renderBoolean preset.useFont})\n"
+    + "\n# end of GIMP tool preset file\n";
+}

--- a/modules/programs/gimp/myb.nix
+++ b/modules/programs/gimp/myb.nix
@@ -1,0 +1,18 @@
+{ lib }:
+let
+  renderSetting = setting: {
+    base_value = setting.baseValue;
+    inherit (setting) inputs;
+  };
+in
+{
+  toBrushFile =
+    brush:
+    builtins.toJSON {
+      inherit (brush) comment;
+      inherit (brush) group;
+      parent_brush_name = brush.parentBrushName;
+      inherit (brush) version;
+      settings = lib.mapAttrs (_: renderSetting) brush.settings;
+    };
+}

--- a/modules/programs/gimp/options/appearance.nix
+++ b/modules/programs/gimp/options/appearance.nix
@@ -1,0 +1,31 @@
+{ lib, ... }:
+let
+  inherit (lib) literalExpression mkOption types;
+in
+{
+  options.programs.gimp = {
+    themes = mkOption {
+      type = types.attrsOf types.path;
+      default = { };
+      example = literalExpression ''{ "MyDark" = ./my-dark-theme; }'';
+      description = ''
+        GTK theme directories installed to
+        {file}`$XDG_CONFIG_HOME/GIMP/<version>/themes/<name>/`.
+        Each value must be a directory containing at minimum `gtk-3.0/gtk.css`.
+        Select in GIMP under **Edit → Preferences → Interface → Theme**.
+      '';
+    };
+
+    icons = mkOption {
+      type = types.attrsOf types.path;
+      default = { };
+      example = literalExpression ''{ "Papirus" = "''${pkgs.papirus-icon-theme}/share/icons/Papirus"; }'';
+      description = ''
+        Icon theme directories installed to
+        {file}`$XDG_CONFIG_HOME/GIMP/<version>/icons/<name>/`.
+        Each value must be a directory containing an `index.theme` file.
+        Select in GIMP under **Edit → Preferences → Interface → Icon Theme**.
+      '';
+    };
+  };
+}

--- a/modules/programs/gimp/options/content.nix
+++ b/modules/programs/gimp/options/content.nix
@@ -1,0 +1,218 @@
+{ lib, ... }:
+let
+  inherit (lib) literalExpression mkOption types;
+in
+{
+  options.programs.gimp = {
+    brushes = mkOption {
+      type = types.attrsOf types.path;
+      default = { };
+      example = literalExpression ''{ "my-brush.gbr" = ./my-brush.gbr; }'';
+      description = ''
+        Brush files installed to {file}`$XDG_CONFIG_HOME/GIMP/<version>/brushes/`.
+        Supported formats: `.gbr` (raster), `.gih` (image hose), `.myb` (MyPaint).
+        For parametric brushes use {option}`programs.gimp.parametricBrushes`.
+      '';
+    };
+
+    parametricBrushes = mkOption {
+      type = types.attrsOf (
+        types.either types.path (
+          types.submodule {
+            options = {
+              name = mkOption {
+                type = types.str;
+                description = "Brush name shown in GIMP.";
+              };
+              spacing = mkOption {
+                type = types.float;
+                default = 25.0;
+                description = "Spacing between dabs as a percentage of brush diameter.";
+              };
+              radius = mkOption {
+                type = types.float;
+                description = "Brush radius in pixels.";
+              };
+              hardness = mkOption {
+                type = types.float;
+                default = 0.5;
+                description = "Edge hardness from 0.0 (soft) to 1.0 (hard).";
+              };
+              aspectRatio = mkOption {
+                type = types.float;
+                default = 1.0;
+                description = "Width-to-height ratio. 1.0 = circular.";
+              };
+              angle = mkOption {
+                type = types.float;
+                default = 0.0;
+                description = "Rotation angle in degrees.";
+              };
+              shape = mkOption {
+                type = types.nullOr (
+                  types.enum [
+                    "circle"
+                    "square"
+                    "diamond"
+                  ]
+                );
+                default = null;
+                description = ''
+                  Brush shape for version 1.5 shaped brushes.
+                  `null` produces a standard round brush (version 1.0).
+                '';
+              };
+              spikes = mkOption {
+                type = types.nullOr (types.ints.between 2 20);
+                default = null;
+                description = "Number of spikes for shaped brushes (2–20). Defaults to 2 when `shape` is non-null.";
+              };
+            };
+          }
+        )
+      );
+      default = { };
+      example = literalExpression ''
+        {
+          "soft-round.vbr" = { name = "Soft Round 20"; radius = 20.0; hardness = 0.25; };
+          "star.vbr"       = { name = "Star Brush"; radius = 15.0; shape = "circle"; spikes = 6; };
+        }
+      '';
+      description = ''
+        Parametric brush files (`.vbr`) installed to
+        {file}`$XDG_CONFIG_HOME/GIMP/<version>/brushes/`.
+        Values may be a path or a structured attrset rendered to VBR format.
+      '';
+    };
+
+    gradients = mkOption {
+      type = types.attrsOf (types.either types.path types.lines);
+      default = { };
+      example = literalExpression ''{ "sunset.ggr" = ./sunset.ggr; }'';
+      description = ''
+        Gradient files (`.ggr`) installed to
+        {file}`$XDG_CONFIG_HOME/GIMP/<version>/gradients/`.
+      '';
+    };
+
+    patterns = mkOption {
+      type = types.attrsOf types.path;
+      default = { };
+      example = literalExpression ''{ "concrete.pat" = ./concrete.pat; }'';
+      description = ''
+        Pattern files installed to {file}`$XDG_CONFIG_HOME/GIMP/<version>/patterns/`.
+        Supported formats: `.pat` and common image formats (`.png`, `.jpg`).
+      '';
+    };
+
+    palettes = mkOption {
+      type = types.attrsOf (
+        types.oneOf [
+          types.path
+          types.lines
+          (types.submodule {
+            options = {
+              name = mkOption {
+                type = types.str;
+                description = "Palette name shown in the Palettes dialog.";
+              };
+              columns = mkOption {
+                type = types.ints.between 0 255;
+                default = 0;
+                description = "Number of columns in the swatch grid. 0 = flowing layout.";
+              };
+              colors = mkOption {
+                type = types.listOf (
+                  types.submodule {
+                    options = {
+                      r = mkOption {
+                        type = types.ints.between 0 255;
+                        description = "Red (0–255).";
+                      };
+                      g = mkOption {
+                        type = types.ints.between 0 255;
+                        description = "Green (0–255).";
+                      };
+                      b = mkOption {
+                        type = types.ints.between 0 255;
+                        description = "Blue (0–255).";
+                      };
+                      name = mkOption {
+                        type = types.str;
+                        default = "";
+                        description = "Optional color label.";
+                      };
+                    };
+                  }
+                );
+                default = [ ];
+                description = "Ordered list of palette color entries.";
+              };
+            };
+          })
+        ]
+      );
+      default = { };
+      example = literalExpression ''
+        {
+          "brand.gpl" = {
+            name = "Brand Colors";
+            colors = [
+              { r = 255; g = 0;   b = 0;   name = "Red";   }
+              { r = 0;   g = 128; b = 0;   name = "Green"; }
+            ];
+          };
+        }
+      '';
+      description = ''
+        Palette files (`.gpl`) installed to
+        {file}`$XDG_CONFIG_HOME/GIMP/<version>/palettes/`.
+        Values may be a path, inline GPL text, or a structured attrset.
+      '';
+    };
+
+    scripts = mkOption {
+      type = types.attrsOf (types.either types.path types.lines);
+      default = { };
+      example = literalExpression ''
+        { "auto-save.scm" = "(define (auto-save image) (gimp-image-clean-all image))"; }
+      '';
+      description = ''
+        Script-Fu (`.scm`) scripts installed to
+        {file}`$XDG_CONFIG_HOME/GIMP/<version>/scripts/`.
+      '';
+    };
+
+    environ = mkOption {
+      type = types.attrsOf types.lines;
+      default = { };
+      example = literalExpression ''{ "python-path.env" = "PYTHONPATH=/my/site-packages"; }'';
+      description = ''
+        Environment files installed to {file}`$XDG_CONFIG_HOME/GIMP/<version>/environ/`.
+        Each file sets `KEY=VALUE` variables injected into plug-in processes at launch.
+      '';
+    };
+
+    fonts = mkOption {
+      type = types.either (types.attrsOf types.path) (types.listOf types.path);
+      default = [ ];
+      example = literalExpression ''[ "''${pkgs.inter}/share/fonts/truetype/inter/Inter-Regular.ttf" ]'';
+      description = ''
+        Font files installed to {file}`$XDG_CONFIG_HOME/GIMP/<version>/fonts/`.
+        May be specified as a list of font paths or as an attrset mapping destination font names to paths.
+        Available inside GIMP without a system-wide font install.
+      '';
+    };
+
+    plugins = mkOption {
+      type = types.attrsOf types.path;
+      default = { };
+      example = literalExpression ''{ "my-plugin/my-plugin" = "''${pkgs.my-gimp-plugin}/bin/my-plugin"; }'';
+      description = ''
+        Plug-in files installed to {file}`$XDG_CONFIG_HOME/GIMP/<version>/plug-ins/`.
+        Each plug-in must live in a subdirectory with the same name as the executable
+        (e.g. `"my-plugin/my-plugin"`).
+      '';
+    };
+  };
+}

--- a/modules/programs/gimp/options/gimprc.nix
+++ b/modules/programs/gimp/options/gimprc.nix
@@ -1,0 +1,103 @@
+{ lib, ... }:
+let
+  inherit (lib) literalExpression mkOption types;
+
+  scalarType = types.oneOf [
+    types.bool
+    types.int
+    types.float
+    types.str
+  ];
+
+  nestedSettingsType = lib.mkOptionType {
+    name = "nestedSettings";
+    description = "a scalar value or an arbitrarily deeply nested attribute set of settings";
+    check =
+      value:
+      scalarType.check value
+      || (builtins.isAttrs value && lib.all nestedSettingsType.check (builtins.attrValues value));
+    merge =
+      location: definitions:
+      let
+        isAttrSet = d: builtins.isAttrs d.value;
+        attrDefs = builtins.filter isAttrSet definitions;
+        scalarDefs = builtins.filter (d: !isAttrSet d) definitions;
+      in
+      if scalarDefs != [ ] && attrDefs != [ ] then
+        throw "Conflict at ${lib.showFiles location}: cannot merge a scalar value with a nested attribute set."
+      else if attrDefs != [ ] then
+        (types.attrsOf nestedSettingsType).merge location attrDefs
+      else
+        scalarType.merge location scalarDefs;
+  };
+in
+{
+  options.programs.gimp = {
+    settings = mkOption {
+      type = types.attrsOf nestedSettingsType;
+      default = { };
+      example = literalExpression ''
+        {
+          undo-levels        = 5;
+          tile-cache-size    = { symbol = "4g"; };
+          interpolation-type = { symbol = "cubic"; };
+          default-brush      = "2. Hardness 050";
+          show-tooltips      = false;
+          default-image = {
+            width  = 1920;
+            height = 1080;
+            unit   = { symbol = "pixels"; };
+          };
+          quick-mask-color = { r = 1.0; g = 0.0; b = 0.0; a = 0.5; };
+          default-grid = {
+            xspacing = 10.0;
+            yspacing = 10.0;
+            fgcolor  = { r = 0.0; g = 0.0; b = 0.0; };
+            bgcolor  = { r = 1.0; g = 1.0; b = 1.0; };
+          };
+        }
+      '';
+      description = ''
+        Settings written to {file}`$XDG_CONFIG_HOME/GIMP/<version>/gimprc`
+        as `(key value)` S-expression lines.
+
+        Scalar value rules:
+        - Booleans → `yes` / `no`
+        - Integers and floats → bare number
+        - Strings → `"double-quoted"` (this is what most GIMP properties,
+          including ones that look like bare words, actually expect - e.g.
+          `theme`, or the `brush`/`gradient`/`tool` keys GIMP itself writes
+          into `.gtp` tool presets, are all quoted strings)
+        - `{ symbol = "..."; }` → unquoted symbol/atom, for the minority of
+          properties that need one instead (GIMP's `GParamEnum` properties
+          such as `cursor-mode` or `unit`, and bare-suffix tokens such as
+          `tile-cache-size = { symbol = "4g"; }`). Getting this wrong in
+          either direction is a fatal gimprc parse error that makes GIMP
+          discard the whole file and fall back to defaults, so when in doubt
+          leave a value as a plain string first.
+
+        Colour values: an attrset with `r`, `g`, `b` keys (normalised floats
+        `0.0`–`1.0`) renders as a GIMP colour S-expression. The `a` key is
+        optional and defaults to `1.0` (opaque). `r`/`g`/`b`/`a` must be
+        numbers in `0.0`–`1.0`; e.g. 0-255 values (as used by
+        {option}`programs.gimp.palettes` `.gpl` entries) are out of range
+        here and will fail to evaluate rather than silently rendering an
+        out-of-gamut colour.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        (default-image
+            (width 1920)
+            (height 1080)
+            (unit pixels))
+      '';
+      description = ''
+        Raw gimprc lines appended after {option}`programs.gimp.settings`.
+      '';
+    };
+  };
+}

--- a/modules/programs/gimp/options/input.nix
+++ b/modules/programs/gimp/options/input.nix
@@ -1,0 +1,110 @@
+{ lib, ... }:
+let
+  inherit (lib) literalExpression mkOption types;
+in
+{
+  options.programs.gimp = {
+    keyboardShortcuts = mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          options = {
+            modifiers = mkOption {
+              type = types.listOf (
+                types.enum [
+                  "primary"
+                  "shift"
+                  "alt"
+                  "super"
+                ]
+              );
+              default = [ ];
+              description = "`primary` is Ctrl on Linux/Windows and Cmd on macOS.";
+            };
+            key = mkOption {
+              type = types.str;
+              default = "";
+              description = ''
+                Key name such as `"c"`, `"Return"`, or `"F1"`.
+                Leave empty with no modifiers to unassign the shortcut.
+              '';
+            };
+          };
+        }
+      );
+      default = { };
+      example = literalExpression ''
+        {
+          "edit-copy"  = { modifiers = [ "primary" ];         key = "c"; };
+          "edit-undo"  = { modifiers = [ "primary" "shift" ]; key = "z"; };
+          "file-quit"  = { modifiers = [ "primary" ];         key = "q"; };
+          "select-all" = { };
+        }
+      '';
+      description = ''
+        Keyboard shortcuts written to {file}`$XDG_CONFIG_HOME/GIMP/<version>/shortcutsrc`.
+        An empty attrset `{ }` writes `(action "name")`, unassigning that shortcut.
+        Note: GIMP rewrites `shortcutsrc` on exit.
+      '';
+    };
+
+    controllers = mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          options = {
+            enabled = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Whether this controller is active.";
+            };
+            events = mkOption {
+              type = types.listOf (
+                types.submodule {
+                  options = {
+                    stroke = mkOption {
+                      type = types.str;
+                      description = "Input event identifier, e.g. `\"key-cursor-up\"`.";
+                    };
+                    action = mkOption {
+                      type = types.str;
+                      description = "GIMP action path, e.g. `\"tools/gimp-paintbrush\"`.";
+                    };
+                  };
+                }
+              );
+              default = [ ];
+              description = "Stroke → action bindings for this controller.";
+            };
+          };
+        }
+      );
+      default = { };
+      example = literalExpression ''
+        {
+          GimpControllerKeyboard = {
+            enabled = true;
+            events  = [ { stroke = "key-cursor-up"; action = "tools/gimp-paintbrush"; } ];
+          };
+          GimpControllerMouse = { enabled = false; events = []; };
+        }
+      '';
+      description = ''
+        Input device controllers written to
+        {file}`$XDG_CONFIG_HOME/GIMP/<version>/controllerrc`.
+
+        Attribute names are GIMP controller type names such as
+        `GimpControllerKeyboard`, `GimpControllerMouse`, `GimpControllerWheel`.
+
+        Note: GIMP rewrites `controllerrc` on exit.
+      '';
+    };
+
+    extraControllerrc = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Raw lines appended after the generated `controllerrc`.
+        Use for controller types not expressible via {option}`programs.gimp.controllers`.
+      '';
+    };
+  };
+}

--- a/modules/programs/gimp/options/paint.nix
+++ b/modules/programs/gimp/options/paint.nix
@@ -1,0 +1,185 @@
+{ lib, ... }:
+
+let
+  inherit (lib)
+    literalExpression
+    mapAttrs
+    mkOption
+    types
+    ;
+
+  # Standardized type wrapper for GIMP resources that can be a file path,
+  # inline raw strings, or a structured attribute set.
+  resourceCollectionType =
+    options:
+    types.attrsOf (
+      types.oneOf [
+        types.path
+        types.lines
+        (types.submodule { inherit options; })
+      ]
+    );
+
+  gimprc = import ../gimprc.nix { inherit lib; };
+  inherit (gimprc) gimpValueType;
+
+  # --- Tool Preset Helpers ---
+
+  toolPresetLocks = {
+    useFgBg = "foreground/background colours";
+    useBrush = "brush selection";
+    useDynamics = "paint dynamics";
+    useMypaintBrush = "MyPaint brush selection";
+    useGradient = "gradient selection";
+    usePattern = "pattern selection";
+    usePalette = "palette selection";
+    useFont = "font selection";
+  };
+in
+{
+  options.programs.gimp = {
+    dynamics = mkOption {
+      type = resourceCollectionType {
+        name = mkOption {
+          type = types.str;
+          description = "Dynamics preset name shown in the Dynamics dialog.";
+        };
+        settings = mkOption {
+          type = types.attrsOf gimpValueType;
+          default = { };
+          description = "Freeform dynamics settings and output channels (e.g. `\"opacity-output\".\"use-pressure\" = true;`).";
+        };
+      };
+      default = { };
+      example = literalExpression ''
+        {
+          "pressure-opacity.gdyn" = {
+            name = "Pressure Opacity";
+            settings."opacity-output"."use-pressure" = true;
+            settings."size-output"."use-pressure"    = true;
+          };
+        }
+      '';
+      description = ''
+        Paint dynamics files (`.gdyn`) installed to
+        {file}`$XDG_CONFIG_HOME/GIMP/<version>/dynamics/`.
+
+        Values may be a path, inline text, or a structured attrset.
+      '';
+    };
+
+    toolPresets = mkOption {
+      type = resourceCollectionType (
+        {
+          name = mkOption {
+            type = types.str;
+            description = "Preset name shown in the Tool Presets dialog.";
+          };
+          iconName = mkOption {
+            type = types.str;
+            default = "";
+            description = "GTK icon name for this preset. Leave empty to omit.";
+          };
+          toolOptionsClass = mkOption {
+            type = types.nullOr types.nonEmptyStr;
+            default = null;
+            example = "GimpCropOptions";
+            description = "GIMP tool-options class name. Required when `toolOptions` is non-empty.";
+          };
+          toolOptions = mkOption {
+            type = types.attrsOf gimpValueType;
+            default = { };
+            description = "Tool-specific key-value pairs rendered inside the `tool-options` block.";
+          };
+        }
+        // mapAttrs (
+          _name: target:
+          mkOption {
+            type = types.bool;
+            default = false;
+            description = "Lock ${target}.";
+          }
+        ) toolPresetLocks
+      );
+      default = { };
+      example = literalExpression ''
+        {
+          "portrait-crop.gtp" = {
+            name = "Portrait Crop 3×2";
+            iconName = "gimp-tool-crop";
+            toolOptionsClass = "GimpCropOptions";
+            toolOptions."fixed-rule-active" = true;
+          };
+        }
+      '';
+      description = ''
+        Tool preset files (`.gtp`) installed to
+        {file}`$XDG_CONFIG_HOME/GIMP/<version>/tool-presets/`.
+
+        Values may be a path, inline text, or a structured attrset.
+      '';
+    };
+
+    mypaintBrushes = mkOption {
+      type = resourceCollectionType {
+        comment = mkOption {
+          type = types.str;
+          default = "MyPaint brush file";
+          description = "Comment string embedded in the brush file.";
+        };
+        group = mkOption {
+          type = types.str;
+          default = "";
+          description = "Brush group name.";
+        };
+        parentBrushName = mkOption {
+          type = types.str;
+          default = "";
+          description = "Name of the parent brush this brush is based on.";
+        };
+        version = mkOption {
+          type = types.int;
+          default = 3;
+          description = "MyPaint brush file format version.";
+        };
+        settings = mkOption {
+          type = types.attrsOf (
+            types.submodule {
+              options = {
+                baseValue = mkOption {
+                  type = types.float;
+                  description = "Base value for this setting.";
+                };
+                inputs = mkOption {
+                  type = types.attrsOf (types.listOf (types.listOf types.float));
+                  default = { };
+                  description = "Map from input-source name to [[x,y]…] control points.";
+                };
+              };
+            }
+          );
+          default = { };
+          description = "Brush settings map. Keys are MyPaint setting names like `radius_logarithmic`, `hardness`.";
+        };
+      };
+      default = { };
+      example = literalExpression ''
+        {
+          "ink-dry.myb" = {
+            settings.radius_logarithmic = {
+              baseValue = 2.0;
+              inputs.pressure = [ [ 0.0 0.0 ] [ 1.0 1.0 ] ];
+            };
+            settings.hardness.baseValue = 0.9;
+          };
+        }
+      '';
+      description = ''
+        MyPaint brush files (`.myb`) installed to {file}`~/.mypaint/brushes/`.
+
+        Values may be a path, inline JSON text, or a structured attrset
+        serialised to the MyPaint brush JSON format.
+      '';
+    };
+  };
+}

--- a/modules/programs/gimp/shortcutsrc.nix
+++ b/modules/programs/gimp/shortcutsrc.nix
@@ -1,0 +1,31 @@
+{ lib }:
+
+let
+  gimprc = import ./gimprc.nix { inherit lib; };
+
+  modifierMap = {
+    primary = "<Primary>";
+    shift = "<Shift>";
+    alt = "<Alt>";
+    super = "<Super>";
+  };
+in
+{
+  toShortcutSource =
+    shortcuts:
+    let
+      formatAction =
+        name: short:
+        let
+          modifierString = lib.concatMapStrings (modifier: modifierMap.${modifier}) short.modifiers;
+          binding = "${modifierString}${short.key}";
+        in
+        if binding == "" then
+          "(action ${gimprc.renderScalar name})"
+        else
+          "(action ${gimprc.renderScalar name} ${gimprc.renderScalar binding})";
+
+      lines = [ "(file-version 1)" ] ++ lib.mapAttrsToList formatAction shortcuts ++ [ "" ];
+    in
+    lib.concatStringsSep "\n" lines;
+}

--- a/modules/programs/gimp/vbr.nix
+++ b/modules/programs/gimp/vbr.nix
@@ -1,0 +1,24 @@
+{ lib }:
+{
+  toVbrFile =
+    brush:
+    lib.concatStringsSep "\n" (
+      [
+        "GIMP-VBR"
+        (if brush.shape == null then "1.0" else "1.5")
+        brush.name
+      ]
+      ++ lib.optional (brush.shape != null) brush.shape
+      ++ [
+        (toString brush.spacing)
+        (toString brush.radius)
+      ]
+      ++ lib.optional (brush.shape != null) (toString (if brush.spikes == null then 2 else brush.spikes))
+      ++ [
+        (toString brush.hardness)
+        (toString brush.aspectRatio)
+        (toString brush.angle)
+        ""
+      ]
+    );
+}

--- a/tests/modules/programs/gimp/default.nix
+++ b/tests/modules/programs/gimp/default.nix
@@ -1,0 +1,9 @@
+{
+  gimp-settings = ./gimp-settings.nix;
+  gimp-content = ./gimp-content.nix;
+  gimp-controllers = ./gimp-controllers.nix;
+  gimp-null-package = ./gimp-null-package.nix;
+  gimp-config-version = ./gimp-config-version.nix;
+  gimp-prefer-xdg = ./gimp-prefer-xdg.nix;
+  gimp-exact-output = ./gimp-exact-output.nix;
+}

--- a/tests/modules/programs/gimp/gimp-config-version.nix
+++ b/tests/modules/programs/gimp/gimp-config-version.nix
@@ -1,0 +1,30 @@
+{ config, pkgs, ... }:
+# Verifies no files leak into the GIMP/3.0/ directory.
+{
+  home.enableNixpkgsReleaseCheck = false;
+
+  programs.gimp = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "gimp";
+      outPath = "@gimp@";
+      version = "3.2.0";
+    };
+
+    settings.single-window-mode = true;
+  };
+
+  nmt.script =
+    let
+      base =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "home-files/Library/Application Support/GIMP"
+        else
+          "home-files/.config/GIMP";
+    in
+    ''
+      assertFileExists "${base}/3.2/gimprc"
+      assertFileRegex "${base}/3.2/gimprc" "(single-window-mode yes)"
+      assertPathNotExists "${base}/3.0/gimprc"
+    '';
+}

--- a/tests/modules/programs/gimp/gimp-content.nix
+++ b/tests/modules/programs/gimp/gimp-content.nix
@@ -1,0 +1,141 @@
+{ config, pkgs, ... }:
+# content subdirectory options testing
+{
+  home.enableNixpkgsReleaseCheck = false;
+
+  programs.gimp = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "gimp";
+      outPath = "@gimp@";
+      version = "3.0.8";
+    };
+
+    brushes."my-brush.gbr" = builtins.toFile "my-brush.gbr" "GIMP brush";
+    gradients."sunset.ggr" = "GIMP Gradient\nName: Sunset\n";
+    patterns."concrete.pat" = builtins.toFile "concrete.pat" "GIMP pattern";
+    scripts."hello.scm" = "(define (hello) (gimp-message \"Hello World\"))";
+    environ."python.env" = "PYTHONPATH=/my/site-packages";
+
+    palettes = {
+      "brand.gpl" = {
+        name = "Brand";
+        columns = 5;
+        colors = [
+          {
+            r = 255;
+            g = 0;
+            b = 0;
+            name = "Red";
+          }
+        ];
+      };
+      # columns = 0 (default) must NOT emit a Columns: line
+      "simple.gpl" = {
+        name = "Simple";
+        colors = [
+          {
+            r = 10;
+            g = 20;
+            b = 30;
+          }
+        ];
+      };
+    };
+
+    dynamics."velocity.gdyn" = {
+      name = "Velocity";
+      settings."opacity-output" = {
+        use-velocity = true;
+        use-pressure = false;
+      };
+    };
+
+    toolPresets."portrait-crop.gtp" = {
+      name = "Portrait Crop";
+      iconName = "gimp-tool-crop";
+      toolOptionsClass = "GimpCropOptions";
+      toolOptions."fixed-rule-active" = true;
+    };
+
+    mypaintBrushes."ink.myb" = {
+      parentBrushName = "classic/ink";
+      settings.radius_logarithmic = {
+        baseValue = 2.0;
+        inputs.pressure = [
+          [
+            0.0
+            0.0
+          ]
+          [
+            1.0
+            1.0
+          ]
+        ];
+      };
+    };
+
+    parametricBrushes = {
+      "round.vbr" = {
+        name = "Round 20";
+        radius = 20.0;
+      };
+      # shape set → version 1.5
+      "star.vbr" = {
+        name = "Star";
+        radius = 15.0;
+        shape = "circle";
+        spikes = 6;
+      };
+    };
+
+    fonts =
+      let
+        fakeFont = pkgs.runCommand "fake-inter" { } ''
+          mkdir -p "$out"
+          printf 'fake ttf' > "$out/Inter-Regular.ttf"
+        '';
+      in
+      [ "${fakeFont}/Inter-Regular.ttf" ];
+
+    plugins."my-plugin/my-plugin" = builtins.toFile "my-plugin" "#!/bin/sh\necho hello";
+
+    themes."MyDark" = pkgs.runCommand "fake-theme" { } ''
+      mkdir -p "$out/gtk-3.0"
+      echo '* { color: black; }' > "$out/gtk-3.0/gtk.css"
+    '';
+
+    icons."Papirus" = pkgs.runCommand "fake-icons" { } ''
+      mkdir -p "$out"
+      printf '[Icon Theme]\nName=Papirus\n' > "$out/index.theme"
+    '';
+  };
+
+  nmt.script =
+    let
+      d =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "home-files/Library/Application Support/GIMP/3.0"
+        else
+          "home-files/.config/GIMP/3.0";
+    in
+    ''
+      assertFileRegex    "${d}/palettes/brand.gpl"          "Columns: 5"
+      assertFileNotRegex "${d}/palettes/simple.gpl"         "Columns:"
+      assertFileRegex    "${d}/dynamics/velocity.gdyn"      "use-velocity yes"
+      assertFileRegex    "${d}/dynamics/velocity.gdyn"      "use-pressure no"
+      assertFileRegex    "${d}/tool-presets/portrait-crop.gtp" "gimp-tool-crop"
+      assertFileRegex    "${d}/tool-presets/portrait-crop.gtp" "fixed-rule-active yes"
+      assertFileRegex    "${d}/tool-presets/portrait-crop.gtp" "use-font no"
+      # MyPaint brushes bypass the GIMP config directory and XDG prefs entirely;
+      # they always land at ~/.mypaint/brushes/ (see programs.gimp.mypaintBrushes).
+      assertFileRegex    "home-files/.mypaint/brushes/ink.myb" "base_value"
+      assertFileRegex    "${d}/brushes/round.vbr"           "^1\.0$"
+      assertFileRegex    "${d}/brushes/star.vbr"            "^1\.5$"
+
+      assertFileExists "${d}/fonts/Inter-Regular.ttf"
+      assertFileExists "${d}/plug-ins/my-plugin/my-plugin"
+      assertFileExists "${d}/themes/MyDark/gtk-3.0/gtk.css"
+      assertFileExists "${d}/icons/Papirus/index.theme"
+    '';
+}

--- a/tests/modules/programs/gimp/gimp-controllers.nix
+++ b/tests/modules/programs/gimp/gimp-controllers.nix
@@ -1,0 +1,72 @@
+{ config, pkgs, ... }:
+# Covers the full controllerrcc rendering and shortcutsrc renderring
+{
+  home.enableNixpkgsReleaseCheck = false;
+
+  programs.gimp = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "gimp";
+      outPath = "@gimp@";
+      version = "3.0.8";
+    };
+
+    controllers = {
+      GimpControllerKeyboard = {
+        enabled = true;
+        events = [
+          {
+            stroke = "key-cursor-up";
+            action = "tools/gimp-paintbrush";
+          }
+        ];
+      };
+      GimpControllerMouse = {
+        enabled = false;
+        events = [ ];
+      };
+    };
+
+    extraControllerrc = "(gimp-controllers-extra (GimpInputDeviceCoords (enabled yes) (events ())))\n";
+
+    keyboardShortcuts = {
+      "edit-copy" = {
+        modifiers = [ "primary" ];
+        key = "c";
+      };
+      "edit-undo" = {
+        modifiers = [
+          "primary"
+          "shift"
+        ];
+        key = "z";
+      };
+      "gimp-quit" = {
+        key = "q";
+      };
+      "file-new" = { };
+    };
+  };
+
+  nmt.script =
+    let
+      d =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "home-files/Library/Application Support/GIMP/3.0"
+        else
+          "home-files/.config/GIMP/3.0";
+    in
+    ''
+      assertFileRegex "${d}/controllerrc" "enabled yes"
+      assertFileRegex "${d}/controllerrc" "key-cursor-up"
+      assertFileRegex "${d}/controllerrc" "enabled no"
+      assertFileRegex "${d}/controllerrc" 'mapping'
+      assertFileRegex "${d}/controllerrc" 'gimp-controllers-extra'
+
+
+      assertFileRegex "${d}/shortcutsrc" '"edit-copy" "<Primary>c"'
+      assertFileRegex "${d}/shortcutsrc" '"edit-undo" "<Primary><Shift>z"'
+      assertFileRegex "${d}/shortcutsrc" '"gimp-quit" "q"'
+      assertFileRegex "${d}/shortcutsrc" '(action "file-new")'
+    '';
+}

--- a/tests/modules/programs/gimp/gimp-exact-output.nix
+++ b/tests/modules/programs/gimp/gimp-exact-output.nix
@@ -1,0 +1,143 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  # Unit-tests the gimprc `{ r, g, b, a }` colour renderer directly
+  sexp = import ../../../../modules/programs/gimp/gimprc.nix { inherit lib; };
+
+  tryRenderColor = color: builtins.tryEval (sexp.renderColor color);
+
+  validOpaqueBlack = tryRenderColor {
+    r = 0.0;
+    g = 0.0;
+    b = 0.0;
+  };
+  validBoundaryInts = tryRenderColor {
+    r = 0;
+    g = 1;
+    b = 1;
+    a = 1;
+  };
+
+  invalidStringComponent = tryRenderColor {
+    r = "1.0";
+    g = 0.0;
+    b = 0.0;
+  };
+  invalidBoolComponent = tryRenderColor {
+    r = true;
+    g = 0.0;
+    b = 0.0;
+  };
+  invalidOutOfRangeHigh = tryRenderColor {
+    # easy to reach for by analogy with 0-255 .gpl palette colours
+    r = 255;
+    g = 0;
+    b = 0;
+  };
+  invalidOutOfRangeLow = tryRenderColor {
+    r = -0.1;
+    g = 0.0;
+    b = 0.0;
+  };
+  invalidNullAlpha = tryRenderColor {
+    r = 0.0;
+    g = 0.0;
+    b = 0.0;
+    a = null;
+  };
+in
+{
+  home.enableNixpkgsReleaseCheck = false;
+
+  programs.gimp = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "gimp";
+      outPath = "@gimp@";
+      version = "3.0.8";
+    };
+
+    settings = {
+      quick-mask-color = {
+        r = 1.0;
+        g = 0.0;
+        b = 0.0;
+        a = 0.5;
+      };
+    };
+
+    controllers = {
+      GimpControllerMouse = {
+        enabled = false;
+        events = [ ];
+      };
+    };
+
+    dynamics = {
+      "custom.gdyn" = {
+        name = "Custom Dynamics";
+        settings."opacity-output"."use-pressure" = true;
+        settings."force-output"."use-pressure" = true;
+      };
+    };
+
+    toolPresets = {
+      "crop.gtp" = {
+        name = "Crop 3x2";
+        toolOptionsClass = "GimpCropOptions";
+        toolOptions."fixed-rule-active" = true;
+      };
+      "minimal.gtp" = {
+        name = "Minimal Preset";
+      };
+    };
+
+    parametricBrushes = {
+      "star.vbr" = {
+        name = "Star Brush";
+        radius = 10.0;
+        shape = "circle";
+        spikes = 5;
+      };
+    };
+
+    fonts = {
+      "custom-font.ttf" = pkgs.writeText "font.ttf" "font-data";
+    };
+  };
+
+  nmt.script =
+    let
+      d =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "home-files/Library/Application Support/GIMP/3.0"
+        else
+          "home-files/.config/GIMP/3.0";
+    in
+    ''
+      assertFileRegex "${d}/gimprc" 'quick-mask-color .color-rgba 1.000000 0.000000 0.000000 0.500000.'
+      assertFileRegex "${d}/controllerrc" 'mapping'
+      assertFileRegex "${d}/dynamics/custom.gdyn" 'opacity-output'
+      assertFileRegex "${d}/dynamics/custom.gdyn" 'use-pressure yes'
+      assertFileRegex "${d}/dynamics/custom.gdyn" 'force-output'
+      assertFileRegex "${d}/tool-presets/crop.gtp" 'tool-options "GimpCropOptions"'
+      assertFileRegex "${d}/tool-presets/crop.gtp" 'fixed-rule-active yes'
+      assertFileExists "${d}/fonts/custom-font.ttf"
+
+      test '${builtins.toJSON validOpaqueBlack.success}' = 'true'
+      test '${builtins.toJSON validOpaqueBlack.value}' = '${builtins.toJSON "(color-rgba 0.000000 0.000000 0.000000 1.000000)"}'
+
+      test '${builtins.toJSON validBoundaryInts.success}' = 'true'
+      test '${builtins.toJSON validBoundaryInts.value}' = '${builtins.toJSON "(color-rgba 0 1 1 1)"}'
+
+      test '${builtins.toJSON invalidStringComponent.success}' = 'false'
+      test '${builtins.toJSON invalidBoolComponent.success}' = 'false'
+      test '${builtins.toJSON invalidOutOfRangeHigh.success}' = 'false'
+      test '${builtins.toJSON invalidOutOfRangeLow.success}' = 'false'
+      test '${builtins.toJSON invalidNullAlpha.success}' = 'false'
+    '';
+}

--- a/tests/modules/programs/gimp/gimp-null-package.nix
+++ b/tests/modules/programs/gimp/gimp-null-package.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+# package = null is valid: config files are still written, home.packages is empty.
+# configVersion has no package to derive a default from, so it must be set explicitly.
+{
+  home.enableNixpkgsReleaseCheck = false;
+
+  programs.gimp = {
+    enable = true;
+    package = null;
+    configVersion = "3.0";
+    settings.single-window-mode = true;
+  };
+
+  nmt.script =
+    let
+      configDir =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "home-files/Library/Application Support/GIMP/3.0"
+        else
+          "home-files/.config/GIMP/3.0";
+    in
+    ''
+      assertFileExists "${configDir}/gimprc"
+      assertFileRegex "${configDir}/gimprc" "(single-window-mode yes)"
+    '';
+}

--- a/tests/modules/programs/gimp/gimp-prefer-xdg.nix
+++ b/tests/modules/programs/gimp/gimp-prefer-xdg.nix
@@ -1,0 +1,24 @@
+{ config, ... }:
+# home.preferXdgDirectories = true forces XDG paths even on macOS,
+# overriding the default Library/Application Support placement on Darwin.
+{
+  home.enableNixpkgsReleaseCheck = false;
+  home.preferXdgDirectories = true;
+
+  programs.gimp = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "gimp";
+      outPath = "@gimp@";
+      version = "3.0.8";
+    };
+
+    settings.single-window-mode = true;
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/.config/GIMP/3.0/gimprc"
+    assertFileRegex "home-files/.config/GIMP/3.0/gimprc" "(single-window-mode yes)"
+    assertPathNotExists "home-files/Library/Application Support/GIMP/3.0/gimprc"
+  '';
+}

--- a/tests/modules/programs/gimp/gimp-settings.nix
+++ b/tests/modules/programs/gimp/gimp-settings.nix
@@ -1,0 +1,65 @@
+{ config, pkgs, ... }:
+# Covers gimprc scalar and colour rendering.
+{
+  home.enableNixpkgsReleaseCheck = false;
+
+  programs.gimp = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "gimp";
+      outPath = "@gimp@";
+      version = "3.0.8";
+    };
+
+    settings = {
+      single-window-mode = true; # bool to yes
+      show-tooltips = false;
+      undo-levels = 5; # int
+      tile-cache-size = {
+        symbol = "4g";
+      }; # memory value -- bare symbol, no quoting
+      interpolation-type = {
+        symbol = "cubic";
+      }; # identifier -- bare symbol, no quoting
+      default-brush = "2. Hardness 050"; # quoted (space + dot force quoting)
+      quick-mask-color = {
+        r = 1.0;
+        g = 0.0;
+        b = 0.0;
+        a = 0.5;
+      };
+      default-grid = {
+        xspacing = 10.0;
+        fgcolor = {
+          r = 0.0;
+          g = 0.0;
+          b = 0.0;
+        };
+      };
+    };
+
+    extraConfig = "(default-image (width 1920) (height 1080))\n";
+  };
+
+  nmt.script =
+    let
+      d =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "home-files/Library/Application Support/GIMP/3.0"
+        else
+          "home-files/.config/GIMP/3.0";
+    in
+    ''
+      assertFileRegex "${d}/gimprc" "(single-window-mode yes)"
+      assertFileRegex "${d}/gimprc" "(show-tooltips no)"
+      assertFileRegex "${d}/gimprc" "(tile-cache-size 4g)"
+      assertFileRegex "${d}/gimprc" "(interpolation-type cubic)"
+      assertFileRegex "${d}/gimprc" '(default-brush "2. Hardness 050")'
+
+      # color-rgba format
+      assertFileRegex "${d}/gimprc" 'quick-mask-color .color-rgba 1.000000 0.000000 0.000000 0.500000.'
+      assertFileRegex "${d}/gimprc" 'fgcolor'
+      assertFileRegex "${d}/gimprc" 'default-image'
+
+    '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This adds the GIMP module! This is a pretty huge PR, may be one of the largest modules, really went the extra mile to keep everything feeling super nix-like. There's probably a lot to finish out on the PR to make it better, just because I wanted it to support the full breadth of features, so review away :) 

Odd things:
- Null true doesn't really work because we need to know the version of the package to properly create the configuration folder, so there's an assertion to ensure this always holds.
- GIMP does write back, but when the configuration is write-only, it just writes to the next path on the chain.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
