### PR TITLE
syncthing: support legacy config dir

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -19,11 +19,28 @@ let
   isUnixGui = (builtins.substring 0 1 cfg.guiAddress) == "/";
 
   # syncthing's configuration directory (see https://docs.syncthing.net/users/config.html)
-  syncthing_dir =
+  syncthingDir =
     if pkgs.stdenv.isDarwin then
       "$HOME/Library/Application Support/Syncthing"
     else
       "\${XDG_STATE_HOME:-$HOME/.local/state}/syncthing";
+
+  syncthingDirShell =
+    if pkgs.stdenv.isDarwin then
+      ''
+        syncthing_dir="${syncthingDir}"
+      ''
+    else
+      ''
+        syncthing_state_dir="${syncthingDir}"
+        syncthing_config_dir="''${XDG_CONFIG_HOME:-$HOME/.config}/syncthing"
+
+        if [[ -e "$syncthing_state_dir/config.xml" || ! -e "$syncthing_config_dir/config.xml" ]]; then
+            syncthing_dir="$syncthing_state_dir"
+        else
+            syncthing_dir="$syncthing_config_dir"
+        fi
+      '';
 
   defaultGuiAddress = "127.0.0.1:8384";
 
@@ -75,16 +92,20 @@ let
   mkpasswd = lib.getExe pkgs.mkpasswd;
 
   copyKeys = pkgs.writers.writeBash "syncthing-copy-keys" ''
-    ${install} -dm700 "${syncthing_dir}"
+    ${syncthingDirShell}
+
+    ${install} -dm700 "$syncthing_dir"
     ${lib.optionalString (cfg.cert != null) ''
-      ${install} -Dm400 ${toString cfg.cert} "${syncthing_dir}/cert.pem"
+      ${install} -Dm400 ${toString cfg.cert} "$syncthing_dir/cert.pem"
     ''}
     ${lib.optionalString (cfg.key != null) ''
-      ${install} -Dm400 ${toString cfg.key} "${syncthing_dir}/key.pem"
+      ${install} -Dm400 ${toString cfg.key} "$syncthing_dir/key.pem"
     ''}
   '';
 
   curlShellFunction = ''
+    ${syncthingDirShell}
+
     # systemd sets and creates RUNTIME_DIRECTORY on Linux
     # on Darwin, we create it manually via mktemp
     RUNTIME_DIRECTORY="''${RUNTIME_DIRECTORY:=$(${mktemp} -d)}"
@@ -94,7 +115,7 @@ let
         while
             ! ${pkgs.libxml2}/bin/xmllint \
                 --xpath 'string(configuration/gui/apikey)' \
-                "${syncthing_dir}/config.xml" \
+                "$syncthing_dir/config.xml" \
                 >"$RUNTIME_DIRECTORY/api_key"
         do ${sleep} 1; done
         (${printf} "X-API-Key: "; ${cat} "$RUNTIME_DIRECTORY/api_key") >"$RUNTIME_DIRECTORY/headers"

--- a/tests/modules/services/syncthing/linux/gui-address-init.nix
+++ b/tests/modules/services/syncthing/linux/gui-address-init.nix
@@ -12,5 +12,7 @@
 
     updateScript=$(grep -o '/nix/store/[^ ]*-merge-syncthing-config' "$TESTED/$serviceFile")
     assertFileContains "$updateScript" "127.0.0.1:8385/rest/config/gui"
+    assertFileContains "$updateScript" 'syncthing_config_dir="''${XDG_CONFIG_HOME:-$HOME/.config}/syncthing"'
+    assertFileContains "$updateScript" 'syncthing_dir="$syncthing_config_dir"'
   '';
 }


### PR DESCRIPTION
Syncthing still supports existing Linux installations that keep config.xml under XDG_CONFIG_HOME/syncthing. Resolve the runtime directory from the generated scripts so Home Manager waits on and copies keys into the existing legacy directory when no state-dir config exists.

Fixes #6933

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
