### PR TITLE
nix-darwin: pass DRY_RUN to activation

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -24,7 +24,12 @@ in
           in
           ''
             echo Activating home-manager configuration for ${usercfg.home.username} >&2
-            launchctl asuser "$(id -u ${usercfg.home.username})" sudo -u ${usercfg.home.username} --set-home ${pkgs.writeShellScript "activation-${usercfg.home.username}" ''
+            hmDryRunArgs=()
+            hmParentArgs="$(ps -p "$PPID" -ww -o args= || true)"
+            if [[ -v DRY_RUN || "$hmParentArgs" == *" --dry-run"* ]]; then
+              hmDryRunArgs=(env DRY_RUN=1)
+            fi
+            launchctl asuser "$(id -u ${usercfg.home.username})" sudo -u ${usercfg.home.username} --set-home "''${hmDryRunArgs[@]}" ${pkgs.writeShellScript "activation-${usercfg.home.username}" ''
               ${lib.optionalString (
                 cfg.backupFileExtension != null
               ) "export HOME_MANAGER_BACKUP_EXT=${lib.escapeShellArg cfg.backupFileExtension}"}


### PR DESCRIPTION
## Summary
Preserve DRY_RUN when nix-darwin invokes Home Manager user activation through sudo

Closes #7344

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
