### PR TITLE
prismlauncher: add themes option

### DIFF
--- a/all-maintainers.nix
+++ b/all-maintainers.nix
@@ -119,6 +119,13 @@
     name = "Denis Kaynar";
     source = "home-manager";
   };
+  ErinaYip = {
+    email = "erinayip@outlook.com";
+    github = "ErinaYip";
+    githubId = 227132255;
+    name = "erina";
+    source = "home-manager";
+  };
   Eveeifyeve = {
     email = "eveeg1971@gmail.com";
     github = "Eveeifyeve";

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -175,6 +175,12 @@
     github = "epixtm";
     githubId = 168025607;
   };
+  ErinaYip = {
+    name = "erina";
+    email = "erinayip@outlook.com";
+    github = "ErinaYip";
+    githubId = 227132255;
+  };
   exzombie = {
     name = "Jure Varlec";
     email = "jure@varlec.si";

--- a/modules/misc/news/2026/06/2026-06-03_22-14-24.nix
+++ b/modules/misc/news/2026/06/2026-06-03_22-14-24.nix
@@ -1,0 +1,13 @@
+{ config, ... }:
+{
+  time = "2026-06-03T14:14:24+00:00";
+  condition = config.programs.prismlauncher.enable;
+  message = ''
+    `programs.prismlauncher` now supports managing Prism Launcher
+    themes through {option}`programs.prismlauncher.themes`.
+
+    Themes can be configured either as paths to complete theme directories, or
+    as attribute sets used to generate `theme.json` and optionally
+    `themeStyle.css`.
+  '';
+}

--- a/modules/programs/prismlauncher.nix
+++ b/modules/programs/prismlauncher.nix
@@ -27,6 +27,7 @@ in
 
 {
   meta.maintainers = with lib.maintainers; [
+    ErinaYip
     mikaeladev
   ];
 

--- a/modules/programs/prismlauncher.nix
+++ b/modules/programs/prismlauncher.nix
@@ -20,6 +20,9 @@ let
   cfg = config.programs.prismlauncher;
 
   iniFormat = pkgs.formats.ini { };
+  jsonFormat = pkgs.formats.json { };
+  isStorePathString = value: builtins.isString value && lib.hasPrefix "${builtins.storeDir}/" value;
+  isPathLike = value: lib.isPath value || isStorePathString value || lib.isDerivation value;
 in
 
 {
@@ -55,6 +58,64 @@ in
       '';
     };
 
+    themes = mkOption {
+      type = types.attrsOf (
+        types.either types.path (
+          types.submodule {
+            options = {
+              theme = mkOption {
+                inherit (jsonFormat) type;
+                default = { };
+                description = ''
+                  Contents of the theme's {file}`theme.json`.
+                '';
+              };
+
+              style = mkOption {
+                type = types.nullOr (types.either types.lines types.path);
+                default = null;
+                description = ''
+                  Contents of, or path to, the theme's {file}`themeStyle.css`.
+                '';
+              };
+            };
+          }
+        )
+      );
+      default = { };
+      example = literalExpression ''
+        {
+          Tokyo-Night = ./Tokyo-Night;
+
+          custom = {
+            theme = {
+              name = "Custom";
+              colors = {
+                background = "#1a1b26";
+                foreground = "#c0caf5";
+              };
+            };
+            style = '''
+              QWidget {
+                font-family: "Inter";
+              }
+            ''';
+          };
+        }
+      '';
+      description = ''
+        Prism Launcher widget themes.
+
+        Attribute names are used as theme directory names. A theme can either be
+        a path to a complete theme directory, or an attribute set used to
+        generate {file}`theme.json` and optionally {file}`themeStyle.css`.
+
+        These will be linked in {file}`$XDG_DATA_HOME/PrismLauncher/themes` on
+        Linux and {file}`~/Library/Application Support/PrismLauncher/themes` on
+        macOS.
+      '';
+    };
+
     settings = mkOption {
       type = types.attrsOf iniFormat.lib.types.atom;
       default = { };
@@ -86,8 +147,39 @@ in
         ${lib.getExe pkgs.crudini} --merge --ini-options=nospace \
           ${escapeShellArg filePath} < ${escapeShellArg staticSettingsFile}
       '';
+
+      themeFiles = lib.concatMapAttrs (
+        name: theme:
+        if isPathLike theme then
+          {
+            "${dataDir}/themes/${name}" = {
+              source = theme;
+              recursive = true;
+            };
+          }
+        else
+          {
+            "${dataDir}/themes/${name}/theme.json" = {
+              source = jsonFormat.generate "prismlauncher-${name}-theme.json" theme.theme;
+            };
+          }
+          // lib.optionalAttrs (theme.style != null) {
+            "${dataDir}/themes/${name}/themeStyle.css" =
+              if isPathLike theme.style then { source = theme.style; } else { text = theme.style; };
+          }
+      ) cfg.themes;
     in
     mkIf cfg.enable {
+      assertions =
+        lib.mapAttrsToList (name: theme: {
+          assertion = !isPathLike theme || lib.pathIsDirectory theme;
+          message = "`programs.prismlauncher.themes.${name}` must be a directory when set to a path.";
+        }) cfg.themes
+        ++ lib.mapAttrsToList (name: theme: {
+          assertion = isPathLike theme || theme.theme != { };
+          message = "`programs.prismlauncher.themes.${name}.theme` must not be empty.";
+        }) cfg.themes;
+
       home = {
         packages = lib.mkMerge ([ (mkIf (cfg.package != null) [ cfg.package ]) ] ++ cfg.extraPackages);
 
@@ -99,14 +191,17 @@ in
           );
         };
 
-        file = mkIf (cfg.icons != [ ]) (
-          listToAttrs (
-            map (source: {
-              name = "${dataDir}/icons/${baseNameOf source}";
-              value = { inherit source; };
-            }) cfg.icons
-          )
-        );
+        file = lib.mkMerge [
+          (mkIf (cfg.icons != [ ]) (
+            listToAttrs (
+              map (source: {
+                name = "${dataDir}/icons/${baseNameOf source}";
+                value = { inherit source; };
+              }) cfg.icons
+            )
+          ))
+          themeFiles
+        ];
       };
     };
 }

