### PR TITLE
treewide: remove literalExpression where unneeded

### DIFF
--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -53,12 +53,10 @@ in
       quickPhrase = lib.mkOption {
         type = with lib.types; attrsOf str;
         default = { };
-        example = lib.literalExpression ''
-          {
-            smile = "（・∀・）";
-            angry = "(￣ー￣)";
-          }
-        '';
+        example = {
+          smile = "（・∀・）";
+          angry = "(￣ー￣)";
+        };
         description = "Quick phrases.";
       };
 
@@ -83,18 +81,16 @@ in
           description = ''
             The global options in `config` file in ini format.
           '';
-          example = lib.literalExpression ''
-            {
-              Behavior = {
-                ActiveByDefault = false;
-              };
-              Hotkey = {
-                EnumerateWithTriggerKeys = true;
-                EnumerateSkipFirst = false;
-                ModifierOnlyKeyTimeout = 250;
-              };
-            }
-          '';
+          example = {
+            Behavior = {
+              ActiveByDefault = false;
+            };
+            Hotkey = {
+              EnumerateWithTriggerKeys = true;
+              EnumerateSkipFirst = false;
+              ModifierOnlyKeyTimeout = 250;
+            };
+          };
         };
         inputMethod = lib.mkOption {
           type = lib.types.submodule {
@@ -104,18 +100,16 @@ in
           description = ''
             The input method configure in `profile` file in ini format.
           '';
-          example = lib.literalExpression ''
-            {
-              GroupOrder."0" = "Default";
-              "Groups/0" = {
-                Name = "Default";
-                "Default Layout" = "us";
-                DefaultIM = "pinyin";
-              };
-              "Groups/0/Items/0".Name = "keyboard-us";
-              "Groups/0/Items/1".Name = "pinyin";
-            }
-          '';
+          example = {
+            GroupOrder."0" = "Default";
+            "Groups/0" = {
+              Name = "Default";
+              "Default Layout" = "us";
+              DefaultIM = "pinyin";
+            };
+            "Groups/0/Items/0".Name = "keyboard-us";
+            "Groups/0/Items/1".Name = "pinyin";
+          };
         };
         addons = lib.mkOption {
           type = with lib.types; (attrsOf iniGlobalFormat.type);
@@ -124,12 +118,10 @@ in
             The addon configures in `conf` folder in ini format with global sections.
             Each item is written to the corresponding file.
           '';
-          example = lib.literalExpression ''
-            {
-              classicui.globalSection.Theme = "example";
-              pinyin.globalSection.EmojiEnabled = "True";
-            }
-          '';
+          example = {
+            classicui.globalSection.Theme = "example";
+            pinyin.globalSection.EmojiEnabled = "True";
+          };
         };
       };
 

