### PR TITLE
ssh: add settings.<name>.header option

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -661,9 +661,15 @@ in
               '';
               description = ''
                 The literal `Host` or `Match` line that opens this block.
-                Set this when the header cannot be expressed as the
+
+                By default this is derived from the attribute name: names
+                starting with `Host ` or `Match ` are used literally, and
+                all other names are prefixed with `Host `. This default is
+                suitable for most configurations.
+
+                Set this only when the header cannot be expressed as the
                 attribute name, e.g. when it carries Nix string context
-                (store paths) or when a stable attribute name is wanted
+                (store paths), or when a stable attribute name is wanted
                 for {option}`lib.hm.dag` ordering.
               '';
             };

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -496,12 +496,12 @@ let
     optionalString (!isLiteralHeader) "Host " + name;
 
   matchBlockStr =
-    key: cf:
+    _key: cf:
     let
-      header = cf.__hmSshBlockHeader or (blockHeader key);
+      inherit (cf) header;
       extraOptions = cf.__hmSshBlockExtraOptions or { };
       settings = lib.removeAttrs cf [
-        "__hmSshBlockHeader"
+        "header"
         "__hmSshBlockExtraOptions"
         "extraOptions"
       ];
@@ -529,7 +529,7 @@ let
         optional (cf.match != null) "Match ${cf.match}" ++ optional (cf.host != null) "Host ${cf.host}";
     in
     lib.filterAttrs (_: v: v != null && v != [ ] && v != { }) {
-      __hmSshBlockHeader = lib.head (headers ++ [ null ]);
+      header = lib.head (headers ++ [ null ]);
       Port = cf.port;
       ForwardAgent = cf.forwardAgent;
       ForwardX11 = if cf.forwardX11 then true else null;
@@ -648,9 +648,27 @@ in
 
     settings = mkOption {
       type = lib.hm.types.dagOf (
-        types.submodule {
-          freeformType = types.attrsOf types.anything;
-        }
+        types.submodule (
+          { dagName, ... }:
+          {
+            freeformType = types.attrsOf types.anything;
+            options.header = mkOption {
+              type = types.str;
+              default = blockHeader dagName;
+              defaultText = lib.literalMD ''
+                The attribute name, prefixed with `Host ` unless it already
+                starts with `Host ` or `Match `.
+              '';
+              description = ''
+                The literal `Host` or `Match` line that opens this block.
+                Set this when the header cannot be expressed as the
+                attribute name, e.g. when it carries Nix string context
+                (store paths) or when a stable attribute name is wanted
+                for {option}`lib.hm.dag` ordering.
+              '';
+            };
+          }
+        )
       );
       default = { };
       example = literalExpression ''

--- a/tests/modules/programs/ssh/default.nix
+++ b/tests/modules/programs/ssh/default.nix
@@ -6,6 +6,7 @@
   ssh-renamed-options = ./renamed-options.nix;
   ssh-includes = ./includes.nix;
   ssh-settings = ./settings.nix;
+  ssh-settings-header = ./settings-header.nix;
   ssh-settings-extra-options-assertion = ./settings-extra-options-assertion.nix;
   ssh-settings-raw-forwards = ./settings-raw-forwards.nix;
   ssh-match-blocks = ./match-blocks-attrs.nix;

--- a/tests/modules/programs/ssh/settings-header-expected.conf
+++ b/tests/modules/programs/ssh/settings-header-expected.conf
@@ -1,0 +1,8 @@
+Match exec "/nix/store/9znzy4h4xnxn8jg9xw6nipd3zvp1pw6y-predicate"
+  IdentityFile ~/.ssh/id_ed25519_sk
+
+Host foo foo-tmux bar bar-tmux
+  ForwardAgent yes
+
+Host *-tmux
+  RemoteCommand tmux attach

--- a/tests/modules/programs/ssh/settings-header.nix
+++ b/tests/modules/programs/ssh/settings-header.nix
@@ -1,0 +1,43 @@
+{ config, lib, ... }:
+{
+  config = {
+    programs.ssh = {
+      enable = true;
+      enableDefaultConfig = false;
+      settings = {
+        # Stable name for dag ordering, header carries the actual pattern.
+        suffixed = lib.hm.dag.entryBefore [ "tmux" ] {
+          header = "Host foo foo-tmux bar bar-tmux";
+          ForwardAgent = true;
+        };
+
+        tmux = {
+          header = "Host *-tmux";
+          RemoteCommand = "tmux attach";
+        };
+
+        # Match condition referring to a store path; cannot be expressed
+        # as the attribute name because Nix forbids string context there.
+        local-exec = {
+          header = ''Match exec "${builtins.toFile "predicate" ''
+            #!/bin/sh
+            true
+          ''}"'';
+          IdentityFile = "~/.ssh/id_ed25519_sk";
+        };
+      };
+    };
+
+    home.file.assertions.text = builtins.toJSON (
+      map (a: a.message) (lib.filter (a: !a.assertion) config.assertions)
+    );
+
+    nmt.script = ''
+      assertFileExists home-files/.ssh/config
+      assertFileContent \
+        home-files/.ssh/config \
+        ${./settings-header-expected.conf}
+      assertFileContent home-files/assertions ${./no-assertions.json}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Since #9331, `programs.ssh.settings` derives the `Host`/`Match` line from the attribute name. That makes two things impossible to express cleanly:

- Headers that carry Nix string context, e.g.
  ```nix
  programs.ssh.settings.local-fido = {
    header = ''Match exec "${lib.getExe somePredicateScript}"'';
    IdentityFile = "~/.ssh/id_ed25519_sk";
  };
  ```
  Nix refuses store paths in attribute names with `the string '…' is not allowed to refer to a store path`, so the only way to write this today is via the undocumented `__hmSshBlockHeader` that the legacy `matchBlocks` shim writes internally.

- Stable logical names for `lib.hm.dag` ordering when the actual pattern is long or computed at eval time.

This adds an explicit `header` option on each block that defaults to the attribute name (with the existing `Host `/`Match ` prefix detection), and switches the legacy `matchBlocks` shim to populate it instead of `__hmSshBlockHeader`. The rendered config is unchanged for existing users.

cc @khaneliman

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
