### PR TITLE
zsh: improve startup env and plugin fpath handling

### DIFF
--- a/modules/lib/zsh.nix
+++ b/modules/lib/zsh.nix
@@ -7,7 +7,7 @@ rec {
     if builtins.isBool v then
       if v then "true" else "false"
     else if builtins.isString v then
-      ''"${v}"''
+      ''"${lib.escape [ "\\" "\"" "`" ] v}"''
     else if builtins.isList v then
       let
         shell = import ./shell.nix { inherit lib; };

--- a/modules/misc/news/2026/05/2026-05-18_12-00-00.nix
+++ b/modules/misc/news/2026/05/2026-05-18_12-00-00.nix
@@ -1,0 +1,18 @@
+{ config, ... }:
+{
+  time = "2026-05-18T17:00:00+00:00";
+  condition = config.programs.zsh.enable;
+  message = ''
+    The `programs.zsh` module now sources Home Manager session variables from
+    `.zprofile` for login shells. Non-login shells continue to source them from
+    `.zshenv`.
+
+    As a result, Home Manager now always writes `.zprofile` when
+    `programs.zsh.enable` is set, instead of only writing it when
+    `programs.zsh.profileExtra` is configured.
+
+    This keeps `home.sessionPath` entries from being overwritten or reordered
+    by system login startup files such as NixOS' `/etc/zprofile` or macOS'
+    `path_helper`.
+  '';
+}

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -398,6 +398,9 @@ in
       dirHashesStr = concatStringsSep "\n" (
         lib.mapAttrsToList (k: v: ''hash -d ${k}="${v}"'') cfg.dirHashes
       );
