### PR TITLE
swayosd: remove `ConditionEnvironment` to prevent service skipping

### DIFF
--- a/modules/services/swayosd.nix
+++ b/modules/services/swayosd.nix
@@ -68,7 +68,6 @@ in
           Description = "Volume/backlight OSD indicator";
           PartOf = [ config.wayland.systemd.target ];
           After = [ config.wayland.systemd.target ];
-          ConditionEnvironment = "WAYLAND_DISPLAY";
           Documentation = "man:swayosd(1)";
           StartLimitBurst = 5;
           StartLimitIntervalSec = 10;

--- a/tests/modules/services/swayosd/swayosd.nix
+++ b/tests/modules/services/swayosd/swayosd.nix
@@ -26,7 +26,6 @@
 
         [Unit]
         After=graphical-session.target
-        ConditionEnvironment=WAYLAND_DISPLAY
         Description=Volume/backlight OSD indicator
         Documentation=man:swayosd(1)
         PartOf=graphical-session.target


### PR DESCRIPTION
### Description

Fixes a startup race condition where the `swayosd` systemd user service would silently fail to start on login.

#### The Problem
Previously, the service was starting immediately when `config.wayland.systemd.target` was reached. However, at that exact millisecond, the Wayland compositor had not yet imported its environment variables into the `systemd --user` session. 

So the user had to start it himself using `systemctl --user start swayosd.service`.

Because `ConditionEnvironment=WAYLAND_DISPLAY` was evaluated before the variable existed, systemd skipped the service entirely with the following log footprint:
```text
systemd[1953]: Volume/backlight OSD indicator was skipped because of an unmet condition check (ConditionEnvironment=WAYLAND_DISPLAY).
```

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
