### PR TITLE
mcp: suppor for file links and a common MCP transform function

### DIFF
--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -12,6 +12,7 @@ rec {
   git = import ./git.nix { inherit lib; };
   gvariant = import ./gvariant.nix { inherit lib; };
   maintainers = import ./maintainers.nix;
+  mcp = import ./mcp.nix { inherit lib; };
   strings = import ./strings.nix { inherit lib; };
   types = import ./types.nix { inherit gvariant lib; };
 

--- a/modules/lib/mcp.nix
+++ b/modules/lib/mcp.nix
@@ -1,0 +1,118 @@
+{ lib }:
+
+let
+  /*
+    Merge a server's `env` and `envFiles` into a single attribute set,
+    converting each `envFiles` path using the provided template function.
+
+    The `mkFileRef` function receives the file path string and returns the
+    substitution string for that path.
+
+    Type: mergeEnv :: (String -> String) -> AttrSet -> AttrSet
+
+    Example:
+      mergeEnv (path: "{file:${path}}") {
+        env = { API_KEY = "literal"; };
+        envFiles = { TOKEN = /run/secrets/token; };
+      }
+      => { API_KEY = "literal"; TOKEN = "{file:/run/secrets/token}"; }
+  */
+  mergeEnv = mkFileRef: server: server.env // lib.mapAttrs (_: mkFileRef) server.envFiles;
+
+  /*
+    Wrap a local MCP server command in a shell script that reads secrets from
+    `envFiles` paths into the environment before executing the original process.
+    Compatible with file-based secret managers such as sops-nix or systemd credentials.
+
+    Type: mkEnvFilesWrapper :: { pkgs, name, server } -> Derivation
+  */
+  mkEnvFilesWrapper =
+    {
+      pkgs,
+      name,
+      server,
+    }:
+    pkgs.writeShellScript "mcp-${name}-wrapper" ''
+      ${lib.concatStrings (
+        lib.mapAttrsToList (var: path: ''
+          if ${var}=$(cat ${lib.escapeShellArg path}); then
+            export ${var}
+          else
+            printf '[${name} wrapper ] Failed to read env var %s from %s\n' \
+              ${lib.escapeShellArg var} \
+              ${lib.escapeShellArg path} >&2
+          fi
+        '') server.envFiles
+      )}
+      exec ${lib.escapeShellArgs ([ server.command ] ++ server.args)}
+    '';
+
+  /*
+    If the server has `envFiles` set and a non-null `command`, return
+    attribute overrides that replace `command` with an `mkEnvFilesWrapper`
+    wrapper script and reset `args` to `[]`.
+
+    Returns `{}` when no wrapping is needed.
+
+    Type: envFilesOverrides :: Pkgs -> String -> AttrSet -> AttrSet
+  */
+  envFilesOverrides =
+    pkgs: name: server:
+    (lib.optionalAttrs (server.envFiles != { } && server.command != null) {
+      command = mkEnvFilesWrapper { inherit pkgs name server; };
+      args = [ ];
+    });
+in
+{
+  inherit mkEnvFilesWrapper;
+
+  /*
+    `mergeEnv` specialised for the `{file:…}` reference syntax, which
+    resolves secret paths at runtime without a wrapper script. Use this
+    in MCP client integrations that support the syntax natively instead
+    of falling back to `mkEnvFilesWrapper`.
+
+    Example:
+      mergeEnvFile { env = {}; envFiles = { TOKEN = /run/secrets/token; }; }
+      => { TOKEN = "{file:/run/secrets/token}"; }
+  */
+  mergeEnvFile = mergeEnv (path: "{file:${path}}");
+
+  /*
+    Normalise an MCP server attribute set for consumption by a client
+    program. Applies the following transformations:
+
+    - Adds `enabled` as the inverse of `disabled`
+    - Adds `type` derived from whether `url` is set (`"http"` or `"stdio"`)
+    - Wraps `command` via `mkEnvFilesWrapper` when `envFiles` is non-empty
+    - Removes `disabled`, `envFiles`, and any attributes listed in `exclude`
+    - Removes attributes whose value is `null`
+
+    Type: transformMcpServer :: { exclude?, pkgs, name, server } -> AttrSet
+  */
+  transformMcpServer =
+    {
+      exclude ? [ ],
+      pkgs,
+      name,
+      server,
+    }:
+    lib.filterAttrs (_: v: v != null && v != [ ] && v != { }) (
+      lib.removeAttrs
+        (
+          server
+          // {
+            enabled = !server.disabled;
+            type = if server.url != null then "http" else "stdio";
+          }
+          // (envFilesOverrides pkgs name server)
+        )
+        (
+          [
+            "disabled"
+            "envFiles"
+          ]
+          ++ exclude
+        )
+    );
+}

--- a/modules/lib/mcp.nix
+++ b/modules/lib/mcp.nix
@@ -62,33 +62,27 @@ let
       command = mkEnvFilesWrapper { inherit pkgs name server; };
       args = [ ];
     });
+
+  # Check if mcp server config is remote
+  isRemote = server: server.url != null;
 in
 {
   inherit mkEnvFilesWrapper;
 
   /*
-    `mergeEnv` specialised for the `{file:…}` reference syntax, which
-    resolves secret paths at runtime without a wrapper script. Use this
-    in MCP client integrations that support the syntax natively instead
-    of falling back to `mkEnvFilesWrapper`.
-
-    Example:
-      mergeEnvFile { env = {}; envFiles = { TOKEN = /run/secrets/token; }; }
-      => { TOKEN = "{file:/run/secrets/token}"; }
-  */
-  mergeEnvFile = mergeEnv (path: "{file:${path}}");
-
-  /*
     Normalise an MCP server attribute set for consumption by a client
     program. Applies the following transformations:
 
-    - Adds `enabled` as the inverse of `disabled`
-    - Adds `type` derived from whether `url` is set (`"http"` or `"stdio"`)
-    - Wraps `command` via `mkEnvFilesWrapper` when `envFiles` is non-empty
-    - Removes `disabled`, `envFiles`, and any attributes listed in `exclude`
-    - Removes attributes whose value is `null`
+    - Resolves effective `enabled` from optional `enabled`/`disabled`
+    - `transformStyle = "wrapping"`:
+      - Adds `enabled`
+      - Adds `type` derived from whether `url` is set (`"http"` or `"stdio"`)
+      - Wraps `command` via `mkEnvFilesWrapper` when `envFiles` is non-empty
+      - Removes `disabled`, `envFiles`, and attributes listed in `exclude`
+    - `transformStyle = "opencode"`:
+      - Produces OpenCode-native shape (`local`/`remote`, command list, environment)
 
-    Type: transformMcpServer :: { exclude?, pkgs, name, server } -> AttrSet
+    Type: transformMcpServer :: { exclude?, pkgs, name, server, transformStyle? } -> AttrSet
   */
   transformMcpServer =
     {
@@ -96,23 +90,60 @@ in
       pkgs,
       name,
       server,
+      transformStyle ? "wrapping",
     }:
-    lib.filterAttrs (_: v: v != null && v != [ ] && v != { }) (
-      lib.removeAttrs
-        (
+    let
+      hasEnabled = server ? enabled && server.enabled != null;
+      hasDisabled = server ? disabled && server.disabled != null;
+      enabled =
+        if hasEnabled then
+          server.enabled
+        else if hasDisabled then
+          !server.disabled
+        else
+          null;
+      transformedServer =
+        if transformStyle == "wrapping" then
           server
           // {
-            enabled = !server.disabled;
-            type = if server.url != null then "http" else "stdio";
+            inherit enabled;
+            type = if isRemote server then "http" else "stdio";
           }
           // (envFilesOverrides pkgs name server)
-        )
-        (
-          [
-            "disabled"
-            "envFiles"
-          ]
-          ++ exclude
-        )
+        else if transformStyle == "opencode" then
+          let
+            mergedEnvFile = mergeEnv (path: "{file:${path}}") server;
+          in
+          {
+            inherit enabled;
+          }
+          // (
+            if isRemote server then
+              {
+                type = "remote";
+                inherit (server) url;
+              }
+              // lib.optionalAttrs (server.headers != { }) { inherit (server) headers; }
+            else
+              {
+                type = "local";
+                command = [ server.command ] ++ server.args;
+              }
+              // lib.optionalAttrs (mergedEnvFile != { }) { environment = mergedEnvFile; }
+          )
+        else
+          throw ''
+            lib.hm.mcp.transformMcpServer: unknown transformStyle `${transformStyle}`.
+            Expected one of: "wrapping", "opencode".
+          '';
+    in
+    lib.filterAttrs (_: v: v != null && v != [ ] && v != { }) (
+      lib.removeAttrs transformedServer (
+        [
+          "disabled"
+          "envFiles"
+        ]
+        ++ exclude
+      )
     );
 }

