### PR TITLE
dunst: support ordered settings

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -97,15 +97,11 @@ in
       };
 
       settings = mkOption {
-        type = types.submodule {
-          freeformType = with types; attrsOf (attrsOf eitherStrBoolIntList);
-          options = {
-            global.icon_path = mkOption {
-              type = types.separatedString ":";
-              description = "Paths where dunst will look for icons.";
-            };
-          };
-        };
+        type = lib.hm.types.dagOf (
+          types.submodule {
+            freeformType = with types; attrsOf eitherStrBoolIntList;
+          }
+        );
         default = { };
         description = "Configuration written to {file}`$XDG_CONFIG_HOME/dunst/dunstrc`.";
         example = literalExpression ''
@@ -118,12 +114,18 @@ in
               transparency = 10;
               frame_color = "#eceff1";
               font = "Droid Sans 9";
+              icon_path = "/run/current-system/sw/share/icons/hicolor/32x32/status:/run/current-system/sw/share/icons/hicolor/32x32/devices";
             };
 
             urgency_normal = {
               background = "#37474f";
               foreground = "#eceff1";
               timeout = 10;
+            };
+
+            custom-rule = lib.hm.dag.entryAfter [ "global" ] {
+              appname = "custom-app";
+              timeout = 1;
             };
           };
         '';
@@ -142,7 +144,14 @@ in
       "${cfg.package}/share/dbus-1/services/org.knopwob.dunst.service";
 
     xdg.configFile."dunst/dunstrc" = lib.mkIf (cfg.settings != { }) {
-      text = toDunstIni cfg.settings;
+      text =
+        let
+          sortedSettings = lib.hm.dag.topoSort cfg.settings;
+          sections =
+            sortedSettings.result
+              or (abort "Dependency cycle in dunst settings: ${builtins.toJSON sortedSettings}");
+        in
+        lib.concatStringsSep "\n" (map (section: toDunstIni { ${section.name} = section.data; }) sections);
     };
 
     services.dunst.settings.global.icon_path =

--- a/tests/modules/services/dunst/default.nix
+++ b/tests/modules/services/dunst/default.nix
@@ -2,5 +2,6 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   dunst-with-settings = ./with-settings.nix;
+  dunst-with-ordered-settings = ./with-ordered-settings.nix;
   dunst-without-settings = ./without-settings.nix;
 }

--- a/tests/modules/services/dunst/with-ordered-settings-expected.ini
+++ b/tests/modules/services/dunst/with-ordered-settings-expected.ini
@@ -1,0 +1,11 @@
+[global]
+font="Droid Sans 9"
+icon_path="/run/current-system/sw/share/icons/hicolor/32x32/status:/run/current-system/sw/share/icons/hicolor/32x32/devices"
+timeout=30
+
+[bgtvolctl]
+appname="bgtvolctl"
+timeout=1
+
+[urgency_critical]
+background="#c33"

--- a/tests/modules/services/dunst/with-ordered-settings.nix
+++ b/tests/modules/services/dunst/with-ordered-settings.nix
@@ -1,0 +1,39 @@
+{ config, lib, ... }:
+let
+  inherit (config.lib.test) mkStubPackage;
+in
+{
+  services.dunst = {
+    enable = true;
+    package = mkStubPackage {
+      name = "dunst";
+      buildScript = ''
+        mkdir -p $out/share/dbus-1/services
+        echo test > $out/share/dbus-1/services/org.knopwob.dunst.service
+      '';
+    };
+    settings = {
+      global = {
+        timeout = 30;
+        font = "Droid Sans 9";
+        icon_path = lib.mkForce "/run/current-system/sw/share/icons/hicolor/32x32/status:/run/current-system/sw/share/icons/hicolor/32x32/devices";
+      };
+
+      bgtvolctl = lib.hm.dag.entryAfter [ "global" ] {
+        appname = "bgtvolctl";
+        timeout = 1;
+      };
+
+      urgency_critical = lib.hm.dag.entryAfter [ "bgtvolctl" ] {
+        background = "#c33";
+      };
+    };
+  };
+
+  nmt.script = ''
+    configFile=home-files/.config/dunst/dunstrc
+
+    assertFileExists $configFile
+    assertFileContent $configFile ${./with-ordered-settings-expected.ini}
+  '';
+}


### PR DESCRIPTION
Add `dagOf` support for ordered attrsets. 

Closes #8961

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
