### PR TITLE
gnome-shell: use user-themes extension

### DIFF
--- a/modules/programs/gnome-shell.nix
+++ b/modules/programs/gnome-shell.nix
@@ -74,7 +74,7 @@ in
           { package = pkgs.gnomeExtensions.dash-to-panel; }
           {
             id = "user-theme@gnome-shell-extensions.gcampax.github.com";
-            package = pkgs.gnome-shell-extensions;
+            package = pkgs.gnomeExtensions.user-themes;
           }
         ]
       '';
@@ -114,8 +114,7 @@ in
 
         programs.gnome-shell.extensions = [
           {
-            id = "user-theme@gnome-shell-extensions.gcampax.github.com";
-            package = pkgs.gnome-shell-extensions;
+            package = pkgs.gnomeExtensions.user-themes;
           }
         ];
 

--- a/tests/modules/programs/gnome-shell/gnome-shell.nix
+++ b/tests/modules/programs/gnome-shell/gnome-shell.nix
@@ -5,10 +5,15 @@
   ...
 }:
 let
-  dummy-gnome-shell-extensions = pkgs.runCommand "dummy-package" { } ''
-    mkdir -p $out/share/gnome-shell/extensions/dummy-package
-    touch $out/share/gnome-shell/extensions/dummy-package/test
-  '';
+  dummy-user-themes =
+    pkgs.runCommand "dummy-user-themes"
+      {
+        passthru.extensionUuid = "user-theme@gnome-shell-extensions.gcampax.github.com";
+      }
+      ''
+        mkdir -p $out/share/gnome-shell/extensions/user-theme@gnome-shell-extensions.gcampax.github.com
+        touch $out/share/gnome-shell/extensions/user-theme@gnome-shell-extensions.gcampax.github.com/test
+      '';
 
   test-extension = pkgs.runCommand "test-extension" { } ''
     mkdir -p $out/share/gnome-shell/extensions/test-extension
@@ -43,7 +48,11 @@ let
 in
 {
   nixpkgs.overlays = [
-    (_final: _prev: { gnome-shell-extensions = dummy-gnome-shell-extensions; })
+    (_final: prev: {
+      gnomeExtensions = prev.gnomeExtensions // {
+        user-themes = dummy-user-themes;
+      };
+    })
   ];
 
   programs.gnome-shell.enable = true;
@@ -82,7 +91,7 @@ in
   ];
 
   nmt.script = ''
-    assertFileExists home-path/share/gnome-shell/extensions/dummy-package/test
+    assertFileExists home-path/share/gnome-shell/extensions/user-theme@gnome-shell-extensions.gcampax.github.com/test
     assertFileExists home-path/share/gnome-shell/extensions/test-extension/test
     assertFileExists home-path/share/gnome-shell/extensions/test-extension-uuid/test
     assertFileExists home-path/share/themes/Test/gnome-shell/test


### PR DESCRIPTION
## Summary

- use `pkgs.gnomeExtensions.user-themes` for implicit GNOME Shell theme support
- stop installing the full `gnome-shell-extensions` package for User Themes
- update the GNOME Shell module test fixture

Closes #9171

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)