--- a/modules/lib/mcp.nix
+++ b/modules/lib/mcp.nix
@@ -1,28 +1,31 @@
 { lib }:
 
 let
+  isFileRef = v: lib.isAttrs v && v ? file;
+
+  literalEnv = env: lib.filterAttrs (_: v: !isFileRef v) env;
+  fileRefEnv = env: lib.mapAttrs (_: v: v.file) (lib.filterAttrs (_: isFileRef) env);
+
   /*
-    Merge a server's `env` and `envFiles` into a single attribute set,
-    converting each `envFiles` path using the provided template function.
+    Render an `env` attrset (literals + file refs) as a flat `attrsOf str` by
+    mapping file refs through `mkFileRef path` and leaving literals untouched.
 
-    The `mkFileRef` function receives the file path string and returns the
-    substitution string for that path.
-
-    Type: mergeEnv :: (String -> String) -> AttrSet -> AttrSet
+    Type: renderEnv :: (String -> String) -> AttrSet -> AttrSet
 
     Example:
-      mergeEnv (path: "{file:${path}}") {
-        env = { API_KEY = "literal"; };
-        envFiles = { TOKEN = /run/secrets/token; };
+      renderEnv (p: "{file:${p}}") {
+        A = "literal";
+        B.file = "/run/secrets/token";
       }
-      => { API_KEY = "literal"; TOKEN = "{file:/run/secrets/token}"; }
+      => { A = "literal"; B = "{file:/run/secrets/token}"; }
   */
-  mergeEnv = mkFileRef: server: server.env // lib.mapAttrs (_: mkFileRef) server.envFiles;
+  renderEnv = mkFileRef: env: lib.mapAttrs (_: v: if isFileRef v then mkFileRef v.file else v) env;
 
   /*
-    Wrap a local MCP server command in a shell script that reads secrets from
-    `envFiles` paths into the environment before executing the original process.
-    Compatible with file-based secret managers such as sops-nix or systemd credentials.
+    Wrap a local MCP server command in a shell script that reads file-backed
+    env values into the environment before executing the original process.
+    Compatible with file-based secret managers such as sops-nix or systemd
+    credentials. Reads file refs from `server.env`.
 
     Type: mkEnvFilesWrapper :: { pkgs, name, server } -> Derivation
   */
@@ -32,6 +35,9 @@ let
       name,
       server,
     }:
+    let
+      files = fileRefEnv (server.env or { });
+    in
     pkgs.writeShellScript "mcp-${name}-wrapper" ''
       ${lib.concatStrings (
         lib.mapAttrsToList (var: path: ''
@@ -42,108 +48,111 @@ let
               ${lib.escapeShellArg var} \
               ${lib.escapeShellArg path} >&2
           fi
-        '') server.envFiles
+        '') files
       )}
       exec ${lib.escapeShellArgs ([ server.command ] ++ server.args)}
     '';
 
   /*
-    If the server has `envFiles` set and a non-null `command`, return
-    attribute overrides that replace `command` with an `mkEnvFilesWrapper`
-    wrapper script and reset `args` to `[]`.
+    extraTransform that adds `type = "stdio" | "http"` based on whether the
+    server has a `url`.
 
-    Returns `{}` when no wrapping is needed.
-
-    Type: envFilesOverrides :: Pkgs -> String -> AttrSet -> AttrSet
+    Type: deriveType :: AttrSet -> AttrSet
   */
-  envFilesOverrides =
-    pkgs: name: server:
-    (lib.optionalAttrs (server.envFiles != { } && server.command != null) {
-      command = mkEnvFilesWrapper { inherit pkgs name server; };
-      args = [ ];
-    });
-
-  # Check if mcp server config is remote
-  isRemote = server: server.url != null;
-in
-{
-  inherit mkEnvFilesWrapper;
+  deriveType = s: s // { type = if s.url or null != null then "http" else "stdio"; };
 
   /*
-    Normalise an MCP server attribute set for consumption by a client
-    program. Applies the following transformations:
+    extraTransform factory: when the server has file refs in `env` and a
+    local `command`, replace `command` with a wrapper script that reads
+    those files at startup, reset `args` to `[ ]`, and drop the file refs
+    from `env` (leaving only literal entries).
 
-    - Resolves effective `enabled` from optional `enabled`/`disabled`
-    - `transformStyle = "wrapping"`:
-      - Adds `enabled`
-      - Adds `type` derived from whether `url` is set (`"http"` or `"stdio"`)
-      - Wraps `command` via `mkEnvFilesWrapper` when `envFiles` is non-empty
-      - Removes `disabled`, `envFiles`, and attributes listed in `exclude`
-    - `transformStyle = "opencode"`:
-      - Produces OpenCode-native shape (`local`/`remote`, command list, environment)
+    When there is nothing to wrap, returns the server unchanged.
 
-    Type: transformMcpServer :: { exclude?, pkgs, name, server, transformStyle? } -> AttrSet
+    Type: wrapEnvFilesCommand :: { pkgs, name } -> AttrSet -> AttrSet
   */
-  transformMcpServer =
-    {
-      exclude ? [ ],
-      pkgs,
-      name,
-      server,
-      transformStyle ? "wrapping",
-    }:
+  wrapEnvFilesCommand =
+    { pkgs, name }:
+    s:
+    let
+      files = fileRefEnv (s.env or { });
+    in
+    if files == { } || (s.command or null) == null then
+      s
+    else
+      s
+      // {
+        command = mkEnvFilesWrapper {
+          inherit pkgs name;
+          server = s;
+        };
+        args = [ ];
+        env = literalEnv (s.env or { });
+      };
+
+  resolveEnabled =
+    server:
     let
       hasEnabled = server ? enabled && server.enabled != null;
       hasDisabled = server ? disabled && server.disabled != null;
