### PR TITLE
git-credential-keepassxc: fix misplaced parentheses

### DIFF
--- a/modules/programs/git-credential-keepassxc.nix
+++ b/modules/programs/git-credential-keepassxc.nix
@@ -52,7 +52,7 @@ in
       if cfg.hosts == [ ] then
         helperConfig
       else
-        lib.listToAttrs (map (host: lib.nameValuePair host helperConfig)) cfg.hosts;
+        lib.listToAttrs (map (host: lib.nameValuePair host helperConfig) cfg.hosts);
   };
 
 }

--- a/tests/modules/programs/git-credential-keepassxc/custom-hosts.nix
+++ b/tests/modules/programs/git-credential-keepassxc/custom-hosts.nix
@@ -1,0 +1,13 @@
+{
+  programs.git.enable = true;
+  programs.git-credential-keepassxc = {
+    enable = true;
+    hosts = [ "https://codeberg.org" ];
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContains home-files/.config/git/config '[credential "https://codeberg.org"]'
+    assertFileRegex home-files/.config/git/config 'helper = "\S*/bin/git-credential-keepassxc --git-groups"'
+  '';
+}

--- a/tests/modules/programs/git-credential-keepassxc/default.nix
+++ b/tests/modules/programs/git-credential-keepassxc/default.nix
@@ -1,4 +1,5 @@
 {
   git-credential-keepassxc-default-config = ./default-config.nix;
   git-credential-keepassxc-custom-groups = ./custom-groups.nix;
+  git-credential-keepassxc-custom-hosts = ./custom-hosts.nix;
 }


### PR DESCRIPTION
### Description

I noticed that when I do this:
```nix
{
  programs.git-credential-keepassxc = {
    enable = true;
    hosts = [ "https://codeberg.org" ];
  };
}
```

I got this error:

<details>

```
… while calling the 'listToAttrs' builtin
  at /nix/store/ph0npf16gpv2g0wlkl8w0x62h1hxzkxd-source/modules/programs/git-credential-keepassxc.nix:55:9:
    54|       else
    55|         lib.listToAttrs (map (host: lib.nameValuePair host helperConfig)) cfg.hosts;
      |         ^
    56|   };

… while evaluating the argument passed to builtins.listToAttrs

error: expected a list but found the partially applied built-in function 'map': «partially applied primop map»

note: trace involved the following derivations:
derivation 'home-manager-generation'
derivation 'home-manager-files'
```

</details>

So I patched that out.

Tested with `nix run .#tests -- git-credential-keepassxc`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
