### PR TITLE
prismlauncher: fix string escaping and hygiene

### DIFF
--- a/modules/programs/prismlauncher.nix
+++ b/modules/programs/prismlauncher.nix
@@ -77,14 +77,14 @@ in
           "${config.xdg.dataHome}/PrismLauncher";
 
       impureConfigMerger = filePath: staticSettingsFile: emptySettingsFile: ''
-        mkdir -p $(dirname '${escapeShellArg filePath}')
+        mkdir -p "$(dirname ${escapeShellArg filePath})"
 
-        if [ ! -e '${escapeShellArg filePath}' ]; then
-          cat '${escapeShellArg emptySettingsFile}' > '${escapeShellArg filePath}'
+        if [ ! -e ${escapeShellArg filePath} ]; then
+          cat ${escapeShellArg emptySettingsFile} > ${escapeShellArg filePath}
         fi
 
         ${lib.getExe pkgs.crudini} --merge --ini-options=nospace \
-          '${escapeShellArg filePath}' < '${escapeShellArg staticSettingsFile}'
+          ${escapeShellArg filePath} < ${escapeShellArg staticSettingsFile}
       '';
     in
     mkIf cfg.enable {


### PR DESCRIPTION
### Description

single quotes around `escapeShellArgs`ed strings break them because they create pairs of outer single quotes that match up and nullify the escape. This generally isn't observable on platforms where the config path contains no spaces, which is most platforms except for darwin (`Application Support`).
this PR removes all of the single quotes around escapeShellArgs and adds a pair of double quotes around the output of a subshell `dirname` which may output a path containing spaces.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```
  cc @mikaeladev 
