### PR TITLE
infat: use list for autoActivate extraArgs

### DIFF
--- a/modules/programs/infat.nix
+++ b/modules/programs/infat.nix
@@ -7,7 +7,6 @@
 let
   cfg = config.programs.infat;
   tomlFormat = pkgs.formats.toml { };
-  mkCli = lib.cli.toCommandLineShellGNU { };
 
   configDir =
     if config.xdg.enable then
@@ -75,18 +74,12 @@ in
                     '';
                   };
                   extraArgs = lib.mkOption {
-                    type =
-                      with lib.types;
-                      attrsOf (oneOf [
-                        str
-                        bool
-                      ]);
-                    default = {
-                      robust = true;
-                    };
-                    example = {
-                      quiet = true;
-                    };
+                    type = lib.types.listOf lib.types.str;
+                    default = [ "--robust" ];
+                    example = [
+                      "--robust"
+                      "--quiet"
+                    ];
                     description = ''
                       Additional arguments to pass when auto-activating infat.
                       This can be used to customize the behavior of infat when
@@ -104,9 +97,10 @@ in
         default = { };
         example = {
           enable = true;
-          extraArgs = {
-            quiet = true;
-          };
+          extraArgs = [
+            "--robust"
+            "--quiet"
+          ];
         };
         description = ''
           Auto-activation settings for infat.
@@ -122,24 +116,38 @@ in
     assertions = [
       (lib.hm.assertions.assertPlatform "programs.infat" pkgs lib.platforms.darwin)
     ];
+
     warnings = lib.optional cfg.autoActivate._legacyBoolean ''
       Using `programs.infat.autoActivate` as a Boolean is deprecated and will be
       removed in a future release. Please use `programs.infat.autoActivate.enable`
       instead.
     '';
-    programs.infat.autoActivate.extraArgs = lib.mkIf (cfg.settings != { }) {
-      config = configFile;
-    };
+
     home = {
       packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
       file.${configFile} = lib.mkIf (cfg.settings != { }) {
         source = tomlFormat.generate "infat-settings.toml" cfg.settings;
       };
+
       activation =
-        lib.mkIf (cfg.package != null && cfg.autoActivate.enable && cfg.autoActivate.extraArgs ? config)
+        let
+          autoActivateExtraArgs =
+            cfg.autoActivate.extraArgs
+            ++ lib.optionals (cfg.settings != { } && !lib.elem "--config" cfg.autoActivate.extraArgs) [
+              "--config"
+              configFile
+            ];
+        in
+        lib.mkIf
+          (
+            cfg.package != null
+            && cfg.autoActivate.enable
+            && (cfg.settings != { } || lib.elem "--config" cfg.autoActivate.extraArgs)
+          )
           {
             infat = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-              run ${lib.getExe cfg.package} ${mkCli cfg.autoActivate.extraArgs} $VERBOSE_ARG
+              run ${lib.getExe cfg.package} ${lib.escapeShellArgs autoActivateExtraArgs} $VERBOSE_ARG
             '';
           };
     };

--- a/tests/modules/programs/infat/auto-activate-args.nix
+++ b/tests/modules/programs/infat/auto-activate-args.nix
@@ -1,18 +1,7 @@
 {
-  config,
-  pkgs,
-  ...
-}:
-
-let
-  activationScript = pkgs.writeText "activation-script" config.home.activation.infat.data;
-in
-{
   programs.infat = {
     enable = true;
-    autoActivate.extraArgs = {
-      quiet = true;
-    };
+    autoActivate.extraArgs = [ "--quiet" ];
     settings = {
       extensions = {
         md = "TextEdit";
@@ -23,8 +12,8 @@ in
   test.stubs.infat = { };
 
   nmt.script = ''
-    assertFileRegex "${activationScript}" '.*--config'
-    assertFileRegex "${activationScript}" '.*--quiet'
-    assertFileNotRegex "${activationScript}" '.*--robust'
+    assertFileContains activate ' --config'
+    assertFileContains activate ' --quiet'
+    assertFileNotRegex activate '.*--robust'
   '';
 }

--- a/tests/modules/programs/infat/example-settings.nix
+++ b/tests/modules/programs/infat/example-settings.nix
@@ -35,5 +35,6 @@
     ''
       assertFileExists "${expectedConfigPath}"
       assertFileContent "${expectedConfigPath}" "${expectedConfigContent}"
+      assertFileContains activate ' --robust'
     '';
 }


### PR DESCRIPTION
### Description
Follow up to https://github.com/nix-community/home-manager/pull/8930 for consistency with rest of repo
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
