### PR TITLE
zsh: fix oh-my-zsh custom path expansion

### DIFF
--- a/modules/programs/zsh/plugins/oh-my-zsh.nix
+++ b/modules/programs/zsh/plugins/oh-my-zsh.nix
@@ -13,9 +13,11 @@ let
     types
     ;
 
-  inherit (import ../lib.nix { inherit config lib; }) dotDirRel;
+  inherit (import ../lib.nix { inherit config lib; }) dotDirRel mkShellVarPathStr;
 
   cfg = config.programs.zsh;
+
+  shellVarPathArg = path: ''"${lib.escape [ "\\" "\"" "`" ] (mkShellVarPathStr path)}"'';
 
   ohMyZshModule = types.submodule {
     options = {
@@ -98,7 +100,7 @@ in
       ${optionalString (
         cfg.oh-my-zsh.plugins != [ ]
       ) "plugins=(${escapeShellArgs cfg.oh-my-zsh.plugins})"}
-      ${optionalString (cfg.oh-my-zsh.custom != "") "ZSH_CUSTOM=${escapeShellArg cfg.oh-my-zsh.custom}"}
+      ${optionalString (cfg.oh-my-zsh.custom != "") "ZSH_CUSTOM=${shellVarPathArg cfg.oh-my-zsh.custom}"}
       ${optionalString (cfg.oh-my-zsh.theme != "") "ZSH_THEME=${escapeShellArg cfg.oh-my-zsh.theme}"}
       source $ZSH/oh-my-zsh.sh
     '';

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -20,6 +20,7 @@
   zsh-history-path-zdotdir-variable = import ./history-path.nix "zdotdir-variable";
   zsh-history-substring-search = ./history-substring-search.nix;
   zsh-legacy-warning = ./legacy-warning.nix;
+  zsh-oh-my-zsh-custom = ./oh-my-zsh-custom.nix;
   zsh-plugins-completions-renamed = ./plugins-completions-renamed.nix;
   zsh-siteFunctions-mkcd = ./siteFunctions-mkcd.nix;
   zsh-plugins = ./plugins.nix;

--- a/tests/modules/programs/zsh/oh-my-zsh-custom.nix
+++ b/tests/modules/programs/zsh/oh-my-zsh-custom.nix
@@ -1,0 +1,31 @@
+{
+  config = {
+    programs.zsh = {
+      enable = true;
+
+      oh-my-zsh = {
+        enable = true;
+        custom = "$HOME/extra/zsh";
+        theme = "sigma";
+      };
+    };
+
+    home.file.omz-zsh-theme = {
+      source = builtins.toFile "sigma.zsh-theme" ''
+        echo sigma
+      '';
+      target = "extra/zsh/themes/sigma.zsh-theme";
+    };
+
+    test.stubs = {
+      oh-my-zsh = { };
+      zsh = { };
+    };
+
+    nmt.script = ''
+      assertFileContains home-files/.zshrc 'ZSH_CUSTOM="$HOME/extra/zsh"'
+      assertFileContains home-files/.zshrc 'ZSH_THEME=sigma'
+      assertFileExists home-files/extra/zsh/themes/sigma.zsh-theme
+    '';
+  };
+}


### PR DESCRIPTION
Preserve shell-variable paths for programs.zsh.oh-my-zsh.custom while still escaping values for a double-quoted shell assignment.

This restores runtime expansion for values like $HOME/extra/zsh, which otherwise became a literal path after the previous escapeShellArg change.

closes https://github.com/nix-community/home-manager/issues/9393
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