-      enabled =
-        if hasEnabled then
-          server.enabled
-        else if hasDisabled then
-          !server.disabled
-        else
-          null;
-      transformedServer =
-        if transformStyle == "wrapping" then
-          server
-          // {
-            inherit enabled;
-            type = if isRemote server then "http" else "stdio";
-          }
-          // (envFilesOverrides pkgs name server)
-        else if transformStyle == "opencode" then
-          let
-            mergedEnvFile = mergeEnv (path: "{file:${path}}") server;
-          in
-          {
-            inherit enabled;
-          }
-          // (
-            if isRemote server then
-              {
-                type = "remote";
-                inherit (server) url;
-              }
-              // lib.optionalAttrs (server.headers != { }) { inherit (server) headers; }
-            else
-              {
-                type = "local";
-                command = [ server.command ] ++ server.args;
-              }
-              // lib.optionalAttrs (mergedEnvFile != { }) { environment = mergedEnvFile; }
-          )
-        else
-          throw ''
-            lib.hm.mcp.transformMcpServer: unknown transformStyle `${transformStyle}`.
-            Expected one of: "wrapping", "opencode".
-          '';
     in
-    lib.filterAttrs (_: v: v != null && v != [ ] && v != { }) (
-      lib.removeAttrs transformedServer (
-        [
-          "disabled"
-          "envFiles"
-        ]
-        ++ exclude
-      )
-    );
+    if hasEnabled then
+      server.enabled
+    else if hasDisabled then
+      !server.disabled
+    else
+      null;
+in
+{
+  inherit
+    isFileRef
+    literalEnv
+    fileRefEnv
+    renderEnv
+    mkEnvFilesWrapper
+    wrapEnvFilesCommand
+    deriveType
+    ;
+
+  /*
+    Normalise an MCP server attribute set for consumption by a client
+    program. Performs only universal steps:
+
+    1. Resolve `enabled` from optional `enabled`/`disabled` fields.
+    2. Apply each function in `extraTransforms` to the server attrs, in
+       order. Transforms run before `mkFileRef`, `exclude` and the
+       empty-value filter, so a transform can still read attrs that will
+       be excluded and operate on the raw env shape (with file refs).
+    3. Render any remaining file refs in `env` through `mkFileRef path`.
+       Callers that consume file refs themselves (e.g. via
+       `wrapEnvFilesCommand`) will have stripped them in an
+       extraTransform, so `mkFileRef` is a no-op for them.
+    4. Remove `disabled` and any keys listed in `exclude`.
+    5. Filter `null`, `[]`, and `{}` values.
+
+    Type: transformMcpServer ::
+      { server, exclude?, extraTransforms?, mkFileRef? }
+      -> AttrSet
+  */
+  transformMcpServer =
+    {
+      server,
+      exclude ? [ ],
+      extraTransforms ? [ ],
+      mkFileRef ? (p: "{file:${p}}"),
+    }:
+    let
+      enabled = resolveEnabled server;
+      withEnabled = server // {
+        inherit enabled;
+      };
+      transformed = lib.foldl' (acc: f: f acc) withEnabled extraTransforms;
+      withRenderedEnv =
+        transformed
+        // lib.optionalAttrs (transformed ? env) {
+          env = renderEnv mkFileRef transformed.env;
+        };
+      cleaned = removeAttrs withRenderedEnv ([ "disabled" ] ++ exclude);
+    in
+    lib.filterAttrs (_: v: v != null && v != [ ] && v != { }) cleaned;
 }

--- a/modules/misc/news/2026/04/2026-04-19_14-05-24.nix
+++ b/modules/misc/news/2026/04/2026-04-19_14-05-24.nix
@@ -1,0 +1,14 @@
+_: {
+  time = "2026-04-19T12:05:24+00:00";
+  # condition = pkgs.stdenv.hostPlatform.isLinux;
+  # condition = config.programs.neovim.enable;
+  condition = true;
+  # if behavior changed, explain how to restore previous behavior.
+  message = ''
+    The {option}`programs.mcp.servers.<name>.envFiles` option has been added to {option}`programs.mcp`.
+    It maps environment variable names to secret file paths (e.g. sops-nix, systemd credentials).
+
+    In {file}`mcp.json` each entry is resolved to a {file}`{file:…}`-substitution in {option}`env`.
+    Clients that do not support this syntax (e.g. claude-code, codex) receive a generated wrapper script that reads the secret at startup instead.
+  '';
+}

--- a/modules/misc/news/2026/04/2026-04-19_14-05-24.nix
+++ b/modules/misc/news/2026/04/2026-04-19_14-05-24.nix
@@ -1,14 +1,16 @@
 _: {
   time = "2026-04-19T12:05:24+00:00";
-  # condition = pkgs.stdenv.hostPlatform.isLinux;
-  # condition = config.programs.neovim.enable;
   condition = true;
-  # if behavior changed, explain how to restore previous behavior.
   message = ''
-    The {option}`programs.mcp.servers.<name>.envFiles` option has been added to {option}`programs.mcp`.
-    It maps environment variable names to secret file paths (e.g. sops-nix, systemd credentials).
+    The {option}`programs.mcp.servers.<name>.envFiles` option has been replaced.
+    Use {option}`env.<NAME> = { file = "/path"; }` to load a value from a file at
+    startup, and plain string values for literal environment variables.
 
-    In {file}`mcp.json` each entry is resolved to a {file}`{file:…}`-substitution in {option}`env`.
-    Clients that do not support this syntax (e.g. claude-code, codex) receive a generated wrapper script that reads the secret at startup instead.
+    The shared {file}`mcp.json` is now written in the de-facto-standard shape
+    used by Claude Code, Claude Desktop, Cursor, and others
+    ({option}`command` string, {option}`args` list, {option}`env` flat object,
+    {option}`type` `"stdio"` or `"http"`). File-backed values render as
+    {file}`{file:/path}` substitutions, matching opencode's native syntax;
+    clients without that extension see the substitution as a literal string.
   '';
 }

--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -21,8 +21,16 @@ let
 
   transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
     lib.mapAttrs (
-      name: server: lib.hm.mcp.transformMcpServer { inherit pkgs name server; }
-    ) config.programs.mcp.servers # envFiles currently still need wrapping https://github.com/anthropics/claude-code/issues/28942
+      # file-backed env entries currently still need wrapping https://github.com/anthropics/claude-code/issues/28942
+      name: server:
+      lib.hm.mcp.transformMcpServer {
+        inherit server;
+        extraTransforms = [
+          lib.hm.mcp.deriveType
+          (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
+        ];
+      }
+    ) config.programs.mcp.servers
   );
 
   mkContentOption =

