### PR TITLE
password-store: improve warning message

### DIFF
--- a/modules/programs/password-store.nix
+++ b/modules/programs/password-store.nix
@@ -23,7 +23,7 @@ let
       value = {
         PASSWORD_STORE_DIR = "${config.xdg.dataHome}/password-store";
       };
-      text = ''{ PASSWORD_STORE_DIR = "$XDG_DATA_HOME/password-store"; }'';
+      text = ''{ PASSWORD_STORE_DIR = "''${config.xdg.dataHome}/password-store"; }'';
     };
     current.value = { };
     deferWarningToConfig = true;

--- a/tests/modules/programs/password-store/old-default-path.nix
+++ b/tests/modules/programs/password-store/old-default-path.nix
@@ -5,10 +5,10 @@
 
   test.asserts.warnings.expected = [
     ''
-      The default value of `programs.password-store.settings` has changed from `{ PASSWORD_STORE_DIR = "$XDG_DATA_HOME/password-store"; }` to `{ }`.
-      You are currently using the legacy default (`{ PASSWORD_STORE_DIR = "$XDG_DATA_HOME/password-store"; }`) because `home.stateVersion` is less than "25.11".
+      The default value of `programs.password-store.settings` has changed from `{ PASSWORD_STORE_DIR = "''${config.xdg.dataHome}/password-store"; }` to `{ }`.
+      You are currently using the legacy default (`{ PASSWORD_STORE_DIR = "''${config.xdg.dataHome}/password-store"; }`) because `home.stateVersion` is less than "25.11".
       To silence this warning and keep legacy behavior, set:
-        programs.password-store.settings = { PASSWORD_STORE_DIR = "$XDG_DATA_HOME/password-store"; };
+        programs.password-store.settings = { PASSWORD_STORE_DIR = "''${config.xdg.dataHome}/password-store"; };
       To adopt the new default behavior, set:
         programs.password-store.settings = { };
     ''

--- a/tests/modules/services/pass-secret-service/old-default-path.nix
+++ b/tests/modules/services/pass-secret-service/old-default-path.nix
@@ -10,10 +10,10 @@
 
   test.asserts.warnings.expected = [
     ''
-      The default value of `programs.password-store.settings` has changed from `{ PASSWORD_STORE_DIR = "$XDG_DATA_HOME/password-store"; }` to `{ }`.
-      You are currently using the legacy default (`{ PASSWORD_STORE_DIR = "$XDG_DATA_HOME/password-store"; }`) because `home.stateVersion` is less than "25.11".
+      The default value of `programs.password-store.settings` has changed from `{ PASSWORD_STORE_DIR = "''${config.xdg.dataHome}/password-store"; }` to `{ }`.
+      You are currently using the legacy default (`{ PASSWORD_STORE_DIR = "''${config.xdg.dataHome}/password-store"; }`) because `home.stateVersion` is less than "25.11".
       To silence this warning and keep legacy behavior, set:
-        programs.password-store.settings = { PASSWORD_STORE_DIR = "$XDG_DATA_HOME/password-store"; };
+        programs.password-store.settings = { PASSWORD_STORE_DIR = "''${config.xdg.dataHome}/password-store"; };
       To adopt the new default behavior, set:
         programs.password-store.settings = { };
     ''


### PR DESCRIPTION
### Description
The warning message is confusing, when used verbatim doesn't work because it doesn't reflect the old configuration value.


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
