### PR TITLE
aerospace: skip config reload when AeroSpace is not running

### DIFF
--- a/modules/programs/aerospace.nix
+++ b/modules/programs/aerospace.nix
@@ -208,7 +208,11 @@ in
 
         onChange = lib.mkIf cfg.launchd.enable ''
           echo "AeroSpace config changed, reloading..."
-          ${lib.getExe cfg.package} reload-config
+          if ${lib.getExe cfg.package} list-modes --current >/dev/null 2>&1; then
+            ${lib.getExe cfg.package} reload-config
+          else
+            echo "AeroSpace is not running yet, skipping reload-config."
+          fi
         '';
       };
     };

--- a/tests/modules/programs/aerospace/aerospace-settings-no-xdg.nix
+++ b/tests/modules/programs/aerospace/aerospace-settings-no-xdg.nix
@@ -70,6 +70,7 @@ in
     assertPathNotExists "home-files/.config/aerospace";
     assertFileExists "home-files/.aerospace.toml"
     assertFileContent "home-files/.aerospace.toml" ${./settings-expected.toml}
+    assertFileContains activate 'list-modes --current >/dev/null 2>&1'
 
     serviceFile=$(normalizeStorePaths LaunchAgents/org.nix-community.home.aerospace.plist)
     assertFileExists $serviceFile

--- a/tests/modules/programs/aerospace/aerospace-settings.nix
+++ b/tests/modules/programs/aerospace/aerospace-settings.nix
@@ -70,6 +70,7 @@ in
     assertPathNotExists "home-files/.aerospace.toml";
     assertFileExists "home-files/.config/aerospace/aerospace.toml"
     assertFileContent "home-files/.config/aerospace/aerospace.toml" ${./settings-expected.toml}
+    assertFileContains activate 'list-modes --current >/dev/null 2>&1'
 
     serviceFile=$(normalizeStorePaths LaunchAgents/org.nix-community.home.aerospace.plist)
     assertFileExists $serviceFile


### PR DESCRIPTION
### Description

Avoid failing Home Manager activation when the generated AeroSpace
configuration changes while AeroSpace is not yet running.

The AeroSpace module currently runs `aerospace reload-config` from the
config file `onChange` hook whenever the generated config changes. In
practice, this hook can run before a running AeroSpace instance is
available, which causes the reload command to fail and interrupts Home
Manager activation.

This change probes the running instance with
`aerospace list-modes --current` before calling `reload-config`, and
skips the reload when AeroSpace is not yet running.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