--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -19,17 +19,10 @@ let
 
   upstreamConfigDir = "${config.home.homeDirectory}/.claude";
 
-  mkMcpServer =
-    server:
-    (removeAttrs server [ "disabled" ])
-    // (optionalAttrs (server ? url) { type = "http"; })
-    // (optionalAttrs (server ? command) { type = "stdio"; })
-    // {
-      enabled = !(server.disabled or false);
-    };
-
-  transformedMcpServers = optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
-    lib.mapAttrs (_name: mkMcpServer) config.programs.mcp.servers
+  transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
+    lib.mapAttrs (
+      name: server: lib.hm.mcp.transformMcpServer { inherit pkgs name server; }
+    ) config.programs.mcp.servers # envFiles currently still need wrapping https://github.com/anthropics/claude-code/issues/28942
   );
 
   mkContentOption =

--- a/modules/programs/codex.nix
+++ b/modules/programs/codex.nix
@@ -224,20 +224,23 @@ in
 
       transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
         lib.mapAttrs (
-          name: server:
           # NOTE: Convert shared programs.mcp fields to Codex config keys:
           # - "disabled" becomes inverse "enabled"
           # - "headers" is renamed to "http_headers"
-          # - "envFiles" are wrapped in a shell script that sets environment variables before exec
+          # - file-backed env entries are wrapped in a shell script that sets environment variables before exec
           # See: https://developers.openai.com/codex/mcp#other-configuration-options
-          (lib.hm.mcp.transformMcpServer {
-            inherit pkgs name server;
+          name: server:
+          lib.hm.mcp.transformMcpServer {
+            inherit server;
             exclude = [
               "headers"
               "type"
             ];
-          })
-          // lib.optionalAttrs (server.headers != { }) { http_headers = server.headers; }
+            extraTransforms = [
+              (s: s // lib.optionalAttrs (s.headers or { } != { }) { http_headers = s.headers; })
+              (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
+            ];
+          }
         ) config.programs.mcp.servers
       );
 

--- a/modules/programs/codex.nix
+++ b/modules/programs/codex.nix
@@ -17,8 +17,8 @@ let
   settingsFormat = if isTomlConfig then tomlFormat else yamlFormat;
 in
 {
-  meta.maintainers = [
-    lib.maintainers.delafthi
+  meta.maintainers = with lib.maintainers; [
+    delafthi
   ];
 
   imports = [
@@ -224,22 +224,20 @@ in
 
       transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
         lib.mapAttrs (
-          _name: server:
+          name: server:
           # NOTE: Convert shared programs.mcp fields to Codex config keys:
-          # - removeAttrs drops keys that Codex does not use directly
           # - "disabled" becomes inverse "enabled"
           # - "headers" is renamed to "http_headers"
+          # - "envFiles" are wrapped in a shell script that sets environment variables before exec
           # See: https://developers.openai.com/codex/mcp#other-configuration-options
-          (lib.removeAttrs server [
-            "disabled"
-            "headers"
-          ])
-          // (lib.optionalAttrs (server ? headers && !(server ? http_headers)) {
-            http_headers = server.headers;
+          (lib.hm.mcp.transformMcpServer {
+            inherit pkgs name server;
+            exclude = [
+              "headers"
+              "type"
+            ];
           })
-          // {
-            enabled = !(server.disabled or false);
-          }
+          // lib.optionalAttrs (server.headers != { }) { http_headers = server.headers; }
         ) config.programs.mcp.servers
       );
 

--- a/modules/programs/gemini-cli.nix
+++ b/modules/programs/gemini-cli.nix
@@ -236,9 +236,16 @@ in
     lib.mkIf cfg.enable (
       lib.mkMerge [
         {
-          programs.gemini-cli.settings.mcpServers = lib.mkIf (
-            cfg.enableMcpIntegration && config.programs.mcp.enable
-          ) (lib.mapAttrs (_n: lib.mkDefault) config.programs.mcp.servers);
+          programs.gemini-cli.settings.mcpServers =
+            lib.mkIf (cfg.enableMcpIntegration && config.programs.mcp.enable)
+              (
+                lib.mapAttrs (
+                  name: server:
+                  lib.hm.mcp.transformMcpServer {
+                    inherit pkgs name server;
+                  }
+                ) config.programs.mcp.servers
+              );
         }
         {
           home = {

--- a/modules/programs/gemini-cli.nix
+++ b/modules/programs/gemini-cli.nix
@@ -242,7 +242,11 @@ in
                 lib.mapAttrs (
                   name: server:
                   lib.hm.mcp.transformMcpServer {
-                    inherit pkgs name server;
+                    inherit server;
+                    extraTransforms = [
+                      lib.hm.mcp.deriveType
+                      (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
+                    ];
                   }
                 ) config.programs.mcp.servers
               );

--- a/modules/programs/mcp.nix
+++ b/modules/programs/mcp.nix
@@ -13,52 +13,176 @@ let
     ;
 
   cfg = config.programs.mcp;
-
   jsonFormat = pkgs.formats.json { };
+
+  serverModule = lib.types.submodule {
+    freeformType = jsonFormat.type;
+
+    options = {
+      command = mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Executable for a local (stdio) MCP server.
+          Mutually exclusive with {option}`url`.
+        '';
+        example = "npx";
+      };
+
+      args = mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = ''
+          Arguments passed to {option}`command`.
+          Only valid for local servers.
+        '';
+        example = [
+          "-y"
+          "@modelcontextprotocol/server-everything"
+        ];
+      };
+
+      env = mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        description = ''
+          Environment variables set when spawning the MCP server.
+          Values are literal strings.
+          For file-based secrets use {option}`envFiles`.
+          Only valid for local servers.
+        '';
+        example = literalExpression ''
+          { API_BASE_URL = "https://api.example.com"; }
+        '';
+      };
+
+      envFiles = mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        description = ''
+          Environment variables whose values are read from files at startup.
+          Maps variable names to file paths (e.g. sops-nix, systemd credentials).
+
+          In {file}`mcp.json` each entry is resolved to a {file:`…`} substitution in {option}`env`.
+          Consumers that do not understand this syntax must handle {option}`envFiles` themselves (e.g. via a generated wrapper script).
+        '';
+        example = literalExpression ''
+          { FORGEJO_ACCESS_TOKEN = "/run/secrets/forgejo_token"; }
+        '';
+      };
+
+      url = mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          HTTP(S) endpoint for a remote (SSE/HTTP) MCP server.
+          Mutually exclusive with {option}`command`.
+        '';
+        example = "https://mcp.context7.com/mcp";
+      };
+
+      headers = mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        description = ''
+          HTTP headers for requests to a remote MCP server.
+          Only valid for remote servers.
+        '';
+        example = literalExpression ''
+          { MY_API_KEY = "{env:MY_API_KEY}"; }
+        '';
+      };
+
+      disabled = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether this MCP server is disabled. Disabled servers remain in the
+          configuration but are not started.
+        '';
+      };
+    };
+  };
+
 in
 {
-  meta.maintainers = with lib.maintainers; [ delafthi ];
+  meta.maintainers = with lib.maintainers; [
+    delafthi
+    malik
+  ];
 
   options.programs.mcp = {
     enable = mkEnableOption "mcp";
 
     servers = mkOption {
-      inherit (jsonFormat) type;
+      type = lib.types.attrsOf serverModule;
       default = { };
       example = literalExpression ''
         {
           everything = {
             command = "npx";
-            args = [
-              "-y"
-              "@modelcontextprotocol/server-everything"
-            ];
+            args = [ "-y" "@modelcontextprotocol/server-everything" ];
           };
           context7 = {
             url = "https://mcp.context7.com/mcp";
-            headers = {
-              CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";
-            };
+            headers.CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";
+          };
+          codeberg = {
+            command = "/path/to/forgejo-mcp";
+            args = [ "transport" "stdio" "--url" "https://codeberg.org" ];
+            envFiles.FORGEJO_ACCESS_TOKEN = "/run/secrets/codeberg_token";
           };
         }
       '';
       description = ''
-        MCP server configurations written to
-        {file}`XDG_CONFIG_HOME/mcp/mcp.json`
+        MCP server configurations written to {file}`$XDG_CONFIG_HOME/mcp/mcp.json`.
+
+        Each server is either a local (stdio) server via {option}`command`
+        or a remote (HTTP/SSE) server via {option}`url`.
       '';
     };
   };
 
   config = mkIf cfg.enable {
-    xdg.configFile = mkIf (cfg.servers != { }) (
-      let
-        mcp-config = {
-          mcpServers = cfg.servers;
-        };
-      in
-      {
-        "mcp/mcp.json".source = jsonFormat.generate "mcp.json" mcp-config;
-      }
+    assertions = lib.concatLists (
+      lib.mapAttrsToList (name: server: [
+        {
+          assertion = (server.command != null) != (server.url != null);
+          message = ''
+            programs.mcp.servers.${name}: exactly one of `command` or `url` must be set.
+          '';
+        }
+        {
+          assertion =
+            server.url == null || (server.args == [ ] && server.env == { } && server.envFiles == { });
+          message = ''
+            programs.mcp.servers.${name}: `args`, `env`, and `envFiles` are only valid for local servers (`command`).
+          '';
+        }
+        {
+          assertion = server.command == null || server.headers == { };
+          message = ''
+            programs.mcp.servers.${name}: `headers` is only valid for remote servers (`url`).
+          '';
+        }
+      ]) cfg.servers
     );
+
+    xdg.configFile = mkIf (cfg.servers != { }) {
+      "mcp/mcp.json".source = jsonFormat.generate "mcp.json" {
+        mcpServers = lib.mapAttrs (
+          _name: server:
+          let
+            # Resolve envFiles into env using {file:...} substitution syntax.
+            # Consumers that don't understand this syntax must handle envFiles
+            # themselves (e.g. via a wrapper script).
+            mergedEnv = lib.hm.mcp.mergeEnvFile server;
+          in
+          lib.filterAttrs (_: v: v != null && v != [ ] && v != { }) (
+            (lib.removeAttrs server [ "envFiles" ]) // lib.optionalAttrs (mergedEnv != { }) { env = mergedEnv; }
+          )
+        ) cfg.servers;
+      };
+    };
   };
 }

--- a/modules/programs/mcp.nix
+++ b/modules/programs/mcp.nix
@@ -43,31 +43,36 @@ let
       };
 
       env = mkOption {
-        type = lib.types.attrsOf lib.types.str;
+        type = lib.types.attrsOf (
+          lib.types.either lib.types.str (
+            lib.types.submodule {
+              options.file = mkOption {
+                type = lib.types.str;
+                description = ''
+                  Path to a file whose contents become the value of this variable at startup
+                  (e.g. sops-nix, systemd credentials).
+                '';
+              };
+            }
+          )
+        );
         default = { };
         description = ''
-          Environment variables set when spawning the MCP server.
-          Values are literal strings.
-          For file-based secrets use {option}`envFiles`.
+          Environment variables for the MCP server. Each value is either a
+          literal string or `{ file = "/path"; }`, in which case the variable
+          is loaded from the file at startup.
+
+          In {file}`mcp.json` file references are rendered as {file}`{file:…}`
+          substitutions. Consumers that do not understand that syntax handle
+          file references themselves (typically via a generated wrapper script).
+
           Only valid for local servers.
         '';
         example = literalExpression ''
-          { API_BASE_URL = "https://api.example.com"; }
-        '';
-      };
-
-      envFiles = mkOption {
-        type = lib.types.attrsOf lib.types.str;
-        default = { };
-        description = ''
-          Environment variables whose values are read from files at startup.
-          Maps variable names to file paths (e.g. sops-nix, systemd credentials).
-
-          In {file}`mcp.json` each entry is resolved to a {file:`…`} substitution in {option}`env`.
-          Consumers that do not understand this syntax must handle {option}`envFiles` themselves (e.g. via a generated wrapper script).
-        '';
-        example = literalExpression ''
-          { FORGEJO_ACCESS_TOKEN = "/run/secrets/forgejo_token"; }
+          {
+            API_BASE_URL = "https://api.example.com";
+            FORGEJO_ACCESS_TOKEN.file = "/run/secrets/forgejo_token";
+          }
         '';
       };
 
