### PR TITLE
mkFirefoxModule: allow per-extension settings force

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -84,6 +84,10 @@ let
   extensionSettingsNeedForce =
     extensionSettings: builtins.any (ext: ext.settings != { }) (attrValues extensionSettings);
 
+  extensionSettingsMissingForce =
+    extensionSettings:
+    builtins.any (ext: ext.settings != { } && !ext.force) (attrValues extensionSettings);
+
   mkUserJs =
     prePrefs: prefs: extraPrefs: bookmarksFile: extensions:
     let
@@ -836,11 +840,13 @@ in
               assertions = [
                 (mkNoDuplicateAssertion config.containers "container")
                 {
-                  assertion = !(extensionSettingsNeedForce config.extensions.settings) || config.extensions.force;
+                  assertion = !(extensionSettingsMissingForce config.extensions.settings) || config.extensions.force;
                   message = ''
                     Using '${lib.showOption profilePath}.extensions.settings' will override all
-                    previous extensions settings. Enable
-                    '${lib.showOption profilePath}.extensions.force' to acknowledge this.
+                    previous extensions settings. Enable either
+                    '${lib.showOption profilePath}.extensions.force' or the corresponding
+                    '${lib.showOption profilePath}.extensions.settings.<extensionId>.force'
+                    to acknowledge this.
                   '';
                 }
               ]

--- a/tests/modules/programs/firefox/common.nix
+++ b/tests/modules/programs/firefox/common.nix
@@ -33,6 +33,9 @@ builtins.mapAttrs
     "${name}-profiles-extensions" = ./profiles/extensions;
     "${name}-profiles-extensions-assertions" = ./profiles/extensions/assertions.nix;
     "${name}-profiles-extensions-extensible" = ./profiles/extensions/extensible.nix;
+    "${name}-profiles-extensions-per-extension-force" = ./profiles/extensions/per-extension-force.nix;
+    "${name}-profiles-extensions-per-extension-force-assertions" =
+      ./profiles/extensions/per-extension-force-assertions.nix;
     "${name}-profiles-extensions-exhaustive" = ./profiles/extensions/exhaustive.nix;
     "${name}-profiles-extensions-exact" = ./profiles/extensions/exact.nix;
     "${name}-profiles-handlers" = ./profiles/handlers;

--- a/tests/modules/programs/firefox/profiles/extensions/assertions.nix
+++ b/tests/modules/programs/firefox/profiles/extensions/assertions.nix
@@ -55,8 +55,10 @@ in
       test.asserts.assertions.expected = [
         ''
           Using '${lib.showOption modulePath}.profiles.extensions.extensions.settings' will override all
-          previous extensions settings. Enable
-          '${lib.showOption modulePath}.profiles.extensions.extensions.force' to acknowledge this.
+          previous extensions settings. Enable either
+          '${lib.showOption modulePath}.profiles.extensions.extensions.force' or the corresponding
+          '${lib.showOption modulePath}.profiles.extensions.extensions.settings.<extensionId>.force'
+          to acknowledge this.
         ''
         ''
           Extension uBlock0@raymondhill.net requests permissions that weren't

--- a/tests/modules/programs/firefox/profiles/extensions/per-extension-force-assertions.nix
+++ b/tests/modules/programs/firefox/profiles/extensions/per-extension-force-assertions.nix
@@ -1,0 +1,35 @@
+modulePath:
+{ config, lib, ... }:
+
+let
+  firefoxMockOverlay = import ../../setup-firefox-mock-overlay.nix modulePath;
+in
+{
+  imports = [ firefoxMockOverlay ];
+
+  config = lib.mkIf config.test.enableBig (
+    lib.setAttrByPath modulePath {
+      enable = true;
+      profiles.extensions = {
+        extensions.settings = {
+          "forced@example.com" = {
+            force = true;
+            settings.enabled = true;
+          };
+          "unforced@example.com".settings.enabled = true;
+        };
+      };
+    }
+    // {
+      test.asserts.assertions.expected = [
+        ''
+          Using '${lib.showOption modulePath}.profiles.extensions.extensions.settings' will override all
+          previous extensions settings. Enable either
+          '${lib.showOption modulePath}.profiles.extensions.extensions.force' or the corresponding
+          '${lib.showOption modulePath}.profiles.extensions.extensions.settings.<extensionId>.force'
+          to acknowledge this.
+        ''
+      ];
+    }
+  );
+}

--- a/tests/modules/programs/firefox/profiles/extensions/per-extension-force.nix
+++ b/tests/modules/programs/firefox/profiles/extensions/per-extension-force.nix
@@ -1,0 +1,42 @@
+modulePath:
+{ config, lib, ... }:
+
+let
+  cfg = lib.getAttrFromPath modulePath config;
+
+  firefoxMockOverlay = import ../../setup-firefox-mock-overlay.nix modulePath;
+in
+{
+  imports = [ firefoxMockOverlay ];
+
+  config = lib.mkIf config.test.enableBig (
+    lib.setAttrByPath modulePath {
+      enable = true;
+      profiles.extensions = {
+        extensions.settings."uBlock0@raymondhill.net" = {
+          force = true;
+          settings = {
+            selectedFilterLists = [
+              "ublock-filters"
+              "ublock-badware"
+              "ublock-privacy"
+              "ublock-unbreak"
+              "ublock-quick-fixes"
+            ];
+          };
+        };
+      };
+    }
+    // {
+      nmt.script = ''
+        assertFileContent \
+          "home-files/${cfg.profilesPath}/extensions/browser-extension-data/uBlock0@raymondhill.net/storage.js" \
+          ${./expected-storage.js}
+
+        assertFileContent \
+          "home-files/${cfg.profilesPath}/extensions/user.js" \
+          ${./expected-user.js}
+      '';
+    }
+  );
+}


### PR DESCRIPTION
Fixes the force acknowledgement logic for extension settings so an extension-specific force flag is sufficient for that extension.

References
https://github.com/nix-community/home-manager/discussions/7910

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
