### PR TITLE
devenv: init module

### DIFF
--- a/modules/misc/news/2026/06/2026-06-22.nix
+++ b/modules/misc/news/2026/06/2026-06-22.nix
@@ -1,0 +1,14 @@
+{
+  time = "2026-06-22T19:16:41+00:00";
+  condition = true;
+  message = ''
+    A new {option}`programs.devenv` module has been added to Home Manager.
+
+    devenv is a tool for fast, declarative, reproducible and composable
+    developer environments using Nix. The module provides options to enable
+    devenv and configure shell integration for Bash, Fish, Nushell, and Zsh.
+
+    To use it, set {option}`programs.devenv.enable` to `true`. Shell
+    integration is enabled by default for installed shells.
+  '';
+}

--- a/modules/programs/devenv.nix
+++ b/modules/programs/devenv.nix
@@ -1,0 +1,63 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkIf
+    mkAfter
+    getExe
+    ;
+
+  cfg = config.programs.devenv;
+
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    leiserfg
+  ];
+
+  options.programs.devenv = {
+    enable = mkEnableOption "devenv, Fast, Declarative, Reproducible and Composable Developer Environments using Nix";
+
+    package = mkPackageOption pkgs "devenv" { };
+
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
+
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
+
+    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
+
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    programs = {
+      bash.initExtra = mkIf cfg.enableBashIntegration (mkAfter ''
+        eval "$(${getExe cfg.package} hook bash)"
+      '');
+
+      fish.interactiveShellInit = mkIf cfg.enableFishIntegration (mkAfter ''
+        ${getExe cfg.package} hook fish | source
+      '');
+
+      zsh.initContent = mkIf cfg.enableZshIntegration ''
+        eval "$(${getExe cfg.package} hook zsh)"
+      '';
+
+      nushell = mkIf cfg.enableNushellIntegration {
+        extraConfig = "source ${
+          pkgs.runCommand "devenv-nushell-config.nu" { } ''
+            ${getExe cfg.package} hook nu > $out
+          ''
+        } ";
+      };
+    };
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -43,6 +43,7 @@ let
     "cudatext"
     "darcs"
     "delta"
+    "devenv"
     "difftastic"
     "dircolors"
     "direnv"

--- a/tests/modules/programs/devenv/basic-config.nix
+++ b/tests/modules/programs/devenv/basic-config.nix
@@ -1,0 +1,55 @@
+{ config, pkgs, ... }:
+{
+  programs = {
+    devenv = {
+      enable = true;
+      enableBashIntegration = true;
+      enableNushellIntegration = true;
+      enableZshIntegration = true;
+      enableFishIntegration = true;
+
+      package = config.lib.test.mkStubPackage {
+        name = "devenv";
+        buildScript = ''
+          mkdir -p $out/bin
+          cat > $out/bin/devenv << 'EOF'
+          #! /bin/sh
+          echo "Stub called with args $@"
+          EOF
+          chmod +x $out/bin/devenv
+        '';
+      };
+    };
+    bash.enable = true;
+    fish.enable = true;
+    nushell.enable = true;
+    zsh.enable = true;
+  };
+
+  nmt.script =
+    let
+      nushellConfigFile =
+        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+          "home-files/Library/Application Support/nushell/config.nu"
+        else
+          "home-files/.config/nushell/config.nu";
+    in
+    # Bash
+    ''
+      assertFileRegex home-files/.bashrc \
+        'eval.*devenv hook bash'
+
+      # Test zsh integration
+      assertFileRegex home-files/.zshrc \
+        'eval.*devenv hook zsh'
+
+      # Test fish integration (enabled by default)
+      assertFileRegex home-files/.config/fish/config.fish \
+        'devenv hook fish.*source'
+
+      # Test nushell integration
+      assertFileExists "${nushellConfigFile}"
+      assertFileRegex "${nushellConfigFile}" 'source /nix/store.*devenv-nushell-config.nu'
+
+    '';
+}

--- a/tests/modules/programs/devenv/default.nix
+++ b/tests/modules/programs/devenv/default.nix
@@ -1,0 +1,3 @@
+{
+  devenv = ./basic-config.nix;
+}


### PR DESCRIPTION
### Description

New module for devenv

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