@@ -132,7 +137,7 @@ in
           codeberg = {
             command = "/path/to/forgejo-mcp";
             args = [ "transport" "stdio" "--url" "https://codeberg.org" ];
-            envFiles.FORGEJO_ACCESS_TOKEN = "/run/secrets/codeberg_token";
+            env.FORGEJO_ACCESS_TOKEN.file = "/run/secrets/codeberg_token";
           };
         }
       '';
@@ -157,10 +162,9 @@ in
           '';
         }
         {
-          assertion =
-            server.url == null || (server.args == [ ] && server.env == { } && server.envFiles == { });
+          assertion = server.url == null || (server.args == [ ] && server.env == { });
           message = ''
-            programs.mcp.servers.${name}: `args`, `env`, and `envFiles` are only valid for local servers (`command`).
+            programs.mcp.servers.${name}: `args` and `env` are only valid for local servers (`command`).
           '';
         }
         {
@@ -183,10 +187,10 @@ in
     xdg.configFile = mkIf (cfg.servers != { }) {
       "mcp/mcp.json".source = jsonFormat.generate "mcp.json" {
         mcpServers = lib.mapAttrs (
-          name: server:
+          _: server:
           lib.hm.mcp.transformMcpServer {
-            inherit pkgs name server;
-            transformStyle = "opencode";
+            inherit server;
+            extraTransforms = [ lib.hm.mcp.deriveType ];
           }
         ) cfg.servers;
       };

--- a/modules/programs/mcp.nix
+++ b/modules/programs/mcp.nix
@@ -93,12 +93,14 @@ let
         '';
       };
 
-      disabled = mkOption {
-        type = lib.types.bool;
-        default = false;
+      enabled = mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
         description = ''
-          Whether this MCP server is disabled. Disabled servers remain in the
-          configuration but are not started.
+          Whether this MCP server is enabled.
+
+          If this option and `disabled` are both set, they must satisfy
+          `enabled == !disabled`.
         '';
       };
     };
