### PR TITLE
home-manager: set 26.05 as stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Releases
 Home Manager is developed against `nixos-unstable` branch, which often causes
 it to contain tweaks for changes/packages not yet released in stable [NixOS][].
 To avoid breaking users' configurations, Home Manager is released in branches
-corresponding to NixOS releases (e.g. `release-25.11`). These branches get
+corresponding to NixOS releases (e.g. `release-26.05`). These branches get
 fixes, but usually not new modules. If you need a module to be backported, then
 feel free to open an issue.
 
@@ -49,7 +49,7 @@ dconf store and cannot tell whether a configuration that is about to be
 overwritten was from a previous Home Manager generation or from manual
 configuration.
 
-Home Manager targets [NixOS][] unstable and NixOS version 25.11 (the current
+Home Manager targets [NixOS][] unstable and NixOS version 26.05 (the current
 stable version), it may or may not work on other Linux distributions and NixOS
 versions.
 

--- a/docs/manual/installation/nix-darwin.md
+++ b/docs/manual/installation/nix-darwin.md
@@ -15,10 +15,10 @@ $ nix-channel --add https://github.com/nix-community/home-manager/archive/master
 $ nix-channel --update
 ```
 
-and if you follow a Nixpkgs version 25.11 channel, you can run
+and if you follow a Nixpkgs version 26.05 channel, you can run
 
 ``` shell
-$ nix-channel --add https://github.com/nix-community/home-manager/archive/release-25.11.tar.gz home-manager
+$ nix-channel --add https://github.com/nix-community/home-manager/archive/release-26.05.tar.gz home-manager
 $ nix-channel --update
 ```
 
@@ -45,7 +45,7 @@ home-manager.users.eve = { pkgs, ... }: {
 
   # The state version is required and should stay at the version you
   # originally installed.
-  home.stateVersion = "25.11";
+  home.stateVersion = "26.05";
 };
 ```
 

--- a/docs/manual/installation/nixos.md
+++ b/docs/manual/installation/nixos.md
@@ -17,10 +17,10 @@ $ sudo nix-channel --add https://github.com/nix-community/home-manager/archive/m
 $ sudo nix-channel --update
 ```
 
-and if you follow a Nixpkgs version 25.11 channel, you can run
+and if you follow a Nixpkgs version 26.05 channel, you can run
 
 ``` shell
-$ sudo nix-channel --add https://github.com/nix-community/home-manager/archive/release-25.11.tar.gz home-manager
+$ sudo nix-channel --add https://github.com/nix-community/home-manager/archive/release-26.05.tar.gz home-manager
 $ sudo nix-channel --update
 ```
 
@@ -39,7 +39,7 @@ Alternatively, home-manager installation can be done declaratively through confi
 { config, pkgs, lib, ... }:
 
 let
-  home-manager = builtins.fetchTarball https://github.com/nix-community/home-manager/archive/release-25.11.tar.gz;
+  home-manager = builtins.fetchTarball https://github.com/nix-community/home-manager/archive/release-26.05.tar.gz;
 in
 {
   imports =
@@ -54,7 +54,7 @@ in
 
     # The state version is required and should stay at the version you
     # originally installed.
-    home.stateVersion = "25.11";
+    home.stateVersion = "26.05";
   };
 }
 ```
@@ -74,7 +74,7 @@ home-manager.users.eve = { pkgs, ... }: {
   # You should not change this value, even if you update Home Manager. If you do
   # want to update the value, then make sure to first check the Home Manager
   # release notes.
-  home.stateVersion = "25.11"; # Please read the comment before changing. 
+  home.stateVersion = "26.05"; # Please read the comment before changing.
 
 };
 ```
@@ -154,4 +154,3 @@ you create. This contains the system's NixOS configuration.
 
 Once installed you can see [Using Home Manager](#ch-usage) for a more detailed
 description of Home Manager and how to use it.
-

--- a/docs/manual/installation/standalone.md
+++ b/docs/manual/installation/standalone.md
@@ -19,10 +19,10 @@
     $ nix-channel --update
     ```
 
-    and if you follow a Nixpkgs version 25.11 channel you can run
+    and if you follow a Nixpkgs version 26.05 channel you can run
 
     ``` shell
-    $ nix-channel --add https://github.com/nix-community/home-manager/archive/release-25.11.tar.gz home-manager
+    $ nix-channel --add https://github.com/nix-community/home-manager/archive/release-26.05.tar.gz home-manager
     $ nix-channel --update
     ```
 

--- a/docs/manual/manual.md
+++ b/docs/manual/manual.md
@@ -1,6 +1,6 @@
 # Home Manager Manual {#home-manager-manual}
 
-## Version 26.05 (unstable)
+## Version 26.05
 
 
 ```{=include=} preface

--- a/docs/manual/nix-flakes/standalone.md
+++ b/docs/manual/nix-flakes/standalone.md
@@ -11,10 +11,10 @@ then to generate and activate a basic configuration run the command
 $ nix run home-manager/master -- init --switch
 ```
 
-For Nixpkgs or NixOS version 25.11 run
+For Nixpkgs or NixOS version 26.05 run
 
 ``` shell
-$ nix run home-manager/release-25.11 -- init --switch
+$ nix run home-manager/release-26.05 -- init --switch
 ```
 
 This will generate a `flake.nix` and a `home.nix` file in
@@ -59,7 +59,7 @@ $ # Edit files in ~/.config/home-manager
 $ nix run home-manager/$branch -- init --switch
 ```
 
-Where `$branch` is one of `master` or `release-25.11`.
+Where `$branch` is one of `master` or `release-26.05`.
 
 After the initial activation has completed successfully then building
 and activating your flake-based configuration is as simple as

--- a/docs/manual/usage/configuration.md
+++ b/docs/manual/usage/configuration.md
@@ -20,7 +20,7 @@ A fresh install of Home Manager will generate a minimal
   # You can update Home Manager without changing this value. See
   # the Home Manager release notes for a list of state version
   # changes in each release.
-  home.stateVersion = "25.11";
+  home.stateVersion = "26.05";
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;
@@ -65,7 +65,7 @@ follows:
   # You can update Home Manager without changing this value. See
   # the Home Manager release notes for a list of state version
   # changes in each release.
-  home.stateVersion = "25.11";
+  home.stateVersion = "26.05";
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/docs/release-notes/rl-2605.md
+++ b/docs/release-notes/rl-2605.md
@@ -1,7 +1,6 @@
 # Release 26.05 {#sec-release-26.05}
 
-This is the current unstable branch and the information in this
-section is therefore not final.
+The 26.05 release branch became stable in May, 2026.
 
 ## Highlights {#sec-release-26.05-highlights}
 

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -403,7 +403,7 @@ $xdgVars
   # You should not change this value, even if you update Home Manager. If you do
   # want to update the value, then make sure to first check the Home Manager
   # release notes.
-  home.stateVersion = "25.11"; # Please read the comment before changing.
+  home.stateVersion = "26.05"; # Please read the comment before changing.
 
   # The home.packages option allows you to install Nix packages into your
   # environment.
@@ -1041,7 +1041,7 @@ function doUninstall() {
   uninstall = true;
   home.username = "$(escapeForNix "$USER")";
   home.homeDirectory = "$(escapeForNix "$HOME")";
-  home.stateVersion = "25.11";
+  home.stateVersion = "26.05";
 }
 EOF
             # shellcheck disable=2064

--- a/modules/misc/uninstall.nix
+++ b/modules/misc/uninstall.nix
@@ -22,7 +22,7 @@ in
   config = mkIf config.uninstall {
     home.packages = lib.mkForce [ ];
     home.file = lib.mkForce { };
-    home.stateVersion = lib.mkForce "25.11";
+    home.stateVersion = lib.mkForce "26.05";
     home.enableNixpkgsReleaseCheck = lib.mkForce false;
     manual.manpages.enable = lib.mkForce false;
     news.display = lib.mkForce "silent";


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