+      # Keep double quotes so existing configs using shell variables like
+      # $HOME still expand, while escaping chars special inside them.
+      cdpathStr = concatStringsSep " " (map (v: ''"${lib.escape [ "\\" "\"" "`" ] v}"'') cfg.cdpath);
     in
     mkIf cfg.enable (
       lib.mkMerge [
@@ -520,7 +523,7 @@ in
 
             (lib.mkIf (cfg.cdpath != [ ]) (
               mkOrder 510 ''
-                cdpath+=(${concatStringsSep " " cfg.cdpath})
+                cdpath+=(${cdpathStr})
               ''
             ))
 

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -373,6 +373,21 @@ in
     let
       envVarsStr = config.lib.zsh.exportAll cfg.sessionVariables { indent = "  "; };
       localVarsStr = config.lib.zsh.defineAll cfg.localVariables;
+      sessionVarsStr = lib.removeSuffix "\n" ''
+        # Environment variables
+        . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
+
+        # Only source this once
+        if [[ -z "''${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
+          export __HM_ZSH_SESS_VARS_SOURCED=1
+          ${envVarsStr}
+        fi
+      '';
+      indentNonEmptyLines =
+        str:
+        concatStringsSep "\n" (
+          map (line: if line == "" then "" else "  ${line}") (lib.splitString "\n" str)
+        );
 
       aliasesStr = concatStringsSep "\n" (
         lib.mapAttrsToList (
@@ -441,10 +456,6 @@ in
           home.file."${dotDirRel}/.zshenv".text = cfg.envExtra;
         })
 
-        (mkIf (cfg.profileExtra != "") {
-          home.file."${dotDirRel}/.zprofile".text = cfg.profileExtra;
-        })
-
         (mkIf (cfg.loginExtra != "") {
           home.file."${dotDirRel}/.zlogin".text = cfg.loginExtra;
         })
@@ -478,14 +489,17 @@ in
 
         {
           home.file."${dotDirRel}/.zshenv".text = ''
-            # Environment variables
-            . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
-
-            # Only source this once
-            if [[ -z "''${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
-              export __HM_ZSH_SESS_VARS_SOURCED=1
-              ${envVarsStr}
+            if [[ ! -o login ]]; then
+            ${indentNonEmptyLines sessionVarsStr}
             fi
+          '';
+
+          home.file."${dotDirRel}/.zprofile".text = ''
+            ${sessionVarsStr}
+          ''
+          + optionalString (cfg.profileExtra != "") ''
+
+            ${cfg.profileExtra}
           '';
         }
 

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -395,11 +395,13 @@ in
         ) cfg.shellAliases
       );
 
-      dirHashesStr = concatStringsSep "\n" (
-        lib.mapAttrsToList (k: v: ''hash -d ${k}="${v}"'') cfg.dirHashes
-      );
       # Keep double quotes so existing configs using shell variables like
       # $HOME still expand, while escaping chars special inside them.
+      dirHashesStr = concatStringsSep "\n" (
+        lib.mapAttrsToList (
+          k: v: ''hash -d ${lib.escapeShellArg k}="${lib.escape [ "\\" "\"" "`" ] v}"''
+        ) cfg.dirHashes
+      );
       cdpathStr = concatStringsSep " " (map (v: ''"${lib.escape [ "\\" "\"" "`" ] v}"'') cfg.cdpath);
     in
     mkIf cfg.enable (

--- a/modules/programs/zsh/plugins/default.nix
+++ b/modules/programs/zsh/plugins/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   ...
 }:
 let
@@ -23,6 +24,10 @@ in
       pluginModule = types.submodule (
         { config, ... }:
         {
+          imports = [
+            (lib.mkRenamedOptionModule [ "completions" ] [ "functions" ])
+          ];
+
           options = {
             src = mkOption {
               type = types.path;
@@ -49,7 +54,7 @@ in
               '';
             };
 
-            completions = mkOption {
+            functions = mkOption {
               default = [ ];
               type = types.listOf types.str;
               description = "Paths of additional functions to add to {env}`fpath`.";
@@ -80,7 +85,7 @@ in
             name = "wd";
             src = pkgs.zsh-wd;
             file = "share/wd/wd.plugin.zsh";
-            completions = [ "share/zsh/site-functions" ];
+            functions = [ "share/zsh/site-functions" ];
           }
           ]
         '';
@@ -89,6 +94,19 @@ in
     };
 
   config = lib.mkIf (cfg.plugins != [ ]) {
+    warnings = lib.concatMap (
+      definition:
+      lib.optionals (builtins.isList definition.value) (
+        lib.concatMap (
+          value:
+          lib.optional (builtins.isAttrs value && value ? completions)
+            "The option `programs.zsh.plugins.*.completions' defined in ${
+              lib.showFiles [ definition.file ]
+            } has been renamed to `programs.zsh.plugins.*.functions'."
+        ) definition.value
+      )
+    ) options.programs.zsh.plugins.definitionsWithLocations;
+
     home.file = lib.mkIf cfg.enable (
       lib.foldl' (a: b: a // b) { } (
         map (plugin: { "${pluginsDir}/${plugin.name}".source = plugin.src; }) cfg.plugins
@@ -104,8 +122,8 @@ in
         (lib.mkOrder 560 (
           let
             pluginNames = map (plugin: plugin.name) cfg.plugins;
-            completionPaths = lib.flatten (
-              map (plugin: map (completion: "${plugin.name}/${completion}") plugin.completions) cfg.plugins
+            functionPaths = lib.flatten (
+              map (plugin: map (function: "${plugin.name}/${function}") plugin.functions) cfg.plugins
             );
           in
           ''
@@ -122,13 +140,13 @@ in
               done
             done
             unset plugin_dir plugin_dirs plugin_fpath_dir
-            ${lib.optionalString (completionPaths != [ ]) ''
-              # Add completion paths to fpath
-              ${lib.hm.zsh.define "completion_paths" completionPaths}
-              for completion_path in "''${completion_paths[@]}"; do
-                fpath+="${pluginsDir}/$completion_path"
+            ${lib.optionalString (functionPaths != [ ]) ''
+              # Add additional function paths to fpath
+              ${lib.hm.zsh.define "function_paths" functionPaths}
+              for function_path in "''${function_paths[@]}"; do
+                fpath+="${pluginsDir}/$function_path"
               done
-              unset completion_path completion_paths
+              unset function_path function_paths
             ''}
           ''
         ))

--- a/modules/programs/zsh/plugins/default.nix
+++ b/modules/programs/zsh/plugins/default.nix
@@ -114,8 +114,14 @@ in
             for plugin_dir in "''${plugin_dirs[@]}"; do
               path+="${pluginsDir}/$plugin_dir"
               fpath+="${pluginsDir}/$plugin_dir"
+              for plugin_fpath_dir in \
+                "$plugin_dir/share/zsh/plugins/$plugin_dir" \
+                "$plugin_dir/share/zsh/site-functions" \
+                "$plugin_dir/share/zsh/vendor-completions"; do
+                [[ -d "${pluginsDir}/$plugin_fpath_dir" ]] && fpath+="${pluginsDir}/$plugin_fpath_dir"
+              done
             done
-            unset plugin_dir plugin_dirs
+            unset plugin_dir plugin_dirs plugin_fpath_dir
             ${lib.optionalString (completionPaths != [ ]) ''
               # Add completion paths to fpath
               ${lib.hm.zsh.define "completion_paths" completionPaths}

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -20,6 +20,7 @@
   zsh-history-path-zdotdir-variable = import ./history-path.nix "zdotdir-variable";
   zsh-history-substring-search = ./history-substring-search.nix;
   zsh-legacy-warning = ./legacy-warning.nix;
+  zsh-plugins-completions-renamed = ./plugins-completions-renamed.nix;
   zsh-siteFunctions-mkcd = ./siteFunctions-mkcd.nix;
   zsh-plugins = ./plugins.nix;
   zsh-prezto = ./prezto.nix;

--- a/tests/modules/programs/zsh/plugins-completions-renamed.nix
+++ b/tests/modules/programs/zsh/plugins-completions-renamed.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  options,
+  pkgs,
+  ...
+}:
+
+let
+  mockZshPluginSrc = pkgs.runCommand "mock-zsh-plugin-src" { } ''
+    mkdir -p "$out/share/mockPlugin" "$out/share/zsh/site-functions"
+    touch "$out/share/mockPlugin/mockPlugin.plugin.zsh"
+  '';
+in
+{
+  programs.zsh = {
+    enable = true;
+    plugins = [
+      {
+        name = "mockPlugin";
+        file = "share/mockPlugin/mockPlugin.plugin.zsh";
+        src = mockZshPluginSrc;
+        completions = [ "share/zsh/site-functions" ];
+      }
+    ];
+  };
+
+  test.stubs.zsh = { };
+
+  test.asserts.warnings.expected = [
+    "The option `programs.zsh.plugins.*.completions' defined in ${lib.showFiles options.programs.zsh.plugins.files} has been renamed to `programs.zsh.plugins.*.functions'."
+  ];
+
+  nmt.script = ''
+    assertFileContains home-files/.zshrc 'mockPlugin/share/zsh/site-functions'
+  '';
+}

--- a/tests/modules/programs/zsh/plugins.nix
+++ b/tests/modules/programs/zsh/plugins.nix
@@ -12,7 +12,7 @@ in
           name = "mockPlugin";
           file = "share/mockPlugin/mockPlugin.plugin.zsh";
           src = mockZshPluginSrc;
-          completions = [
+          functions = [
             "share/zsh/site-functions"
             "share/zsh/vendor-completions"
           ];

--- a/tests/modules/programs/zsh/plugins.nix
+++ b/tests/modules/programs/zsh/plugins.nix
@@ -30,14 +30,17 @@ in
       assertFileContains home-files/.zshrc 'for plugin_dir in "''${plugin_dirs[@]}"; do'
       assertFileContains home-files/.zshrc 'path+="/home/hm-user/.zsh/plugins/$plugin_dir"'
       assertFileContains home-files/.zshrc 'fpath+="/home/hm-user/.zsh/plugins/$plugin_dir"'
+      assertFileContains home-files/.zshrc '$plugin_dir/share/zsh/plugins/$plugin_dir'
+      assertFileContains home-files/.zshrc '$plugin_dir/share/zsh/site-functions'
+      assertFileContains home-files/.zshrc '$plugin_dir/share/zsh/vendor-completions'
 
       # Test the completion paths loop structure
-      assertFileContains home-files/.zshrc '# Add completion paths to fpath'
-      assertFileContains home-files/.zshrc 'completion_paths=('
+      assertFileContains home-files/.zshrc '# Add additional function paths to fpath'
+      assertFileContains home-files/.zshrc 'function_paths=('
       assertFileContains home-files/.zshrc 'mockPlugin/share/zsh/site-functions'
       assertFileContains home-files/.zshrc 'mockPlugin/share/zsh/vendor-completions'
-      assertFileContains home-files/.zshrc 'for completion_path in "''${completion_paths[@]}"; do'
-      assertFileContains home-files/.zshrc 'fpath+="/home/hm-user/.zsh/plugins/$completion_path"'
+      assertFileContains home-files/.zshrc 'for function_path in "''${function_paths[@]}"; do'
+      assertFileContains home-files/.zshrc 'fpath+="/home/hm-user/.zsh/plugins/$function_path"'
 
       # Test the plugin loading structure
       assertFileContains home-files/.zshrc '# Source plugins'
@@ -45,7 +48,6 @@ in
       assertFileContains home-files/.zshrc 'mockPlugin/share/mockPlugin/mockPlugin.plugin.zsh'
       assertFileContains home-files/.zshrc 'for plugin in "''${plugins[@]}"; do'
       assertFileContains home-files/.zshrc '[[ -f "/home/hm-user/.zsh/plugins/$plugin" ]] && source "/home/hm-user/.zsh/plugins/$plugin"'
-      assertFileContains home-files/.zshrc 'done'
     '';
   };
 }

--- a/tests/modules/programs/zsh/session-variables.nix
+++ b/tests/modules/programs/zsh/session-variables.nix
@@ -18,5 +18,7 @@
   nmt.script = ''
     assertFileExists home-files/.zshenv
     assertFileContent $(normalizeStorePaths home-files/.zshenv) ${./session-variables.zshenv}
+    assertFileExists home-files/.zprofile
+    assertFileContent $(normalizeStorePaths home-files/.zprofile) ${./session-variables.zprofile}
   '';
 }

--- a/tests/modules/programs/zsh/session-variables.zprofile
+++ b/tests/modules/programs/zsh/session-variables.zprofile
@@ -1,0 +1,13 @@
+# Environment variables
+. "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
+
+# Only source this once
+if [[ -z "${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
+  export __HM_ZSH_SESS_VARS_SOURCED=1
+  export IS_EMPTY=""
+  export IS_FALSE=false
+  export IS_TRUE=true
+  export PATH="$HOME/bin:$PATH"
+  export V1="v1"
+  export V2="v2-v1"
+fi

--- a/tests/modules/programs/zsh/session-variables.zshenv
+++ b/tests/modules/programs/zsh/session-variables.zshenv
@@ -1,13 +1,15 @@
-# Environment variables
-. "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
+if [[ ! -o login ]]; then
+  # Environment variables
+  . "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
 
-# Only source this once
-if [[ -z "${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
-  export __HM_ZSH_SESS_VARS_SOURCED=1
-  export IS_EMPTY=""
-  export IS_FALSE=false
-  export IS_TRUE=true
-  export PATH="$HOME/bin:$PATH"
-  export V1="v1"
-  export V2="v2-v1"
+  # Only source this once
+  if [[ -z "${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
+    export __HM_ZSH_SESS_VARS_SOURCED=1
+    export IS_EMPTY=""
+    export IS_FALSE=false
+    export IS_TRUE=true
+    export PATH="$HOME/bin:$PATH"
+    export V1="v1"
+    export V2="v2-v1"
+  fi
 fi

--- a/tests/modules/programs/zsh/zshrc-content-priorities.nix
+++ b/tests/modules/programs/zsh/zshrc-content-priorities.nix
@@ -8,6 +8,12 @@
       "/tmp/with space"
       "/tmp/with[glob]"
     ];
+    dirHashes = {
+      docs = "/tmp/with space";
+      glob = "/tmp/with[glob]";
+      home = "$HOME/Documents";
+      quoted = ''/tmp/with "quotes"'';
+    };
 
     initContent = lib.mkMerge [
       (lib.mkBefore ''
@@ -70,6 +76,12 @@
 
           # Default priority
           echo "Default priority content"
+
+          # Named Directory Hashes
+          hash -d docs="/tmp/with space"
+          hash -d glob="/tmp/with[glob]"
+          hash -d home="$HOME/Documents"
+          hash -d quoted="/tmp/with \"quotes\""
 
           zprof
           # Low priority (mkAfter)

--- a/tests/modules/programs/zsh/zshrc-content-priorities.nix
+++ b/tests/modules/programs/zsh/zshrc-content-priorities.nix
@@ -14,6 +14,11 @@
       home = "$HOME/Documents";
       quoted = ''/tmp/with "quotes"'';
     };
+    localVariables = {
+      BACKTICK = "`literal`";
+      QUOTED = ''value "quoted"'';
+      RUNTIME = "$HOME/bin";
+    };
 
     initContent = lib.mkMerge [
       (lib.mkBefore ''
@@ -54,6 +59,9 @@
 
           HELPDIR="@zsh@/share/zsh/$ZSH_VERSION/help"
 
+          BACKTICK="\`literal\`"
+          QUOTED="value \"quoted\""
+          RUNTIME="$HOME/bin"
           autoload -U compinit && compinit
           # History options should be set in .zshrc and after oh-my-zsh sourcing.
           # See https://github.com/nix-community/home-manager/issues/177.

--- a/tests/modules/programs/zsh/zshrc-content-priorities.nix
+++ b/tests/modules/programs/zsh/zshrc-content-priorities.nix
@@ -3,6 +3,12 @@
   programs.zsh = {
     enable = true;
 
+    cdpath = [
+      "$HOME/projects"
+      "/tmp/with space"
+      "/tmp/with[glob]"
+    ];
+
     initContent = lib.mkMerge [
       (lib.mkBefore ''
         # High priority (mkBefore)
@@ -34,6 +40,8 @@
           echo "High priority content"
 
           typeset -U path cdpath fpath manpath
+          cdpath+=("$HOME/projects" "/tmp/with space" "/tmp/with[glob]")
+
           for profile in ''${(z)NIX_PROFILES}; do
             fpath+=($profile/share/zsh/site-functions $profile/share/zsh/$ZSH_VERSION/functions $profile/share/zsh/vendor-completions)
           done


### PR DESCRIPTION
### Description

This moves Home Manager session variable loading for login shells into `.zprofile`, while keeping non-login shells covered by `.zshenv`. This prevents system login startup files, such as NixOS `/etc/zprofile` and macOS `path_helper`, from overriding and reordering `home.sessionPath` entries after Home Manager has set them.

Also tightens zsh-generated shell output by escaping user-provided values in `cdpath`, named directory hashes, and double-quoted zsh variable values.

Closes #2991
Related https://github.com/nix-community/home-manager/discussions/8701#discussioncomment-16966141

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