@@ -139,6 +141,8 @@ in
 
         Each server is either a local (stdio) server via {option}`command`
         or a remote (HTTP/SSE) server via {option}`url`.
+
+        Besides declared options, arbitrary MCP fields are allowed.
       '';
     };
   };
@@ -160,9 +164,17 @@ in
           '';
         }
         {
-          assertion = server.command == null || server.headers == { };
+          assertion = server.headers == { } || server.url != null;
           message = ''
             programs.mcp.servers.${name}: `headers` is only valid for remote servers (`url`).
+          '';
+        }
+        {
+          assertion =
+            !(server.enabled != null && server ? disabled && server.disabled != null)
+            || server.enabled != server.disabled;
+          message = ''
+            programs.mcp.servers.${name}: `enabled` and `disabled` are set to incompatible values.
           '';
         }
       ]) cfg.servers
@@ -171,16 +183,11 @@ in
     xdg.configFile = mkIf (cfg.servers != { }) {
       "mcp/mcp.json".source = jsonFormat.generate "mcp.json" {
         mcpServers = lib.mapAttrs (
-          _name: server:
-          let
-            # Resolve envFiles into env using {file:...} substitution syntax.
-            # Consumers that don't understand this syntax must handle envFiles
-            # themselves (e.g. via a wrapper script).
-            mergedEnv = lib.hm.mcp.mergeEnvFile server;
-          in
-          lib.filterAttrs (_: v: v != null && v != [ ] && v != { }) (
-            (lib.removeAttrs server [ "envFiles" ]) // lib.optionalAttrs (mergedEnv != { }) { env = mergedEnv; }
-          )
+          name: server:
+          lib.hm.mcp.transformMcpServer {
+            inherit pkgs name server;
+            transformStyle = "opencode";
+          }
         ) cfg.servers;
       };
     };

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -18,28 +18,32 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
-  transformMcpServer = name: server: {
-    inherit name;
-    value = {
-      enabled = !(server.disabled or false);
-    }
-    // (
-      if server ? url then
-        {
-          type = "remote";
-          inherit (server) url;
-        }
-        // (lib.optionalAttrs (server ? headers) { inherit (server) headers; })
-      else if server ? command then
-        {
-          type = "local";
-          command = [ server.command ] ++ (server.args or [ ]);
-        }
-        // (lib.optionalAttrs (server ? env) { environment = server.env; })
-      else
-        { }
-    );
-  };
+  transformMcpServer =
+    name: server:
+    let
+      # Translate envFiles to opencode's native {file:...} substitution syntax
+      mergedEnv = lib.hm.mcp.mergeEnvFile server;
+    in
+    {
+      inherit name;
+      value = {
+        enabled = !server.disabled;
+      }
+      // (
+        if server.url != null then
+          {
+            type = "remote";
+            inherit (server) url;
+          }
+          // lib.optionalAttrs (server.headers != { }) { inherit (server) headers; }
+        else
+          {
+            type = "local";
+            command = [ server.command ] ++ server.args;
+          }
+          // lib.optionalAttrs (mergedEnv != { }) { environment = mergedEnv; }
+      );
+    };
 
   transformedMcpServers =
     if cfg.enableMcpIntegration && config.programs.mcp.enable && config.programs.mcp.servers != { } then

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -18,13 +18,37 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
+  toOpencodeShape =
+    s:
+    let
+      env = lib.hm.mcp.renderEnv (p: "{file:${p}}") (s.env or { });
+      isRemote = s.url or null != null;
+    in
+    {
+      inherit (s) enabled;
+    }
+    // (
+      if isRemote then
+        {
+          type = "remote";
+          inherit (s) url;
+        }
+        // lib.optionalAttrs (s.headers or { } != { }) { inherit (s) headers; }
+      else
+        {
+          type = "local";
+          command = [ s.command ] ++ s.args;
+        }
+        // lib.optionalAttrs (env != { }) { environment = env; }
+    );
+
   transformedMcpServers =
     if cfg.enableMcpIntegration && config.programs.mcp.enable && config.programs.mcp.servers != { } then
       lib.mapAttrs (
-        name: server:
+        _: server:
         lib.hm.mcp.transformMcpServer {
-          inherit pkgs name server;
-          transformStyle = "opencode";
+          inherit server;
+          extraTransforms = [ toOpencodeShape ];
         }
       ) config.programs.mcp.servers
     else

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -18,36 +18,15 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
-  transformMcpServer =
-    name: server:
-    let
-      # Translate envFiles to opencode's native {file:...} substitution syntax
-      mergedEnv = lib.hm.mcp.mergeEnvFile server;
-    in
-    {
-      inherit name;
-      value = {
-        enabled = !server.disabled;
-      }
-      // (
-        if server.url != null then
-          {
-            type = "remote";
-            inherit (server) url;
-          }
-          // lib.optionalAttrs (server.headers != { }) { inherit (server) headers; }
-        else
-          {
-            type = "local";
-            command = [ server.command ] ++ server.args;
-          }
-          // lib.optionalAttrs (mergedEnv != { }) { environment = mergedEnv; }
-      );
-    };
-
   transformedMcpServers =
     if cfg.enableMcpIntegration && config.programs.mcp.enable && config.programs.mcp.servers != { } then
-      lib.listToAttrs (lib.mapAttrsToList transformMcpServer config.programs.mcp.servers)
+      lib.mapAttrs (
+        name: server:
+        lib.hm.mcp.transformMcpServer {
+          inherit pkgs name server;
+          transformStyle = "opencode";
+        }
+      ) config.programs.mcp.servers
     else
       { };
 

--- a/modules/programs/vscode/mkVscodeModule.nix
+++ b/modules/programs/vscode/mkVscodeModule.nix
@@ -70,32 +70,10 @@ let
 
   isPath = p: builtins.isPath p || lib.isStorePath p;
 
