### PR TITLE
git: use absolute paths for git-lfs in config

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -522,12 +522,13 @@ in
         programs.git.iniContent.filter.lfs =
           let
             skipArg = lib.optional cfg.lfs.skipSmudge "--skip";
+            lfsPath = if cfg.lfs.package != null then lib.getExe cfg.lfs.package else "git-lfs";
           in
           {
-            clean = "git-lfs clean -- %f";
+            clean = "${lfsPath} clean -- %f";
             process = concatStringsSep " " (
               [
-                "git-lfs"
+                lfsPath
                 "filter-process"
               ]
               ++ skipArg
@@ -535,7 +536,7 @@ in
             required = true;
             smudge = concatStringsSep " " (
               [
-                "git-lfs"
+                lfsPath
                 "smudge"
               ]
               ++ skipArg

--- a/tests/modules/programs/git/git-expected.conf
+++ b/tests/modules/programs/git/git-expected.conf
@@ -20,10 +20,10 @@
 	value = "test"
 
 [filter "lfs"]
-	clean = "git-lfs clean -- %f"
-	process = "git-lfs filter-process"
+	clean = "@git-lfs@/bin/git-lfs clean -- %f"
+	process = "@git-lfs@/bin/git-lfs filter-process"
 	required = true
-	smudge = "git-lfs smudge -- %f"
+	smudge = "@git-lfs@/bin/git-lfs smudge -- %f"
 
 [gpg]
 	format = "openpgp"

--- a/tests/modules/programs/git/git-with-lfs-expected.conf
+++ b/tests/modules/programs/git/git-with-lfs-expected.conf
@@ -1,8 +1,8 @@
 [filter "lfs"]
-	clean = "git-lfs clean -- %f"
-	process = "git-lfs filter-process --skip"
+	clean = "@git-lfs@/bin/git-lfs clean -- %f"
+	process = "@git-lfs@/bin/git-lfs filter-process --skip"
 	required = true
-	smudge = "git-lfs smudge --skip -- %f"
+	smudge = "@git-lfs@/bin/git-lfs smudge --skip -- %f"
 
 [gpg]
 	format = "openpgp"


### PR DESCRIPTION
### Description

Problem statement: In the current git config setup, `git-lfs` is referred to just by its command name (`git-lfs`) rather than the absolute path of the supplied package. In my setup, I have things that access git and therefore the git config from outside the nix/home-manager walled garden and therefore don't have access to the nix-installed `git-lfs` binary on the system-configured path.

This change makes the git config refer to git-lfs by absolute path if the `package` option is populated, and by `git-lfs` alone if not.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

---

**NOTE:** This change currently breaks the git tests which refer to `tests/modules/programs/git/git-expected.conf` because `git-lfs` is now referred to by absolute path. I don't know what the preferred fix is, so I didn't change it, but obviously this needs to be corrected.