### PR TITLE
claude-code: mark hook scripts executable

### DIFF
--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -558,10 +558,14 @@ in
           name: content: nameValuePair "${cfg.configDir}/${subdir}/${name}.md" (mkSourceEntry content)
         ) attrs;
 
-      mkTextEntries =
-        subdir: attrs:
+      mkHookEntries =
+        attrs:
         lib.mapAttrs' (
-          name: content: nameValuePair "${cfg.configDir}/${subdir}/${name}" { text = content; }
+          name: content:
+          nameValuePair "${cfg.configDir}/hooks/${name}" {
+            text = content;
+            executable = true;
+          }
         ) attrs;
 
       mkRecursiveDirAttrs =
@@ -727,7 +731,7 @@ in
               recursive = true;
             };
           })
-          (mkTextEntries "hooks" cfg.hooks)
+          (mkHookEntries cfg.hooks)
           (lib.optionalAttrs (builtins.isAttrs cfg.skills) (lib.mapAttrs' mkSkillEntry cfg.skills))
           (mkMarkdownEntries "output-styles" cfg.outputStyles)
         ];

--- a/tests/modules/programs/claude-code/config-dir.nix
+++ b/tests/modules/programs/claude-code/config-dir.nix
@@ -66,6 +66,7 @@
     assertFileExists home-files/.config/claude/commands/hello.md
     assertFileExists home-files/.config/claude/rules/style.md
     assertFileExists home-files/.config/claude/hooks/pre-edit
+    assertFileIsExecutable home-files/.config/claude/hooks/pre-edit
     assertFileExists home-files/.config/claude/output-styles/concise.md
     assertFileExists home-files/.config/claude/skills/pdf/SKILL.md
 

--- a/tests/modules/programs/claude-code/full-config.nix
+++ b/tests/modules/programs/claude-code/full-config.nix
@@ -135,9 +135,11 @@
     assertFileContent home-files/.claude/commands/commit.md ${./expected-commit}
 
     assertFileExists home-files/.claude/hooks/pre-edit
+    assertFileIsExecutable home-files/.claude/hooks/pre-edit
     assertFileRegex home-files/.claude/hooks/pre-edit "About to edit file"
 
     assertFileExists home-files/.claude/hooks/post-commit
+    assertFileIsExecutable home-files/.claude/hooks/post-commit
     assertFileRegex home-files/.claude/hooks/post-commit "Committed with message"
   '';
 }


### PR DESCRIPTION
### Description

Inline `programs.claude-code.hooks` entries now write hook scripts with the executable bit set, matching Claude Code's expectation that hook files are runnable scripts.

Closes #9401

Tests run:

- `nix fmt`
- `nix run .#tests -- claude-code-config-dir claude-code-full-config`
- `nix run .#tests -- claude-code`

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
