### PR TITLE
fontconfig: document defaulting behavior on NixOS

### DIFF
--- a/modules/config/i18n.nix
+++ b/modules/config/i18n.nix
@@ -16,9 +16,10 @@
 # https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/pkgs/development/libraries/glibc/nix-locale-archive.patch
 
 {
-  lib,
-  pkgs,
   config,
+  lib,
+  nixosConfig,
+  pkgs,
   ...
 }:
 
@@ -55,9 +56,8 @@ in
 
         This option only applies to the Linux platform.
 
-        When Home Manager is configured with NixOS, the default value
-        will be set to {var}`i18n.glibcLocales` from the
-        system configuration.
+        If Home Manager is installed as a NixOS submodule, this
+        option defaults to NixOS' {var}`i18n.glibcLocales`.
       '';
       example = lib.literalExpression ''
         pkgs.glibcLocales.override {
@@ -65,9 +65,8 @@ in
           locales = [ "en_US.UTF-8/UTF-8" ];
         }
       '';
-      # NB. See nixos/default.nix for NixOS default.
-      default = pkgs.glibcLocales;
-      defaultText = lib.literalExpression "pkgs.glibcLocales";
+      default = nixosConfig.i18n.glibcLocales or pkgs.glibcLocales;
+      defaultText = lib.literalExpression "nixosConfig.i18n.glibcLocales or pkgs.glibcLocales";
     };
   };
 

--- a/modules/misc/fontconfig.nix
+++ b/modules/misc/fontconfig.nix
@@ -72,11 +72,13 @@ in
         type = lib.types.bool;
         default = false;
         description = ''
-          Whether to enable fontconfig configuration. This will, for
-          example, allow fontconfig to discover fonts and
-          configurations installed through
-          {var}`home.packages` and
-          {command}`nix-env`.
+          Whether to enable fontconfig configuration. This will, for example,
+          allow fontconfig to discover fonts and configurations installed through
+          {var}`home.packages` and {command}`nix-env`.
+
+          If Home Manager is installed as a NixOS submodule and
+          {var}`home-manager.useUserPackages` is enabled, this option defaults to the
+          value of NixOS' {var}`fonts.fontconfig.enable`.
         '';
       };
 

--- a/modules/misc/fontconfig.nix
+++ b/modules/misc/fontconfig.nix
@@ -5,6 +5,7 @@
 {
   config,
   lib,
+  nixosConfig,
   pkgs,
   ...
 }:
@@ -70,7 +71,6 @@ in
     fonts.fontconfig = {
       enable = lib.mkOption {
         type = lib.types.bool;
-        default = false;
         description = ''
           Whether to enable fontconfig configuration. This will, for example,
           allow fontconfig to discover fonts and configurations installed through
@@ -79,6 +79,17 @@ in
           If Home Manager is installed as a NixOS submodule and
           {var}`home-manager.useUserPackages` is enabled, this option defaults to the
           value of NixOS' {var}`fonts.fontconfig.enable`.
+        '';
+        # On NixOS, the per-user directory inside /etc/profiles is not known by
+        # fontconfig by default.
+        default =
+          nixosConfig != null
+          && nixosConfig.home-manager.useUserPackages
+          && nixosConfig.fonts.fontconfig.enable;
+        defaultText = lib.literalExpression ''
+          nixosConfig != null
+          && nixosConfig.home-manager.useUserPackages
+          && nixosConfig.fonts.fontconfig.enable;
         '';
       };
 

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -79,6 +79,9 @@ in
             config = {
               # The per-user directory inside /etc/profiles is not known by
               # fontconfig by default.
+              #
+              # When changing the following line, remember to reflect these
+              # changes in the description of 'fonts.fontconfig.enable'!
               fonts.fontconfig.enable = lib.mkDefault (cfg.useUserPackages && config.fonts.fontconfig.enable);
 
               # Inherit glibcLocales setting from NixOS.

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -68,29 +68,7 @@ in
   };
 
   config = lib.mkMerge [
-    {
-      home-manager = {
-        extraSpecialArgs.nixosConfig = config;
-
-        sharedModules = [
-          {
-            key = "home-manager#nixos-shared-module";
-
-            config = {
-              # The per-user directory inside /etc/profiles is not known by
-              # fontconfig by default.
-              #
-              # When changing the following line, remember to reflect these
-              # changes in the description of 'fonts.fontconfig.enable'!
-              fonts.fontconfig.enable = lib.mkDefault (cfg.useUserPackages && config.fonts.fontconfig.enable);
-
-              # Inherit glibcLocales setting from NixOS.
-              i18n.glibcLocales = lib.mkDefault config.i18n.glibcLocales;
-            };
-          }
-        ];
-      };
-    }
+    { home-manager.extraSpecialArgs.nixosConfig = config; }
 
     (mkIf (!cfg.startAsUserService && cfg.users != { }) {
       systemd.services = lib.mapAttrs' (


### PR DESCRIPTION
### Description

`fonts.fontconfig.enable` is, according to the documentation, disabled by default. However, when Home Manager is installed as a NixOS submodule and `home-manager.useUserPackages` is enabled, it defaults to NixOS' `fonts.fontconfig.enable`. This commit makes this behaviour transparent.

Closes #3966.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
