### PR TITLE
home-environment: reload session variables on change

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -652,24 +652,41 @@ in
       // (maybeSet "LC_MEASUREMENT" cfg.language.measurement);
 
     # Provide a file holding all session variables.
-    home.sessionVariablesPackage = pkgs.writeTextFile {
-      name = "hm-session-vars.sh";
-      destination = "/etc/profile.d/hm-session-vars.sh";
-      text = ''
-        # Only source this once.
-        if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
-        export __HM_SESS_VARS_SOURCED=1
+    home.sessionVariablesPackage =
+      let
+        # The actual variable definitions sourced by the shells. Kept separate
+        # from the guard below so we can derive a content-based sentinel from it.
+        sessionVarsBody =
+          config.lib.shell.exportAll cfg.sessionVariables
+          + "\n"
+          + lib.concatStringsSep "\n" (
+            lib.mapAttrsToList (
+              env: values: config.lib.shell.export env (config.lib.shell.prependToVar ":" env values)
+            ) cfg.sessionSearchVariables
+          )
+          + "\n"
+          + cfg.sessionVariablesExtra;
 
-        ${config.lib.shell.exportAll cfg.sessionVariables}
-      ''
-      + lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (
-          env: values: config.lib.shell.export env (config.lib.shell.prependToVar ":" env values)
-        ) cfg.sessionSearchVariables
-      )
-      + "\n"
-      + cfg.sessionVariablesExtra;
-    };
+        # A sentinel that changes whenever the variable definitions change. The
+        # guard records it in the exported `__HM_SESS_VARS_SOURCED` variable, so
+        # that after a switch any shell started from a session that sourced an
+        # older generation sees a mismatch and re-exports the new values instead
+        # of skipping. Shells of the same generation still source only once.
+        sentinel = builtins.hashString "sha256" sessionVarsBody;
+      in
+      pkgs.writeTextFile {
+        name = "hm-session-vars.sh";
+        destination = "/etc/profile.d/hm-session-vars.sh";
+        text = ''
+          # Only source this once per set of variables. The sentinel changes
+          # when the variables do, so updated values are picked up by the next
+          # shell without requiring a full re-login.
+          if [ "''${__HM_SESS_VARS_SOURCED-}" = "${sentinel}" ]; then return; fi
+          export __HM_SESS_VARS_SOURCED="${sentinel}"
+
+        ''
+        + sessionVarsBody;
+      };
 
     home.sessionSearchVariables.PATH = lib.mkIf (cfg.sessionPath != [ ]) cfg.sessionPath;
 

--- a/modules/misc/news/2026/05/2026-05-25_10-01-01.nix
+++ b/modules/misc/news/2026/05/2026-05-25_10-01-01.nix
@@ -1,0 +1,16 @@
+{
+  time = "2026-05-25T10:01:01+00:00";
+  condition = true;
+  message = ''
+    The source-guard in `hm-session-vars.sh` now keys off a hash of the
+    variable definitions rather than a constant. This means that after
+    `home-manager switch` changes `home.sessionVariables`, newly started
+    shells pick up the updated values instead of skipping the file because
+    a parent session already sourced an older generation. Previously the
+    new values only took effect after a full re-login.
+
+    Shells started from the same generation still source the file only once,
+    so the de-duplication behaviour is unchanged. Already-running shells are
+    not affected; they still need to be restarted to see new values.
+  '';
+}

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -4,11 +4,10 @@ let
 
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
-  linuxExpected = ''
-    # Only source this once.
-    if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
-    export __HM_SESS_VARS_SOURCED=1
-
+  # The variable definitions emitted after the source-guard. The expected file
+  # is rebuilt from these below so the sentinel hash stays in sync with the
+  # content without being hard-coded.
+  linuxBody = ''
     export IS_EMPTY=""
     export IS_FALSE="false"
     export IS_TRUE="true"
@@ -23,11 +22,7 @@ let
 
   '';
 
-  darwinExpected = ''
-    # Only source this once.
-    if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
-    export __HM_SESS_VARS_SOURCED=1
-
+  darwinBody = ''
     export IS_EMPTY=""
     export IS_FALSE="false"
     export IS_TRUE="true"
@@ -44,7 +39,22 @@ let
     export TERM="$TERM"
   '';
 
-  expected = pkgs.writeText "expected" (if isDarwin then darwinExpected else linuxExpected);
+  body = if isDarwin then darwinBody else linuxBody;
+
+  # Mirrors the sentinel derivation in modules/home-environment.nix.
+  sentinel = builtins.hashString "sha256" body;
+
+  expected = pkgs.writeText "expected" (
+    ''
+      # Only source this once per set of variables. The sentinel changes
+      # when the variables do, so updated values are picked up by the next
+      # shell without requiring a full re-login.
+      if [ "''${__HM_SESS_VARS_SOURCED-}" = "${sentinel}" ]; then return; fi
+      export __HM_SESS_VARS_SOURCED="${sentinel}"
+
+    ''
+    + body
+  );
 
 in
 {


### PR DESCRIPTION
### Description

`home.sessionVariables` were not picked up by newly started shells after a `home-manager switch` — they only refreshed after a full re-login or reboot.

The source-guard at the top of `hm-session-vars.sh` used a constant sentinel:

```sh
if [ -n "${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
export __HM_SESS_VARS_SOURCED=1
```

Because `__HM_SESS_VARS_SOURCED` is exported, the value `1` propagates down the whole process tree. The guard is an optimization (avoid re-running the exports in subshells), but after a switch every newly started shell — including new fish processes, which do re-source the file via `config.fish` — inherited `=1` from the still-running login/desktop session, hit the guard, and returned early without applying the new definitions.

This derives the sentinel from a SHA-256 hash of the variable definitions instead:

- **Same generation** → same hash → subshells still source the file only once (optimization preserved).
- **Changed configuration** → different hash → a shell that inherited the old hash sees a mismatch and re-exports the new values.

This fixes bash, zsh and fish at once, since they all source the same `hm-session-vars.sh` (fish via `babelfish`, which translates the new string-equality guard into valid fish). Already-running shells are unaffected (a process's environment can't be mutated externally), but any newly opened shell now reflects the change without a re-login.

### Checklist

- [x] Change is backwards compatible. (`__HM_SESS_VARS_SOURCED` is an internal, double-underscore-prefixed variable; its value changes from `1` to a content hash, but its semantics for shells are unchanged.)
- [x] Code formatted with `nix fmt` or `nix-shell -A dev --run treefmt`.
- [x] Code tested through `nix run .#tests -- test-all` or `nix-shell --pure tests -A run.all`. (Ran the affected tests locally — `home-session-variables`, `bash-session-variables`, `zsh-session-variables`, `fish-session-variables`, and `news-validation`; the full matrix runs in CI.)
- [x] Test cases updated/added. Updated `tests/modules/home-environment/session-variables.nix` to recompute the same hash from the body, so it stays robust against nixpkgs store-path changes rather than hard-coding the sentinel.
- [x] Commit messages are formatted like
  ```
  {component}: {description}

  {long description}
  ```

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. Added `modules/misc/news/2026/05/2026-05-25_10-01-01.nix`.

Assisted-by: claude-code with claude-opus-4-7[1m]-xhigh