--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -21,17 +21,18 @@ let
         config = lib.mkOption {
           type = lib.types.submodule (import ./launchd.nix);
           default = { };
-          example = lib.literalExpression ''
-            {
-              ProgramArguments = [ "/usr/bin/say" "Good afternoon" ];
-              StartCalendarInterval = [
-                {
-                  Hour = 12;
-                  Minute = 0;
-                }
-              ];
-            }
-          '';
+          example = {
+            ProgramArguments = [
+              "/usr/bin/say"
+              "Good afternoon"
+            ];
+            StartCalendarInterval = [
+              {
+                Hour = 12;
+                Minute = 0;
+              }
+            ];
+          };
           description = ''
             Define a launchd job. See {manpage}`launchd.plist(5)` for details.
           '';

--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -335,13 +335,15 @@ in
     settings = mkOption {
       type = types.submodule { freeformType = semanticConfType; };
       default = { };
-      example = literalExpression ''
-        {
-          sandbox = true;
-          show-trace = true;
-          system-features = [ "big-parallel" "kvm" "recursive-nix" ];
-        }
-      '';
+      example = {
+        sandbox = true;
+        show-trace = true;
+        system-features = [
+          "big-parallel"
+          "kvm"
+          "recursive-nix"
+        ];
+      };
       description = ''
         Configuration for Nix; see {manpage}`nix.conf(5)` for available options.
         The value declared here will be translated directly to the key-value pairs Nix expects.

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -296,19 +296,17 @@ in
         lib.mkOption {
           type = lib.types.nullOr qtctFormat.type;
           default = null;
-          example = lib.literalExpression ''
-            {
-              Appearance = {
-                style = "kvantum";
-                icon_theme = "Papirus-Dark";
-                standard_dialogs = "xdgdesktopportal";
-              };
-              Fonts = {
-                fixed = "\"DejaVuSansM Nerd Font Mono,12\"";
-                general = "\"DejaVu Sans,12\"";
-              };
-            }
-          '';
+          example = {
+            Appearance = {
+              style = "kvantum";
+              icon_theme = "Papirus-Dark";
+              standard_dialogs = "xdgdesktopportal";
+            };
+            Fonts = {
+              fixed = ''"DejaVuSansM Nerd Font Mono,12"'';
+              general = ''"DejaVu Sans,12"'';
+            };
+          };
           description = ''
             Qtct configuration. Writes settings to `${name}/${name}.conf`
             file. Lists will be translated to comma-separated strings.

--- a/modules/misc/xdg-desktop-entries.nix
+++ b/modules/misc/xdg-desktop-entries.nix
@@ -121,12 +121,10 @@ let
           This may override other values.
         '';
         default = { };
-        example = literalExpression ''
-          {
-            Keywords = "calc;math";
-            DBusActivatable = "false";
-          }
-        '';
+        example = {
+          Keywords = "calc;math";
+          DBusActivatable = "false";
+        };
       };
 
       actions = mkOption {
@@ -212,18 +210,22 @@ in
     '';
     default = { };
     type = types.attrsOf (types.submodule desktopEntry);
-    example = literalExpression ''
-      {
-        firefox = {
-          name = "Firefox";
-          genericName = "Web Browser";
-          exec = "firefox %U";
-          terminal = false;
-          categories = [ "Network" "WebBrowser" ];
-          mimeType = [ "text/html" "text/xml" ];
-        };
-      }
-    '';
+    example = {
+      firefox = {
+        name = "Firefox";
+        genericName = "Web Browser";
+        exec = "firefox %U";
+        terminal = false;
+        categories = [
+          "Network"
+          "WebBrowser"
+        ];
+        mimeType = [
+          "text/html"
+          "text/xml"
+        ];
+      };
+    };
   };
 
   config = lib.mkIf (config.xdg.desktopEntries != { }) {

--- a/modules/misc/xdg-mime-apps.nix
+++ b/modules/misc/xdg-mime-apps.nix
@@ -33,12 +33,14 @@ in
     associations.added = mkOption {
       type = types.attrsOf strListOrSingleton;
       default = { };
-      example = lib.literalExpression ''
-        {
-          "mimetype1" = [ "foo1.desktop" "foo2.desktop" "foo3.desktop" ];
-          "mimetype2" = "foo4.desktop";
-        }
-      '';
+      example = {
+        "mimetype1" = [
+          "foo1.desktop"
+          "foo2.desktop"
+          "foo3.desktop"
+        ];
+        "mimetype2" = "foo4.desktop";
+      };
       description = ''
         Defines additional associations of applications with
         mimetypes, as if the .desktop file was listing this mimetype
@@ -62,11 +64,12 @@ in
     defaultApplications = mkOption {
       type = types.attrsOf strListOrSingleton;
       default = { };
-      example = lib.literalExpression ''
-        {
-          "mimetype1" = [ "default1.desktop" "default2.desktop" ];
-        }
-      '';
+      example = {
+        "mimetype1" = [
+          "default1.desktop"
+          "default2.desktop"
+        ];
+      };
       description = ''
         The default application to be used for a given mimetype. This
         is, for instance, the one that will be started when

--- a/modules/misc/xdg-system-dirs.nix
+++ b/modules/misc/xdg-system-dirs.nix
@@ -22,7 +22,7 @@ in
     config = lib.mkOption {
       type = types.listOf types.str;
       default = [ ];
-      example = lib.literalExpression ''[ "/etc/xdg" ]'';
+      example = [ "/etc/xdg" ];
       description = ''
         Directory names to add to {env}`XDG_CONFIG_DIRS`
         in the user session.
@@ -32,7 +32,10 @@ in
     data = lib.mkOption {
       type = types.listOf types.str;
       default = [ ];
-      example = lib.literalExpression ''[ "/usr/share" "/usr/local/share" ]'';
+      example = [
+        "/usr/share"
+        "/usr/local/share"
+      ];
       description = ''
         Directory names to add to {env}`XDG_DATA_DIRS`
         in the user session.

--- a/modules/programs/aerc/accounts.nix
+++ b/modules/programs/aerc/accounts.nix
@@ -69,7 +69,9 @@ in
           extraAccounts = mkOption {
             type = confSection;
             default = { };
-            example = literalExpression ''{ source = "maildir://~/Maildir/example"; }'';
+            example = {
+              source = "maildir://~/Maildir/example";
+            };
             description = ''
               Extra config added to the configuration section for this account in
               {file}`$HOME/.config/aerc/accounts.conf`.
@@ -91,7 +93,11 @@ in
           extraConfig = mkOption {
             type = confSections;
             default = { };
-            example = literalExpression "{ ui = { sidebar-width = 25; }; }";
+            example = {
+              ui = {
+                sidebar-width = 25;
+              };
+            };
             description = ''
               Config specific to this account, added to {file}`$HOME/.config/aerc/aerc.conf`.
               Aerc only supports per-account UI configuration.

--- a/modules/programs/aerc/default.nix
+++ b/modules/programs/aerc/default.nix
@@ -72,7 +72,11 @@ in
     extraAccounts = mkOption {
       type = sectionsOrLines;
       default = { };
-      example = literalExpression ''{ Work = { source = "maildir://~/Maildir/work"; }; }'';
+      example = {
+        Work = {
+          source = "maildir://~/Maildir/work";
+        };
+      };
       description = ''
         Extra lines added to {file}`$HOME/.config/aerc/accounts.conf`.
 
@@ -83,7 +87,11 @@ in
     extraBinds = mkOption {
       type = sectionsOrLines;
       default = { };
-      example = literalExpression ''{ messages = { q = ":quit<Enter>"; }; }'';
+      example = {
+        messages = {
+          q = ":quit<Enter>";
+        };
+      };
       description = ''
         Extra lines added to {file}`$HOME/.config/aerc/binds.conf`.
         Global keybindings can be set in the `global` section.
@@ -95,7 +103,11 @@ in
     extraConfig = mkOption {
       type = sectionsOrLines;
       default = { };
-      example = literalExpression ''{ ui = { sort = "-r date"; }; }'';
+      example = {
+        ui = {
+          sort = "-r date";
+        };
+      };
       description = ''
         Extra lines added to {file}`$HOME/.config/aerc/aerc.conf`.
 

--- a/modules/programs/aerospace.nix
+++ b/modules/programs/aerospace.nix
@@ -103,43 +103,41 @@ in
     settings = mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          gaps = {
-            outer.left = 8;
-            outer.bottom = 8;
-            outer.top = 8;
-            outer.right = 8;
-          };
-          mode.main.binding = {
-            alt-h = "focus left";
-            alt-j = "focus down";
-            alt-k = "focus up";
-            alt-l = "focus right";
-          };
-          on-window-detected = [
-            {
-              "if".app-id = "com.apple.finder";
-              run = "move-node-to-workspace 9";
-            }
+      example = {
+        gaps = {
+          outer.left = 8;
+          outer.bottom = 8;
+          outer.top = 8;
+          outer.right = 8;
+        };
+        mode.main.binding = {
+          alt-h = "focus left";
+          alt-j = "focus down";
+          alt-k = "focus up";
+          alt-l = "focus right";
+        };
+        on-window-detected = [
+          {
+            "if".app-id = "com.apple.finder";
+            run = "move-node-to-workspace 9";
+          }
 
-            {
-              "if" = {
-                app-id = "com.apple.systempreferences";
-                app-name-regex-substring = "settings";
-                window-title-regex-substring = "substring";
-                workspace = "workspace-name";
-                during-aerospace-startup = true;
-              };
-              check-further-callbacks = true;
-              run = [
-                "layout floating"
-                "move-node-to-workspace S"
-              ];
-            }
-          ];
-        }
-      '';
+          {
+            "if" = {
+              app-id = "com.apple.systempreferences";
+              app-name-regex-substring = "settings";
+              window-title-regex-substring = "substring";
+              workspace = "workspace-name";
+              during-aerospace-startup = true;
+            };
+            check-further-callbacks = true;
+            run = [
+              "layout floating"
+              "move-node-to-workspace S"
+            ];
+          }
+        ];
+      };
       description = ''
         AeroSpace configuration, see
         <https://nikitabobko.github.io/AeroSpace/guide#configuring-aerospace>

--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -36,21 +36,19 @@ in
       settings = lib.mkOption {
         inherit (tomlFormat) type;
         default = { };
-        example = lib.literalExpression ''
-          {
-            window.dimensions = {
-              lines = 3;
-              columns = 200;
-            };
-            keyboard.bindings = [
-              {
-                key = "K";
-                mods = "Control";
-                chars = "\\u000c";
-              }
-            ];
-          }
-        '';
+        example = {
+          window.dimensions = {
+            lines = 3;
+            columns = 200;
+          };
+          keyboard.bindings = [
+            {
+              key = "K";
+              mods = "Control";
+              chars = "\\u000c";
+            }
+          ];
+        };
         description = ''
           Configuration written to
           {file}`$XDG_CONFIG_HOME/alacritty/alacritty.yml` or

--- a/modules/programs/alot/default.nix
+++ b/modules/programs/alot/default.nix
@@ -251,13 +251,11 @@ in
           handle_mouse = true;
           prefer_plaintext = true;
         };
-        example = lib.literalExpression ''
-          {
-            auto_remove_unread = true;
-            ask_subject = false;
-            thread_indent_replies = 2;
-          }
-        '';
+        example = {
+          auto_remove_unread = true;
+          ask_subject = false;
+          thread_indent_replies = 2;
+        };
         description = ''
           Configuration options added to alot configuration file.
         '';

--- a/modules/programs/aria2.nix
+++ b/modules/programs/aria2.nix
@@ -34,15 +34,13 @@ in
         {manpage}`aria2c(1)`
         for options.
       '';
-      example = lib.literalExpression ''
-        {
-          listen-port = 60000;
-          dht-listen-port = 60000;
-          seed-ratio = 1.0;
-          max-upload-limit = "50K";
-          ftp-pasv = true;
-        }
-      '';
+      example = {
+        listen-port = 60000;
+        dht-listen-port = 60000;
+        seed-ratio = 1.0;
+        max-upload-limit = "50K";
+        ftp-pasv = true;
+      };
     };
 
     systemd.enable = lib.mkEnableOption "Aria2 systemd integration";

--- a/modules/programs/astroid/default.nix
+++ b/modules/programs/astroid/default.nix
@@ -110,11 +110,9 @@ in
       extraConfig = mkOption {
         inherit (jsonFormat) type;
         default = { };
-        example = lib.literalExpression ''
-          {
-            poll.interval = 0;
-          }
-        '';
+        example = {
+          poll.interval = 0;
+        };
         description = ''
           JSON config that will override the default Astroid configuration.
         '';

--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -137,13 +137,23 @@ let
       transform = mkOption {
         type = types.nullOr (matrixOf 3 3 types.float);
         default = null;
-        example = literalExpression ''
+        example = [
           [
-            [ 0.6 0.0 0.0 ]
-            [ 0.0 0.6 0.0 ]
-            [ 0.0 0.0 1.0 ]
+            0.6
+            0.0
+            0.0
           ]
-        '';
+          [
+            0.0
+            0.6
+            0.0
+          ]
+          [
+            0.0
+            0.0
+            1.0
+          ]
+        ];
         description = ''
           Refer to
           {manpage}`xrandr(1)`
@@ -199,12 +209,10 @@ let
           exclusive.
         '';
         default = null;
-        example = literalExpression ''
-          {
-            x = 1.25;
-            y = 1.25;
-          }
-        '';
+        example = {
+          x = 1.25;
+          y = 1.25;
+        };
       };
 
       filter = mkOption {

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -158,12 +158,10 @@ in
       shellAliases = mkOption {
         default = { };
         type = types.attrsOf types.str;
-        example = lib.literalExpression ''
-          {
-            ll = "ls -l";
-            ".." = "cd ..";
-          }
-        '';
+        example = {
+          ll = "ls -l";
+          ".." = "cd ..";
+        };
         description = ''
           An attribute set that maps aliases (the top level attribute names in
           this option) to command strings or directly to build outputs.

--- a/modules/programs/bluetuith.nix
+++ b/modules/programs/bluetuith.nix
@@ -23,20 +23,18 @@ in
     settings = lib.mkOption {
       inherit (jsonFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          adapter = "hci0";
-          receive-dir = "/home/user/files";
+      example = {
+        adapter = "hci0";
+        receive-dir = "/home/user/files";
 
-          keybindings = {
-            Menu = "Alt+m";
-          };
+        keybindings = {
+          Menu = "Alt+m";
+        };
 
-          theme = {
-            Adapter = "red";
-          };
-        }
-      '';
+        theme = {
+          Adapter = "red";
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/bluetuith/bluetuith.conf`.

--- a/modules/programs/borgmatic.nix
+++ b/modules/programs/borgmatic.nix
@@ -118,15 +118,13 @@ let
 
               Mutually exclusive with [](#opt-programs.borgmatic.backups._name_.location.sourceDirectories).
             '';
-            example = literalExpression ''
-              [
-                "R /home/user"
-                "- home/user/.cache"
-                "- home/user/Downloads"
-                "+ home/user/Videos/Important Video"
-                "- home/user/Videos"
-              ]
-            '';
+            example = [
+              "R /home/user"
+              "- home/user/.cache"
+              "- home/user/Downloads"
+              "+ home/user/Videos/Important Video"
+              "- home/user/Videos"
+            ];
           };
 
           repositories = mkOption {

--- a/modules/programs/bottom.nix
+++ b/modules/programs/bottom.nix
@@ -32,18 +32,16 @@ in
           See <https://github.com/ClementTsang/bottom/blob/master/sample_configs/default_config.toml>
           for the default configuration.
         '';
-        example = lib.literalExpression ''
-          {
-            flags = {
-              avg_cpu = true;
-              temperature_type = "c";
-            };
+        example = {
+          flags = {
+            avg_cpu = true;
+            temperature_type = "c";
+          };
 
-            colors = {
-              low_battery_color = "red";
-            };
-          }
-        '';
+          colors = {
+            low_battery_color = "red";
+          };
+        };
       };
     };
   };

--- a/modules/programs/boxxy.nix
+++ b/modules/programs/boxxy.nix
@@ -55,12 +55,10 @@ let
       only = mkOption {
         type = types.listOf types.str;
         default = [ ];
-        example = literalExpression ''
-          [
-            "bash"
-            "/usr/bin/sh"
-          ]
-        '';
+        example = [
+          "bash"
+          "/usr/bin/sh"
+        ];
         description = ''
           Apply redirection ONLY to specified executable names.
         '';
@@ -78,11 +76,9 @@ let
       env = mkOption {
         type = types.attrsOf types.str;
         default = { };
-        example = literalExpression ''
-          {
-            MY_ENV_VAR = "my_env_var_value";
-          }
-        '';
+        example = {
+          MY_ENV_VAR = "my_env_var_value";
+        };
         description = ''
           Give certain environment variables for said match.
         '';

--- a/modules/programs/broot.nix
+++ b/modules/programs/broot.nix
@@ -83,24 +83,22 @@ let
       skin = mkOption {
         type = types.attrsOf types.str;
         default = { };
-        example = literalExpression ''
-          {
-            status_normal_fg = "grayscale(18)";
-            status_normal_bg = "grayscale(3)";
-            status_error_fg = "red";
-            status_error_bg = "yellow";
-            tree_fg = "red";
-            selected_line_bg = "grayscale(7)";
-            permissions_fg = "grayscale(12)";
-            size_bar_full_bg = "red";
-            size_bar_void_bg = "black";
-            directory_fg = "lightyellow";
-            input_fg = "cyan";
-            flag_value_fg = "lightyellow";
-            table_border_fg = "red";
-            code_fg = "lightyellow";
-          }
-        '';
+        example = {
+          status_normal_fg = "grayscale(18)";
+          status_normal_bg = "grayscale(3)";
+          status_error_fg = "red";
+          status_error_bg = "yellow";
+          tree_fg = "red";
+          selected_line_bg = "grayscale(7)";
+          permissions_fg = "grayscale(12)";
+          size_bar_full_bg = "red";
+          size_bar_void_bg = "black";
+          directory_fg = "lightyellow";
+          input_fg = "cyan";
+          flag_value_fg = "lightyellow";
+          table_border_fg = "red";
+          code_fg = "lightyellow";
+        };
         description = ''
           Color configuration.
 

--- a/modules/programs/bun.nix
+++ b/modules/programs/bun.nix
@@ -20,19 +20,17 @@ in
     settings = lib.mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          smol = true;
-          telemetry = false;
-          test = {
-            coverage = true;
-            coverageThreshold = 0.9;
-          };
-          install.lockfile = {
-            print = "yarn";
-          };
-        }
-      '';
+      example = {
+        smol = true;
+        telemetry = false;
+        test = {
+          coverage = true;
+          coverageThreshold = 0.9;
+        };
+        install.lockfile = {
+          print = "yarn";
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/.bunfig.toml`.

--- a/modules/programs/chawan.nix
+++ b/modules/programs/chawan.nix
@@ -24,15 +24,13 @@ in
 
         See {manpage}`cha-config(5)`
       '';
-      example = lib.literalExpression ''
-        {
-          buffer = {
-            images = true;
-            autofocus = true;
-          };
-          page."C-k" = "() => pager.load('ddg:')";
-        }
-      '';
+      example = {
+        buffer = {
+          images = true;
+          autofocus = true;
+        };
+        page."C-k" = "() => pager.load('ddg:')";
+      };
     };
   };
 

--- a/modules/programs/dbeaver.nix
+++ b/modules/programs/dbeaver.nix
@@ -39,17 +39,15 @@ in
     settings = mkOption {
       type = types.attrsOf (types.attrsOf types.str);
       default = { };
-      example = lib.literalExpression ''
-        {
-          "org.jkiss.dbeaver.core" = {
-            "ui.showSystemObjects" = "false";
-            "ui.showUtilityObjects" = "false";
-          };
-          "org.jkiss.dbeaver.model" = {
-            "read.expiration.period" = "10000";
-          };
-        }
-      '';
+      example = {
+        "org.jkiss.dbeaver.core" = {
+          "ui.showSystemObjects" = "false";
+          "ui.showUtilityObjects" = "false";
+        };
+        "org.jkiss.dbeaver.model" = {
+          "read.expiration.period" = "10000";
+        };
+      };
 
       description = ''
         DBeaver workspace preferences. Each attribute set key corresponds to
@@ -71,24 +69,22 @@ in
     dataSourcesSettings = mkOption {
       inherit (jsonFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          folders = { };
-          connections = {
-            "postgresql-local" = {
-              provider = "postgresql";
-              driver = "postgres-jdbc";
-              name = "Local PostgreSQL";
-              save-password = false;
-              configuration = {
-                host = "localhost";
-                port = "5432";
-                database = "mydb";
-              };
+      example = {
+        folders = { };
+        connections = {
+          "postgresql-local" = {
+            provider = "postgresql";
+            driver = "postgres-jdbc";
+            name = "Local PostgreSQL";
+            save-password = false;
+            configuration = {
+              host = "localhost";
+              port = "5432";
+              database = "mydb";
             };
           };
-        }
-      '';
+        };
+      };
 
       description = ''
         Configuration for DBeaver's `data-sources.json`. This file stores

--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -46,13 +46,11 @@ in
         See {command}`dircolors --print-database`
         for options.
       '';
-      example = lib.literalExpression ''
-        {
-          OTHER_WRITABLE = "30;46";
-          ".sh" = "01;32";
-          ".csh" = "01;32";
-        }
-      '';
+      example = {
+        OTHER_WRITABLE = "30;46";
+        ".sh" = "01;32";
+        ".csh" = "01;32";
+      };
     };
 
     extraConfig = mkOption {

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -469,16 +469,14 @@ in
       shellAbbrs = mkOption {
         type = with types; attrsOf (either str abbrModule);
         default = { };
-        example = literalExpression ''
-          {
-            l = "less";
-            gco = "git checkout";
-            "-C" = {
-              position = "anywhere";
-              expansion = "--color";
-            };
-          }
-        '';
+        example = {
+          l = "less";
+          gco = "git checkout";
+          "-C" = {
+            position = "anywhere";
+            expansion = "--color";
+          };
+        };
         description = ''
           An attribute set that maps aliases (the top level attribute names
           in this option) to abbreviations. Abbreviations are expanded with

--- a/modules/programs/flashspace.nix
+++ b/modules/programs/flashspace.nix
@@ -20,21 +20,19 @@ in
     settings = lib.mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          showFlashSpace = "cmd+shift+space";
-          toggleFlashSpace = "control+option+command+t";
-          showFloatingNotifications = true;
-          displayMode = "static";
-          centerCursorOnWorkspaceChange = true;
-          enableWorkspaceTransitions = true;
-          workspaceTransitionDuration = 0.25;
-          integrations = {
-            enableIntegrations = true;
-            runScriptOnWorkspaceChange = "~/.config/flashspace/scripts/notify.sh";
-          };
-        }
-      '';
+      example = {
+        showFlashSpace = "cmd+shift+space";
+        toggleFlashSpace = "control+option+command+t";
+        showFloatingNotifications = true;
+        displayMode = "static";
+        centerCursorOnWorkspaceChange = true;
+        enableWorkspaceTransitions = true;
+        workspaceTransitionDuration = 0.25;
+        integrations = {
+          enableIntegrations = true;
+          runScriptOnWorkspaceChange = "~/.config/flashspace/scripts/notify.sh";
+        };
+      };
       description = ''
         General app settings written to
         {file}`$XDG_CONFIG_HOME/flashspace/settings.toml`.
@@ -49,54 +47,52 @@ in
     profiles = lib.mkOption {
       inherit (jsonFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          profiles = [
-            {
-              id = "550e8400-e29b-41d4-a716-446655440000";
-              name = "Work";
-              shortcut = "control+option+1";
-              workspaces = [
-                {
-                  id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
-                  name = "Coding";
-                  display = "Built-in Retina Display";
-                  shortcut = "cmd+1";
-                  symbolIconName = "terminal.fill";
-                  openAppsOnActivation = true;
-                  apps = [
-                    {
-                      name = "Xcode";
-                      bundleIdentifier = "com.apple.dt.Xcode";
-                      autoOpen = true;
-                    }
-                    {
-                      name = "iTerm2";
-                      bundleIdentifier = "com.googlecode.iterm2";
-                      autoOpen = true;
-                    }
-                  ];
-                }
-                {
-                  id = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
-                  name = "Communication";
-                  display = "Built-in Retina Display";
-                  shortcut = "cmd+2";
-                  symbolIconName = "message.fill";
-                  openAppsOnActivation = false;
-                  apps = [
-                    {
-                      name = "Slack";
-                      bundleIdentifier = "com.tinyspeck.slackmacgap";
-                      autoOpen = false;
-                    }
-                  ];
-                }
-              ];
-            }
-          ];
-        }
-      '';
+      example = {
+        profiles = [
+          {
+            id = "550e8400-e29b-41d4-a716-446655440000";
+            name = "Work";
+            shortcut = "control+option+1";
+            workspaces = [
+              {
+                id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+                name = "Coding";
+                display = "Built-in Retina Display";
+                shortcut = "cmd+1";
+                symbolIconName = "terminal.fill";
+                openAppsOnActivation = true;
+                apps = [
+                  {
+                    name = "Xcode";
+                    bundleIdentifier = "com.apple.dt.Xcode";
+                    autoOpen = true;
+                  }
+                  {
+                    name = "iTerm2";
+                    bundleIdentifier = "com.googlecode.iterm2";
+                    autoOpen = true;
+                  }
+                ];
+              }
+              {
+                id = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
+                name = "Communication";
+                display = "Built-in Retina Display";
+                shortcut = "cmd+2";
+                symbolIconName = "message.fill";
+                openAppsOnActivation = false;
+                apps = [
+                  {
+                    name = "Slack";
+                    bundleIdentifier = "com.tinyspeck.slackmacgap";
+                    autoOpen = false;
+                  }
+                ];
+              }
+            ];
+          }
+        ];
+      };
       description = ''
         Profiles, workspaces, and app assignments written to
         {file}`$XDG_CONFIG_HOME/flashspace/profiles.json`.

--- a/modules/programs/foliate.nix
+++ b/modules/programs/foliate.nix
@@ -32,24 +32,22 @@ in
         the scheme is defined at
         <https://github.com/johnfactotum/foliate/blob/gtk4/data/com.github.johnfactotum.Foliate.gschema.xml>
       '';
-      example = lib.literalExpression ''
-        {
-          myTheme = {
-            color-scheme = 0;
-            library = {
-              view-mode = "grid";
-              show-covers = true;
-            };
-            "viewer/view" = {
-              theme = "myTheme.json";
-            };
-            "viewer/font" = {
-              monospace = "Maple Mono";
-              default-size = 12;
-            };
+      example = {
+        myTheme = {
+          color-scheme = 0;
+          library = {
+            view-mode = "grid";
+            show-covers = true;
           };
-        }
-      '';
+          "viewer/view" = {
+            theme = "myTheme.json";
+          };
+          "viewer/font" = {
+            monospace = "Maple Mono";
+            default-size = 12;
+          };
+        };
+      };
     };
     themes = mkOption {
       type = types.attrsOf (

--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -42,20 +42,18 @@ in
         {file}`$XDG_CONFIG_HOME/foot/foot.ini`. See <https://codeberg.org/dnkl/foot/src/branch/master/foot.ini>
         for a list of available options.
       '';
-      example = lib.literalExpression ''
-        {
-          main = {
-            term = "xterm-256color";
+      example = {
+        main = {
+          term = "xterm-256color";
 
-            font = "Fira Code:size=11";
-            dpi-aware = "yes";
-          };
+          font = "Fira Code:size=11";
+          dpi-aware = "yes";
+        };
 
-          mouse = {
-            hide-when-typing = "yes";
-          };
-        }
-      '';
+        mouse = {
+          hide-when-typing = "yes";
+        };
+      };
     };
   };
 

--- a/modules/programs/freetube.nix
+++ b/modules/programs/freetube.nix
@@ -13,7 +13,6 @@ let
     mkEnableOption
     mkPackageOption
     mkOption
-    literalExpression
     ;
 
   cfg = config.programs.freetube;
@@ -41,14 +40,12 @@ in
     settings = mkOption {
       type = lib.types.attrs;
       default = { };
-      example = literalExpression ''
-        {
-          allowDashAv1Formats = true;
-          checkForUpdates     = false;
-          defaultQuality      = "1080";
-          baseTheme           = "catppuccinMocha";
-        }
-      '';
+      example = {
+        allowDashAv1Formats = true;
+        checkForUpdates = false;
+        defaultQuality = "1080";
+        baseTheme = "catppuccinMocha";
+      };
       description = ''
         Configuration settings for FreeTube.
 

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -174,7 +174,7 @@ in
       shellIntegrationOptions = mkOption {
         type = types.listOf types.str;
         default = [ ];
-        example = literalExpression ''[ "-d 40%" ]'';
+        example = [ "-d 40%" ];
         description = ''
           If {option}`programs.fzf.tmux.enableShellIntegration` is set to `true`,
           shell integration will use these options for fzf-tmux.

--- a/modules/programs/gallery-dl.nix
+++ b/modules/programs/gallery-dl.nix
@@ -20,11 +20,9 @@ in
     settings = lib.mkOption {
       inherit (jsonFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          extractor.base-directory = "~/Downloads";
-        }
-      '';
+      example = {
+        extractor.base-directory = "~/Downloads";
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/gallery-dl/config.json`. See

--- a/modules/programs/gh-dash.nix
+++ b/modules/programs/gh-dash.nix
@@ -23,14 +23,14 @@ in
     settings = lib.mkOption {
       inherit (yamlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          prSections = [{
+      example = {
+        prSections = [
+          {
             title = "My Pull Requests";
             filters = "is:open author:@me";
-          }];
-        }
-      '';
+          }
+        ];
+      };
       description = ''
         Configuration written to {file}`$XDG_CONFIG_HOME/gh-dash/config.yml`.
       '';

--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -23,12 +23,10 @@ let
       aliases = mkOption {
         type = with types; attrsOf str;
         default = { };
-        example = literalExpression ''
-          {
-            co = "pr checkout";
-            pv = "pr view";
-          }
-        '';
+        example = {
+          co = "pr checkout";
+          pv = "pr view";
+        };
         description = ''
           Aliases that allow you to create nicknames for gh commands.
         '';

--- a/modules/programs/ghostty.nix
+++ b/modules/programs/ghostty.nix
@@ -49,16 +49,14 @@ in
       settings = lib.mkOption {
         inherit (keyValue) type;
         default = { };
-        example = lib.literalExpression ''
-          {
-            theme = "catppuccin-mocha";
-            font-size = 10;
-            keybind = [
-              "ctrl+h=goto_split:left"
-              "ctrl+l=goto_split:right"
-            ];
-          }
-        '';
+        example = {
+          theme = "catppuccin-mocha";
+          font-size = 10;
+          keybind = [
+            "ctrl+h=goto_split:left"
+            "ctrl+l=goto_split:right"
+          ];
+        };
         description = ''
           Configuration written to {file}`$XDG_CONFIG_HOME/ghostty/config`.
 

--- a/modules/programs/git-cliff.nix
+++ b/modules/programs/git-cliff.nix
@@ -19,12 +19,10 @@ in
     settings = lib.mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          header = "Changelog";
-          trim = true;
-        }
-      '';
+      example = {
+        header = "Changelog";
+        trim = true;
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/git-cliff/cliff.toml`. See

--- a/modules/programs/git-credential-oauth.nix
+++ b/modules/programs/git-credential-oauth.nix
@@ -22,7 +22,7 @@ in
       extraFlags = lib.mkOption {
         type = lib.types.listOf lib.types.str;
         default = [ ];
-        example = lib.literalExpression ''[ "-device" ]'';
+        example = [ "-device" ];
         description = ''
           Extra command-line arguments passed to git-credential-oauth.
 

--- a/modules/programs/github-copilot-cli.nix
+++ b/modules/programs/github-copilot-cli.nix
@@ -106,15 +106,13 @@ in
     settings = mkOption {
       type = lib.types.attrsOf jsonFormat.type;
       default = { };
-      example = literalExpression ''
-        {
-          model = "claude-sonnet-4-5";
-          theme = "default";
-          trusted_folders = [ "/home/user/projects" ];
-          renderMarkdown = true;
-          autoUpdate = false;
-        }
-      '';
+      example = {
+        model = "claude-sonnet-4-5";
+        theme = "default";
+        trusted_folders = [ "/home/user/projects" ];
+        renderMarkdown = true;
+        autoUpdate = false;
+      };
       description = ''
         Configuration written to {file}`config.json` inside
         {option}`programs.github-copilot-cli.configDir`.

--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -169,12 +169,10 @@ in
 
     settings = mkOption {
       type = types.attrsOf (types.either primitiveType (types.listOf types.str));
-      example = literalExpression ''
-        {
-          no-comments = false;
-          s2k-cipher-algo = "AES128";
-        }
-      '';
+      example = {
+        no-comments = false;
+        s2k-cipher-algo = "AES128";
+      };
       description = ''
         GnuPG configuration options. Available options are described
         in
@@ -189,11 +187,9 @@ in
     scdaemonSettings = mkOption {
       type = types.attrsOf (types.either primitiveType (types.listOf types.str));
       default = { };
-      example = literalExpression ''
-        {
-          disable-ccid = true;
-        }
-      '';
+      example = {
+        disable-ccid = true;
+      };
       description = ''
         SCdaemon configuration options. Available options are described
         in
@@ -224,11 +220,9 @@ in
     gpgsmSettings = mkOption {
       type = types.attrsOf (types.either primitiveType (types.listOf types.str));
       default = { };
-      example = literalExpression ''
-        {
-          with-key-data = true;
-        }
-      '';
+      example = {
+        with-key-data = true;
+      };
       description = ''
         GPGSM configuration options. Available options are described
         in

--- a/modules/programs/grype.nix
+++ b/modules/programs/grype.nix
@@ -28,11 +28,9 @@ in
       inherit (yamlFormat) type;
       default = { };
       defaultText = literalExpression "{ }";
-      example = literalExpression ''
-        {
-          check-for-app-update = false;
-        }
-      '';
+      example = {
+        check-for-app-update = false;
+      };
       description = ''
         Configuration written to {file}`$XDG_CONFIG_HOME/grype/config.yaml`.
         See <https://oss.anchore.com/docs/reference/grype/configuration/> for supported values.

--- a/modules/programs/gurk-rs.nix
+++ b/modules/programs/gurk-rs.nix
@@ -25,22 +25,20 @@ in
         or {file}`Library/Application Support/gurk/gurk.toml`. Options are
         declared at <https://github.com/boxdot/gurk-rs/blob/main/src/config.rs>.
       '';
-      example = lib.literalExpression ''
-        {
-          data_dir = "/home/USERNAME/.local/share/gurk/signal-db";
-          first_name_only = false;
-          show_receipts = true;
-          notifications = true;
-          bell = true;
-          colored_messages = false;
-          default_keybindings = true;
-          user = {
-            name = "MYNAME";
-            phone_number = "MYNUMBER";
-          };
-          keybindings =  { };
-        }
-      '';
+      example = {
+        data_dir = "/home/USERNAME/.local/share/gurk/signal-db";
+        first_name_only = false;
+        show_receipts = true;
+        notifications = true;
+        bell = true;
+        colored_messages = false;
+        default_keybindings = true;
+        user = {
+          name = "MYNAME";
+          phone_number = "MYNUMBER";
+        };
+        keybindings = { };
+      };
     };
   };
 

--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -57,21 +57,22 @@ in
     settings = mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          theme = "base16";
-          editor = {
-            line-number = "relative";
-            lsp.display-messages = true;
-          };
-          keys.normal = {
-            space.space = "file_picker";
-            space.w = ":w";
-            space.q = ":q";
-            esc = [ "collapse_selection" "keep_primary_selection" ];
-          };
-        }
-      '';
+      example = {
+        theme = "base16";
+        editor = {
+          line-number = "relative";
+          lsp.display-messages = true;
+        };
+        keys.normal = {
+          space.space = "file_picker";
+          space.w = ":w";
+          space.q = ":q";
+          esc = [
+            "collapse_selection"
+            "keep_primary_selection"
+          ];
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/helix/config.toml`.

--- a/modules/programs/hyfetch.nix
+++ b/modules/programs/hyfetch.nix
@@ -20,15 +20,13 @@ in
     settings = lib.mkOption {
       inherit (jsonFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          preset = "rainbow";
-          mode = "rgb";
-          color_align = {
-            mode = "horizontal";
-          };
-        }
-      '';
+      example = {
+        preset = "rainbow";
+        mode = "rgb";
+        color_align = {
+          mode = "horizontal";
+        };
+      };
       description = "JSON config for HyFetch";
     };
   };

--- a/modules/programs/i3status.nix
+++ b/modules/programs/i3status.nix
@@ -118,13 +118,11 @@ in
                 {manpage}`i3status(1)`
                 for options.
               '';
-              example = literalExpression ''
-                {
-                  format = "♪ %volume";
-                  format_muted = "♪ muted (%volume)";
-                  device = "pulse:1";
-                }
-              '';
+              example = {
+                format = "♪ %volume";
+                format_muted = "♪ muted (%volume)";
+                device = "pulse:1";
+              };
             };
           };
         }
@@ -136,24 +134,22 @@ in
         {manpage}`i3status(1)`
         for options.
       '';
-      example = literalExpression ''
-        {
-          "volume master" = {
-            position = 1;
-            settings = {
-              format = "♪ %volume";
-              format_muted = "♪ muted (%volume)";
-              device = "pulse:1";
-            };
+      example = {
+        "volume master" = {
+          position = 1;
+          settings = {
+            format = "♪ %volume";
+            format_muted = "♪ muted (%volume)";
+            device = "pulse:1";
           };
-          "disk /" = {
-            position = 2;
-            settings = {
-              format = "/ %avail";
-            };
+        };
+        "disk /" = {
+          position = 2;
+          settings = {
+            format = "/ %avail";
           };
-        }
-      '';
+        };
+      };
     };
 
     package = lib.mkPackageOption pkgs "i3status" { nullable = true; };

--- a/modules/programs/iamb.nix
+++ b/modules/programs/iamb.nix
@@ -22,21 +22,19 @@ in
     settings = lib.mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          default_profile = "personal";
-          settings = {
-            notifications.enabled = true;
-            image_preview.protocol = {
-              type = "kitty";
-              size = {
-                height = 10;
-                width = 66;
-              };
+      example = {
+        default_profile = "personal";
+        settings = {
+          notifications.enabled = true;
+          image_preview.protocol = {
+            type = "kitty";
+            size = {
+              height = 10;
+              width = 66;
             };
           };
-        }
-      '';
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/iamb/config.toml`.

--- a/modules/programs/imv.nix
+++ b/modules/programs/imv.nix
@@ -37,12 +37,10 @@ in
         Configuration options for imv. See
         {manpage}`imv(5)`.
       '';
-      example = lib.literalExpression ''
-        {
-          options.background = "ffffff";
-          aliases.x = "close";
-        }
-      '';
+      example = {
+        options.background = "ffffff";
+        aliases.x = "close";
+      };
     };
   };
 

--- a/modules/programs/infat.nix
+++ b/modules/programs/infat.nix
@@ -28,22 +28,20 @@ in
       settings = lib.mkOption {
         inherit (tomlFormat) type;
         default = { };
-        example = lib.literalExpression ''
-          {
-            extensions = {
-              md = "TextEdit";
-              html = "Safari";
-              pdf = "Preview";
-            };
-            schemes = {
-              mailto = "Mail";
-              web = "Safari";
-            };
-            types = {
-              plain-text = "VSCode";
-            };
-          }
-        '';
+        example = {
+          extensions = {
+            md = "TextEdit";
+            html = "Safari";
+            pdf = "Preview";
+          };
+          schemes = {
+            mailto = "Mail";
+            web = "Safari";
+          };
+          types = {
+            plain-text = "VSCode";
+          };
+        };
         description = ''
           Configuration written to
           {file}`$XDG_CONFIG_HOME/infat/config.toml`.

--- a/modules/programs/inori.nix
+++ b/modules/programs/inori.nix
@@ -10,7 +10,6 @@ let
     mkOption
     mkEnableOption
     mkPackageOption
-    literalExpression
     mkIf
     hm
     maintainers
@@ -34,12 +33,10 @@ in
     settings = mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          seek_seconds = 10;
-          dvorak_keybindings = true;
-        }
-      '';
+      example = {
+        seek_seconds = 10;
+        dvorak_keybindings = true;
+      };
       description = ''
         Configuration written to {file}`$XDG_CONFIG_HOME/inori/config.toml`.
 

--- a/modules/programs/ion.nix
+++ b/modules/programs/ion.nix
@@ -32,11 +32,9 @@ in
     shellAliases = mkOption {
       type = with types; attrsOf str;
       default = { };
-      example = lib.literalExpression ''
-        {
-          g = "git";
-        }
-      '';
+      example = {
+        g = "git";
+      };
       description = ''
         An attribute set that maps aliases (the top level attribute names
         in this option) to command strings or directly to build outputs.

--- a/modules/programs/irssi.nix
+++ b/modules/programs/irssi.nix
@@ -206,21 +206,19 @@ in
 
       networks = mkOption {
         default = { };
-        example = lib.literalExpression ''
-          {
-            liberachat = {
-              nick = "hmuser";
-              server = {
-                address = "irc.libera.chat";
-                port = 6697;
-                autoConnect = true;
-              };
-              channels = {
-                nixos.autoJoin = true;
-              };
+        example = {
+          liberachat = {
+            nick = "hmuser";
+            server = {
+              address = "irc.libera.chat";
+              port = 6697;
+              autoConnect = true;
             };
-          }
-        '';
+            channels = {
+              nixos.autoJoin = true;
+            };
+          };
+        };
         description = "An attribute set of chat networks.";
         type = types.attrsOf networkType;
       };

--- a/modules/programs/jq.nix
+++ b/modules/programs/jq.nix
@@ -45,18 +45,16 @@ in
           of the jq manual.
         '';
 
-        example = lib.literalExpression ''
-          {
-            null       = "1;30";
-            false      = "0;31";
-            true       = "0;32";
-            numbers    = "0;36";
-            strings    = "0;33";
-            arrays     = "1;35";
-            objects    = "1;37";
-            objectKeys = "1;34";
-          }
-        '';
+        example = {
+          null = "1;30";
+          false = "0;31";
+          true = "0;32";
+          numbers = "0;36";
+          strings = "0;33";
+          arrays = "1;35";
+          objects = "1;37";
+          objectKeys = "1;34";
+        };
 
         default = null;
 

--- a/modules/programs/k9s.nix
+++ b/modules/programs/k9s.nix
@@ -103,15 +103,13 @@ in
         or {file}`Library/Application Support/k9s/hotkeys.yaml` (darwin). See
         <https://k9scli.io/topics/hotkeys/> for supported values.
       '';
-      example = literalExpression ''
-        {
-          shift-0 = {
-            shortCut = "Shift-0";
-            description = "Viewing pods";
-            command = "pods";
-          };
-        }
-      '';
+      example = {
+        shift-0 = {
+          shortCut = "Shift-0";
+          description = "Viewing pods";
+          command = "pods";
+        };
+      };
     };
 
     plugins = mkOption {
@@ -155,21 +153,19 @@ in
         or {file}`Library/Application Support/k9s/views.yaml` (darwin).
         See <https://k9scli.io/topics/columns/> for supported values.
       '';
-      example = literalExpression ''
-        {
-          "v1/pods" = {
-            columns = [
-              "AGE"
-              "NAMESPACE"
-              "NAME"
-              "IP"
-              "NODE"
-              "STATUS"
-              "READY"
-            ];
-          };
-        }
-      '';
+      example = {
+        "v1/pods" = {
+          columns = [
+            "AGE"
+            "NAMESPACE"
+            "NAME"
+            "IP"
+            "NODE"
+            "STATUS"
+            "READY"
+          ];
+        };
+      };
     };
   };
 

--- a/modules/programs/keepassxc.nix
+++ b/modules/programs/keepassxc.nix
@@ -44,20 +44,18 @@ in
     settings = lib.mkOption {
       inherit (iniFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          Browser.Enabled = true;
+      example = {
+        Browser.Enabled = true;
 
-          GUI = {
-            AdvancedSettings = true;
-            ApplicationTheme = "dark";
-            CompactMode = true;
-            HidePasswords = true;
-          };
+        GUI = {
+          AdvancedSettings = true;
+          ApplicationTheme = "dark";
+          CompactMode = true;
+          HidePasswords = true;
+        };
 
-          SSHAgent.Enabled = true;
-        }
-      '';
+        SSHAgent.Enabled = true;
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/keepassxc/keepassxc.ini`.

--- a/modules/programs/khal/default.nix
+++ b/modules/programs/khal/default.nix
@@ -215,17 +215,15 @@ in
     settings = mkOption {
       inherit (iniFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          default = {
-            default_calendar = "Calendar";
-            timedelta = "5d";
-          };
-          view = {
-            agenda_event_format =
-              "{calendar-color}{cancelled}{start-end-time-style} {title}{repeat-symbol}{reset}";
-          };
-        }'';
+      example = {
+        default = {
+          default_calendar = "Calendar";
+          timedelta = "5d";
+        };
+        view = {
+          agenda_event_format = "{calendar-color}{cancelled}{start-end-time-style} {title}{repeat-symbol}{reset}";
+        };
+      };
       description = ''
         Configuration options to add to the various sections in the configuration file.
       '';

--- a/modules/programs/khard.nix
+++ b/modules/programs/khard.nix
@@ -65,24 +65,38 @@ in
           <https://khard.readthedocs.io/en/latest/#configuration>
           for more information.
         '';
-        example = lib.literalExpression ''
-          {
-            general = {
-              default_action = "list";
-              editor = ["vim" "-i" "NONE"];
-            };
+        example = {
+          general = {
+            default_action = "list";
+            editor = [
+              "vim"
+              "-i"
+              "NONE"
+            ];
+          };
 
-            "contact table" = {
-              display = "formatted_name";
-              preferred_phone_number_type = ["pref" "cell" "home"];
-              preferred_email_address_type = ["pref" "work" "home"];
-            };
+          "contact table" = {
+            display = "formatted_name";
+            preferred_phone_number_type = [
+              "pref"
+              "cell"
+              "home"
+            ];
+            preferred_email_address_type = [
+              "pref"
+              "work"
+              "home"
+            ];
+          };
 
-            vcard = {
-              private_objects = ["Jabber" "Skype" "Twitter"];
-            };
-          }
-        '';
+          vcard = {
+            private_objects = [
+              "Jabber"
+              "Skype"
+              "Twitter"
+            ];
+          };
+        };
       };
     };
 

--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -133,25 +133,21 @@ in
       type = types.nullOr (types.listOf types.str);
       default = null;
       description = "Command-line options to use when launched by Mac OS GUI";
-      example = literalExpression ''
-        [
-          "--single-instance"
-          "--directory=/tmp/my-dir"
-          "--listen-on=unix:/tmp/my-socket"
-        ]
-      '';
+      example = [
+        "--single-instance"
+        "--directory=/tmp/my-dir"
+        "--listen-on=unix:/tmp/my-socket"
+      ];
     };
 
     settings = mkOption {
       type = types.attrsOf settingsValueType;
       default = { };
-      example = literalExpression ''
-        {
-          scrollback_lines = 10000;
-          enable_audio_bell = false;
-          update_check_interval = 0;
-        }
-      '';
+      example = {
+        scrollback_lines = 10000;
+        enable_audio_bell = false;
+        update_check_interval = 0;
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/kitty/kitty.conf`. See
@@ -205,13 +201,11 @@ in
         Kitty applies these based on the OS color scheme, and they override
         other color and background image settings.
       '';
-      example = literalExpression ''
-        {
-          light = "GitHub";
-          dark = "TokyoNight";
-          noPreference = "OneDark";
-        }
-      '';
+      example = {
+        light = "GitHub";
+        dark = "TokyoNight";
+        noPreference = "OneDark";
+      };
     };
 
     font = mkOption {
@@ -224,24 +218,20 @@ in
       type = types.attrsOf types.str;
       default = { };
       description = "Define action aliases.";
-      example = literalExpression ''
-        {
-          "launch_tab" = "launch --cwd=current --type=tab";
-          "launch_window" = "launch --cwd=current --type=os-window";
-        }
-      '';
+      example = {
+        "launch_tab" = "launch --cwd=current --type=tab";
+        "launch_window" = "launch --cwd=current --type=os-window";
+      };
     };
 
     keybindings = mkOption {
       type = types.attrsOf types.str;
       default = { };
       description = "Mapping of keybindings to actions.";
-      example = literalExpression ''
-        {
-          "ctrl+c" = "copy_or_interrupt";
-          "ctrl+f>2" = "set_font_size 20";
-        }
-      '';
+      example = {
+        "ctrl+c" = "copy_or_interrupt";
+        "ctrl+f>2" = "set_font_size 20";
+      };
     };
 
     mouseBindings = mkOption {
@@ -260,11 +250,9 @@ in
       type = types.attrsOf types.str;
       default = { };
       description = "Environment variables to set or override.";
-      example = literalExpression ''
-        {
-          "LS_COLORS" = "1";
-        }
-      '';
+      example = {
+        "LS_COLORS" = "1";
+      };
     };
 
     shellIntegration = {
@@ -318,13 +306,11 @@ in
     quickAccessTerminalConfig = mkOption {
       type = types.attrsOf settingsValueType;
       default = { };
-      example = literalExpression ''
-        {
-          start_as_hidden = false;
-          hide_on_focus_loss = false;
-          background_opacity = 0.85;
-        }
-      '';
+      example = {
+        start_as_hidden = false;
+        hide_on_focus_loss = false;
+        background_opacity = 0.85;
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/kitty/quick-access-terminal.conf`. See

--- a/modules/programs/kodi.nix
+++ b/modules/programs/kodi.nix
@@ -177,9 +177,9 @@ in
         in
         nullOr valueType;
       default = null;
-      example = literalExpression ''
-        { videolibrary.showemptytvshows = "true"; }
-      '';
+      example = {
+        videolibrary.showemptytvshows = "true";
+      };
       description = ''
         Configuration to write to the `advancedsettings.xml`
         file in kodis userdata directory. Settings specified here will be
@@ -237,9 +237,9 @@ in
     addonSettings = mkOption {
       type = with types; nullOr (attrsOf (attrsOf str));
       default = null;
-      example = literalExpression ''
-        { "service.xbmc.versioncheck".versioncheck_enable = "false"; }
-      '';
+      example = {
+        "service.xbmc.versioncheck".versioncheck_enable = "false";
+      };
       description = ''
         Attribute set with the plugin namespace as toplevel key and the plugins
         settings as lower level key/value pairs.

--- a/modules/programs/lapce.nix
+++ b/modules/programs/lapce.nix
@@ -97,22 +97,20 @@ let
       description = ''
         Plugins to install.
       '';
-      example = literalExpression ''
-        [
-          {
-            author = "MrFoxPro";
-            name = "lapce-nix";
-            version = "0.0.1";
-            hash = "sha256-...";
-          }
-          {
-            author = "dzhou121";
-            name = "lapce-rust";
-            version = "0.3.1932";
-            hash = "sha256-...";
-          }
-        ]
-      '';
+      example = [
+        {
+          author = "MrFoxPro";
+          name = "lapce-nix";
+          version = "0.0.1";
+          hash = "sha256-...";
+        }
+        {
+          author = "dzhou121";
+          name = "lapce-rust";
+          version = "0.3.1932";
+          hash = "sha256-...";
+        }
+      ];
     };
     keymaps = mkOption {
       inherit (settingsFormat) type;
@@ -121,14 +119,12 @@ let
         Keymaps written to {file}`$XDG_CONFIG_HOME/lapce/keymaps.toml`.
         See <https://github.com/lapce/lapce/blob/master/defaults/keymaps-common.toml> for examples.
       '';
-      example = literalExpression ''
-        [
-          {
-            command = "open_log_file";
-            key = "Ctrl+Shift+L";
-          }
-        ]
-      '';
+      example = [
+        {
+          command = "open_log_file";
+          key = "Ctrl+Shift+L";
+        }
+      ];
     };
   };
 

--- a/modules/programs/lazydocker.nix
+++ b/modules/programs/lazydocker.nix
@@ -31,15 +31,16 @@ in
       default = {
         commandTemplates.dockerCompose = "docker compose"; # Lazydocker uses docker-compose by default which will not work
       };
-      example = lib.literalExpression ''
-        {
-          gui.theme = {
-            activeBorderColor = ["red" "bold"];
-            inactiveBorderColor = ["blue"];
-          };
-          commandTemplates.dockerCompose = "docker compose compose -f docker-compose.yml";
-        }
-      '';
+      example = {
+        gui.theme = {
+          activeBorderColor = [
+            "red"
+            "bold"
+          ];
+          inactiveBorderColor = [ "blue" ];
+        };
+        commandTemplates.dockerCompose = "docker compose compose -f docker-compose.yml";
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/lazydocker/config.yml`

--- a/modules/programs/lazygit.nix
+++ b/modules/programs/lazygit.nix
@@ -32,16 +32,17 @@ in
       inherit (yamlFormat) type;
       default = { };
       defaultText = lib.literalExpression "{ }";
-      example = lib.literalExpression ''
-        {
-          gui.theme = {
-            lightTheme = true;
-            activeBorderColor = [ "blue" "bold" ];
-            inactiveBorderColor = [ "black" ];
-            selectedLineBgColor = [ "default" ];
-          };
-        }
-      '';
+      example = {
+        gui.theme = {
+          lightTheme = true;
+          activeBorderColor = [
+            "blue"
+            "bold"
+          ];
+          inactiveBorderColor = [ "black" ];
+          selectedLineBgColor = [ "default" ];
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/lazygit/config.yml`

--- a/modules/programs/lf.nix
+++ b/modules/programs/lf.nix
@@ -81,7 +81,9 @@ in
       cmdKeybindings = mkOption {
         type = with types; attrsOf (nullOr str);
         default = { };
-        example = literalExpression ''{ "<c-g>" = "cmd-escape"; }'';
+        example = {
+          "<c-g>" = "cmd-escape";
+        };
         description = ''
           Keys to bind to command line commands which can only be one of the
           builtin commands. Keys set to null or an empty string are deleted.

--- a/modules/programs/librewolf.nix
+++ b/modules/programs/librewolf.nix
@@ -48,12 +48,10 @@ in
     settings = lib.mkOption {
       type = with lib.types; attrsOf (either bool (either int str));
       default = { };
-      example = lib.literalExpression ''
-        {
-          "webgl.disabled" = false;
-          "privacy.resistFingerprinting" = false;
-        }
-      '';
+      example = {
+        "webgl.disabled" = false;
+        "privacy.resistFingerprinting" = false;
+      };
       description = ''
         Attribute set of global LibreWolf settings and overrides. Refer to
         <https://librewolf.net/docs/settings/>

--- a/modules/programs/looking-glass-client.nix
+++ b/modules/programs/looking-glass-client.nix
@@ -20,30 +20,28 @@ in
       inherit (settingsFormat) type;
       default = { };
       description = "looking-glass-client settings.";
-      example = lib.literalExpression ''
-        {
-          app = {
-            allowDMA = true;
-            shmFile = "/dev/kvmfr0";
-          };
+      example = {
+        app = {
+          allowDMA = true;
+          shmFile = "/dev/kvmfr0";
+        };
 
-          win = {
-            fullScreen = true;
-            showFPS = false;
-            jitRender = true;
-          };
+        win = {
+          fullScreen = true;
+          showFPS = false;
+          jitRender = true;
+        };
 
-          spice = {
-            enable = true;
-            audio = true;
-          };
+        spice = {
+          enable = true;
+          audio = true;
+        };
 
-          input = {
-            rawMouse = true;
-            escapeKey = 62;
-          };
-        }
-      '';
+        input = {
+          rawMouse = true;
+          escapeKey = 62;
+        };
+      };
     };
   };
 

--- a/modules/programs/macchina/settings.nix
+++ b/modules/programs/macchina/settings.nix
@@ -3,7 +3,6 @@ let
   inherit (lib)
     mkOption
     types
-    literalExpression
     ;
 in
 {
@@ -107,7 +106,12 @@ in
         )
       );
       default = null;
-      example = literalExpression ''[ "Battery" "Memory" "Processor" "Shell" ]'';
+      example = [
+        "Battery"
+        "Memory"
+        "Processor"
+        "Shell"
+      ];
       description = ''
         Display only the specified readouts. When null, all readouts are shown.
         Values are case-sensitive.

--- a/modules/programs/macchina/theme.nix
+++ b/modules/programs/macchina/theme.nix
@@ -3,7 +3,6 @@ let
   inherit (lib)
     mkOption
     types
-    literalExpression
     ;
   colorType = types.str;
 
@@ -372,65 +371,66 @@ in
   themes = mkOption {
     type = types.attrsOf themeModule;
     default = { };
-    example = literalExpression ''
-      {
-        Hydrogen = {
-          spacing = 2;
-          padding = 0;
-          hide_ascii = true;
-          separator = ">";
-          key_color = "Cyan";
-          separator_color = "White";
+    example = {
+      Hydrogen = {
+        spacing = 2;
+        padding = 0;
+        hide_ascii = true;
+        separator = ">";
+        key_color = "Cyan";
+        separator_color = "White";
 
-          palette = {
-            type = "Full";
-            visible = false;
-          };
+        palette = {
+          type = "Full";
+          visible = false;
+        };
 
-          bar = {
-            glyph = "o";
-            symbol_open = "[";
-            symbol_close = "]";
-            hide_delimiters = true;
-            visible = true;
-          };
+        bar = {
+          glyph = "o";
+          symbol_open = "[";
+          symbol_close = "]";
+          hide_delimiters = true;
+          visible = true;
+        };
 
-          box = {
-            border = "plain";
-            visible = true;
-            inner_margin = { x = 1; y = 0; };
-          };
-
-          randomize = {
-            key_color = false;
-            separator_color = false;
-          };
-
-          keys = {
-            host = "Host";
-            kernel = "Kernel";
-            battery = "Battery";
-            os = "OS";
-            de = "DE";
-            wm = "WM";
-            distro = "Distro";
-            terminal = "Terminal";
-            shell = "Shell";
-            packages = "Packages";
-            uptime = "Uptime";
-            memory = "Memory";
-            machine = "Machine";
-            local_ip = "Local IP";
-            backlight = "Brightness";
-            resolution = "Resolution";
-            cpu_load = "CPU Load";
-            cpu = "CPU";
-            gpu = "GPU";
-            disk_space = "Disk Space";
+        box = {
+          border = "plain";
+          visible = true;
+          inner_margin = {
+            x = 1;
+            y = 0;
           };
         };
-      }
-    '';
+
+        randomize = {
+          key_color = false;
+          separator_color = false;
+        };
+
+        keys = {
+          host = "Host";
+          kernel = "Kernel";
+          battery = "Battery";
+          os = "OS";
+          de = "DE";
+          wm = "WM";
+          distro = "Distro";
+          terminal = "Terminal";
+          shell = "Shell";
+          packages = "Packages";
+          uptime = "Uptime";
+          memory = "Memory";
+          machine = "Machine";
+          local_ip = "Local IP";
+          backlight = "Brightness";
+          resolution = "Resolution";
+          cpu_load = "CPU Load";
+          cpu = "CPU";
+          gpu = "GPU";
+          disk_space = "Disk Space";
+        };
+      };
+    };
     description = ''
       Attribute set of macchina themes. Each entry is written to
       {file}`$XDG_CONFIG_HOME/macchina/themes/<name>.toml`.

--- a/modules/programs/mangohud.nix
+++ b/modules/programs/mangohud.nix
@@ -78,13 +78,11 @@ in
       settingsPerApplication = mkOption {
         type = with types; attrsOf (attrsOf settingsType);
         default = { };
-        example = lib.literalExpression ''
-          {
-            mpv = {
-              no_display = true;
-            };
-          }
-        '';
+        example = {
+          mpv = {
+            no_display = true;
+          };
+        };
         description = ''
           Sets MangoHud settings per application.
           Configuration written to

--- a/modules/programs/matplotlib.nix
+++ b/modules/programs/matplotlib.nix
@@ -28,17 +28,15 @@ in
         Add terms to the {file}`matplotlibrc` file to
         control the default matplotlib behavior.
       '';
-      example = lib.literalExpression ''
-        {
-          backend = "Qt5Agg";
-          axes = {
-            grid = true;
-            facecolor = "black";
-            edgecolor = "FF9900";
-          };
-          grid.color = "FF9900";
-        }
-      '';
+      example = {
+        backend = "Qt5Agg";
+        axes = {
+          grid = true;
+          facecolor = "black";
+          edgecolor = "FF9900";
+        };
+        grid.color = "FF9900";
+      };
     };
 
     extraConfig = mkOption {

--- a/modules/programs/mbsync/accounts.nix
+++ b/modules/programs/mbsync/accounts.nix
@@ -103,14 +103,12 @@ let
         extraConfig = mkOption {
           type = extraConfigType;
           default = { };
-          example = literalExpression ''
-            {
-              Create = "both";
-              CopyArrivalDate = "yes";
-              MaxMessages = 10000;
-              MaxSize = "1m";
-            }
-          '';
+          example = {
+            Create = "both";
+            CopyArrivalDate = "yes";
+            MaxMessages = 10000;
+            MaxSize = "1m";
+          };
           description = ''
             Extra configuration lines to add to *THIS* channel's
             configuration.

--- a/modules/programs/mbsync/default.nix
+++ b/modules/programs/mbsync/default.nix
@@ -9,7 +9,6 @@ let
     any
     concatStringsSep
     concatMapStringsSep
-    literalExpression
     mapAttrsToList
     mkIf
     mkOption
@@ -259,14 +258,12 @@ in
       groups = mkOption {
         type = types.attrsOf (types.attrsOf (types.listOf types.str));
         default = { };
-        example = literalExpression ''
-          {
-            inboxes = {
-              account1 = [ "Inbox" ];
-              account2 = [ "Inbox" ];
-            };
-          }
-        '';
+        example = {
+          inboxes = {
+            account1 = [ "Inbox" ];
+            account2 = [ "Inbox" ];
+          };
+        };
         description = ''
           Definition of groups.
         '';

--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -75,23 +75,21 @@ in
     settings = mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          colors = {
-            menubar = {
-              bg = "black";
-              fg = "red";
-            };
-            darkmode = {
-              prompt = "cyan";
-              timing = "yellow";
-              results_selection_fg = "cyan";
-              results_selection_bg = "black";
-              results_selection_hl = "red";
-            };
+      example = {
+        colors = {
+          menubar = {
+            bg = "black";
+            fg = "red";
           };
-        }
-      '';
+          darkmode = {
+            prompt = "cyan";
+            timing = "yellow";
+            results_selection_fg = "cyan";
+            results_selection_bg = "black";
+            results_selection_hl = "red";
+          };
+        };
+      };
       description = ''
         Settings written to {file}`~/.config/mcfly/config.toml`.
 

--- a/modules/programs/micro.nix
+++ b/modules/programs/micro.nix
@@ -21,12 +21,10 @@ in
       settings = lib.mkOption {
         inherit (jsonFormat) type;
         default = { };
-        example = lib.literalExpression ''
-          {
-            autosu = false;
-            cursorline = false;
-          }
-        '';
+        example = {
+          autosu = false;
+          cursorline = false;
+        };
         description = ''
           Configuration written to
           {file}`$XDG_CONFIG_HOME/micro/settings.json`. See

--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -148,14 +148,12 @@ in
         '';
         type = mpvOptions;
         default = { };
-        example = literalExpression ''
-          {
-            profile = "gpu-hq";
-            force-window = true;
-            ytdl-format = "bestvideo+bestaudio";
-            cache-default = 4000000;
-          }
-        '';
+        example = {
+          profile = "gpu-hq";
+          force-window = true;
+          ytdl-format = "bestvideo+bestaudio";
+          cache-default = 4000000;
+        };
       };
 
       includes = mkOption {
@@ -213,13 +211,11 @@ in
         '';
         type = mpvBindings;
         default = { };
-        example = literalExpression ''
-          {
-            WHEEL_UP = "seek 10";
-            WHEEL_DOWN = "seek -10";
-            "Alt+0" = "set window-scale 0.5";
-          }
-        '';
+        example = {
+          WHEEL_UP = "seek 10";
+          WHEEL_DOWN = "seek -10";
+          "Alt+0" = "set window-scale 0.5";
+        };
       };
 
       extraInput = mkOption {

--- a/modules/programs/mr.nix
+++ b/modules/programs/mr.nix
@@ -27,17 +27,15 @@ in
         See <https://myrepos.branchable.com/>
         for an example configuration.
       '';
-      example = lib.literalExpression ''
-        {
-          foo = {
-            checkout = "git clone git@github.com:joeyh/foo.git";
-            update = "git pull --rebase";
-          };
-          ".local/share/password-store" = {
-            checkout = "git clone git@github.com:myuser/password-store.git";
-          };
-        }
-      '';
+      example = {
+        foo = {
+          checkout = "git clone git@github.com:joeyh/foo.git";
+          update = "git pull --rebase";
+        };
+        ".local/share/password-store" = {
+          checkout = "git clone git@github.com:myuser/password-store.git";
+        };
+      };
     };
   };
 

--- a/modules/programs/mypy.nix
+++ b/modules/programs/mypy.nix
@@ -22,14 +22,12 @@ in
     settings = lib.mkOption {
       inherit (iniFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          mypy = {
-            warn_return_any = true;
-            warn_unused_configs = true;
-          };
-        }
-      '';
+      example = {
+        mypy = {
+          warn_return_any = true;
+          warn_unused_configs = true;
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/mypy/config`.

--- a/modules/programs/navi.nix
+++ b/modules/programs/navi.nix
@@ -29,15 +29,13 @@ in
     settings = lib.mkOption {
       inherit (yamlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          cheats = {
-            paths = [
-              "~/cheats/"
-            ];
-          };
-        }
-      '';
+      example = {
+        cheats = {
+          paths = [
+            "~/cheats/"
+          ];
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/navi/config.yaml` on Linux or

--- a/modules/programs/ncmpcpp.nix
+++ b/modules/programs/ncmpcpp.nix
@@ -108,14 +108,30 @@ in
       type = types.listOf bindingType;
       default = [ ];
       description = "List of keybindings.";
-      example = literalExpression ''
-        [
-          { key = "j"; command = "scroll_down"; }
-          { key = "k"; command = "scroll_up"; }
-          { key = "J"; command = [ "select_item" "scroll_down" ]; }
-          { key = "K"; command = [ "select_item" "scroll_up" ]; }
-        ]
-      '';
+      example = [
+        {
+          key = "j";
+          command = "scroll_down";
+        }
+        {
+          key = "k";
+          command = "scroll_up";
+        }
+        {
+          key = "J";
+          command = [
+            "select_item"
+            "scroll_down"
+          ];
+        }
+        {
+          key = "K";
+          command = [
+            "select_item"
+            "scroll_up"
+          ];
+        }
+      ];
     };
   };
 

--- a/modules/programs/ncspot.nix
+++ b/modules/programs/ncspot.nix
@@ -22,12 +22,10 @@ in
     settings = lib.mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          shuffle = true;
-          gapless = true;
-        }
-      '';
+      example = {
+        shuffle = true;
+        gapless = true;
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/ncspot/config.toml`.

--- a/modules/programs/neovide.nix
+++ b/modules/programs/neovide.nix
@@ -22,27 +22,25 @@ in
     settings = lib.mkOption {
       inherit (settingsFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          fork = false;
-          frame = "full";
-          idle = true;
-          maximized = false;
-          neovim-bin = "/usr/bin/nvim";
-          no-multigrid = false;
-          srgb = false;
-          tabs = true;
-          theme = "auto";
-          title-hidden = true;
-          vsync = true;
-          wsl = false;
+      example = {
+        fork = false;
+        frame = "full";
+        idle = true;
+        maximized = false;
+        neovim-bin = "/usr/bin/nvim";
+        no-multigrid = false;
+        srgb = false;
+        tabs = true;
+        theme = "auto";
+        title-hidden = true;
+        vsync = true;
+        wsl = false;
 
-          font = {
-            normal = [];
-            size = 14.0;
-          };
-        }
-      '';
+        font = {
+          normal = [ ];
+          size = 14.0;
+        };
+      };
       description = ''
         Neovide configuration.
         For available settings see <https://neovide.dev/config-file.html>.

--- a/modules/programs/neovim/default.nix
+++ b/modules/programs/neovim/default.nix
@@ -330,9 +330,9 @@ in
                 # passing actual "${xdg.configHome}/nvim" as basePath was a bit tricky
                 # due to how fileType.target is implemented
                 type = fileType "programs.neovim.plugins._.runtime" "{var}`xdg.configHome/nvim`" "nvim";
-                example = literalExpression ''
-                  { "ftplugin/c.vim".text = "setlocal omnifunc=v:lua.vim.lsp.omnifunc"; }
-                '';
+                example = {
+                  "ftplugin/c.vim".text = "setlocal omnifunc=v:lua.vim.lsp.omnifunc";
+                };
                 description = ''
                   Set of files that have to be linked in nvim config folder.
                 '';
@@ -375,28 +375,29 @@ in
         settings = mkOption {
           inherit (jsonFormat) type;
           default = { };
-          example = literalExpression ''
-            {
-              "suggest.noselect" = true;
-              "suggest.enablePreview" = true;
-              "suggest.enablePreselect" = false;
-              "suggest.disableKind" = true;
-              languageserver = {
-                haskell = {
-                  command = "haskell-language-server-wrapper";
-                  args = [ "--lsp" ];
-                  rootPatterns = [
-                    "*.cabal"
-                    "stack.yaml"
-                    "cabal.project"
-                    "package.yaml"
-                    "hie.yaml"
-                  ];
-                  filetypes = [ "haskell" "lhaskell" ];
-                };
+          example = {
+            "suggest.noselect" = true;
+            "suggest.enablePreview" = true;
+            "suggest.enablePreselect" = false;
+            "suggest.disableKind" = true;
+            languageserver = {
+              haskell = {
+                command = "haskell-language-server-wrapper";
+                args = [ "--lsp" ];
+                rootPatterns = [
+                  "*.cabal"
+                  "stack.yaml"
+                  "cabal.project"
+                  "package.yaml"
+                  "hie.yaml"
+                ];
+                filetypes = [
+                  "haskell"
+                  "lhaskell"
+                ];
               };
-            }
-          '';
+            };
+          };
           description = ''
             Extra configuration lines to add to
             {file}`$XDG_CONFIG_HOME/nvim/coc-settings.json`

--- a/modules/programs/noti.nix
+++ b/modules/programs/noti.nix
@@ -26,17 +26,15 @@ in
         {manpage}`noti.yaml(5)`.
         for the full list of options.
       '';
-      example = lib.literalExpression ''
-        {
-          say = {
-            voice = "Alex";
-          };
-          slack = {
-            token = "1234567890abcdefg";
-            channel = "@jaime";
-          };
-        }
-      '';
+      example = {
+        say = {
+          voice = "Alex";
+        };
+        slack = {
+          token = "1234567890abcdefg";
+          channel = "@jaime";
+        };
+      };
     };
   };
 

--- a/modules/programs/nvchecker.nix
+++ b/modules/programs/nvchecker.nix
@@ -77,20 +77,18 @@ in
             newver = "new_ver.json";
           };
         '';
-        example = lib.literalExpression ''
-          {
-            __config__ = {
-              oldver = "my_custom_oldver.json";
-              newver = "~/separately_placed_newver.json";
-              keyfile = "keyfile.toml";
-            };
+        example = {
+          __config__ = {
+            oldver = "my_custom_oldver.json";
+            newver = "~/separately_placed_newver.json";
+            keyfile = "keyfile.toml";
+          };
 
-            nvchecker = {
-              source = "github";
-              github = "lilydjwg/nvchecker";
-            };
-          }
-        '';
+          nvchecker = {
+            source = "github";
+            github = "lilydjwg/nvchecker";
+          };
+        };
         description = ''
           Configuration written to
           {file}`$HOME/Library/Application Support/nvchecker/nvchecker.toml` (on Darwin) or

--- a/modules/programs/offlineimap/default.nix
+++ b/modules/programs/offlineimap/default.nix
@@ -151,15 +151,13 @@ in
       extraConfig.mbnames = mkOption {
         type = extraConfigType;
         default = { };
-        example = lib.literalExpression ''
-          {
-            filename = "~/.config/mutt/mailboxes";
-            header = "'mailboxes '";
-            peritem = "'+%(accountname)s/%(foldername)s'";
-            sep = "' '";
-            footer = "'\\n'";
-          }
-        '';
+        example = {
+          filename = "~/.config/mutt/mailboxes";
+          header = "'mailboxes '";
+          peritem = "'+%(accountname)s/%(foldername)s'";
+          sep = "' '";
+          footer = "'\\n'";
+        };
         description = ''
           Extra configuration options added to the
           `mbnames` section.

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -103,13 +103,11 @@ in
     settings = mkOption {
       inherit (jsonFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          model = "anthropic/claude-sonnet-4-20250514";
-          autoshare = false;
-          autoupdate = true;
-        }
-      '';
+      example = {
+        model = "anthropic/claude-sonnet-4-20250514";
+        autoshare = false;
+        autoupdate = true;
+      };
       description = ''
         Configuration written to {file}`$XDG_CONFIG_HOME/opencode/opencode.json`.
         See <https://opencode.ai/docs/config/> for the documentation.
@@ -121,14 +119,12 @@ in
     tui = mkOption {
       inherit (jsonFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          theme = "system";
-          keybinds = {
-            leader = "alt+b";
-          };
-        }
-      '';
+      example = {
+        theme = "system";
+        keybinds = {
+          leader = "alt+b";
+        };
+      };
 
       description = ''
         TUI-specific configuration written to {file}`$XDG_CONFIG_HOME/opencode/tui.json`.

--- a/modules/programs/openstackclient.nix
+++ b/modules/programs/openstackclient.nix
@@ -20,19 +20,17 @@ in
     clouds = lib.mkOption {
       type = lib.types.submodule { freeformType = yamlFormat.type; };
       default = { };
-      example = lib.literalExpression ''
-        {
-          my-infra = {
-            cloud = "example-cloud";
-            auth = {
-              project_id = "0123456789abcdef0123456789abcdef";
-              username = "openstack";
-            };
-            region_name = "XXX";
-            interface = "internal";
+      example = {
+        my-infra = {
+          cloud = "example-cloud";
+          auth = {
+            project_id = "0123456789abcdef0123456789abcdef";
+            username = "openstack";
           };
-        }
-      '';
+          region_name = "XXX";
+          interface = "internal";
+        };
+      };
       description = ''
         Configuration needed to connect to one or more clouds.
 

--- a/modules/programs/pandoc.nix
+++ b/modules/programs/pandoc.nix
@@ -47,15 +47,13 @@ in
     defaults = mkOption {
       inherit (jsonFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          metadata = {
-            author = "John Doe";
-          };
-          pdf-engine = "xelatex";
-          citeproc = true;
-        }
-      '';
+      example = {
+        metadata = {
+          author = "John Doe";
+        };
+        pdf-engine = "xelatex";
+        citeproc = true;
+      };
       description = ''
         Options to set by default.
         These will be converted to JSON and written to a defaults

--- a/modules/programs/papis.nix
+++ b/modules/programs/papis.nix
@@ -93,11 +93,9 @@ in
                     str
                   ]);
                 default = { };
-                example = lib.literalExpression ''
-                  {
-                    dir = "~/papers/";
-                  }
-                '';
+                example = {
+                  dir = "~/papers/";
+                };
                 description = ''
                   Configuration for this library.
                 '';

--- a/modules/programs/pet.nix
+++ b/modules/programs/pet.nix
@@ -43,7 +43,10 @@ let
       tag = mkOption {
         type = types.listOf types.str;
         default = [ ];
-        example = lib.literalExpression ''["git" "nixpkgs"]'';
+        example = [
+          "git"
+          "nixpkgs"
+        ];
         description = ''
           List of tags attached to the command.
         '';

--- a/modules/programs/pgcli.nix
+++ b/modules/programs/pgcli.nix
@@ -11,7 +11,6 @@ let
     mkEnableOption
     mkPackageOption
     mkOption
-    literalExpression
     ;
 
   iniFormat = pkgs.formats.ini { };
@@ -29,16 +28,14 @@ in
     settings = mkOption {
       inherit (iniFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          main = {
-            smart_completion = true;
-            vi = true;
-          };
+      example = {
+        main = {
+          smart_completion = true;
+          vi = true;
+        };
 
-          "named queries".simple = "select * from abc where a is not Null";
-        }
-      '';
+        "named queries".simple = "select * from abc where a is not Null";
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/pgcli/config`.

--- a/modules/programs/pianobar.nix
+++ b/modules/programs/pianobar.nix
@@ -10,7 +10,6 @@ let
     mkIf
     mkOption
     mkPackageOption
-    literalExpression
     ;
 
   inherit (lib.types)
@@ -75,17 +74,15 @@ in
         `programs.pianobar.settings.password_command` value.
       '';
 
-      example = literalExpression ''
-        {
-          programs.pianobar = {
-            enable = true;
-            settings = {
-              user = "groovy-tunes@example.com";
-              password_command = "cat /run/secrets/pianobar/groovy-tunes";
-            };
+      example = {
+        programs.pianobar = {
+          enable = true;
+          settings = {
+            user = "groovy-tunes@example.com";
+            password_command = "cat /run/secrets/pianobar/groovy-tunes";
           };
-        }
-      '';
+        };
+      };
     };
   };
 

--- a/modules/programs/pistol.nix
+++ b/modules/programs/pistol.nix
@@ -62,13 +62,20 @@ in
     associations = mkOption {
       type = types.listOf association;
       default = [ ];
-      example = lib.literalExpression ''
-        [
-          { mime = "application/json"; command = "bat %pistol-filename%"; }
-          { mime = "application/*"; command = "hexyl %pistol-filename%"; }
-          { fpath = ".*.md$"; command = "sh: bat --paging=never --color=always %pistol-filename% | head -8"; }
-        ]
-      '';
+      example = [
+        {
+          mime = "application/json";
+          command = "bat %pistol-filename%";
+        }
+        {
+          mime = "application/*";
+          command = "hexyl %pistol-filename%";
+        }
+        {
+          fpath = ".*.md$";
+          command = "sh: bat --paging=never --color=always %pistol-filename% | head -8";
+        }
+      ];
       description = ''
         Associations written to the Pistol configuration at
         {file}`$XDG_CONFIG_HOME/pistol/pistol.conf`.

--- a/modules/programs/piston-cli.nix
+++ b/modules/programs/piston-cli.nix
@@ -19,14 +19,12 @@ in
     settings = lib.mkOption {
       inherit (yamlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          theme = "emacs";
-          box_style = "MINIMAL_DOUBLE_HEAD";
-          prompt_continuation = "...";
-          prompt_start = ">>>";
-        }
-      '';
+      example = {
+        theme = "emacs";
+        box_style = "MINIMAL_DOUBLE_HEAD";
+        prompt_continuation = "...";
+        prompt_start = ">>>";
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/piston-cli/config.yml`.

--- a/modules/programs/poetry.nix
+++ b/modules/programs/poetry.nix
@@ -11,7 +11,6 @@ let
     mkEnableOption
     mkPackageOption
     mkOption
-    literalExpression
     ;
 
   tomlFormat = pkgs.formats.toml { };
@@ -36,12 +35,10 @@ in
     settings = mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          virtualenvs.create = true;
-          virtualenvs.in-project = true;
-        }
-      '';
+      example = {
+        virtualenvs.create = true;
+        virtualenvs.in-project = true;
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/pypoetry/config.toml` on Linux or

--- a/modules/programs/powerline-go.nix
+++ b/modules/programs/powerline-go.nix
@@ -113,9 +113,9 @@ in
           may use '~' to represent your home directory but you should
           protect it to avoid shell substitution.
         '';
-        example = lib.literalExpression ''
-          { "\\~/projects/home-manager" = "prj:home-manager"; }
-        '';
+        example = {
+          "\\~/projects/home-manager" = "prj:home-manager";
+        };
       };
 
       settings = mkOption {
@@ -132,14 +132,15 @@ in
           This can be any key/value pair as described in
           <https://github.com/justjanne/powerline-go>.
         '';
-        example = lib.literalExpression ''
-          {
-            hostname-only-if-ssh = true;
-            numeric-exit-codes = true;
-            cwd-max-depth = 7;
-            ignore-repos = [ "/home/me/big-project" "/home/me/huge-project" ];
-          }
-        '';
+        example = {
+          hostname-only-if-ssh = true;
+          numeric-exit-codes = true;
+          cwd-max-depth = 7;
+          ignore-repos = [
+            "/home/me/big-project"
+            "/home/me/huge-project"
+          ];
+        };
       };
 
       extraUpdatePS1 = mkOption {

--- a/modules/programs/qalculate.nix
+++ b/modules/programs/qalculate.nix
@@ -23,23 +23,21 @@ in
     settings = lib.mkOption {
       inherit (iniFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          General = {
-            precision = 10;
-            colorize = 1;
-            save_mode_on_exit = 1;
-            save_definitions_on_exit = 0;
-          };
-          Mode = {
-            calculate_as_you_type = 1;
-            angle_unit = 1;
-            number_base = 10;
-            min_deci = 0;
-            max_deci = -1;
-          };
-        }
-      '';
+      example = {
+        General = {
+          precision = 10;
+          colorize = 1;
+          save_mode_on_exit = 1;
+          save_definitions_on_exit = 0;
+        };
+        Mode = {
+          calculate_as_you_type = 1;
+          angle_unit = 1;
+          number_base = 10;
+          min_deci = 0;
+          max_deci = -1;
+        };
+      };
 
       description = ''
         Configuration written to

--- a/modules/programs/readline.nix
+++ b/modules/programs/readline.nix
@@ -42,9 +42,9 @@ in
     bindings = mkOption {
       default = { };
       type = types.attrsOf types.str;
-      example = lib.literalExpression ''
-        { "\\C-h" = "backward-kill-word"; }
-      '';
+      example = {
+        "\\C-h" = "backward-kill-word";
+      };
       description = "Readline bindings.";
     };
 

--- a/modules/programs/rectangle.nix
+++ b/modules/programs/rectangle.nix
@@ -31,15 +31,13 @@ in
     defaults = lib.mkOption {
       type = lib.types.attrsOf lib.types.anything;
       default = { };
-      example = lib.literalExpression ''
-        {
-          launchOnLogin = true;
-          gapSize = 8.0;
-          windowSnapping = 1;
-          almostMaximizeHeight = 0.9;
-          almostMaximizeWidth = 0.9;
-        }
-      '';
+      example = {
+        launchOnLogin = true;
+        gapSize = 8.0;
+        windowSnapping = 1;
+        almostMaximizeHeight = 0.9;
+        almostMaximizeWidth = 0.9;
+      };
       description = ''
         Rectangle application defaults. Each attribute name is written as a
         native macOS preference key in Rectangle's plist file.
@@ -82,16 +80,32 @@ in
         }
       );
       default = { };
-      example = lib.literalExpression ''
-        {
-          leftHalf   = { keyCode = 123; modifierFlags = "ctrl+option+command"; };
-          rightHalf  = { keyCode = 124; modifierFlags = "ctrl+option+command"; };
-          topHalf    = { keyCode = 126; modifierFlags = "ctrl+option+command"; };
-          bottomHalf = { keyCode = 125; modifierFlags = "ctrl+option+command"; };
-          maximize   = { keyCode = 46;  modifierFlags = "ctrl+option+command"; };
-          center     = { keyCode = 8;   modifierFlags = "ctrl+option+command"; };
-        }
-      '';
+      example = {
+        leftHalf = {
+          keyCode = 123;
+          modifierFlags = "ctrl+option+command";
+        };
+        rightHalf = {
+          keyCode = 124;
+          modifierFlags = "ctrl+option+command";
+        };
+        topHalf = {
+          keyCode = 126;
+          modifierFlags = "ctrl+option+command";
+        };
+        bottomHalf = {
+          keyCode = 125;
+          modifierFlags = "ctrl+option+command";
+        };
+        maximize = {
+          keyCode = 46;
+          modifierFlags = "ctrl+option+command";
+        };
+        center = {
+          keyCode = 8;
+          modifierFlags = "ctrl+option+command";
+        };
+      };
       description = ''
         Rectangle keyboard shortcuts. Attribute names are Rectangle action
         identifiers (e.g. `leftHalf`, `rightHalf`, `maximize`). Each value

--- a/modules/programs/riff.nix
+++ b/modules/programs/riff.nix
@@ -9,7 +9,6 @@ let
   cfg = config.programs.riff;
 
   inherit (lib)
-    literalExpression
     mkEnableOption
     mkIf
     mkOption
@@ -42,7 +41,7 @@ in
     commandLineOptions = mkOption {
       type = types.listOf types.str;
       default = [ ];
-      example = literalExpression ''[ "--no-adds-only-special" ]'';
+      example = [ "--no-adds-only-special" ];
       apply = lib.concatStringsSep " ";
       description = ''
         Command line arguments to include in the <command>RIFF</command> environment variable.

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -303,15 +303,13 @@ in
 
     extraConfig = mkOption {
       default = { };
-      example = literalExpression ''
-        {
-          kb-primary-paste = "Control+V,Shift+Insert";
-          kb-secondary-paste = "Control+v,Insert";
-          "run,drun" = {
-            display-name = "open:";
-          };
-        }
-      '';
+      example = {
+        kb-primary-paste = "Control+V,Shift+Insert";
+        kb-secondary-paste = "Control+v,Insert";
+        "run,drun" = {
+          display-name = "open:";
+        };
+      };
       type = extraConfigType;
       description = "Additional configuration to add.";
     };

--- a/modules/programs/ruff.nix
+++ b/modules/programs/ruff.nix
@@ -22,16 +22,21 @@ in
     settings = lib.mkOption {
       inherit (settingsFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          line-length = 100;
-          per-file-ignores = { "__init__.py" = [ "F401" ]; };
-          lint = {
-            select = [ "E4" "E7" "E9" "F" ];
-            ignore = [ ];
-          };
-        }
-      '';
+      example = {
+        line-length = 100;
+        per-file-ignores = {
+          "__init__.py" = [ "F401" ];
+        };
+        lint = {
+          select = [
+            "E4"
+            "E7"
+            "E9"
+            "F"
+          ];
+          ignore = [ ];
+        };
+      };
       description = ''
         Ruff configuration.
         For available settings see <https://docs.astral.sh/ruff/settings>.

--- a/modules/programs/sbt.nix
+++ b/modules/programs/sbt.nix
@@ -123,20 +123,18 @@ in
     plugins = mkOption {
       type = types.listOf (sbtTypes.plugin);
       default = [ ];
-      example = literalExpression ''
-        [
-          {
-            org = "net.virtual-void";
-            artifact = "sbt-dependency-graph";
-            version = "0.10.0-RC1";
-          }
-          {
-            org = "com.dwijnand";
-            artifact = "sbt-project-graph";
-            version = "0.4.0";
-          }
-        ]
-      '';
+      example = [
+        {
+          org = "net.virtual-void";
+          artifact = "sbt-dependency-graph";
+          version = "0.10.0-RC1";
+        }
+        {
+          org = "com.dwijnand";
+          artifact = "sbt-project-graph";
+          version = "0.4.0";
+        }
+      ];
       description = ''
         A list of plugins to place in the sbt configuration directory.
       '';
@@ -145,11 +143,9 @@ in
     pluginsExtra = mkOption {
       type = types.listOf (types.str);
       default = [ ];
-      example = literalExpression ''
-        [
-          "addDependencyTreePlugin"
-        ]
-      '';
+      example = [
+        "addDependencyTreePlugin"
+      ];
       description = ''
         A list of extra commands to put in plugins conf file.
         Use it in last resort when you can't use the `plugins` option.
@@ -159,14 +155,14 @@ in
     credentials = mkOption {
       type = types.listOf (sbtTypes.credential);
       default = [ ];
-      example = literalExpression ''
-        [{
+      example = [
+        {
           realm = "Sonatype Nexus Repository Manager";
           host = "example.com";
           user = "user";
           passwordCommand = "pass show sbt/user@example.com";
-        }]
-      '';
+        }
+      ];
       description = ''
         A list of credentials to define in the sbt configuration directory.
       '';

--- a/modules/programs/senpai.nix
+++ b/modules/programs/senpai.nix
@@ -71,13 +71,11 @@ in
           };
         };
       };
-      example = lib.literalExpression ''
-        {
-          address = "libera.chat:6697";
-          nickname = "nicholas";
-          password = "verysecurepassword";
-        }
-      '';
+      example = {
+        address = "libera.chat:6697";
+        nickname = "nicholas";
+        password = "verysecurepassword";
+      };
       description = ''
         Configuration for senpai. For a complete list of options, see
         {manpage}`senpai(5)`.

--- a/modules/programs/sheldon.nix
+++ b/modules/programs/sheldon.nix
@@ -31,7 +31,7 @@ in
       inherit (tomlFormat) type;
       default = { };
       description = "";
-      example = lib.literalExpression "";
+      example = "";
     };
 
     enableZshIntegration = hm.shell.mkZshIntegrationOption { inherit config; };

--- a/modules/programs/sioyek.nix
+++ b/modules/programs/sioyek.nix
@@ -58,16 +58,14 @@ in
           See <https://github.com/ahrm/sioyek/blob/main/pdf_viewer/prefs.config>.
         '';
         default = { };
-        example = literalExpression ''
-          {
-            "background_color" = "1.0 1.0 1.0";
-            "text_highlight_color" = "1.0 0.0 0.0";
-            startup_commands = [
-              "toggle_visual_scroll"
-              "toggle_dark_mode"
-            ];
-          }
-        '';
+        example = {
+          "background_color" = "1.0 1.0 1.0";
+          "text_highlight_color" = "1.0 0.0 0.0";
+          startup_commands = [
+            "toggle_visual_scroll"
+            "toggle_dark_mode"
+          ];
+        };
         type = types.submodule {
           freeformType = types.attrsOf types.str;
 

--- a/modules/programs/sm64ex.nix
+++ b/modules/programs/sm64ex.nix
@@ -48,7 +48,7 @@ in
       description = ''
         Your baserom's region. Note that only "us", "eu", and "jp" are supported.
       '';
-      example = literalExpression "jp";
+      example = "jp";
     };
 
     baserom = mkOption {

--- a/modules/programs/spotify-player.nix
+++ b/modules/programs/spotify-player.nix
@@ -10,7 +10,6 @@ let
     mkEnableOption
     mkPackageOption
     mkOption
-    literalExpression
     mkIf
     ;
   inherit (lib.types) listOf;
@@ -30,20 +29,18 @@ in
     settings = mkOption {
       type = tomlType;
       default = { };
-      example = literalExpression ''
-        {
-          theme = "default";
-          playback_window_position = "Top";
-          copy_command = {
-            command = "wl-copy";
-            args = [];
-          };
-          device = {
-            audio_cache = false;
-            normalization = false;
-          };
-        }
-      '';
+      example = {
+        theme = "default";
+        playback_window_position = "Top";
+        copy_command = {
+          command = "wl-copy";
+          args = [ ];
+        };
+        device = {
+          audio_cache = false;
+          normalization = false;
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/spotify-player/app.toml`.
@@ -57,44 +54,70 @@ in
     themes = mkOption {
       type = listOf tomlType;
       default = [ ];
-      example = literalExpression ''
-        [
-          {
-            name = "default2";
-            palette = {
-              black = "black";
-              red = "red";
-              green = "green";
-              yellow = "yellow";
-              blue = "blue";
-              magenta = "magenta";
-              cyan = "cyan";
-              white = "white";
-              bright_black = "bright_black";
-              bright_red = "bright_red";
-              bright_green = "bright_green";
-              bright_yellow = "bright_yellow";
-              bright_blue = "bright_blue";
-              bright_magenta = "bright_magenta";
-              bright_cyan = "bright_cyan";
-              bright_white = "bright_white";
+      example = [
+        {
+          name = "default2";
+          palette = {
+            black = "black";
+            red = "red";
+            green = "green";
+            yellow = "yellow";
+            blue = "blue";
+            magenta = "magenta";
+            cyan = "cyan";
+            white = "white";
+            bright_black = "bright_black";
+            bright_red = "bright_red";
+            bright_green = "bright_green";
+            bright_yellow = "bright_yellow";
+            bright_blue = "bright_blue";
+            bright_magenta = "bright_magenta";
+            bright_cyan = "bright_cyan";
+            bright_white = "bright_white";
+          };
+          component_style = {
+            block_title = {
+              fg = "Magenta";
             };
-            component_style = {
-              block_title = { fg = "Magenta"; };
-              border = {};
-              playback_track = { fg = "Cyan"; modifiers = ["Bold"]; };
-              playback_artists = { fg = "Cyan"; modifiers = ["Bold"]; };
-              playback_album = { fg = "Yellow"; };
-              playback_metadata = { fg = "BrightBlack"; };
-              playback_progress_bar = { bg = "BrightBlack"; fg = "Green"; };
-              current_playing = { fg = "Green"; modifiers = ["Bold"]; };
-              page_desc = { fg = "Cyan"; modifiers = ["Bold"]; };
-              table_header = { fg = "Blue"; };
-              selection = { modifiers = ["Bold" "Reversed"]; };
+            border = { };
+            playback_track = {
+              fg = "Cyan";
+              modifiers = [ "Bold" ];
             };
-          }
-        ]
-      '';
+            playback_artists = {
+              fg = "Cyan";
+              modifiers = [ "Bold" ];
+            };
+            playback_album = {
+              fg = "Yellow";
+            };
+            playback_metadata = {
+              fg = "BrightBlack";
+            };
+            playback_progress_bar = {
+              bg = "BrightBlack";
+              fg = "Green";
+            };
+            current_playing = {
+              fg = "Green";
+              modifiers = [ "Bold" ];
+            };
+            page_desc = {
+              fg = "Cyan";
+              modifiers = [ "Bold" ];
+            };
+            table_header = {
+              fg = "Blue";
+            };
+            selection = {
+              modifiers = [
+                "Bold"
+                "Reversed"
+              ];
+            };
+          };
+        }
+      ];
       description = ''
         Configuration written to the `themes` field of
         {file}`$XDG_CONFIG_HOME/spotify-player/theme.toml`.
@@ -108,30 +131,28 @@ in
     keymaps = mkOption {
       type = listOf tomlType;
       default = [ ];
-      example = literalExpression ''
-        [
-          {
-            command = "NextTrack";
-            key_sequence = "g n";
-          }
-          {
-            command = "PreviousTrack";
-            key_sequence = "g p";
-          }
-          {
-            command = "Search";
-            key_sequence = "C-c C-x /";
-          }
-          {
-            command = "ResumePause";
-            key_sequence = "M-enter";
-          }
-          {
-            command = "None";
-            key_sequence = "q";
-          }
-        ]
-      '';
+      example = [
+        {
+          command = "NextTrack";
+          key_sequence = "g n";
+        }
+        {
+          command = "PreviousTrack";
+          key_sequence = "g p";
+        }
+        {
+          command = "Search";
+          key_sequence = "C-c C-x /";
+        }
+        {
+          command = "ResumePause";
+          key_sequence = "M-enter";
+        }
+        {
+          command = "None";
+          key_sequence = "q";
+        }
+      ];
       description = ''
         Configuration written to the `keymaps` field of
         {file}`$XDG_CONFIG_HOME/spotify-player/keymap.toml`.
@@ -145,23 +166,21 @@ in
     actions = mkOption {
       type = listOf tomlType;
       default = [ ];
-      example = literalExpression ''
-        [
-          {
-            action = "GoToArtist";
-            key_sequence = "g A";
-          }
-          {
-            action = "GoToAlbum";
-            key_sequence = "g B";
-            target = "PlayingTrack";
-          }
-          {
-            action = "ToggleLiked";
-            key_sequence = "C-l";
-          }
-        ]
-      '';
+      example = [
+        {
+          action = "GoToArtist";
+          key_sequence = "g A";
+        }
+        {
+          action = "GoToAlbum";
+          key_sequence = "g B";
+          target = "PlayingTrack";
+        }
+        {
+          action = "ToggleLiked";
+          key_sequence = "C-l";
+        }
+      ];
       description = ''
         Configuration written to the `actions` field of
         {file}`$XDG_CONFIG_HOME/spotify-player/keymap.toml`.

--- a/modules/programs/sqls.nix
+++ b/modules/programs/sqls.nix
@@ -20,17 +20,15 @@ in
     settings = lib.mkOption {
       inherit (yamlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-           lowercaseKeywords = true;
-           connections = [
-             {
-               driver = "mysql";
-               dataSourceName = "root:root@tcp(127.0.0.1:13306)/world";
-             }
-           ];
-        }
-      '';
+      example = {
+        lowercaseKeywords = true;
+        connections = [
+          {
+            driver = "mysql";
+            dataSourceName = "root:root@tcp(127.0.0.1:13306)/world";
+          }
+        ];
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/sqls/config.yml`. See

--- a/modules/programs/streamlink.nix
+++ b/modules/programs/streamlink.nix
@@ -59,11 +59,9 @@ let
             ]))
           ]);
         default = { };
-        example = lib.literalExpression ''
-          {
-            quiet = true;
-          }
-        '';
+        example = {
+          quiet = true;
+        };
         description = ''
           Configuration for the specific plugin, written to
           {file}`$XDG_CONFIG_HOME/streamlink/config.<name>` (linux) or

--- a/modules/programs/t3code.nix
+++ b/modules/programs/t3code.nix
@@ -78,24 +78,22 @@ in
     userSettings = mkOption {
       inherit (jsonFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          enableAssistantStreaming = true;
-          providerInstances = {
-            codex = {
-              driver = "codex";
+      example = {
+        enableAssistantStreaming = true;
+        providerInstances = {
+          codex = {
+            driver = "codex";
+            enabled = true;
+            config = {
               enabled = true;
-              config = {
-                enabled = true;
-                binaryPath = "codex";
-                homePath = "";
-                shadowHomePath = "";
-                customModels = [ ];
-              };
+              binaryPath = "codex";
+              homePath = "";
+              shadowHomePath = "";
+              customModels = [ ];
             };
           };
-        }
-      '';
+        };
+      };
       description = ''
         Configuration written to t3code's {file}`settings.json`.
       '';
@@ -104,24 +102,22 @@ in
     keybindings = mkOption {
       inherit (jsonFormat) type;
       default = [ ];
-      example = literalExpression ''
-        [
-          {
-            key = "mod+j";
-            command = "terminal.toggle";
-          }
-          {
-            key = "mod+d";
-            command = "terminal.split";
-            when = "terminalFocus";
-          }
-          {
-            key = "mod+d";
-            command = "diff.toggle";
-            when = "!terminalFocus";
-          }
-        ]
-      '';
+      example = [
+        {
+          key = "mod+j";
+          command = "terminal.toggle";
+        }
+        {
+          key = "mod+d";
+          command = "terminal.split";
+          when = "terminalFocus";
+        }
+        {
+          key = "mod+d";
+          command = "diff.toggle";
+          when = "!terminalFocus";
+        }
+      ];
       description = ''
         Configuration written to t3code's {file}`keybindings.json`.
       '';
@@ -130,20 +126,18 @@ in
     clientSettings = mkOption {
       inherit (jsonFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          settings = {
-            favorites = [
-              {
-                provider = "codex";
-                model = "gpt-5.5";
-              }
-            ];
-            sidebarProjectGroupingMode = "repository";
-            timestampFormat = "locale";
-          };
-        }
-      '';
+      example = {
+        settings = {
+          favorites = [
+            {
+              provider = "codex";
+              model = "gpt-5.5";
+            }
+          ];
+          sidebarProjectGroupingMode = "repository";
+          timestampFormat = "locale";
+        };
+      };
       description = ''
         Configuration written to t3code's {file}`client-settings.json`.
       '';

--- a/modules/programs/tealdeer.nix
+++ b/modules/programs/tealdeer.nix
@@ -23,7 +23,7 @@ let
           auto_update_interval_hours = mkOption {
             type = types.ints.positive;
             default = 720;
-            example = lib.literalExpression "24";
+            example = 24;
             description = ''
               Duration, since the last cache update, after which the cache will be refreshed.
               This parameter is ignored if {var}`auto_update` is set to `false`.

--- a/modules/programs/television.nix
+++ b/modules/programs/television.nix
@@ -26,19 +26,20 @@ in
         See <https://github.com/alexpasmantier/television/blob/main/.config/config.toml>
         for the full list of options.
       '';
-      example = lib.literalExpression ''
-        {
-          tick_rate = 50;
-          ui = {
-            use_nerd_font_icons = true;
-            ui_scale = 120;
-            show_preview_panel = false;
-          };
-          keybindings = {
-            quit = [ "esc" "ctrl-c" ];
-          };
-        }
-      '';
+      example = {
+        tick_rate = 50;
+        ui = {
+          use_nerd_font_icons = true;
+          ui_scale = 120;
+          show_preview_panel = false;
+        };
+        keybindings = {
+          quit = [
+            "esc"
+            "ctrl-c"
+          ];
+        };
+      };
     };
 
     channels = lib.mkOption {

--- a/modules/programs/tex-fmt.nix
+++ b/modules/programs/tex-fmt.nix
@@ -11,7 +11,6 @@ let
     mkEnableOption
     mkPackageOption
     mkOption
-    literalExpression
     ;
 
   configDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else config.xdg.configHome;
@@ -34,14 +33,12 @@ in
     settings = mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          wrap = true;
-          tabsize = 2;
-          tabchar = "space";
-          lists = [];
-        }
-      '';
+      example = {
+        wrap = true;
+        tabsize = 2;
+        tabchar = "space";
+        lists = [ ];
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/tex-fmt/tex-fmt.toml` on Linux or

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -522,21 +522,19 @@ in
                 settings = mkOption {
                   type = thunderbirdJson;
                   default = { };
-                  example = literalExpression ''
-                    {
-                      "mail.spellcheck.inline" = false;
-                      "mailnews.database.global.views.global.columns" = {
-                        selectCol = {
-                          visible = false;
-                          ordinal = 1;
-                        };
-                        threadCol = {
-                          visible = true;
-                          ordinal = 2;
-                        };
+                  example = {
+                    "mail.spellcheck.inline" = false;
+                    "mailnews.database.global.views.global.columns" = {
+                      selectCol = {
+                        visible = false;
+                        ordinal = 1;
                       };
-                    }
-                  '';
+                      threadCol = {
+                        visible = true;
+                        ordinal = 2;
+                      };
+                    };
+                  };
                   description = ''
                     Preferences to add to this profile's
                     {file}`user.js`.
@@ -689,12 +687,10 @@ in
       settings = mkOption {
         type = thunderbirdJson;
         default = { };
-        example = literalExpression ''
-          {
-            "general.useragent.override" = "";
-            "privacy.donottrackheader.enabled" = true;
-          }
-        '';
+        example = {
+          "general.useragent.override" = "";
+          "privacy.donottrackheader.enabled" = true;
+        };
         description = ''
           Attribute set of Thunderbird preferences to be added to
           all profiles.
@@ -739,9 +735,10 @@ in
               profiles = mkOption {
                 type = with types; listOf str;
                 default = [ ];
-                example = literalExpression ''
-                  [ "profile1" "profile2" ]
-                '';
+                example = [
+                  "profile1"
+                  "profile2"
+                ];
                 description = ''
                   List of Thunderbird profiles for which this account should be
                   enabled. If this list is empty (the default), this account will
@@ -854,17 +851,15 @@ in
                   });
                 default = [ ];
                 defaultText = literalExpression "[ ]";
-                example = literalExpression ''
-                  [
-                    {
-                      name = "Mark as Read on Archive";
-                      enabled = true;
-                      type = "128";
-                      action = "Mark read";
-                      condition = "ALL";
-                    }
-                  ]
-                '';
+                example = [
+                  {
+                    name = "Mark as Read on Archive";
+                    enabled = true;
+                    type = "128";
+                    action = "Mark read";
+                    condition = "ALL";
+                  }
+                ];
                 description = ''
                   List of message filters to add to this Thunderbird account configuration.
 
@@ -894,9 +889,10 @@ in
             profiles = mkOption {
               type = with types; listOf str;
               default = [ ];
-              example = literalExpression ''
-                [ "profile1" "profile2" ]
-              '';
+              example = [
+                "profile1"
+                "profile2"
+              ];
               description = ''
                 List of Thunderbird profiles for which this account should be
                 enabled. If this list is empty (the default), this account will
@@ -961,9 +957,10 @@ in
             profiles = mkOption {
               type = with types; listOf str;
               default = [ ];
-              example = literalExpression ''
-                [ "profile1" "profile2" ]
-              '';
+              example = [
+                "profile1"
+                "profile2"
+              ];
               description = ''
                 List of Thunderbird profiles for which this account should be
                 enabled. If this list is empty (the default), this account will

--- a/modules/programs/tirith.nix
+++ b/modules/programs/tirith.nix
@@ -32,16 +32,14 @@ in
     policy = lib.mkOption {
       inherit (yamlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          version = 1;
-          fail_mode = "open";
-          allow_bypass = true;
-          severity_overrides = {
-            docker_untrusted_registry = "CRITICAL";
-          };
-        }
-      '';
+      example = {
+        version = 1;
+        fail_mode = "open";
+        allow_bypass = true;
+        severity_overrides = {
+          docker_untrusted_registry = "CRITICAL";
+        };
+      };
       description = ''
         Tirith policy configuration.
         Written to `$XDG_CONFIG_HOME/tirith/policy.yaml`.

--- a/modules/programs/tmate.nix
+++ b/modules/programs/tmate.nix
@@ -6,7 +6,6 @@
 }:
 let
   inherit (lib)
-    literalExpression
     mkOption
     optional
     types
@@ -26,7 +25,7 @@ in
       host = mkOption {
         type = with types; nullOr str;
         default = null;
-        example = literalExpression "tmate.io";
+        example = "tmate.io";
         description = "Tmate server address.";
       };
 
@@ -40,14 +39,14 @@ in
       dsaFingerprint = mkOption {
         type = with types; nullOr str;
         default = null;
-        example = literalExpression "SHA256:1111111111111111111111111111111111111111111";
+        example = "SHA256:1111111111111111111111111111111111111111111";
         description = "Tmate server EdDSA key fingerprint.";
       };
 
       rsaFingerprint = mkOption {
         type = with types; nullOr str;
         default = null;
-        example = literalExpression "SHA256:1111111111111111111111111111111111111111111";
+        example = "SHA256:1111111111111111111111111111111111111111111";
         description = "Tmate server RSA key fingerprint.";
       };
 

--- a/modules/programs/tmuxinator.nix
+++ b/modules/programs/tmuxinator.nix
@@ -25,26 +25,24 @@ in
         See <https://github.com/tmuxinator/tmuxinator> for the project
         configuration format.
       '';
-      example = lib.literalExpression ''
-        {
-          myproject = {
-            root = "~/code/myproject";
-            windows = [
-              {
-                editor = {
-                  layout = "main-vertical";
-                  panes = [
-                    { editor = [ "vim" ]; }
-                    "guard"
-                  ];
-                };
-              }
-              { server = "bundle exec rails s"; }
-              { logs = "tail -f log/development.log"; }
-            ];
-          };
-        }
-      '';
+      example = {
+        myproject = {
+          root = "~/code/myproject";
+          windows = [
+            {
+              editor = {
+                layout = "main-vertical";
+                panes = [
+                  { editor = [ "vim" ]; }
+                  "guard"
+                ];
+              };
+            }
+            { server = "bundle exec rails s"; }
+            { logs = "tail -f log/development.log"; }
+          ];
+        };
+      };
     };
   };
 

--- a/modules/programs/topgrade.nix
+++ b/modules/programs/topgrade.nix
@@ -22,22 +22,20 @@ in
       inherit (tomlFormat) type;
       default = { };
       defaultText = lib.literalExpression "{ }";
-      example = lib.literalExpression ''
-        {
-          misc = {
-            assume_yes = true;
-            disable = [
-              "flutter"
-              "node"
-            ];
-            set_title = false;
-            cleanup = true;
-          };
-          commands = {
-            "Run garbage collection on Nix store" = "nix-collect-garbage";
-          };
-        }
-      '';
+      example = {
+        misc = {
+          assume_yes = true;
+          disable = [
+            "flutter"
+            "node"
+          ];
+          set_title = false;
+          cleanup = true;
+        };
+        commands = {
+          "Run garbage collection on Nix store" = "nix-collect-garbage";
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/topgrade.toml`.

--- a/modules/programs/ttyper.nix
+++ b/modules/programs/ttyper.nix
@@ -6,7 +6,6 @@
 }:
 let
   inherit (lib)
-    literalExpression
     mkIf
     mkOption
     ;
@@ -31,16 +30,14 @@ in
         See <https://github.com/max-niederman/ttyper> for all available options,
         including supported languages and theme keys.
       '';
-      example = literalExpression ''
-        {
-          default_language = "english200";
-          theme = {
-            border_type = "rounded";
-            prompt_correct = "green";
-            prompt_incorrect = "red";
-          };
-        }
-      '';
+      example = {
+        default_language = "english200";
+        theme = {
+          border_type = "rounded";
+          prompt_correct = "green";
+          prompt_incorrect = "red";
+        };
+      };
     };
   };
 

--- a/modules/programs/ty.nix
+++ b/modules/programs/ty.nix
@@ -9,7 +9,6 @@ let
     mkEnableOption
     mkPackageOption
     mkOption
-    literalExpression
     ;
 
   tomlFormat = pkgs.formats.toml { };
@@ -26,11 +25,9 @@ in
     settings = mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          rules.index-out-of-bounds = "ignore";
-        }
-      '';
+      example = {
+        rules.index-out-of-bounds = "ignore";
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/ty/ty.toml`.

--- a/modules/programs/urxvt.nix
+++ b/modules/programs/urxvt.nix
@@ -26,12 +26,10 @@ in
       type = types.attrsOf types.str;
       default = { };
       description = "Mapping of keybindings to actions";
-      example = lib.literalExpression ''
-        {
-          "Shift-Control-C" = "eval:selection_to_clipboard";
-          "Shift-Control-V" = "eval:paste_clipboard";
-        }
-      '';
+      example = {
+        "Shift-Control-C" = "eval:selection_to_clipboard";
+        "Shift-Control-V" = "eval:paste_clipboard";
+      };
     };
 
     iso14755 = mkOption {

--- a/modules/programs/vesktop/mkVesktopLikeModule.nix
+++ b/modules/programs/vesktop/mkVesktopLikeModule.nix
@@ -84,22 +84,20 @@ in
           {file}`$XDG_CONFIG_HOME/${moduleName}/settings/settings.json`. See
           <${cordSettingsLink}> for available options.
         '';
-        example = lib.literalExpression ''
-          {
-            autoUpdate = false;
-            autoUpdateNotification = false;
-            notifyAboutUpdates = false;
-            useQuickCss = true;
-            disableMinSize = true;
-            plugins = {
-              MessageLogger = {
-                enabled = true;
-                ignoreSelf = true;
-              };
-              FakeNitro.enabled = true;
+        example = {
+          autoUpdate = false;
+          autoUpdateNotification = false;
+          notifyAboutUpdates = false;
+          useQuickCss = true;
+          disableMinSize = true;
+          plugins = {
+            MessageLogger = {
+              enabled = true;
+              ignoreSelf = true;
             };
-          }
-        '';
+            FakeNitro.enabled = true;
+          };
+        };
       };
       extraQuickCss = lib.mkOption {
         type = lib.types.lines;

--- a/modules/programs/vicinae/default.nix
+++ b/modules/programs/vicinae/default.nix
@@ -139,18 +139,16 @@ in
     settings = lib.mkOption {
       inherit (jsonFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          favicon_service = "twenty";
-          font.normal.size = 10;
-          pop_to_root_on_close=false;
-          search_files_in_root= false;
-          theme = {
-            dark.name = "vicinae-dark";
-            light.name = "vicinae-light";
-          };
-        }
-      '';
+      example = {
+        favicon_service = "twenty";
+        font.normal.size = 10;
+        pop_to_root_on_close = false;
+        search_files_in_root = false;
+        theme = {
+          dark.name = "vicinae-dark";
+          light.name = "vicinae-light";
+        };
+      };
       description = ''
         Settings written as JSON to {file}`~/.config/vicinae/settings.json`.
         See {command}`vicinae config default`.

--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -111,13 +111,11 @@ in
       settings = mkOption {
         type = vimSettingsType;
         default = { };
-        example = literalExpression ''
-          {
-            expandtab = true;
-            history = 1000;
-            background = "dark";
-          }
-        '';
+        example = {
+          expandtab = true;
+          history = 1000;
+          background = "dark";
+        };
         description = ''
           At attribute set of Vim settings. The attribute names and
           corresponding values must be among the following supported

--- a/modules/programs/vscode/mkVscodeModule.nix
+++ b/modules/programs/vscode/mkVscodeModule.nix
@@ -102,12 +102,10 @@ let
       userSettings = mkOption {
         type = types.either types.path jsonFormat.type;
         default = { };
-        example = literalExpression ''
-          {
-            "files.autoSave" = "off";
-            "[nix]"."editor.tabSize" = 2;
-          }
-        '';
+        example = {
+          "files.autoSave" = "off";
+          "[nix]"."editor.tabSize" = 2;
+        };
         description = ''
           Configuration written to ${name}'s
           {file}`settings.json`.
@@ -118,18 +116,16 @@ let
       userTasks = mkOption {
         type = types.either types.path jsonFormat.type;
         default = { };
-        example = literalExpression ''
-          {
-            version = "2.0.0";
-            tasks = [
-              {
-                type = "shell";
-                label = "Hello task";
-                command = "hello";
-              }
-            ];
-          }
-        '';
+        example = {
+          version = "2.0.0";
+          tasks = [
+            {
+              type = "shell";
+              label = "Hello task";
+              command = "hello";
+            }
+          ];
+        };
         description = ''
           Configuration written to ${name}'s
           {file}`tasks.json`.
@@ -208,15 +204,13 @@ let
           )
         );
         default = [ ];
-        example = literalExpression ''
-          [
-            {
-              key = "ctrl+c";
-              command = "editor.action.clipboardCopyAction";
-              when = "textInputFocus";
-            }
-          ]
-        '';
+        example = [
+          {
+            key = "ctrl+c";
+            command = "editor.action.clipboardCopyAction";
+            when = "textInputFocus";
+          }
+        ];
         description = ''
           Keybindings written to ${name}'s
           {file}`keybindings.json`.
@@ -309,11 +303,9 @@ in
     argvSettings = mkOption {
       type = types.either types.path jsonFormat.type;
       default = { };
-      example = literalExpression ''
-        {
-          enable-crash-reporter = false;
-        }
-      '';
+      example = {
+        enable-crash-reporter = false;
+      };
       description = ''
         Configuration written to ${name}'s
         {file}`argv.json`.

--- a/modules/programs/wallust.nix
+++ b/modules/programs/wallust.nix
@@ -11,7 +11,6 @@ let
     mkPackageOption
     mkOption
     mkIf
-    literalExpression
     ;
   cfg = config.programs.wallust;
   tomlFormat = pkgs.formats.toml { };
@@ -27,11 +26,9 @@ in
     settings = mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          palette = "softdark";
-        }
-      '';
+      example = {
+        palette = "softdark";
+      };
       description = ''
         Configuration written to {file}`$XDG_CONFIG_HOME/wallust/wallust.toml`.
         See <https://explosion-mental.codeberg.page/wallust/config/> for

--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -55,9 +55,11 @@ let
         output = mkOption {
           type = nullOr (either str (listOf str));
           default = null;
-          example = literalExpression ''
-            [ "DP-1" "!DP-2" "!DP-3" ]
-          '';
+          example = [
+            "DP-1"
+            "!DP-2"
+            "!DP-3"
+          ];
           description = ''
             Specifies on which screen this bar will be displayed.
             Exclamation mark(!) can be used to exclude specific output.
@@ -94,18 +96,18 @@ let
           type = nullOr (listOf str);
           default = null;
           description = "Modules that will be displayed on the left.";
-          example = literalExpression ''
-            [ "sway/workspaces" "sway/mode" "wlr/taskbar" ]
-          '';
+          example = [
+            "sway/workspaces"
+            "sway/mode"
+            "wlr/taskbar"
+          ];
         };
 
         modules-center = mkOption {
           type = nullOr (listOf str);
           default = null;
           description = "Modules that will be displayed in the center.";
-          example = literalExpression ''
-            [ "sway/window" ]
-          '';
+          example = [ "sway/window" ];
         };
 
         modules-right = mkOption {
@@ -122,16 +124,14 @@ let
           visible = false;
           default = null;
           description = "Modules configuration.";
-          example = literalExpression ''
-            {
-              "sway/window" = {
-                max-length = 50;
-              };
-              "clock" = {
-                format-alt = "{:%a, %d. %b  %H:%M}";
-              };
-            }
-          '';
+          example = {
+            "sway/window" = {
+              max-length = 50;
+            };
+            "clock" = {
+              format-alt = "{:%a, %d. %b  %H:%M}";
+            };
+          };
         };
 
         margin = mkOption {

--- a/modules/programs/wayprompt.nix
+++ b/modules/programs/wayprompt.nix
@@ -35,17 +35,15 @@ in
     settings = lib.mkOption {
       inherit (iniFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          general = {
-            font-regular = "sans:size=14";
-            pin-square-amount = 32;
-          };
-          colours = {
-            background = "ffffffaa";
-          };
-        }
-      '';
+      example = {
+        general = {
+          font-regular = "sans:size=14";
+          pin-square-amount = 32;
+        };
+        colours = {
+          background = "ffffffaa";
+        };
+      };
       description = ''
         Configuration for wayprompt written to
         {file}`$XDG_CONFIG_HOME/wayprompt/config.ini`.

--- a/modules/programs/wlogout.nix
+++ b/modules/programs/wlogout.nix
@@ -9,7 +9,6 @@ let
   inherit (lib)
     filterAttrs
     isStorePath
-    literalExpression
     types
     ;
   inherit (lib.options) mkEnableOption mkPackageOption mkOption;
@@ -93,16 +92,14 @@ in
         Layout configuration for wlogout, see <https://github.com/ArtsyMacaw/wlogout#config>
         for supported values.
       '';
-      example = literalExpression ''
-        [
-          {
-            label = "shutdown";
-            action = "systemctl poweroff";
-            text = "Shutdown";
-            keybind = "s";
-          }
-        ]
-      '';
+      example = [
+        {
+          label = "shutdown";
+          action = "systemctl poweroff";
+          text = "Shutdown";
+          keybind = "s";
+        }
+      ];
     };
 
     style = mkOption {

--- a/modules/programs/wofi.nix
+++ b/modules/programs/wofi.nix
@@ -31,13 +31,11 @@ in
         Configuration options for wofi. See
         {manpage}`wofi(5)`.
       '';
-      example = lib.literalExpression ''
-        {
-          location = "bottom-right";
-          allow_markup = true;
-          width = 250;
-        }
-      '';
+      example = {
+        location = "bottom-right";
+        allow_markup = true;
+        width = 250;
+      };
     };
 
     style = mkOption {

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -147,19 +147,17 @@ in
     settings = mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          log = {
-            enabled = false;
-          };
-          mgr = {
-            show_hidden = false;
-            sort_by = "mtime";
-            sort_dir_first = true;
-            sort_reverse = true;
-          };
-        }
-      '';
+      example = {
+        log = {
+          enabled = false;
+        };
+        mgr = {
+          show_hidden = false;
+          sort_by = "mtime";
+          sort_dir_first = true;
+          sort_reverse = true;
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/yazi/yazi.toml`.
@@ -196,18 +194,16 @@ in
     vfs = mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          services = {
-            my-server = {
-              host = "1.2.3.4";
-              port = 22;
-              type = "sftp";
-              user = "root";
-            };
+      example = {
+        services = {
+          my-server = {
+            host = "1.2.3.4";
+            port = 22;
+            type = "sftp";
+            user = "root";
           };
-        }
-      '';
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/yazi/vfs.toml`.

--- a/modules/programs/yt-dlp.nix
+++ b/modules/programs/yt-dlp.nix
@@ -44,19 +44,17 @@ in
     settings = mkOption {
       type = with types; attrsOf (either configAtom (listOf configAtom));
       default = { };
-      example = lib.literalExpression ''
-        {
-          embed-thumbnail = true;
-          embed-subs = true;
-          sub-langs = "all";
-          downloader = "aria2c";
-          downloader-args = "aria2c:'-c -x8 -s8 -k1M'";
-          color = [
-            "stdout:no_color"
-            "stderr:always"
-          ];
-        }
-      '';
+      example = {
+        embed-thumbnail = true;
+        embed-subs = true;
+        sub-langs = "all";
+        downloader = "aria2c";
+        downloader-args = "aria2c:'-c -x8 -s8 -k1M'";
+        color = [
+          "stdout:no_color"
+          "stderr:always"
+        ];
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/yt-dlp/config`.

--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -119,19 +119,17 @@ in
       userSettings = mkOption {
         inherit (jsonFormat) type;
         default = { };
-        example = literalExpression ''
-          {
-            features = {
-              copilot = false;
-            };
-            telemetry = {
-              metrics = false;
-            };
-            vim_mode = false;
-            ui_font_size = 16;
-            buffer_font_size = 16;
-          }
-        '';
+        example = {
+          features = {
+            copilot = false;
+          };
+          telemetry = {
+            metrics = false;
+          };
+          vim_mode = false;
+          ui_font_size = 16;
+          buffer_font_size = 16;
+        };
         description = ''
           Configuration written to Zed's {file}`settings.json`.
         '';
@@ -158,15 +156,16 @@ in
       userTasks = mkOption {
         inherit (jsonFormat) type;
         default = [ ];
-        example = literalExpression ''
-          [
-            {
-              label = "Format Code";
-              command = "nix";
-              args = [ "fmt" "$ZED_WORKTREE_ROOT" ];
-            }
-          ]
-        '';
+        example = [
+          {
+            label = "Format Code";
+            command = "nix";
+            args = [
+              "fmt"
+              "$ZED_WORKTREE_ROOT"
+            ];
+          }
+        ];
         description = ''
           Configuration written to Zed's {file}`tasks.json`.
 
@@ -178,17 +177,15 @@ in
       userDebug = mkOption {
         inherit (jsonFormat) type;
         default = [ ];
-        example = literalExpression ''
-          [
-            {
-              label = "Go (Delve)";
-              adapter = "Delve";
-              program = "$ZED_FILE";
-              request = "launch";
-              mode = "debug";
-            }
-          ]
-        '';
+        example = [
+          {
+            label = "Go (Delve)";
+            adapter = "Delve";
+            program = "$ZED_FILE";
+            request = "launch";
+            mode = "debug";
+          }
+        ];
         description = ''
           Configuration written to Zed's {file}`debug.json`.
 
@@ -199,9 +196,11 @@ in
       extensions = mkOption {
         type = types.listOf types.str;
         default = [ ];
-        example = literalExpression ''
-          [ "swift" "nix" "xy-zed" ]
-        '';
+        example = [
+          "swift"
+          "nix"
+          "xy-zed"
+        ];
         description = ''
           A list of the extensions Zed should install on startup.
           Use the name of a repository in the [extension list](https://github.com/zed-industries/extensions/tree/main/extensions).

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -39,98 +39,96 @@ in
         ]
       );
       default = { };
-      example = lib.literalExpression ''
-        {
-          dev = {
-            layout = {
-              _children = [
-                {
-                  default_tab_template = {
-                    _children = [
-                      {
-                        pane = {
-                          size = 1;
-                          borderless = true;
-                          plugin = {
-                            location = "zellij:tab-bar";
-                          };
+      example = {
+        dev = {
+          layout = {
+            _children = [
+              {
+                default_tab_template = {
+                  _children = [
+                    {
+                      pane = {
+                        size = 1;
+                        borderless = true;
+                        plugin = {
+                          location = "zellij:tab-bar";
                         };
-                      }
-                      { "children" = { }; }
-                      {
-                        pane = {
-                          size = 2;
-                          borderless = true;
-                          plugin = {
-                            location = "zellij:status-bar";
-                          };
+                      };
+                    }
+                    { "children" = { }; }
+                    {
+                      pane = {
+                        size = 2;
+                        borderless = true;
+                        plugin = {
+                          location = "zellij:status-bar";
                         };
-                      }
-                    ];
+                      };
+                    }
+                  ];
+                };
+              }
+              {
+                tab = {
+                  _props = {
+                    name = "Project";
+                    focus = true;
                   };
-                }
-                {
-                  tab = {
-                    _props = {
-                      name = "Project";
-                      focus = true;
-                    };
-                    _children = [
-                      {
-                        pane = {
-                          command = "nvim";
-                        };
-                      }
-                    ];
+                  _children = [
+                    {
+                      pane = {
+                        command = "nvim";
+                      };
+                    }
+                  ];
+                };
+              }
+              {
+                tab = {
+                  _props = {
+                    name = "Git";
                   };
-                }
-                {
-                  tab = {
-                    _props = {
-                      name = "Git";
-                    };
-                    _children = [
-                      {
-                        pane = {
-                          command = "lazygit";
-                        };
-                      }
-                    ];
+                  _children = [
+                    {
+                      pane = {
+                        command = "lazygit";
+                      };
+                    }
+                  ];
+                };
+              }
+              {
+                tab = {
+                  _props = {
+                    name = "Files";
                   };
-                }
-                {
-                  tab = {
-                    _props = {
-                      name = "Files";
-                    };
-                    _children = [
-                      {
-                        pane = {
-                          command = "yazi";
-                        };
-                      }
-                    ];
+                  _children = [
+                    {
+                      pane = {
+                        command = "yazi";
+                      };
+                    }
+                  ];
+                };
+              }
+              {
+                tab = {
+                  _props = {
+                    name = "Shell";
                   };
-                }
-                {
-                  tab = {
-                    _props = {
-                      name = "Shell";
-                    };
-                    _children = [
-                      {
-                        pane = {
-                          command = "zsh";
-                        };
-                      }
-                    ];
-                  };
-                }
-              ];
-            };
+                  _children = [
+                    {
+                      pane = {
+                        command = "zsh";
+                      };
+                    }
+                  ];
+                };
+              }
+            ];
           };
-        }
-      '';
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/zellij/layouts/<layout>.kdl`.

--- a/modules/programs/zk.nix
+++ b/modules/programs/zk.nix
@@ -22,23 +22,21 @@ in
     settings = lib.mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          note = {
-            language = "en";
-            default-title = "Untitled";
-            filename = "{{id}}-{{slug title}}";
-            extension = "md";
-            template = "default.md";
-            id-charset = "alphanum";
-            id-length = 4;
-            id-case = "lower";
-          };
-          extra = {
-            author = "Mickaël";
-          };
-        }
-      '';
+      example = {
+        note = {
+          language = "en";
+          default-title = "Untitled";
+          filename = "{{id}}-{{slug title}}";
+          extension = "md";
+          template = "default.md";
+          id-charset = "alphanum";
+          id-length = 4;
+          id-case = "lower";
+        };
+        extra = {
+          author = "Mickaël";
+        };
+      };
       description = ''
         Configuration written to {file}`$XDG_CONFIG_HOME/zk/config.toml`.
 

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -128,12 +128,10 @@ in
 
         shellAliases = mkOption {
           default = { };
-          example = literalExpression ''
-            {
-              ll = "ls -l";
-              ".." = "cd ..";
-            }
-          '';
+          example = {
+            ll = "ls -l";
+            ".." = "cd ..";
+          };
           description = ''
             An attribute set that maps aliases (the top level attribute names in
             this option) to command strings or directly to build outputs.
@@ -143,12 +141,10 @@ in
 
         shellGlobalAliases = mkOption {
           default = { };
-          example = literalExpression ''
-            {
-              UUID = "$(uuidgen | tr -d \\n)";
-              G = "| grep";
-            }
-          '';
+          example = {
+            UUID = "$(uuidgen | tr -d \\n)";
+            G = "| grep";
+          };
           description = ''
             Similar to [](#opt-programs.zsh.shellAliases),
             but are substituted anywhere on a line.

--- a/modules/programs/zsh/history.nix
+++ b/modules/programs/zsh/history.nix
@@ -7,7 +7,7 @@
 let
   cfg = config.programs.zsh;
 
-  inherit (lib) literalExpression mkOption types;
+  inherit (lib) mkOption types;
 
   inherit (import ./lib.nix { inherit config lib; }) dotDirAbs mkShellVarPathStr;
 in
@@ -57,7 +57,10 @@ in
             ignorePatterns = mkOption {
               type = types.listOf types.str;
               default = [ ];
-              example = literalExpression ''[ "rm *" "pkill *" ]'';
+              example = [
+                "rm *"
+                "pkill *"
+              ];
               description = ''
                 Do not enter command lines into the history list
                 if they match any one of the given shell patterns.

--- a/modules/services/avizo.nix
+++ b/modules/services/avizo.nix
@@ -17,17 +17,15 @@ in
     settings = lib.mkOption {
       inherit ((pkgs.formats.ini { })) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          default = {
-            time = 1.0;
-            y-offset = 0.5;
-            fade-in = 0.1;
-            fade-out = 0.2;
-            padding = 10;
-          };
-        }
-      '';
+      example = {
+        default = {
+          time = 1.0;
+          y-offset = 0.5;
+          fade-in = 0.1;
+          fade-out = 0.2;
+          padding = 10;
+        };
+      };
       description = ''
         The settings that will be written to the avizo configuration file.
       '';

--- a/modules/services/comodoro.nix
+++ b/modules/services/comodoro.nix
@@ -25,11 +25,9 @@ in
     environment = lib.mkOption {
       type = with lib.types; attrsOf str;
       default = { };
-      example = lib.literalExpression ''
-        {
-          "PASSWORD_STORE_DIR" = "~/.password-store";
-        }
-      '';
+      example = {
+        "PASSWORD_STORE_DIR" = "~/.password-store";
+      };
       description = ''
         Extra environment variables to be exported in the service.
       '';

--- a/modules/services/darkman.nix
+++ b/modules/services/darkman.nix
@@ -68,13 +68,11 @@ in
     settings = lib.mkOption {
       type = types.submodule { freeformType = yamlFormat.type; };
       default = { };
-      example = lib.literalExpression ''
-        {
-          lat = 52.3;
-          lng = 4.8;
-          usegeoclue = true;
-        }
-      '';
+      example = {
+        lat = 52.3;
+        lng = 4.8;
+        usegeoclue = true;
+      };
       description = ''
         Settings for the {command}`darkman` command. See
         <https://darkman.whynothugo.nl/#CONFIGURATION> for details.

--- a/modules/services/etesync-dav.nix
+++ b/modules/services/etesync-dav.nix
@@ -35,12 +35,10 @@ in
         ]
       );
       default = { };
-      example = lib.literalExpression ''
-        {
-          ETESYNC_LISTEN_ADDRESS = "localhost";
-          ETESYNC_LISTEN_PORT = 37358;
-        }
-      '';
+      example = {
+        ETESYNC_LISTEN_ADDRESS = "localhost";
+        ETESYNC_LISTEN_PORT = 37358;
+      };
       description = ''
         Settings for etesync-dav, passed as environment variables.
       '';

--- a/modules/services/fnott.nix
+++ b/modules/services/fnott.nix
@@ -61,19 +61,17 @@ in
           {manpage}`fnott.ini(5)` for a list of available options and <https://codeberg.org/dnkl/fnott/src/branch/master/fnott.ini>
           for an example configuration.
         '';
-        example = lib.literalExpression ''
-          {
-            main = {
-              notification-margin = 5;
-            };
+        example = {
+          main = {
+            notification-margin = 5;
+          };
 
-            low = {
-              timeout = 5;
-              title-font = "Dina:weight=bold:slant=italic";
-              title-color = "ffffff";
-            };
-          }
-        '';
+          low = {
+            timeout = 5;
+            title-font = "Dina:weight=bold:slant=italic";
+            title-color = "ffffff";
+          };
+        };
       };
     };
   };

--- a/modules/services/hypridle.nix
+++ b/modules/services/hypridle.nix
@@ -43,27 +43,25 @@ in
         should be written as lists. Variables' and colors' names should be
         quoted. See <https://wiki.hypr.land/Hypr-Ecosystem/hypridle/> for more examples.
       '';
-      example = lib.literalExpression ''
-        {
-          general = {
-            after_sleep_cmd = "hyprctl dispatch dpms on";
-            ignore_dbus_inhibit = false;
-            lock_cmd = "hyprlock";
-          };
+      example = {
+        general = {
+          after_sleep_cmd = "hyprctl dispatch dpms on";
+          ignore_dbus_inhibit = false;
+          lock_cmd = "hyprlock";
+        };
 
-          listener = [
-            {
-              timeout = 900;
-              on-timeout = "hyprlock";
-            }
-            {
-              timeout = 1200;
-              on-timeout = "hyprctl dispatch dpms off";
-              on-resume = "hyprctl dispatch dpms on";
-            }
-          ];
-        }
-      '';
+        listener = [
+          {
+            timeout = 900;
+            on-timeout = "hyprlock";
+          }
+          {
+            timeout = 1200;
+            on-timeout = "hyprctl dispatch dpms off";
+            on-resume = "hyprctl dispatch dpms on";
+          }
+        ];
+      };
     };
 
     importantPrefixes = lib.mkOption {

--- a/modules/services/hyprpaper.nix
+++ b/modules/services/hyprpaper.nix
@@ -43,23 +43,21 @@ in
         should be written as lists. Variables' and colors' names should be
         quoted. See <https://wiki.hypr.land/Hypr-Ecosystem/hyprpaper/> for more examples.
       '';
-      example = lib.literalExpression ''
-        {
-          splash = false;
+      example = {
+        splash = false;
 
-          wallpaper = [
-            {
-              monitor = "DP-3";
-              path = "/share/wallpapers/buttons.png";
-              fit_mode = "tile";
-            }
-            {
-              monitor = "DP-1";
-              path = "/share/wallpapers/cat_pacman.png";
-            }
-          ];
-        }
-      '';
+        wallpaper = [
+          {
+            monitor = "DP-3";
+            path = "/share/wallpapers/buttons.png";
+            fit_mode = "tile";
+          }
+          {
+            monitor = "DP-1";
+            path = "/share/wallpapers/cat_pacman.png";
+          }
+        ];
+      };
     };
 
     importantPrefixes = lib.mkOption {

--- a/modules/services/hyprsunset.nix
+++ b/modules/services/hyprsunset.nix
@@ -48,11 +48,12 @@ in
 
                 List of requests to pass to `hyprctl hyprsunset` for this transition. Each inner list represents a separate command.
               '';
-              example = lib.literalExpression ''
+              example = [
                 [
-                  [ "temperature" "3500" ]
+                  "temperature"
+                  "3500"
                 ]
-              '';
+              ];
             };
           };
         }
@@ -63,23 +64,27 @@ in
 
         Set of transitions for different times of day (e.g., sunrise, sunset)
       '';
-      example = lib.literalExpression ''
-        {
-          sunrise = {
-            calendar = "*-*-* 06:00:00";
-            requests = [
-              [ "temperature" "6500" ]
-              [ "gamma 100" ]
-            ];
-          };
-          sunset = {
-            calendar = "*-*-* 19:00:00";
-            requests = [
-              [ "temperature" "3500" ]
-            ];
-          };
-        }
-      '';
+      example = {
+        sunrise = {
+          calendar = "*-*-* 06:00:00";
+          requests = [
+            [
+              "temperature"
+              "6500"
+            ]
+            [ "gamma 100" ]
+          ];
+        };
+        sunset = {
+          calendar = "*-*-* 19:00:00";
+          requests = [
+            [
+              "temperature"
+              "3500"
+            ]
+          ];
+        };
+      };
     };
 
     settings = lib.mkOption {

--- a/modules/services/jellyfin-mpv-shim.nix
+++ b/modules/services/jellyfin-mpv-shim.nix
@@ -47,16 +47,14 @@ in
       settings = lib.mkOption {
         inherit (jsonFormat) type;
         default = { };
-        example = lib.literalExpression ''
-          {
-            allow_transcode_to_h265 = false;
-            always_transcode = false;
-            audio_output = "hdmi";
-            auto_play = true;
-            fullscreen = true;
-            player_name = "mpv-shim";
-          }
-        '';
+        example = {
+          allow_transcode_to_h265 = false;
+          always_transcode = false;
+          audio_output = "hdmi";
+          auto_play = true;
+          fullscreen = true;
+          player_name = "mpv-shim";
+        };
         description = ''
           Configuration written to
           {file}`$XDG_CONFIG_HOME/jellyfin-mpv-shim/conf.json`. See
@@ -74,11 +72,10 @@ in
           )
         );
         default = null;
-        example = lib.literalExpression ''
-          {
-                    profile = "gpu-hq";
-                    force-window = true;
-                  }'';
+        example = {
+          profile = "gpu-hq";
+          force-window = true;
+        };
         description = ''
           mpv configuration options to use for jellyfin-mpv-shim.
           If null, jellyfin-mpv-shim will use its default mpv configuration.
@@ -88,11 +85,10 @@ in
       mpvBindings = lib.mkOption {
         type = lib.types.nullOr (lib.types.attrsOf lib.types.str);
         default = null;
-        example = lib.literalExpression ''
-          {
-                    WHEEL_UP = "seek 10";
-                    WHEEL_DOWN = "seek -10";
-                  }'';
+        example = {
+          WHEEL_UP = "seek 10";
+          WHEEL_DOWN = "seek -10";
+        };
         description = ''
           mpv input bindings to use for jellyfin-mpv-shim.
           If null, jellyfin-mpv-shim will use its default input configuration.

--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -234,28 +234,26 @@ in
       description = ''
         Attribute set of profiles.
       '';
-      example = literalExpression ''
-        {
-          undocked = {
-            outputs = [
-              {
-                criteria = "eDP-1";
-              }
-            ];
-          };
-          docked = {
-            outputs = [
-              {
-                criteria = "eDP-1";
-              }
-              {
-                criteria = "Some Company ASDF 4242";
-                transform = "90";
-              }
-            ];
-          };
-        }
-      '';
+      example = {
+        undocked = {
+          outputs = [
+            {
+              criteria = "eDP-1";
+            }
+          ];
+        };
+        docked = {
+          outputs = [
+            {
+              criteria = "eDP-1";
+            }
+            {
+              criteria = "Some Company ASDF 4242";
+              transform = "90";
+            }
+          ];
+        };
+      };
     };
 
     extraConfig = mkOption {

--- a/modules/services/mpd-discord-rpc.nix
+++ b/modules/services/mpd-discord-rpc.nix
@@ -18,15 +18,13 @@ in
     settings = lib.mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          hosts = [ "localhost:6600" ];
-          format = {
-            details = "$title";
-            state = "On $album by $artist";
-          };
-        }
-      '';
+      example = {
+        hosts = [ "localhost:6600" ];
+        format = {
+          details = "$title";
+          state = "On $album by $artist";
+        };
+      };
       description = ''
         Configuration included in `config.toml`.
         For available options see <https://github.com/JakeStanger/mpd-discord-rpc#configuration>

--- a/modules/services/muchsync.nix
+++ b/modules/services/muchsync.nix
@@ -144,14 +144,12 @@ in
     remotes = mkOption {
       type = with types; attrsOf (submodule syncOptions);
       default = { };
-      example = lib.literalExpression ''
-        {
-          server = {
-            frequency = "*:0/10";
-            remote.host = "server.tld";
-          };
-        }
-      '';
+      example = {
+        server = {
+          frequency = "*:0/10";
+          remote.host = "server.tld";
+        };
+      };
       description = ''
         Muchsync remotes to synchronise with.
       '';

--- a/modules/services/picom.nix
+++ b/modules/services/picom.nix
@@ -294,7 +294,7 @@ in
     extraArgs = mkOption {
       type = with types; listOf str;
       default = [ ];
-      example = literalExpression ''[ "--legacy-backends" ]'';
+      example = [ "--legacy-backends" ];
       description = ''
         Extra arguments to be passed to the picom executable.
       '';

--- a/modules/services/plex-mpv-shim.nix
+++ b/modules/services/plex-mpv-shim.nix
@@ -22,17 +22,15 @@ in
       settings = lib.mkOption {
         inherit (jsonFormat) type;
         default = { };
-        example = lib.literalExpression ''
-          {
-            adaptive_transcode = false;
-            allow_http = false;
-            always_transcode = false;
-            audio_ac3passthrough = false;
-            audio_dtspassthrough = false;
-            auto_play = true;
-            auto_transcode = true;
-          }
-        '';
+        example = {
+          adaptive_transcode = false;
+          allow_http = false;
+          always_transcode = false;
+          audio_ac3passthrough = false;
+          audio_dtspassthrough = false;
+          auto_play = true;
+          auto_transcode = true;
+        };
         description = ''
           Configuration written to
           {file}`$XDG_CONFIG_HOME/plex-mpv-shim/config.json`. See

--- a/modules/services/podman/darwin.nix
+++ b/modules/services/podman/darwin.nix
@@ -174,31 +174,29 @@ in
       type = types.attrsOf machineDefinitionType;
       default = { };
       description = "Declarative podman machine configurations.";
-      example = lib.literalExpression ''
-        {
-          "dev-machine" = {
-            cpus = 4;
-            diskSize = 100;
-            memory = 8192;
-            swap = 2048;
-            timezone = "UTC";
-            volumes = [
-              "/Users:/Users"
-              "/private:/private"
-            ];
-            autoStart = true;
-            watchdogInterval = 30;
-          };
-          "testing" = {
-            cpus = 2;
-            diskSize = 50;
-            image = "ghcr.io/your-org/custom-image:latest";
-            memory = 4096;
-            username = "podman";
-            autoStart = false;
-          };
-        }
-      '';
+      example = {
+        "dev-machine" = {
+          cpus = 4;
+          diskSize = 100;
+          memory = 8192;
+          swap = 2048;
+          timezone = "UTC";
+          volumes = [
+            "/Users:/Users"
+            "/private:/private"
+          ];
+          autoStart = true;
+          watchdogInterval = 30;
+        };
+        "testing" = {
+          cpus = 2;
+          diskSize = 50;
+          image = "ghcr.io/your-org/custom-image:latest";
+          memory = 4096;
+          username = "podman";
+          autoStart = false;
+        };
+      };
     };
   };
 

--- a/modules/services/podman/default.nix
+++ b/modules/services/podman/default.nix
@@ -66,16 +66,14 @@ in
       policy = lib.mkOption {
         default = { };
         type = lib.types.attrs;
-        example = lib.literalExpression ''
-          {
-            default = [ { type = "insecureAcceptAnything"; } ];
-            transports = {
-              docker-daemon = {
-                "" = [ { type = "insecureAcceptAnything"; } ];
-              };
+        example = {
+          default = [ { type = "insecureAcceptAnything"; } ];
+          transports = {
+            docker-daemon = {
+              "" = [ { type = "insecureAcceptAnything"; } ];
             };
-          }
-        '';
+          };
+        };
         description = ''
           Signature verification policy file.
           If this option is empty the default policy file from

--- a/modules/services/podman/linux/builds.nix
+++ b/modules/services/podman/linux/builds.nix
@@ -99,29 +99,25 @@ let
         environment = mkOption {
           type = podman-lib.primitiveAttrs;
           default = { };
-          example = lib.literalExpression ''
-            {
-              VAR1 = "0:100";
-              VAR2 = true;
-              VAR3 = 5;
-            }
-          '';
+          example = {
+            VAR1 = "0:100";
+            VAR2 = true;
+            VAR3 = 5;
+          };
           description = "Environment variables to set in the build.";
         };
 
         extraConfig = mkOption {
           type = podman-lib.extraConfigType;
           default = { };
-          example = lib.literalExpression ''
-            {
-              Build = {
-                Arch = "aarch64";
-              };
-              Service = {
-                TimeoutStartSec = 15;
-              };
-            }
-          '';
+          example = {
+            Build = {
+              Arch = "aarch64";
+            };
+            Service = {
+              TimeoutStartSec = 15;
+            };
+          };
           description = "INI sections and values to populate the Build Quadlet.";
         };
 

--- a/modules/services/podman/linux/containers.nix
+++ b/modules/services/podman/linux/containers.nix
@@ -239,13 +239,11 @@ let
       environment = mkOption {
         type = podman-lib.primitiveAttrs;
         default = { };
-        example = lib.literalExpression ''
-          {
-            VAR1 = "0:100";
-            VAR2 = true;
-            VAR3 = 5;
-          }
-        '';
+        example = {
+          VAR1 = "0:100";
+          VAR2 = true;
+          VAR3 = 5;
+        };
         description = "Environment variables to set in the container.";
       };
 
@@ -281,16 +279,14 @@ let
       extraConfig = mkOption {
         type = podman-lib.extraConfigType;
         default = { };
-        example = lib.literalExpression ''
-          {
-            Container = {
-              User = 1000;
-            };
-            Service = {
-              TimeoutStartSec = 15;
-            };
-          }
-        '';
+        example = {
+          Container = {
+            User = 1000;
+          };
+          Service = {
+            TimeoutStartSec = 15;
+          };
+        };
         description = ''
           INI sections and values to populate the Container Quadlet.
         '';

--- a/modules/services/podman/linux/images.nix
+++ b/modules/services/podman/linux/images.nix
@@ -105,13 +105,11 @@ let
         extraConfig = mkOption {
           type = podman-lib.extraConfigType;
           default = { };
-          example = lib.literalExpression ''
-            {
-              Image = {
-                ContainersConfModule = "/etc/nvd.conf";
-              };
-            }
-          '';
+          example = {
+            Image = {
+              ContainersConfModule = "/etc/nvd.conf";
+            };
+          };
           description = "INI sections and values to populate the Image Quadlet.";
         };
 

--- a/modules/services/podman/linux/networks.nix
+++ b/modules/services/podman/linux/networks.nix
@@ -115,16 +115,14 @@ let
       extraConfig = mkOption {
         type = podman-lib.extraConfigType;
         default = { };
-        example = lib.literalExpression ''
-          {
-            Network = {
-              ContainerConfModule = "/etc/nvd.conf";
-            };
-            Service = {
-              TimeoutStartSec = 30;
-            };
-          }
-        '';
+        example = {
+          Network = {
+            ContainerConfModule = "/etc/nvd.conf";
+          };
+          Service = {
+            TimeoutStartSec = 30;
+          };
+        };
         description = "INI sections and values to populate the Network Quadlet";
       };
 

--- a/modules/services/podman/linux/volumes.nix
+++ b/modules/services/podman/linux/volumes.nix
@@ -120,13 +120,11 @@ let
         extraConfig = mkOption {
           type = podman-lib.extraConfigType;
           default = { };
-          example = lib.literalExpression ''
-            {
-              Volume = {
-                ContainerConfModule = "/etc/nvd.conf";
-              };
-            }
-          '';
+          example = {
+            Volume = {
+              ContainerConfModule = "/etc/nvd.conf";
+            };
+          };
           description = "INI sections and values to populate the Volume Quadlet.";
         };
 

--- a/modules/services/pueue.nix
+++ b/modules/services/pueue.nix
@@ -23,13 +23,11 @@ in
     settings = lib.mkOption {
       inherit (yamlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          daemon = {
-            default_parallel_tasks = 2;
-          };
-        }
-      '';
+      example = {
+        daemon = {
+          default_parallel_tasks = 2;
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/pueue/pueue.yml`.

--- a/modules/services/recoll.nix
+++ b/modules/services/recoll.nix
@@ -127,21 +127,27 @@ in
 
         See {manpage}`recoll.conf(5)` for more details about the configuration.
       '';
-      example = literalExpression ''
-        {
-          nocjk = true;
-          loglevel = 5;
-          topdirs = [ "~/Downloads" "~/Documents" "~/projects" ];
+      example = {
+        nocjk = true;
+        loglevel = 5;
+        topdirs = [
+          "~/Downloads"
+          "~/Documents"
+          "~/projects"
+        ];
 
-          "~/Downloads" = {
-            "skippedNames+" = [ "*.iso" ];
-          };
+        "~/Downloads" = {
+          "skippedNames+" = [ "*.iso" ];
+        };
 
-          "~/projects" = {
-            "skippedNames+" = [ "node_modules" "target" "result" ];
-          };
-        }
-      '';
+        "~/projects" = {
+          "skippedNames+" = [
+            "node_modules"
+            "target"
+            "result"
+          ];
+        };
+      };
     };
 
     configDir = mkOption {

--- a/modules/services/shikane.nix
+++ b/modules/services/shikane.nix
@@ -20,38 +20,36 @@ in
     settings = lib.mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          profile = [
-            {
-              name = "external-monitor-default";
-              output = [
-                {
-                  match = "eDP-1";
-                  enable = true;
-                }
-                {
-                  match = "HDMI-A-1";
-                  enable = true;
-                  position = {
-                    x = 1920;
-                    y = 0;
-                  };
-                }
-              ];
-            }
-            {
-              name = "builtin-monitor-only";
-              output = [
-                {
-                  match = "eDP-1";
-                  enable = true;
-                }
-              ];
-            }
-          ];
-        }
-      '';
+      example = {
+        profile = [
+          {
+            name = "external-monitor-default";
+            output = [
+              {
+                match = "eDP-1";
+                enable = true;
+              }
+              {
+                match = "HDMI-A-1";
+                enable = true;
+                position = {
+                  x = 1920;
+                  y = 0;
+                };
+              }
+            ];
+          }
+          {
+            name = "builtin-monitor-only";
+            output = [
+              {
+                match = "eDP-1";
+                enable = true;
+              }
+            ];
+          }
+        ];
+      };
       description = ''
         Configuration written to
         <filename>$XDG_CONFIG_HOME/shikane/config.toml</filename>.

--- a/modules/services/spotifyd.nix
+++ b/modules/services/spotifyd.nix
@@ -6,7 +6,6 @@
 }:
 
 let
-  inherit (lib) literalExpression;
 
   cfg = config.services.spotifyd;
 
@@ -30,15 +29,13 @@ in
       inherit (tomlFormat) type;
       default = { };
       description = "Configuration for spotifyd";
-      example = literalExpression ''
-        {
-          global = {
-            username = "Alex";
-            password = "foo";
-            device_name = "nix";
-          };
-        }
-      '';
+      example = {
+        global = {
+          username = "Alex";
+          password = "foo";
+          device_name = "nix";
+        };
+      };
     };
   };
 

--- a/modules/services/sxhkd.nix
+++ b/modules/services/sxhkd.nix
@@ -45,7 +45,7 @@ in
       type = types.listOf types.str;
       default = [ ];
       description = "Command line arguments to invoke {command}`sxhkd` with.";
-      example = literalExpression ''[ "-m 1" ]'';
+      example = [ "-m 1" ];
     };
 
     keybindings = mkOption {

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -545,14 +545,12 @@ in
                 will be reverted on restart if [overrideFolders](#opt-services.syncthing.overrideFolders)
                 is enabled.
               '';
-              example = lib.literalExpression ''
-                {
-                  "/home/user/sync" = {
-                    id = "syncme";
-                    devices = [ "bigbox" ];
-                  };
-                }
-              '';
+              example = {
+                "/home/user/sync" = {
+                  id = "syncme";
+                  devices = [ "bigbox" ];
+                };
+              };
               type = types.attrsOf (
                 types.submodule (
                   { name, ... }:
@@ -815,7 +813,7 @@ in
           type = types.str;
           default = "syncthingtray --wait";
           defaultText = literalExpression "syncthingtray --wait";
-          example = literalExpression "qsyncthingtray";
+          example = "qsyncthingtray";
           description = "Syncthing tray command to use.";
         };
 

--- a/modules/services/syshud.nix
+++ b/modules/services/syshud.nix
@@ -27,22 +27,20 @@ in
     settings = mkOption {
       type = iniFormat.type.nestedTypes.elemType;
       default = { };
-      example = lib.literalExpression ''
-        {
-          position = "bottom";
-          orientation = "h";
-          width = 300;
-          height = 50;
-          icon-size = 26;
-          show-percentage = true;
-          margins = "0 0 0 0";
-          timeout = 3;
-          transition-time = 250;
-          listeners = "audio_in,audio_out,backlight";
-          backlight-path = "/sys/class/backlight/gmux_backlight";
-          keyboard-path = "/dev/input/eventXX";
-        }
-      '';
+      example = {
+        position = "bottom";
+        orientation = "h";
+        width = 300;
+        height = 50;
+        icon-size = 26;
+        show-percentage = true;
+        margins = "0 0 0 0";
+        timeout = 3;
+        transition-time = 250;
+        listeners = "audio_in,audio_out,backlight";
+        backlight-path = "/sys/class/backlight/gmux_backlight";
+        keyboard-path = "/dev/input/eventXX";
+      };
       description = ''
         Configuration for syshud.
         All available options can be found here:

--- a/modules/services/trayer.nix
+++ b/modules/services/trayer.nix
@@ -136,14 +136,12 @@ in
           )}
         '';
         default = { };
-        example = lib.literalExpression ''
-          {
-            edge = "top";
-            padding = 6;
-            SetDockType = true;
-            tint = "0x282c34";
-          }
-        '';
+        example = {
+          edge = "top";
+          padding = 6;
+          SetDockType = true;
+          tint = "0x282c34";
+        };
       };
     };
   };

--- a/modules/services/twmn.nix
+++ b/modules/services/twmn.nix
@@ -193,24 +193,20 @@ in
         easeIn = mkOption {
           type = types.submodule { options = animationOpts; };
           default = { };
-          example = literalExpression ''
-            {
-              curve = 19;
-              duration = 618;
-            }
-          '';
+          example = {
+            curve = 19;
+            duration = 618;
+          };
           description = "Options for the notification appearance's animation.";
         };
 
         easeOut = mkOption {
           type = types.submodule { options = animationOpts; };
           default = { };
-          example = literalExpression ''
-            {
-              curve = 19;
-              duration = 618;
-            }
-          '';
+          example = {
+            curve = 19;
+            duration = 618;
+          };
           description = "Options for the notification disappearance's animation.";
         };
 

--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -49,15 +49,13 @@ in
       settings = mkOption {
         inherit (yaml) type;
         default = { };
-        example = lib.literalExpression ''
-          {
-            program_options = {
-              udisks_version = 2;
-              tray = true;
-            };
-            icon_names.media = [ "media-optical" ];
-          }
-        '';
+        example = {
+          program_options = {
+            udisks_version = 2;
+            tray = true;
+          };
+          icon_names.media = [ "media-optical" ];
+        };
         description = ''
           Configuration written to
           {file}`$XDG_CONFIG_HOME/udiskie/config.yml`.

--- a/modules/services/window-managers/bspwm/options.nix
+++ b/modules/services/window-managers/bspwm/options.nix
@@ -1,6 +1,6 @@
 { pkgs, lib }:
 let
-  inherit (lib) literalExpression mkOption types;
+  inherit (lib) mkOption types;
 
   primitive =
     with types;
@@ -243,21 +243,19 @@ in
       type = types.attrsOf rule;
       default = { };
       description = "Rule configuration. The keys of the attribute set are the targets of the rules.";
-      example = literalExpression ''
-        {
-          "Gimp" = {
-            desktop = "^8";
-            state = "floating";
-            follow = true;
-          };
-          "Kupfer.py" = {
-            focus = true;
-          };
-          "Screenkey" = {
-            manage = false;
-          };
-        }
-      '';
+      example = {
+        "Gimp" = {
+          desktop = "^8";
+          state = "floating";
+          follow = true;
+        };
+        "Kupfer.py" = {
+          focus = true;
+        };
+        "Screenkey" = {
+          manage = false;
+        };
+      };
     };
 
     startupPrograms = mkOption {

--- a/modules/services/window-managers/herbstluftwm.nix
+++ b/modules/services/window-managers/herbstluftwm.nix
@@ -65,45 +65,42 @@ in
     keybinds = lib.mkOption {
       type = lib.types.attrsOf lib.types.str;
       default = { };
-      example = lib.literalExpression ''
-        {
-          Mod4-o = "split right";
-          Mod4-u = "split bottom";
-        }
-      '';
+      example = {
+        Mod4-o = "split right";
+        Mod4-u = "split bottom";
+      };
       description = "Herbstluftwm keybinds.";
     };
 
     mousebinds = lib.mkOption {
       type = lib.types.attrsOf lib.types.str;
       default = { };
-      example = lib.literalExpression ''
-        {
-          Mod4-B1 = "move";
-          Mod4-B3 = "resize";
-        }
-      '';
+      example = {
+        Mod4-B1 = "move";
+        Mod4-B3 = "resize";
+      };
       description = "Herbstluftwm mousebinds.";
     };
 
     rules = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
-      example = lib.literalExpression ''
-        [
-          "windowtype~'_NET_WM_WINDOW_TYPE_(DIALOG|UTILITY|SPLASH)' focus=on pseudotile=on"
-          "windowtype~'_NET_WM_WINDOW_TYPE_(NOTIFICATION|DOCK|DESKTOP)' manage=off"
-        ]
-      '';
+      example = [
+        "windowtype~'_NET_WM_WINDOW_TYPE_(DIALOG|UTILITY|SPLASH)' focus=on pseudotile=on"
+        "windowtype~'_NET_WM_WINDOW_TYPE_(NOTIFICATION|DOCK|DESKTOP)' manage=off"
+      ];
       description = "Herbstluftwm rules.";
     };
 
     tags = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
-      example = lib.literalExpression ''
-        [ "work" "browser" "music" "gaming" ]
-      '';
+      example = [
+        "work"
+        "browser"
+        "music"
+        "gaming"
+      ];
       description = "Tags to create on startup.";
     };
 

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -24,7 +24,10 @@ let
           List of font names list used for window titles. Only FreeType fonts are supported.
           The order here is important (e.g. icons font should go before the one used for text).
         '';
-        example = literalExpression ''[ "FontAwesome" "Terminus" ]'';
+        example = [
+          "FontAwesome"
+          "Terminus"
+        ];
       };
 
       style = mkOption {
@@ -104,13 +107,14 @@ let
         fonts = mkOption {
           type = with types; either (listOf str) fontOptions;
           default = { };
-          example = literalExpression ''
-            {
-              names = [ "DejaVu Sans Mono" "FontAwesome5Free" ];
-              style = "Bold Semi-Condensed";
-              size = 11.0;
-            }
-          '';
+          example = {
+            names = [
+              "DejaVu Sans Mono"
+              "FontAwesome5Free"
+            ];
+            style = "Bold Semi-Condensed";
+            size = 11.0;
+          };
           description = "Font configuration for this bar.";
         };
 
@@ -403,13 +407,14 @@ in
   fonts = mkOption {
     type = with types; either (listOf str) fontOptions;
     default = { };
-    example = literalExpression ''
-      {
-        names = [ "DejaVu Sans Mono" "FontAwesome5Free" ];
-        style = "Bold Semi-Condensed";
-        size = 11.0;
-      }
-    '';
+    example = {
+      names = [
+        "DejaVu Sans Mono"
+        "FontAwesome5Free"
+      ];
+      style = "Bold Semi-Condensed";
+      size = 11.0;
+    };
     description = "Font configuration for window titles, nagbar...";
   };
 
@@ -636,12 +641,15 @@ in
       An attribute set that assigns applications to workspaces based
       on criteria.
     '';
-    example = literalExpression ''
-      {
-      "1: web" = [{ class = "^Firefox$"; }];
-      "0: extra" = [{ class = "^Firefox$"; window_role = "About"; }];
-      }
-    '';
+    example = {
+      "1: web" = [ { class = "^Firefox$"; } ];
+      "0: extra" = [
+        {
+          class = "^Firefox$";
+          window_role = "About";
+        }
+      ];
+    };
   };
 
   modifier = mkOption {

--- a/modules/services/window-managers/spectrwm.nix
+++ b/modules/services/window-managers/spectrwm.nix
@@ -48,43 +48,37 @@ in
       settings = mkOption {
         type = types.attrsOf settingType;
         default = { };
-        example = literalExpression ''
-          {
-            modkey = "Mod4";
-            workspace_limit = 5;
-            focus_mode = "manual";
-            focus_close = "next";
-          }
-        '';
+        example = {
+          modkey = "Mod4";
+          workspace_limit = 5;
+          focus_mode = "manual";
+          focus_close = "next";
+        };
         description = "Spectrwm settings.";
       };
 
       bindings = mkOption {
         type = types.attrsOf types.str;
         default = { };
-        example = literalExpression ''
-          {
-            term = "Mod+Return";
-            restart = "Mod+Shift+r";
-            quit = "Mod+Shift+q";
-          }
-        '';
+        example = {
+          term = "Mod+Return";
+          restart = "Mod+Shift+r";
+          quit = "Mod+Shift+q";
+        };
         description = "Spectrwm keybindings.";
       };
 
       unbindings = mkOption {
         type = types.listOf types.str;
         default = [ ];
-        example = literalExpression ''
-          [
-            "MOD+e"
-            "MOD+f"
-            "MOD+m"
-            "MOD+s"
-            "MOD+u"
-            "MOD+t"
-          ]
-        '';
+        example = [
+          "MOD+e"
+          "MOD+f"
+          "MOD+m"
+          "MOD+s"
+          "MOD+u"
+          "MOD+t"
+        ];
         description = ''
           List of keybindings to disable from default Spectrwm configuration.
         '';
@@ -105,12 +99,10 @@ in
       quirks = mkOption {
         type = types.attrsOf types.str;
         default = { };
-        example = literalExpression ''
-          {
-            Matplotlib = "FLOAT";
-            Pavucontrol = "FLOAT";
-          }
-        '';
+        example = {
+          Matplotlib = "FLOAT";
+          Pavucontrol = "FLOAT";
+        };
         description = "Spectrwm quicks (custom window rules).";
       };
     };

--- a/modules/services/window-managers/wayfire.nix
+++ b/modules/services/window-managers/wayfire.nix
@@ -65,15 +65,13 @@
 
           See <https://github.com/WayfireWM/wayfire/wiki/Configuration>
         '';
-        example = lib.literalExpression ''
-          {
-            core.plugins = "command expo cube";
-            command = {
-              binding_terminal = "alacritty";
-              command_terminal = "alacritty";
-            };
-          }
-        '';
+        example = {
+          core.plugins = "command expo cube";
+          command = {
+            binding_terminal = "alacritty";
+            command_terminal = "alacritty";
+          };
+        };
       };
 
       wf-shell = {
@@ -91,14 +89,12 @@
 
             See <https://github.com/WayfireWM/wf-shell/blob/master/wf-shell.ini.example>
           '';
-          example = lib.literalExpression ''
-            {
-              panel = {
-                widgets_left = "menu spacing4 launchers window-list";
-                autohide = true;
-              };
-            }
-          '';
+          example = {
+            panel = {
+              widgets_left = "menu spacing4 launchers window-list";
+              autohide = true;
+            };
+          };
         };
       };
 

--- a/modules/services/wob.nix
+++ b/modules/services/wob.nix
@@ -8,7 +8,6 @@
 let
   inherit (lib)
     getExe
-    literalExpression
     mkEnableOption
     mkIf
     mkOption
@@ -31,16 +30,14 @@ in
     settings = mkOption {
       inherit (settingsFormat) type;
       default = { };
-      example = literalExpression ''
-        {
-          "" = {
-            border_size = 10;
-            height = 50;
-          };
-          "output.foo".name = "DP-1";
-          "style.muted".background_color = "032cfc";
-        }
-      '';
+      example = {
+        "" = {
+          border_size = 10;
+          height = 50;
+        };
+        "output.foo".name = "DP-1";
+        "style.muted".background_color = "032cfc";
+      };
       description = ''
         Configuration written to {file}`$XDG_CONFIG_HOME/wob/wob.ini`.
         See {manpage}`wob.ini(5)` for documentation.

--- a/modules/services/wpaperd.nix
+++ b/modules/services/wpaperd.nix
@@ -42,18 +42,16 @@ in
     settings = lib.mkOption {
       inherit (tomlFormat) type;
       default = { };
-      example = lib.literalExpression ''
-        {
-          eDP-1 = {
-            path = "/home/foo/Pictures/Wallpaper";
-            apply-shadow = true;
-          };
-          DP-2 = {
-            path = "/home/foo/Pictures/Anime";
-            sorting = "descending";
-          };
-        }
-      '';
+      example = {
+        eDP-1 = {
+          path = "/home/foo/Pictures/Wallpaper";
+          apply-shadow = true;
+        };
+        DP-2 = {
+          path = "/home/foo/Pictures/Anime";
+          sorting = "descending";
+        };
+      };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/wpaperd/wallpaper.toml`.

--- a/modules/services/xidlehook.nix
+++ b/modules/services/xidlehook.nix
@@ -61,11 +61,9 @@ in
     environment = mkOption {
       type = types.attrsOf types.str;
       default = { };
-      example = literalExpression ''
-        {
-          "primary-display" = "$(xrandr | awk '/ primary/{print $1}')";
-        }
-      '';
+      example = {
+        "primary-display" = "$(xrandr | awk '/ primary/{print $1}')";
+      };
       description = ''
         Extra environment variables to be exported in the script.
         These options are passed unescaped as `export name=value`.

--- a/modules/services/xsettingsd.nix
+++ b/modules/services/xsettingsd.nix
@@ -8,7 +8,6 @@
 let
   inherit (lib)
     mkOption
-    literalExpression
     types
     ;
 
@@ -48,14 +47,12 @@ in
             str
           ]);
         default = { };
-        example = literalExpression ''
-          {
-            "Net/ThemeName" = "Numix";
-            "Xft/Antialias" = true;
-            "Xft/Hinting" = true;
-            "Xft/RGBA" = "rgb";
-          }
-        '';
+        example = {
+          "Net/ThemeName" = "Numix";
+          "Xft/Antialias" = true;
+          "Xft/Hinting" = true;
+          "Xft/RGBA" = "rgb";
+        };
         description = ''
           Xsettingsd options for configuration file. See
           <https://github.com/derat/xsettingsd/wiki/Settings>

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -414,11 +414,9 @@ in
                       ])
                     );
                   default = { };
-                  example = literalExpression ''
-                    {
-                      PATH = "%u/bin:%u/.cargo/bin";
-                    }
-                  '';
+                  example = {
+                    PATH = "%u/bin:%u/.cargo/bin";
+                  };
                   apply = value: concatStringsSep " " (mapAttrsToList (n: v: "${n}=${escapeShellArg v}") value);
                 }
                 // args;
@@ -439,11 +437,9 @@ in
             };
         };
         default = { };
-        example = literalExpression ''
-          {
-            Manager.DefaultCPUAccounting = true;
-          }
-        '';
+        example = {
+          Manager.DefaultCPUAccounting = true;
+        };
         description = ''
           Extra config options for user session service manager. See {manpage}`systemd-user.conf(5)` for
           available options.

--- a/modules/targets/generic-linux/gpu/default.nix
+++ b/modules/targets/generic-linux/gpu/default.nix
@@ -37,7 +37,7 @@
         version = mkOption {
           type = types.nullOr (types.strMatching "[0-9]{3}\\.[0-9]{2,3}(\\.[0-9]{2,3})?");
           default = null;
-          example = literalExpression "550.163.01";
+          example = "550.163.01";
           description = ''
             The exact version of Nvidia drivers to use. This version **must**
             match the version of the driver used by the host OS.
@@ -47,7 +47,7 @@
         sha256 = mkOption {
           type = types.nullOr (types.strMatching "sha256-.*=");
           default = null;
-          example = literalExpression "sha256-hfK1D5EiYcGRegss9+H5dDr/0Aj9wPIJ9NVWP3dNUC0=";
+          example = "sha256-hfK1D5EiYcGRegss9+H5dDr/0Aj9wPIJ9NVWP3dNUC0=";
           description = ''
             The hash of the downloaded driver file. It can be obtained by
             running, for example,

--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -52,13 +52,17 @@ in
         in
         nullOr (attrsOf entry);
       default = null;
-      example = lib.literalExpression ''
-        {
-          "Emacs*toolBar" = 0;
-          "XTerm*faceName" = "dejavu sans mono";
-          "XTerm*charClass" = [ "37:48" "45-47:48" "58:48" "64:48" "126:48" ];
-        }
-      '';
+      example = {
+        "Emacs*toolBar" = 0;
+        "XTerm*faceName" = "dejavu sans mono";
+        "XTerm*charClass" = [
+          "37:48"
+          "45-47:48"
+          "58:48"
+          "64:48"
+          "126:48"
+        ];
+      };
       description = ''
         X server resources that should be set.
         Booleans are formatted as "true" or "false" respectively.


### PR DESCRIPTION
`literalExpression` is intended just to signify code that needs to stay a string that gets represented exactly as-is for docs. It has been misused heavily and people get confused repeatedly on when or not to use it because of the rampant misuse.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
