### PR TITLE
vscode: make keybindings submodule freeform 

### DIFF
--- a/modules/programs/vscode/mkVscodeModule.nix
+++ b/modules/programs/vscode/mkVscodeModule.nix
@@ -170,6 +170,7 @@ let
         type = types.either types.path (
           types.listOf (
             types.submodule {
+              freeformType = jsonFormat.type;
               options = {
                 key = mkOption {
                   type = types.str;


### PR DESCRIPTION

### Description

VSCode supports overrides per platform key combinations at `mac`, `win` and `linux`

This allows specifying those platform specific key combinations in additional to the base `key`.

Code pointer: 
https://github.com/microsoft/vscode/blob/83b7ce68a7c2496ad9a40ba370656050a9096491/src/vs/workbench/services/keybinding/browser/keybindingService.ts#L105-L120

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
