### PR TITLE
deprecations: make migration warnings assertable

### DIFF
--- a/modules/lib/deprecations.nix
+++ b/modules/lib/deprecations.nix
@@ -1,6 +1,48 @@
 { lib }:
 {
   /*
+    Builds a standard warning for an option value shape that is deprecated.
+
+    Example:
+      mkDeprecatedOptionValueWarning {
+        option = [ "programs" "example" "settings" ];
+        old = "a list";
+        replacement = "`programs.example.settings.items`";
+      }
+
+    => Using `programs.example.settings` as a list is deprecated and will be
+       removed in a future release. Please use `programs.example.settings.items`
+       instead.
+  */
+  mkDeprecatedOptionValueWarning =
+    {
+      option,
+      old,
+      replacement,
+      details ? "",
+    }:
+    ''
+      Using `${lib.showOption option}` as ${old} is deprecated and will be
+      removed in a future release. Please use ${replacement} instead.
+    ''
+    + lib.optionalString (details != "") ''
+
+      ${details}
+    '';
+
+  # Builds a standard warning for an option value that has been renamed.
+  mkDeprecatedOptionValueRenameWarning =
+    {
+      option,
+      old,
+      replacement,
+    }:
+    ''
+      The value ${old} for `${lib.showOption option}` is deprecated and will be
+      removed in a future release. Please use ${replacement} instead.
+    '';
+
+  /*
     Returns a function that maps
       [
         "someOption"

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -319,22 +319,31 @@ in
 
   config =
     let
-      deprecateKde6 =
-        name: optionPath:
-        if name == "kde6" then
-          lib.warn ''
-            The ${optionPath} value "kde6" has been deprecated and renamed to "kde".
-            Please update your configuration:
-              ${optionPath} = "kde";
-          '' "kde"
+      deprecateKde6 = name: if name == "kde6" then "kde" else name;
+
+      deprecatedKde6PlatformThemeOption =
+        if builtins.isString cfg.platformTheme then
+          if cfg.platformTheme == "kde6" then
+            [
+              "qt"
+              "platformTheme"
+            ]
+          else
+            null
+        else if cfg.platformTheme != null && cfg.platformTheme.name == "kde6" then
+          [
+            "qt"
+            "platformTheme"
+            "name"
+          ]
         else
-          name;
+          null;
 
       platformTheme =
         if (builtins.isString cfg.platformTheme) then
           {
             option = "qt.platformTheme";
-            name = deprecateKde6 cfg.platformTheme "qt.platformTheme";
+            name = deprecateKde6 cfg.platformTheme;
             package = null;
           }
         else if cfg.platformTheme == null then
@@ -346,7 +355,7 @@ in
         else
           {
             option = "qt.platformTheme.name";
-            name = deprecateKde6 cfg.platformTheme.name "qt.platformTheme.name";
+            name = deprecateKde6 cfg.platformTheme.name;
             inherit (cfg.platformTheme) package;
           };
 
@@ -392,7 +401,14 @@ in
         ) "The option `qt.platformTheme` has been renamed to `qt.platformTheme.name`.")
         ++ (lib.lists.optional (
           platformTheme.name == "gnome" && platformTheme.package == null
-        ) "The value `gnome` for option `${platformTheme.option}` is deprecated. Use `adwaita` instead.");
+        ) "The value `gnome` for option `${platformTheme.option}` is deprecated. Use `adwaita` instead.")
+        ++ (lib.optional (deprecatedKde6PlatformThemeOption != null) (
+          lib.hm.deprecations.mkDeprecatedOptionValueRenameWarning {
+            option = deprecatedKde6PlatformThemeOption;
+            old = ''"kde6"'';
+            replacement = ''"kde"'';
+          }
+        ));
 
       qt.style.package = lib.mkIf (cfg.style.name != null) (
         lib.mkDefault (stylePackages.${lib.toLower cfg.style.name} or null)

--- a/modules/misc/xdg-user-dirs.nix
+++ b/modules/misc/xdg-user-dirs.nix
@@ -113,25 +113,6 @@ in
           MISC = "''${config.home.homeDirectory}/Misc";
         }
       '';
-      apply =
-        if lib.versionOlder config.home.stateVersion "26.05" then
-          lib.mapAttrs' (
-            k:
-            let
-              matches = lib.match "XDG_(.*)_DIR" k;
-            in
-            lib.nameValuePair (
-              if matches == null then
-                k
-              else
-                let
-                  name = lib.elemAt matches 0;
-                in
-                lib.warn "using keys like ‘${k}’ for xdg.userDirs.extraConfig is deprecated in favor of keys like ‘${name}’" name
-            )
-          )
-        else
-          lib.id;
       description = ''
         Other user directories.
 
@@ -175,6 +156,23 @@ in
 
   config =
     let
+      legacyExtraConfigKeys = lib.filter (key: lib.match "XDG_(.*)_DIR" key != null) (
+        lib.attrNames cfg.extraConfig
+      );
+
+      normalizeExtraConfigKey =
+        key:
+        let
+          matches = lib.match "XDG_(.*)_DIR" key;
+        in
+        if matches == null then key else lib.elemAt matches 0;
+
+      extraConfig =
+        if lib.versionOlder config.home.stateVersion "26.05" then
+          lib.mapAttrs' (key: lib.nameValuePair (normalizeExtraConfigKey key)) cfg.extraConfig
+        else
+          cfg.extraConfig;
+
       directories =
         (lib.filterAttrs (_n: v: !isNull v) {
           DESKTOP = cfg.desktop;
@@ -187,11 +185,26 @@ in
           TEMPLATES = cfg.templates;
           VIDEOS = cfg.videos;
         })
-        // cfg.extraConfig;
+        // extraConfig;
 
       bindings = lib.mapAttrs' (k: lib.nameValuePair "XDG_${k}_DIR") directories;
     in
     lib.mkIf cfg.enable {
+      warnings = lib.optionals (lib.versionOlder config.home.stateVersion "26.05") (
+        map (
+          key:
+          lib.hm.deprecations.mkDeprecatedOptionValueWarning {
+            option = [
+              "xdg"
+              "userDirs"
+              "extraConfig"
+            ];
+            old = "keys like `${key}`";
+            replacement = "keys like `${normalizeExtraConfigKey key}`";
+          }
+        ) legacyExtraConfigKeys
+      );
+
       xdg.configFile."user-dirs.dirs".text =
         let
           # For some reason, these need to be wrapped with quotes to be valid.

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -483,25 +483,11 @@ in
                     (
                       bookmarks:
                       if bookmarks != { } then
-                        lib.warn
-                          ''
-                            ${cfg.name} bookmarks have been refactored into a submodule that now explicitly require a 'force' option to be enabled.
-
-                            Replace:
-
-                            ${moduleName}.profiles.${name}.bookmarks = [ ... ];
-
-                            With:
-
-                            ${moduleName}.profiles.${name}.bookmarks = {
-                              force = true;
-                              settings = [ ... ];
-                            };
-                          ''
-                          {
-                            force = true;
-                            settings = bookmarks;
-                          }
+                        {
+                          force = true;
+                          _legacySettings = if builtins.isList bookmarks then "a list" else "an attribute set";
+                          settings = bookmarks;
+                        }
                       else
                         { }
                     )
@@ -1028,7 +1014,59 @@ in
         ++ optional (cfg.vendorPath != null) ''
           Using '${moduleName}.vendorPath' has been deprecated and
           will be removed in the future. Native messaging hosts will function normally without specifying this path.
-        '';
+        ''
+        ++ lib.flatten (
+          lib.mapAttrsToList (
+            name: profile:
+            lib.optional (profile.bookmarks._legacySettings != null) (
+              let
+                legacySettingsExample =
+                  if profile.bookmarks._legacySettings == "a list" then "[ ... ]" else "{ ... }";
+              in
+              lib.hm.deprecations.mkDeprecatedOptionValueWarning {
+                option = modulePath ++ [
+                  "profiles"
+                  name
+                  "bookmarks"
+                ];
+                old = profile.bookmarks._legacySettings;
+                replacement = "`${
+                  lib.showOption (
+                    modulePath
+                    ++ [
+                      "profiles"
+                      name
+                      "bookmarks"
+                      "settings"
+                    ]
+                  )
+                }` with `${
+                  lib.showOption (
+                    modulePath
+                    ++ [
+                      "profiles"
+                      name
+                      "bookmarks"
+                      "force"
+                    ]
+                  )
+                } = true`";
+                details = ''
+                  Set `force = true` to acknowledge replacing existing custom bookmarks.
+
+                  Replace:
+                    ${moduleName}.profiles.${name}.bookmarks = ${legacySettingsExample};
+
+                  With:
+                    ${moduleName}.profiles.${name}.bookmarks = {
+                      force = true;
+                      settings = ${legacySettingsExample};
+                    };
+                '';
+              }
+            )
+          ) cfg.profiles
+        );
       targets.darwin.defaults = (
         mkIf (cfg.darwinDefaultsId != null && isDarwin) {
 

--- a/modules/programs/firefox/profiles/bookmarks.nix
+++ b/modules/programs/firefox/profiles/bookmarks.nix
@@ -84,6 +84,12 @@ in
   ];
 
   options = {
+    _legacySettings = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      visible = false;
+    };
+
     enable = mkOption {
       type = with types; bool;
       default = config.settings != [ ];

--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -85,17 +86,9 @@ in
     languages = mkOption {
       type =
         with types;
-        coercedTo (listOf tomlFormat.type) (
-          language:
-          lib.warn ''
-            The syntax of programs.helix.languages has changed.
-            It now generates the whole languages.toml file instead of just the language array in that file.
-
-            Use
-            programs.helix.languages = { language = <languages list>; }
-            instead.
-          '' { inherit language; }
-        ) (addCheck tomlFormat.type builtins.isAttrs);
+        coercedTo (listOf tomlFormat.type) (language: { inherit language; }) (
+          addCheck tomlFormat.type builtins.isAttrs
+        );
       default = { };
       example = literalExpression ''
         {
@@ -210,6 +203,24 @@ in
   };
 
   config = mkIf cfg.enable {
+    warnings = lib.optional (lib.any builtins.isList options.programs.helix.languages.definitions) (
+      lib.hm.deprecations.mkDeprecatedOptionValueWarning {
+        option = [
+          "programs"
+          "helix"
+          "languages"
+        ];
+        old = "a list";
+        replacement = "`programs.helix.languages.language`";
+        details = ''
+          This option now generates the whole languages.toml file instead of just the language array in that file.
+
+          Use:
+            programs.helix.languages = { language = <languages list>; }
+        '';
+      }
+    );
+
     home.packages =
       if cfg.extraPackages != [ ] then
         [

--- a/modules/programs/hyprpanel/default.nix
+++ b/modules/programs/hyprpanel/default.nix
@@ -89,29 +89,30 @@ in
 
     xdg.configFile.hyprpanel = lib.mkIf (cfg.settings != { }) {
       target = "hyprpanel/config.json";
-      source = jsonFormat.generate "hyprpanel-config" (
-        if cfg.settings ? theme && cfg.settings.theme ? name then
-          lib.warn ''
-            `settings.theme.name` option has been removed, because the
-            hyprpanel module has been ported to downstream home-manager and
-            implementing it would require IFD
-            (https://nix.dev/manual/nix/2.26/language/import-from-derivation)
-
-            Replace it with:
-            ```nix
-            programs.hyprpanel = {
-              theme = {
-                # paste content of https://github.com/Jas-SinghFSU/HyprPanel/blob/2c0c66a/themes/${cfg.settings.theme.name}.json
-              };
-            };
-            ```
-          '' cfg.settings
-        else
-          cfg.settings
-      );
+      source = jsonFormat.generate "hyprpanel-config" cfg.settings;
       # hyprpanel replaces it with the same file, but without new line in the end
       force = true;
     };
+
+    warnings = lib.optional (cfg.settings ? theme && cfg.settings.theme ? name) (
+      lib.hm.deprecations.mkDeprecatedOptionValueWarning {
+        option = [
+          "programs"
+          "hyprpanel"
+          "settings"
+          "theme"
+          "name"
+        ];
+        old = "a named theme";
+        replacement = "`programs.hyprpanel.settings.theme`";
+        details = ''
+          Named theme loading was removed because it requires import-from-derivation.
+
+          Paste theme contents from:
+            https://github.com/Jas-SinghFSU/HyprPanel/blob/2c0c66a/themes/${cfg.settings.theme.name}.json
+        '';
+      }
+    );
 
     systemd.user.services.hyprpanel = lib.mkIf cfg.systemd.enable {
       Unit = {

--- a/modules/programs/infat.nix
+++ b/modules/programs/infat.nix
@@ -117,11 +117,17 @@ in
       (lib.hm.assertions.assertPlatform "programs.infat" pkgs lib.platforms.darwin)
     ];
 
-    warnings = lib.optional cfg.autoActivate._legacyBoolean ''
-      Using `programs.infat.autoActivate` as a Boolean is deprecated and will be
-      removed in a future release. Please use `programs.infat.autoActivate.enable`
-      instead.
-    '';
+    warnings = lib.optional cfg.autoActivate._legacyBoolean (
+      lib.hm.deprecations.mkDeprecatedOptionValueWarning {
+        option = [
+          "programs"
+          "infat"
+          "autoActivate"
+        ];
+        old = "a Boolean";
+        replacement = "`programs.infat.autoActivate.enable`";
+      }
+    );
 
     home = {
       packages = lib.mkIf (cfg.package != null) [ cfg.package ];

--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -99,22 +100,14 @@ in
       events = mkOption {
         type =
           with types;
-          (coercedTo (listOf attrs)) (
+          coercedTo (listOf attrs) (
             events:
-            lib.warn
-              ''
-                The syntax of services.swayidle.events has changed. While it
-                previously accepted a list of events, it now accepts an attrset
-                keyed by the event name.
-              ''
-              (
-                lib.listToAttrs (
-                  map (e: {
-                    name = e.event;
-                    value = e.command;
-                  }) events
-                )
-              )
+            lib.listToAttrs (
+              map (e: {
+                name = e.event;
+                value = e.command;
+              }) events
+            )
           ) (submodule eventsModule);
         default = { };
         example = literalExpression ''
@@ -145,6 +138,21 @@ in
     };
 
   config = lib.mkIf cfg.enable {
+    warnings = lib.optional (lib.any builtins.isList options.services.swayidle.events.definitions) (
+      lib.hm.deprecations.mkDeprecatedOptionValueWarning {
+        option = [
+          "services"
+          "swayidle"
+          "events"
+        ];
+        old = "a list";
+        replacement = "an attribute set keyed by event name";
+        details = ''
+          Use event names as attribute keys and commands as values.
+        '';
+      }
+    );
+
     assertions = [
       (lib.hm.assertions.assertPlatform "services.swayidle" pkgs lib.platforms.linux)
     ];

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -177,6 +177,7 @@ import nmtSrc {
       (
         [
           # keep-sorted start case=no numeric=yes
+          ./lib/deprecations
           ./lib/generators
           ./lib/types
           ./modules/files

--- a/tests/lib/deprecations/default.nix
+++ b/tests/lib/deprecations/default.nix
@@ -1,0 +1,3 @@
+{
+  lib-deprecations-warnings = ./warnings.nix;
+}

--- a/tests/lib/deprecations/warnings.nix
+++ b/tests/lib/deprecations/warnings.nix
@@ -1,0 +1,42 @@
+{ lib, pkgs, ... }:
+
+{
+  nmt.script =
+    let
+      expected = pkgs.writeText "deprecation-warnings.expected" ''
+        Using `programs.example.settings` as a list is deprecated and will be
+        removed in a future release. Please use `programs.example.settings.items` instead.
+
+        Move list entries under `settings.items`.
+
+        The value "kde6" for `qt.platformTheme.name` is deprecated and will be
+        removed in a future release. Please use "kde" instead.
+      '';
+
+      actual = pkgs.writeText "deprecation-warnings.actual" (
+        lib.hm.deprecations.mkDeprecatedOptionValueWarning {
+          option = [
+            "programs"
+            "example"
+            "settings"
+          ];
+          old = "a list";
+          replacement = "`programs.example.settings.items`";
+          details = "Move list entries under `settings.items`.";
+        }
+        + "\n"
+        + lib.hm.deprecations.mkDeprecatedOptionValueRenameWarning {
+          option = [
+            "qt"
+            "platformTheme"
+            "name"
+          ];
+          old = ''"kde6"'';
+          replacement = ''"kde"'';
+        }
+      );
+    in
+    ''
+      assertFileContent ${actual} ${expected}
+    '';
+}

--- a/tests/modules/misc/qt/qt-platform-theme-kde6-migration.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-kde6-migration.nix
@@ -4,6 +4,13 @@
     platformTheme.name = "kde6"; # Should trigger warning and convert to "kde"
   };
 
+  test.asserts.warnings.expected = [
+    ''
+      The value "kde6" for `qt.platformTheme.name` is deprecated and will be
+      removed in a future release. Please use "kde" instead.
+    ''
+  ];
+
   nmt.script = ''
     # Verify that kde6 gets converted to kde in QT_QPA_PLATFORMTHEME
     assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \

--- a/tests/modules/misc/xdg/default.nix
+++ b/tests/modules/misc/xdg/default.nix
@@ -8,6 +8,7 @@
   xdg-local-bin-in-path = ./local-bin-in-path.nix;
   xdg-local-bin-not-in-path = ./local-bin-not-in-path.nix;
   xdg-user-dirs-mixed = ./user-dirs-mixed.nix;
+  xdg-user-dirs-mixed-current = ./user-dirs-mixed-current.nix;
   xdg-user-dirs-null = ./user-dirs-null.nix;
   xdg-user-dirs-short = ./user-dirs-short.nix;
   xdg-user-dirs-session-vars-legacy = ./user-dirs-session-vars-legacy.nix;

--- a/tests/modules/misc/xdg/user-dirs-mixed-current.nix
+++ b/tests/modules/misc/xdg/user-dirs-mixed-current.nix
@@ -1,0 +1,14 @@
+{ config, ... }:
+
+{
+  config = {
+    home.stateVersion = "26.05";
+
+    xdg.userDirs = {
+      enable = true;
+      extraConfig.XDG_MISC_DIR = "${config.home.homeDirectory}/Misc";
+    };
+
+    test.asserts.warnings.expected = [ ];
+  };
+}

--- a/tests/modules/misc/xdg/user-dirs-mixed.nix
+++ b/tests/modules/misc/xdg/user-dirs-mixed.nix
@@ -15,6 +15,13 @@
       extraConfig.XDG_MISC_DIR = "${config.home.homeDirectory}/Misc";
     };
 
+    test.asserts.warnings.expected = [
+      ''
+        Using `xdg.userDirs.extraConfig` as keys like `XDG_MISC_DIR` is deprecated and will be
+        removed in a future release. Please use keys like `MISC` instead.
+      ''
+    ];
+
     nmt.script = ''
       configFile=home-files/.config/user-dirs.dirs
       assertFileExists $configFile

--- a/tests/modules/programs/firefox/bookmarks-legacy-attrset-warning.nix
+++ b/tests/modules/programs/firefox/bookmarks-legacy-attrset-warning.nix
@@ -1,0 +1,50 @@
+{
+  config,
+  ...
+}:
+
+let
+  cfg = config.programs.firefox;
+in
+{
+  imports = [
+    (import ./setup-firefox-mock-overlay.nix [
+      "programs"
+      "firefox"
+    ])
+  ];
+
+  home.stateVersion = "26.05";
+
+  programs.firefox = {
+    enable = true;
+    profiles.default.bookmarks = {
+      "Home Manager" = {
+        url = "https://wiki.nixos.org/wiki/Home_Manager";
+      };
+    };
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      Using `programs.firefox.profiles.default.bookmarks` as an attribute set is deprecated and will be
+      removed in a future release. Please use `programs.firefox.profiles.default.bookmarks.settings` with `programs.firefox.profiles.default.bookmarks.force = true` instead.
+
+      Set `force = true` to acknowledge replacing existing custom bookmarks.
+
+      Replace:
+        programs.firefox.profiles.default.bookmarks = { ... };
+
+      With:
+        programs.firefox.profiles.default.bookmarks = {
+          force = true;
+          settings = { ... };
+        };
+
+    ''
+  ];
+
+  nmt.script = ''
+    assertFileExists "home-files/${cfg.profilesPath}/default/user.js"
+  '';
+}

--- a/tests/modules/programs/firefox/bookmarks-legacy-warning.nix
+++ b/tests/modules/programs/firefox/bookmarks-legacy-warning.nix
@@ -1,0 +1,51 @@
+{
+  config,
+  ...
+}:
+
+let
+  cfg = config.programs.firefox;
+in
+{
+  imports = [
+    (import ./setup-firefox-mock-overlay.nix [
+      "programs"
+      "firefox"
+    ])
+  ];
+
+  home.stateVersion = "26.05";
+
+  programs.firefox = {
+    enable = true;
+    profiles.default.bookmarks = [
+      {
+        name = "Home Manager";
+        url = "https://wiki.nixos.org/wiki/Home_Manager";
+      }
+    ];
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      Using `programs.firefox.profiles.default.bookmarks` as a list is deprecated and will be
+      removed in a future release. Please use `programs.firefox.profiles.default.bookmarks.settings` with `programs.firefox.profiles.default.bookmarks.force = true` instead.
+
+      Set `force = true` to acknowledge replacing existing custom bookmarks.
+
+      Replace:
+        programs.firefox.profiles.default.bookmarks = [ ... ];
+
+      With:
+        programs.firefox.profiles.default.bookmarks = {
+          force = true;
+          settings = [ ... ];
+        };
+
+    ''
+  ];
+
+  nmt.script = ''
+    assertFileExists "home-files/${cfg.profilesPath}/default/user.js"
+  '';
+}

--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -1,5 +1,7 @@
 { lib, ... }:
 {
+  "firefox-bookmarks-legacy-warning" = ./bookmarks-legacy-warning.nix;
+  "firefox-bookmarks-legacy-attrset-warning" = ./bookmarks-legacy-attrset-warning.nix;
   "firefox-config-path-explicit-legacy" = ./config-path-explicit-legacy.nix;
   "firefox-config-path-explicit-xdg" = ./config-path-explicit-xdg.nix;
   "firefox-config-path-xdg-default" = ./config-path-xdg-default.nix;

--- a/tests/modules/programs/firefox/profiles/bookmarks/attrset.nix
+++ b/tests/modules/programs/firefox/profiles/bookmarks/attrset.nix
@@ -72,6 +72,25 @@ in
       };
     }
     // {
+      test.asserts.warnings.expected = [
+        ''
+          Using `${lib.showOption modulePath}.profiles.bookmarks.bookmarks` as an attribute set is deprecated and will be
+          removed in a future release. Please use `${lib.showOption modulePath}.profiles.bookmarks.bookmarks.settings` with `${lib.showOption modulePath}.profiles.bookmarks.bookmarks.force = true` instead.
+
+          Set `force = true` to acknowledge replacing existing custom bookmarks.
+
+          Replace:
+            ${lib.showOption modulePath}.profiles.bookmarks.bookmarks = { ... };
+
+          With:
+            ${lib.showOption modulePath}.profiles.bookmarks.bookmarks = {
+              force = true;
+              settings = { ... };
+            };
+
+        ''
+      ];
+
       nmt.script = ''
         bookmarksUserJs=$(normalizeStorePaths \
           "home-files/${cfg.profilesPath}/bookmarks/user.js")

--- a/tests/modules/programs/helix/default.nix
+++ b/tests/modules/programs/helix/default.nix
@@ -1,4 +1,5 @@
 {
   helix-example-settings = ./example-settings.nix;
+  helix-legacy-languages = ./legacy-languages.nix;
   helix-only-extraconfig = ./only-extraconfig.nix;
 }

--- a/tests/modules/programs/helix/legacy-languages.nix
+++ b/tests/modules/programs/helix/legacy-languages.nix
@@ -1,0 +1,57 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+
+{
+  # Exercise merging legacy list definitions with new attrset definitions.
+  imports = [
+    {
+      programs.helix.languages.language-server.nil = {
+        command = "nil";
+      };
+    }
+  ];
+
+  programs.helix = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@helix@"; };
+    languages = [
+      {
+        name = "rust";
+        auto-format = false;
+      }
+    ];
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      Using `programs.helix.languages` as a list is deprecated and will be
+      removed in a future release. Please use `programs.helix.languages.language` instead.
+
+      This option now generates the whole languages.toml file instead of just the language array in that file.
+
+      Use:
+        programs.helix.languages = { language = <languages list>; }
+
+    ''
+  ];
+
+  nmt.script =
+    let
+      expectedLanguages = pkgs.writeText "helix-languages.expected.toml" ''
+        [[language]]
+        auto-format = false
+        name = "rust"
+
+        [language-server.nil]
+        command = "nil"
+      '';
+    in
+    ''
+      assertFileContent \
+        home-files/.config/helix/languages.toml \
+        ${expectedLanguages}
+    '';
+}

--- a/tests/modules/programs/hyprpanel/default.nix
+++ b/tests/modules/programs/hyprpanel/default.nix
@@ -2,5 +2,6 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   hyprpanel-basic-config = ./basic-config.nix;
+  hyprpanel-deprecated-theme-name = ./deprecated-theme-name.nix;
   hyprpanel-with-hypridle = ./with-hypridle.nix;
 }

--- a/tests/modules/programs/hyprpanel/deprecated-theme-name.nix
+++ b/tests/modules/programs/hyprpanel/deprecated-theme-name.nix
@@ -1,0 +1,26 @@
+{ config, ... }:
+
+{
+  programs.hyprpanel = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "hyprpanel"; };
+    settings.theme.name = "catppuccin_mocha";
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      Using `programs.hyprpanel.settings.theme.name` as a named theme is deprecated and will be
+      removed in a future release. Please use `programs.hyprpanel.settings.theme` instead.
+
+      Named theme loading was removed because it requires import-from-derivation.
+
+      Paste theme contents from:
+        https://github.com/Jas-SinghFSU/HyprPanel/blob/2c0c66a/themes/catppuccin_mocha.json
+
+    ''
+  ];
+
+  nmt.script = ''
+    assertFileExists "home-files/.config/hyprpanel/config.json"
+  '';
+}

--- a/tests/modules/programs/infat/deprecated-auto-activate-bool.nix
+++ b/tests/modules/programs/infat/deprecated-auto-activate-bool.nix
@@ -15,8 +15,7 @@ _:
     asserts.warnings.expected = [
       ''
         Using `programs.infat.autoActivate` as a Boolean is deprecated and will be
-        removed in a future release. Please use `programs.infat.autoActivate.enable`
-        instead.
+        removed in a future release. Please use `programs.infat.autoActivate.enable` instead.
       ''
     ];
 

--- a/tests/modules/services/swayidle/legacy-configuration.nix
+++ b/tests/modules/services/swayidle/legacy-configuration.nix
@@ -1,5 +1,12 @@
 { config, ... }:
 {
+  # Exercise merging legacy list definitions with new attrset definitions.
+  imports = [
+    {
+      services.swayidle.events.after-resume = "notify-send resumed";
+    }
+  ];
+
   services.swayidle = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@swayidle@"; };
@@ -15,11 +22,13 @@
     ];
   };
 
-  test.asserts.evalWarnings.expected = [
+  test.asserts.warnings.expected = [
     ''
-      The syntax of services.swayidle.events has changed. While it
-      previously accepted a list of events, it now accepts an attrset
-      keyed by the event name.
+      Using `services.swayidle.events` as a list is deprecated and will be
+      removed in a future release. Please use an attribute set keyed by event name instead.
+
+      Use event names as attribute keys and commands as values.
+
     ''
   ];
 
@@ -36,7 +45,7 @@
 
       [Service]
       Environment=PATH=@bash-interactive@/bin
-      ExecStart=@swayidle@/bin/dummy -w before-sleep 'swaylock -fF' lock 'swaylock -fF'
+      ExecStart=@swayidle@/bin/dummy -w after-resume 'notify-send resumed' before-sleep 'swaylock -fF' lock 'swaylock -fF'
       Restart=always
       Type=simple
 


### PR DESCRIPTION
### Description

Adds Home Manager deprecation warning helpers and moves several legacy option-shape migration warnings from inline `lib.warn` into `config.warnings`, so NMT can assert warning text and migrated behavior.

Migrated warnings:

- `qt.platformTheme{,.name} = "kde6"`
- legacy `services.swayidle.events` list syntax
- legacy `programs.helix.languages` list syntax
- `programs.hyprpanel.settings.theme.name`
- legacy Firefox bookmarks list syntax
- legacy `xdg.userDirs.extraConfig` keys like `XDG_MISC_DIR`

Remaining inline `lib.warn` sites are helper/library warnings, Firefox search data migrations, and a Podman ambiguity warning. Those need separate judgment because they are not the same simple option-shape migration pattern.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)