### PR TITLE
kanshi: reload daemon on activation

### DIFF
--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -7,6 +7,7 @@
 let
   inherit (lib)
     concatStringsSep
+    hm
     literalExpression
     mkIf
     mkOption
@@ -373,6 +374,29 @@ in
             WantedBy = [ cfg.systemdTarget ];
           };
         };
+
+        # Re-apply the active profile after activation.
+        #
+        # kanshi only re-evaluates profiles when wlr-output-management
+        # reports a head topology change (head added/removed).  In two
+        # common cases the daemon ends up with stale state without such
+        # an event firing:
+        #
+        #   1. The user edited their kanshi config; the daemon is still
+        #      using the previous profile definitions.
+        #
+        #   2. The compositor reloaded its own config (e.g. sway runs
+        #      `swaymsg reload` via this module's sway onChange when
+        #      packages referenced in sway/config change store paths)
+        #      and re-applied output stanzas, leaving on-screen geometry
+        #      out of sync with the active profile.
+        #
+        # `kanshictl reload` is cheap and idempotent.
+        home.activation.reloadKanshi = hm.dag.entryAfter [ "reloadSystemd" ] ''
+          if ${pkgs.systemd}/bin/systemctl --user --quiet is-active kanshi.service 2>/dev/null; then
+            $DRY_RUN_CMD ${cfg.package}/bin/kanshictl reload 2>/dev/null || true
+          fi
+        '';
       }
     ]
   );


### PR DESCRIPTION
### Description

kanshi only re-evaluates its profiles when wlr-output-management reports a head topology change (head added/removed). Two common scenarios leave the daemon with stale state without such an event firing:

  1. The user edited their kanshi config; the daemon is still using the previous profile definitions.

  2. The compositor reloaded its own config (e.g. sway runs `swaymsg reload` via this module's sway onChange when packages referenced in sway/config change store paths) and re-applied output stanzas, leaving on-screen geometry out of sync with the active profile.

Add a home.activation hook ordered after reloadSystemd that calls `kanshictl reload` when the kanshi service is active, so the active profile is re-applied on every activation. The call is guarded by `systemctl --user is-active` and tolerates a missing IPC socket via `|| true`, so it is a no-op when kanshi is not running.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