-  transformMcpServerForVscode =
-    name: server:
-    let
-      # Remove the disabled field from the server config
-      cleanServer = lib.filterAttrs (n: _v: n != "disabled") server;
-    in
-    {
-      inherit name;
-      value = {
-        enabled = !(server.disabled or false);
-      }
-      // (
-        if server ? url then
-          {
-            type = "http";
-          }
-          // cleanServer
-        else if server ? command then
-          {
-            type = "stdio";
-          }
-          // cleanServer
-        else
-          { }
-      );
-    };
+  transformMcpServerForVscode = name: server: {
+    inherit name;
+    value = lib.hm.mcp.transformMcpServer { inherit pkgs name server; };
+  };
 
   profileType = types.submodule {
     options = {

--- a/modules/programs/vscode/mkVscodeModule.nix
+++ b/modules/programs/vscode/mkVscodeModule.nix
@@ -72,7 +72,13 @@ let
 
   transformMcpServerForVscode = name: server: {
     inherit name;
-    value = lib.hm.mcp.transformMcpServer { inherit pkgs name server; };
+    value = lib.hm.mcp.transformMcpServer {
+      inherit server;
+      extraTransforms = [
+        lib.hm.mcp.deriveType
+        (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
+      ];
+    };
   };
 
   profileType = types.submodule {

--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -31,14 +31,11 @@ let
 
   transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
     lib.mapAttrs (
-      _name: server:
-      # NOTE: Convert shared programs.mcp fields to Zed config keys:
-      # - removeAttrs drops keys that Zed does not use directly
-      # - "disabled" becomes inverse "enabled"
-      # See: https://zed.dev/docs/ai/mcp
-      (lib.removeAttrs server [ "disabled" ])
-      // {
-        enabled = !(server.disabled or false);
+      name: server:
+      # See: https://zed.dev/docs/ai/mcp & https://github.com/zed-industries/zed/discussions/53780
+      lib.hm.mcp.transformMcpServer {
+        inherit pkgs name server;
+        exclude = [ "type" ];
       }
     ) config.programs.mcp.servers
   );

--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -34,8 +34,10 @@ let
       name: server:
       # See: https://zed.dev/docs/ai/mcp & https://github.com/zed-industries/zed/discussions/53780
       lib.hm.mcp.transformMcpServer {
-        inherit pkgs name server;
-        exclude = [ "type" ];
+        inherit server;
+        extraTransforms = [
+          (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
+        ];
       }
     ) config.programs.mcp.servers
   );

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -178,6 +178,7 @@ import nmtSrc {
         [
           # keep-sorted start case=no numeric=yes
           ./lib/generators
+          ./lib/mcp
           ./lib/types
           ./modules/files
           ./modules/home-environment

--- a/tests/lib/mcp/default.nix
+++ b/tests/lib/mcp/default.nix
@@ -1,0 +1,3 @@
+{
+  lib-mcp-wrapper = ./wrapper.nix;
+}

--- a/tests/lib/mcp/wrapper.nix
+++ b/tests/lib/mcp/wrapper.nix
@@ -1,0 +1,30 @@
+{ pkgs, lib, ... }:
+let
+  fakeSecret = pkgs.writeText "fake-npm-token" "supersecret";
+  wrapper = lib.hm.mcp.mkEnvFilesWrapper {
+    inherit pkgs;
+    name = "test-server";
+    server = {
+      command = "npx";
+      args = [
+        "-y"
+        "@modelcontextprotocol/server-everything"
+      ];
+      envFiles.NPM_TOKEN = "${fakeSecret}";
+    };
+  };
+in
+{
+  home.file."mcp-wrapper-under-test" = {
+    source = wrapper;
+  };
+
+  nmt.script = ''
+    assertFileContains home-files/mcp-wrapper-under-test \
+      'if NPM_TOKEN=$(cat ${fakeSecret}); then'
+    assertFileContains home-files/mcp-wrapper-under-test \
+      'export NPM_TOKEN'
+    assertFileContains home-files/mcp-wrapper-under-test \
+      'exec npx -y @modelcontextprotocol/server-everything'
+  '';
+}

--- a/tests/lib/mcp/wrapper.nix
+++ b/tests/lib/mcp/wrapper.nix
@@ -10,7 +10,7 @@ let
         "-y"
         "@modelcontextprotocol/server-everything"
       ];
-      envFiles.NPM_TOKEN = "${fakeSecret}";
+      env.NPM_TOKEN.file = "${fakeSecret}";
     };
   };
 in

--- a/tests/modules/programs/codex/mcp-integration-with-override.toml
+++ b/tests/modules/programs/codex/mcp-integration-with-override.toml
@@ -1,7 +1,6 @@
 model = "gpt-5-codex"
 
 [mcp_servers.context7]
-enabled = true
 url = "https://mcp.context7.com/mcp"
 
 [mcp_servers.context7.http_headers]

--- a/tests/modules/programs/codex/mcp-integration.toml
+++ b/tests/modules/programs/codex/mcp-integration.toml
@@ -1,5 +1,4 @@
 [mcp_servers.context7]
-enabled = true
 url = "https://mcp.context7.com/mcp"
 
 [mcp_servers.context7.http_headers]
@@ -13,4 +12,3 @@ enabled = false
 [mcp_servers.everything]
 args = ["-y", "@modelcontextprotocol/server-everything"]
 command = "npx"
-enabled = true

--- a/tests/modules/programs/mcp/default.nix
+++ b/tests/modules/programs/mcp/default.nix
@@ -1,4 +1,5 @@
 {
   mcp-servers = ./servers.nix;
   mcp-empty-servers = ./empty-servers.nix;
+  mcp-enabled-disabled-conflict = ./enabled-disabled-conflict.nix;
 }

--- a/tests/modules/programs/mcp/enabled-disabled-conflict.nix
+++ b/tests/modules/programs/mcp/enabled-disabled-conflict.nix
@@ -1,0 +1,19 @@
+{
+  programs.mcp = {
+    enable = true;
+    servers = {
+      invalid = {
+        command = "echo";
+        args = [ "test" ];
+        enabled = true;
+        disabled = true;
+      };
+    };
+  };
+
+  test.asserts.assertions.expected = [
+    ''
+      programs.mcp.servers.invalid: `enabled` and `disabled` are set to incompatible values.
+    ''
+  ];
+}

--- a/tests/modules/programs/mcp/mcp.json
+++ b/tests/modules/programs/mcp/mcp.json
@@ -1,17 +1,22 @@
 {
   "mcpServers": {
     "context7": {
+      "disabled": false,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },
-      "serverUrl": "https://mcp.context7.com/mcp"
+      "url": "https://mcp.context7.com/mcp"
     },
     "everything": {
       "args": [
         "-y",
         "@modelcontextprotocol/server-everything"
       ],
-      "command": "npx"
+      "command": "npx",
+      "disabled": false,
+      "env": {
+        "NPM_TOKEN": "{file:/run/secrets/npm-token}"
+      }
     }
   }
 }

--- a/tests/modules/programs/mcp/mcp.json
+++ b/tests/modules/programs/mcp/mcp.json
@@ -1,22 +1,22 @@
 {
   "mcpServers": {
     "context7": {
-      "disabled": false,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },
+      "type": "remote",
       "url": "https://mcp.context7.com/mcp"
     },
     "everything": {
-      "args": [
+      "command": [
+        "npx",
         "-y",
         "@modelcontextprotocol/server-everything"
       ],
-      "command": "npx",
-      "disabled": false,
-      "env": {
+      "environment": {
         "NPM_TOKEN": "{file:/run/secrets/npm-token}"
-      }
+      },
+      "type": "local"
     }
   }
 }

--- a/tests/modules/programs/mcp/mcp.json
+++ b/tests/modules/programs/mcp/mcp.json
@@ -4,19 +4,19 @@
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },
-      "type": "remote",
+      "type": "http",
       "url": "https://mcp.context7.com/mcp"
     },
     "everything": {
-      "command": [
-        "npx",
+      "args": [
         "-y",
         "@modelcontextprotocol/server-everything"
       ],
-      "environment": {
+      "command": "npx",
+      "env": {
         "NPM_TOKEN": "{file:/run/secrets/npm-token}"
       },
-      "type": "local"
+      "type": "stdio"
     }
   }
 }

