### PR TITLE
claude-code: fixes enableMcpIntegration option docstring

### DIFF
--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -94,7 +94,7 @@ in
       description = ''
         Whether to integrate the MCP servers config from
         {option}`programs.mcp.servers` into
-        {option}`programs.opencode.settings.mcp`.
+        {option}`programs.claude-code.mcpServers`.
 
         Note: Settings defined in {option}`programs.mcp.servers` are merged
         with {option}`programs.claude-code.mcpServers`, with Claude Code servers


### PR DESCRIPTION
### Description


Reading the docs for the `claude-code` module (https://nix-community.github.io/home-manager/options.xhtml#opt-programs.claude-code.enableMcpIntegration) I saw that the `enableMcpIntegration` referenced opencode's `programs.opencode.settings.mcp` for some reason.

I assume this is remains from a `opencode`'s module copy-pasta.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [n/a] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module (N/A)

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