--- a/tests/modules/programs/prismlauncher/default.nix
+++ b/tests/modules/programs/prismlauncher/default.nix
@@ -1,3 +1,4 @@
 {
   prismlauncher-settings = ./settings.nix;
+  prismlauncher-themes = ./themes.nix;
 }

--- a/tests/modules/programs/prismlauncher/inline-theme.json
+++ b/tests/modules/programs/prismlauncher/inline-theme.json
@@ -1,0 +1,8 @@
+{
+  "colors": {
+    "accent": "#7aa2f7",
+    "background": "#1a1b26",
+    "foreground": "#c0caf5"
+  },
+  "name": "Inline Theme"
+}

--- a/tests/modules/programs/prismlauncher/inline-themeStyle.css
+++ b/tests/modules/programs/prismlauncher/inline-themeStyle.css
@@ -1,0 +1,3 @@
+QWidget {
+  font-family: "Inter";
+}

--- a/tests/modules/programs/prismlauncher/theme-dir/theme.json
+++ b/tests/modules/programs/prismlauncher/theme-dir/theme.json
@@ -1,0 +1,7 @@
+{
+  "name": "Theme Dir",
+  "colors": {
+    "background": "#1a1b26",
+    "foreground": "#c0caf5"
+  }
+}

--- a/tests/modules/programs/prismlauncher/theme-dir/themeStyle.css
+++ b/tests/modules/programs/prismlauncher/theme-dir/themeStyle.css
@@ -1,0 +1,3 @@
+QWidget {
+  font-family: "Inter";
+}

--- a/tests/modules/programs/prismlauncher/themes.nix
+++ b/tests/modules/programs/prismlauncher/themes.nix
@@ -1,0 +1,48 @@
+{ config, ... }:
+
+{
+  programs.prismlauncher = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    themes = {
+      theme-dir = ./theme-dir;
+
+      inline-theme = {
+        theme = {
+          name = "Inline Theme";
+          colors = {
+            accent = "#7aa2f7";
+            background = "#1a1b26";
+            foreground = "#c0caf5";
+          };
+        };
+        style = ''
+          QWidget {
+            font-family: "Inter";
+          }
+        '';
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.local/share/PrismLauncher/themes/theme-dir/theme.json
+    assertFileContent \
+      home-files/.local/share/PrismLauncher/themes/theme-dir/theme.json \
+      ${./theme-dir/theme.json}
+    assertFileExists home-files/.local/share/PrismLauncher/themes/theme-dir/themeStyle.css
+    assertFileContent \
+      home-files/.local/share/PrismLauncher/themes/theme-dir/themeStyle.css \
+      ${./theme-dir/themeStyle.css}
+
+    assertFileExists home-files/.local/share/PrismLauncher/themes/inline-theme/theme.json
+    assertFileContent \
+      home-files/.local/share/PrismLauncher/themes/inline-theme/theme.json \
+      ${./inline-theme.json}
+    assertFileExists home-files/.local/share/PrismLauncher/themes/inline-theme/themeStyle.css
+    assertFileContent \
+      home-files/.local/share/PrismLauncher/themes/inline-theme/themeStyle.css \
+      ${./inline-themeStyle.css}
+  '';
+}


### PR DESCRIPTION
### Description

Closes #9418.

Adds `programs.prismlauncher.themes` for managing Prism Launcher widget themes.

The option supports linking complete theme directories, such as themes from PrismLauncher/Themes, and generating simple custom themes from Nix attributes by writing `theme.json` and optional `themeStyle.css` under the Prism Launcher themes directory.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
