### PR TITLE
vicinae: allow npmDepsHash for extensions

### DIFF
--- a/modules/programs/vicinae/default.nix
+++ b/modules/programs/vicinae/default.nix
@@ -65,6 +65,7 @@ in
          [
           (config.lib.vicinae.mkExtension {
             name = "test-extension";
+            npmDepsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
             src =
               pkgs.fetchFromGitHub {
                 owner = "schromp";
@@ -78,6 +79,7 @@ in
             name = "gif-search";
             sha256 = "sha256-G7il8T1L+P/2mXWJsb68n4BCbVKcrrtK8GnBNxzt73Q=";
             rev = "4d417c2dfd86a5b2bea202d4a7b48d8eb3dbaeb1";
+            npmDepsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
           })
           (config.lib.vicinae.mkRayCastExtension {
             name = "my-local-raycast-extension";
@@ -85,6 +87,11 @@ in
           })
          ],
           ```
+
+        Set `npmDepsHash` when `src` is produced by a fetcher such as
+        `pkgs.fetchFromGitHub` or `pkgs.fetchgit`; otherwise
+        dependency import reads `package-lock.json` from the fetched source
+        during evaluation.
       '';
     };
 

--- a/modules/programs/vicinae/lib.nix
+++ b/modules/programs/vicinae/lib.nix
@@ -1,15 +1,38 @@
 {
   pkgs,
 }:
+let
+  buildExtension =
+    {
+      name,
+      src,
+      installPhase,
+      npmDepsHash,
+    }:
+    pkgs.buildNpmPackage (
+      {
+        inherit name src installPhase;
+      }
+      // (
+        if npmDepsHash != null then
+          { inherit npmDepsHash; }
+        else
+          {
+            inherit (pkgs.importNpmLock) npmConfigHook;
+            npmDeps = pkgs.importNpmLock { npmRoot = src; };
+          }
+      )
+    );
+in
 {
   mkExtension =
     {
       name,
       src,
+      npmDepsHash ? null,
     }:
-    pkgs.buildNpmPackage {
-      inherit name src;
-      inherit (pkgs.importNpmLock) npmConfigHook;
+    buildExtension {
+      inherit name src npmDepsHash;
       installPhase = ''
         runHook preInstall
 
@@ -18,7 +41,6 @@
 
         runHook postInstall
       '';
-      npmDeps = pkgs.importNpmLock { npmRoot = src; };
     };
 
   mkRayCastExtension =
@@ -27,6 +49,7 @@
       src ? null,
       rev ? null,
       sha256 ? null,
+      npmDepsHash ? null,
     }:
     let
       resolvedSrc =
@@ -40,9 +63,8 @@
           }
           + "/extensions/${name}";
     in
-    pkgs.buildNpmPackage {
-      inherit name;
-      inherit (pkgs.importNpmLock) npmConfigHook;
+    buildExtension {
+      inherit name npmDepsHash;
       src = resolvedSrc;
       installPhase = ''
         runHook preInstall
@@ -52,6 +74,5 @@
 
         runHook postInstall
       '';
-      npmDeps = pkgs.importNpmLock { npmRoot = resolvedSrc; };
     };
 }


### PR DESCRIPTION
Vicinae extension helpers always used importNpmLock, which reads package.json and package-lock.json during evaluation. When extension src comes from fetchgit or fetchFromGitHub, that forces Nix to realize the fetched source during eval and trips allow-import-from-derivation = false.

Accept npmDepsHash in mkExtension and mkRayCastExtension so fetched extension sources can use buildNpmPackage's fixed npm dependency fetcher path instead. Keep the existing importNpmLock behavior for local sources and document the hash requirement in the option example.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