--- a/tests/modules/programs/mcp/servers.nix
+++ b/tests/modules/programs/mcp/servers.nix
@@ -8,9 +8,12 @@
           "-y"
           "@modelcontextprotocol/server-everything"
         ];
+        envFiles = {
+          NPM_TOKEN = "/run/secrets/npm-token";
+        };
       };
       context7 = {
-        serverUrl = "https://mcp.context7.com/mcp";
+        url = "https://mcp.context7.com/mcp";
         headers = {
           CONTEXT7_API_KEY = "{env:CONTEXT7_API_KEY}";
         };

--- a/tests/modules/programs/mcp/servers.nix
+++ b/tests/modules/programs/mcp/servers.nix
@@ -8,9 +8,7 @@
           "-y"
           "@modelcontextprotocol/server-everything"
         ];
-        envFiles = {
-          NPM_TOKEN = "/run/secrets/npm-token";
-        };
+        env.NPM_TOKEN.file = "/run/secrets/npm-token";
       };
       context7 = {
         url = "https://mcp.context7.com/mcp";

--- a/tests/modules/programs/opencode/mcp-integration-with-override.json
+++ b/tests/modules/programs/opencode/mcp-integration-with-override.json
@@ -2,7 +2,6 @@
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
     "context7": {
-      "enabled": true,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },

--- a/tests/modules/programs/opencode/mcp-integration.json
+++ b/tests/modules/programs/opencode/mcp-integration.json
@@ -24,6 +24,9 @@
         "@modelcontextprotocol/server-everything"
       ],
       "enabled": true,
+      "environment": {
+        "NPM_TOKEN": "{file:/run/secrets/npm-token}"
+      },
       "type": "local"
     }
   }

--- a/tests/modules/programs/opencode/mcp-integration.json
+++ b/tests/modules/programs/opencode/mcp-integration.json
@@ -2,7 +2,6 @@
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
     "context7": {
-      "enabled": true,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },
@@ -23,7 +22,6 @@
         "-y",
         "@modelcontextprotocol/server-everything"
       ],
-      "enabled": true,
       "environment": {
         "NPM_TOKEN": "{file:/run/secrets/npm-token}"
       },

--- a/tests/modules/programs/opencode/mcp-integration.nix
+++ b/tests/modules/programs/opencode/mcp-integration.nix
@@ -8,6 +8,9 @@
           "-y"
           "@modelcontextprotocol/server-everything"
         ];
+        envFiles = {
+          NPM_TOKEN = "/run/secrets/npm-token";
+        };
       };
       context7 = {
         url = "https://mcp.context7.com/mcp";

--- a/tests/modules/programs/opencode/mcp-integration.nix
+++ b/tests/modules/programs/opencode/mcp-integration.nix
@@ -21,7 +21,7 @@
       disabled-server = {
         command = "echo";
         args = [ "test" ];
-        disabled = true;
+        enabled = false;
       };
     };
   };

--- a/tests/modules/programs/opencode/mcp-integration.nix
+++ b/tests/modules/programs/opencode/mcp-integration.nix
@@ -8,9 +8,7 @@
           "-y"
           "@modelcontextprotocol/server-everything"
         ];
-        envFiles = {
-          NPM_TOKEN = "/run/secrets/npm-token";
-        };
+        env.NPM_TOKEN.file = "/run/secrets/npm-token";
       };
       context7 = {
         url = "https://mcp.context7.com/mcp";

--- a/tests/modules/programs/vscode/mcp-integration-default.json
+++ b/tests/modules/programs/vscode/mcp-integration-default.json
@@ -1,7 +1,6 @@
 {
   "servers": {
     "context7": {
-      "enabled": true,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },
@@ -19,7 +18,6 @@
         "@modelcontextprotocol/server-everything"
       ],
       "command": "npx",
-      "enabled": true,
       "type": "stdio"
     }
   }

--- a/tests/modules/programs/vscode/mcp-integration-with-override.json
+++ b/tests/modules/programs/vscode/mcp-integration-with-override.json
@@ -5,7 +5,6 @@
       "url": "https://example.com/mcp"
     },
     "context7": {
-      "enabled": true,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },

--- a/tests/modules/programs/zed-editor/mcp-integration-with-override.nix
+++ b/tests/modules/programs/zed-editor/mcp-integration-with-override.nix
@@ -43,7 +43,6 @@
         {
           "context_servers": {
             "custom-server": {
-              "enabled": false
             }
           },
         }
@@ -53,7 +52,6 @@
         {
           "context_servers": {
             "custom-server": {
-              "enabled": false,
               "headers": {
                 "Authorization": "Bearer token"
               },

--- a/tests/modules/programs/zed-editor/mcp-integration-with-override.nix
+++ b/tests/modules/programs/zed-editor/mcp-integration-with-override.nix
@@ -62,8 +62,7 @@
                 "-y",
                 "@modelcontextprotocol/server-everything"
               ],
-              "command": "npx",
-              "enabled": true
+              "command": "npx"
             }
           }
         }

--- a/tests/modules/programs/zed-editor/mcp-integration.json
+++ b/tests/modules/programs/zed-editor/mcp-integration.json
@@ -1,7 +1,6 @@
 {
   "context_servers": {
     "context7": {
-      "enabled": true,
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },

--- a/tests/modules/programs/zed-editor/mcp-integration.json
+++ b/tests/modules/programs/zed-editor/mcp-integration.json
@@ -18,8 +18,7 @@
         "-y",
         "@modelcontextprotocol/server-everything"
       ],
-      "command": "npx",
-      "enabled": true
+      "command": "npx"
     }
   }
 }

--- a/tests/modules/programs/zed-editor/mcp-integration.nix
+++ b/tests/modules/programs/zed-editor/mcp-integration.nix
@@ -44,7 +44,6 @@
         {
           "context_servers": {
             "context7": {
-              "enabled": true,
               "headers": {
                 "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
               },
@@ -62,8 +61,7 @@
                 "-y",
                 "@modelcontextprotocol/server-everything"
               ],
-              "command": "npx",
-              "enabled": true
+              "command": "npx"
             }
           }
         }


### PR DESCRIPTION
**Commit 1:** inline file-backed env values, slim transformMcpServer
Replace the separate `programs.mcp.servers.<name>.envFiles` option with a
file-ref submodule inside `env`, so each entry is either a literal string
or `{ file = "/path"; }`.

Reshape `lib.hm.mcp.transformMcpServer` around an `extraTransforms`
argument and split the program-specific behavior into composable helpers
(`deriveType`, `wrapEnvFilesCommand`, `renderEnv`). The legacy
`transformStyle` / `pkgs` arguments remain as a compatibility shim so
unmigrated callers keep working until the follow-up migration.

`mcp.json` switches from the opencode-flavored shape to the de-facto
standard used by Claude Code, Claude Desktop, Cursor, and others
(`command` string, `args` list, `env` flat object, `type` "stdio"/"http").
File refs render as `{file:/path}` substitutions.

**Commit 2:** migrate to extraTransforms

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
