### PR TITLE
sshAuthSock: set in systemd

### DIFF
--- a/modules/misc/news/2026/06/2026-06-02_17-44-16.nix
+++ b/modules/misc/news/2026/06/2026-06-02_17-44-16.nix
@@ -1,0 +1,18 @@
+{ config, ... }:
+{
+  time = "2026-06-02T15:44:16+00:00";
+  condition =
+    config.services.gpg-agent.enable
+    || config.services.proton-pass-agent.enable
+    || config.services.ssh-agent.enable
+    || config.services.ssh-tpm-agent.enable
+    || config.services.yubikey-agent.enable;
+  message = ''
+    A new module is available: 'sshAuthSock'.
+
+    It takes care of setting the `SSH_AUTH_SOCK` environment variable
+    properly and is implicitly enabled and configured by SSH agent modules.
+    You can use the 'sshAuthSock.systemd.socketProviderUnit' option to make
+    SSH agents accessible to systemd-managed applications.
+  '';
+}

--- a/modules/misc/ssh-auth-sock.nix
+++ b/modules/misc/ssh-auth-sock.nix
@@ -37,6 +37,11 @@ in
         nushell = mkShellInitOption "nushell" // {
           example = "$env.SSH_AUTH_SOCK = $HOME/.ssh/agent.sock";
         };
+        zsh = mkShellInitOption "zsh" // {
+          example = "export SSH_AUTH_SOCK=$HOME/.ssh/agent.sock";
+          default = cfg.initialization.bash;
+          defaultText = lib.literalExpression "config.sshAuthSock.initialization.bash";
+        };
       };
 
   };
@@ -45,11 +50,13 @@ in
     let
       # Preserve $SSH_AUTH_SOCK if it stems from a forwarded agent which is the
       # case if both $SSH_AUTH_SOCK and $SSH_CONNECTION are set.
-      bashIntegration = ''
+      mkShIntegration = code: ''
         if [ -z "$SSH_AUTH_SOCK" -o -z "$SSH_CONNECTION" ]; then
-          ${cfg.initialization.bash}
+          ${code}
         fi
       '';
+      bashIntegration = mkShIntegration cfg.initialization.bash;
+      zshIntegration = mkShIntegration cfg.initialization.zsh;
       fishIntegration = ''
         if test -z "$SSH_AUTH_SOCK"; or test -z "$SSH_CONNECTION"
           ${cfg.initialization.fish}
@@ -70,6 +77,6 @@ in
       programs.bash.profileExtra = lib.mkOrder 900 bashIntegration;
       programs.fish.shellInit = lib.mkOrder 900 fishIntegration;
       programs.nushell.extraConfig = lib.mkOrder 900 nushellIntegration;
-      programs.zsh.envExtra = lib.mkOrder 900 bashIntegration;
+      programs.zsh.envExtra = lib.mkOrder 900 zshIntegration;
     };
 }

--- a/modules/misc/ssh-auth-sock.nix
+++ b/modules/misc/ssh-auth-sock.nix
@@ -2,72 +2,74 @@
 
 let
   cfg = config.sshAuthSock;
-
-  mkShellInitOption =
-    shell:
-    lib.mkOption {
-      description = "Code that initializes {env}`SSH_AUTH_SOCK` in ${shell}.";
-      type = lib.types.str;
-    };
-
-  initSubmodule = {
-    options.bash = mkShellInitOption "bash";
-    options.fish = mkShellInitOption "fish";
-    options.nushell = mkShellInitOption "nushell";
-  };
-
-  # Preserve $SSH_AUTH_SOCK only if it stems from a forwarded agent which
-  # is the case if both $SSH_AUTH_SOCK and $SSH_CONNECTION are set.
-  bashIntegration = ''
-    if [ -z "$SSH_AUTH_SOCK" -o -z "$SSH_CONNECTION" ]; then
-      ${cfg.initialization.bash}
-    fi
-  '';
-  fishIntegration = ''
-    if test -z "$SSH_AUTH_SOCK"; or test -z "$SSH_CONNECTION"
-      ${cfg.initialization.fish}
-    end
-  '';
-  nushellIntegration =
-    let
-      unsetOrEmpty = var: ''("${var}" not-in $env) or ($env.${var} | is-empty)'';
-    in
-    ''
-      if ${unsetOrEmpty "SSH_AUTH_SOCK"} or ${unsetOrEmpty "SSH_CONNECTION"} {
-        ${cfg.initialization.nushell}
-      }
-    '';
-
 in
 {
   meta.maintainers = [ lib.maintainers.bmrips ];
 
-  options.sshAuthSock.initialization = lib.mkOption {
-    description = ''
-      Shell-specific code to initialize {env}`SSH_AUTH_SOCK`.
+  options.sshAuthSock = {
 
-      RATIONALE: {env}`SSH_AUTH_SOCK` must not be set unconditionally through
-      {option}`home.sessionVariables` since its value needs to be preserved if
-      it stems from a forwarded agent. Hence, this option establishes a
-      centralized interface for setting {env}`SSH_AUTH_SOCK`. It checks whether
-      its value has to be preserved and injects the initialization code into the
-      proper {option}`programs.(bash|fish|nushell|zsh).*` options.
-    '';
-    example = {
-      bash = "export SSH_AUTH_SOCK=$HOME/.ssh/agent.sock";
-      fish = "set -x SSH_AUTH_SOCK $HOME/.ssh/agent.sock";
-      nushell = "$env.SSH_AUTH_SOCK = $HOME/.ssh/agent.sock";
+    enable = lib.mkEnableOption "" // {
+      description = ''
+        Whether to set {env}`SSH_AUTH_SOCK` in shells, systemd, and the D-BUS daemon
+        unless it was already defined through SSH agent forwarding.
+
+        Typically, this module will be implicitly enabled and configured by SSH
+        agent modules.
+      '';
     };
-    default = null;
-    internal = true;
-    type = with lib.types; nullOr (submodule initSubmodule);
+
+    initialization =
+      let
+        mkShellInitOption =
+          shell:
+          lib.mkOption {
+            description = "Code that initializes {env}`SSH_AUTH_SOCK` in ${shell}.";
+            type = lib.types.str;
+          };
+      in
+      {
+        bash = mkShellInitOption "bash" // {
+          example = "export SSH_AUTH_SOCK=$HOME/.ssh/agent.sock";
+        };
+        fish = mkShellInitOption "fish" // {
+          example = "set -x SSH_AUTH_SOCK $HOME/.ssh/agent.sock";
+        };
+        nushell = mkShellInitOption "nushell" // {
+          example = "$env.SSH_AUTH_SOCK = $HOME/.ssh/agent.sock";
+        };
+      };
+
   };
 
-  config = lib.mkIf (cfg.initialization != null) {
-    # $SSH_AUTH_SOCK has to be set early since other tools rely on it
-    programs.bash.profileExtra = lib.mkOrder 900 bashIntegration;
-    programs.fish.shellInit = lib.mkOrder 900 fishIntegration;
-    programs.nushell.extraConfig = lib.mkOrder 900 nushellIntegration;
-    programs.zsh.envExtra = lib.mkOrder 900 bashIntegration;
-  };
+  config =
+    let
+      # Preserve $SSH_AUTH_SOCK if it stems from a forwarded agent which is the
+      # case if both $SSH_AUTH_SOCK and $SSH_CONNECTION are set.
+      bashIntegration = ''
+        if [ -z "$SSH_AUTH_SOCK" -o -z "$SSH_CONNECTION" ]; then
+          ${cfg.initialization.bash}
+        fi
+      '';
+      fishIntegration = ''
+        if test -z "$SSH_AUTH_SOCK"; or test -z "$SSH_CONNECTION"
+          ${cfg.initialization.fish}
+        end
+      '';
+      nushellIntegration =
+        let
+          unsetOrEmpty = var: ''("${var}" not-in $env) or ($env.${var} | is-empty)'';
+        in
+        ''
+          if ${unsetOrEmpty "SSH_AUTH_SOCK"} or ${unsetOrEmpty "SSH_CONNECTION"} {
+            ${cfg.initialization.nushell}
+          }
+        '';
+    in
+    lib.mkIf cfg.enable {
+      # $SSH_AUTH_SOCK has to be set early since other tools rely on it
+      programs.bash.profileExtra = lib.mkOrder 900 bashIntegration;
+      programs.fish.shellInit = lib.mkOrder 900 fishIntegration;
+      programs.nushell.extraConfig = lib.mkOrder 900 nushellIntegration;
+      programs.zsh.envExtra = lib.mkOrder 900 bashIntegration;
+    };
 }

--- a/modules/misc/ssh-auth-sock.nix
+++ b/modules/misc/ssh-auth-sock.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.sshAuthSock;
@@ -44,6 +49,18 @@ in
         };
       };
 
+    systemd.socketProviderUnit = lib.mkOption {
+      description = ''
+        The name of the systemd unit responsible for providing the {env}`SSH_AUTH_SOCK`.
+
+        Services that rely on an active SSH authentication agent can reference
+        this option to declare a dependency onto this unit, ensuring that the
+        socket is available and being served before they start.
+      '';
+      example = "ssh-agent.service";
+      type = lib.types.str;
+    };
+
   };
 
   config =
@@ -78,5 +95,26 @@ in
       programs.fish.shellInit = lib.mkOrder 900 fishIntegration;
       programs.nushell.extraConfig = lib.mkOrder 900 nushellIntegration;
       programs.zsh.envExtra = lib.mkOrder 900 zshIntegration;
+
+      # Replace this service by an environment generator as soon as they are
+      # available per-user. See https://github.com/systemd/systemd/issues/32423
+      # for more information.
+      systemd.user.services.set-SSH_AUTH_SOCK = {
+        Unit = {
+          Description = "Sets SSH_AUTH_SOCK in the D-BUS daemon and systemd";
+          Before = [ cfg.systemd.socketProviderUnit ];
+        };
+        Service = {
+          Type = "oneshot";
+          ExecStart = pkgs.writeShellScript "set-SSH_AUTH_SOCK" ''
+            ${bashIntegration}
+            ${pkgs.dbus}/bin/dbus-update-activation-environment --systemd SSH_AUTH_SOCK
+          '';
+        };
+        Install.WantedBy = [
+          "default.target"
+          cfg.systemd.socketProviderUnit
+        ];
+      };
     };
 }

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -366,30 +366,33 @@ in
       ++ [ cfg.extraConfig ]
     );
 
-    sshAuthSock.initialization = lib.mkIf cfg.enableSshSupport {
-      bash = ''
-        unset SSH_AGENT_PID
-        if [ "''${gnupg_SSH_AUTH_SOCK_by:-0}" -ne $$ ]; then
-          export SSH_AUTH_SOCK="$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)"
-        fi
-      '';
-      fish = ''
-        set -e SSH_AGENT_PID
+    sshAuthSock = lib.mkIf cfg.enableSshSupport {
+      enable = true;
+      initialization = {
+        bash = ''
+          unset SSH_AGENT_PID
+          if [ "''${gnupg_SSH_AUTH_SOCK_by:-0}" -ne $$ ]; then
+            export SSH_AUTH_SOCK="$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)"
+          fi
+        '';
+        fish = ''
+          set -e SSH_AGENT_PID
 
-        begin
-          set -l gnupg_val 0
-          if set -q gnupg_SSH_AUTH_SOCK_by
-            set gnupg_val $gnupg_SSH_AUTH_SOCK_by
-          end
+          begin
+            set -l gnupg_val 0
+            if set -q gnupg_SSH_AUTH_SOCK_by
+              set gnupg_val $gnupg_SSH_AUTH_SOCK_by
+            end
 
-          if test $gnupg_val -ne %self
-            set -x SSH_AUTH_SOCK (${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)
+            if test $gnupg_val -ne %self
+              set -x SSH_AUTH_SOCK (${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)
+            end
           end
-        end
-      '';
-      nushell = ''
-        $env.SSH_AUTH_SOCK = $"(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)"
-      '';
+        '';
+        nushell = ''
+          $env.SSH_AUTH_SOCK = $"(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)"
+        '';
+      };
     };
 
     programs = {

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -393,6 +393,7 @@ in
           $env.SSH_AUTH_SOCK = $"(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)"
         '';
       };
+      systemd.socketProviderUnit = "gpg-agent-ssh.socket";
     };
 
     programs = {

--- a/modules/services/proton-pass-agent.nix
+++ b/modules/services/proton-pass-agent.nix
@@ -86,6 +86,7 @@ in
               ''$"($env.XDG_RUNTIME_DIR)/${cfg.socket}"''
           }";
         };
+        systemd.socketProviderUnit = "proton-pass-agent.service";
       };
 
       systemd.user.services.proton-pass-agent = {

--- a/modules/services/proton-pass-agent.nix
+++ b/modules/services/proton-pass-agent.nix
@@ -74,15 +74,18 @@ in
     lib.mkIf cfg.enable {
       home.packages = [ cfg.package ];
 
-      sshAuthSock.initialization = {
-        bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
-        fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
-        nushell = "$env.SSH_AUTH_SOCK = ${
-          if pkgs.stdenv.isDarwin then
-            ''$"(${lib.getExe pkgs.getconf} DARWIN_USER_TEMP_DIR)/${cfg.socket}"''
-          else
-            ''$"($env.XDG_RUNTIME_DIR)/${cfg.socket}"''
-        }";
+      sshAuthSock = {
+        enable = true;
+        initialization = {
+          bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
+          fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
+          nushell = "$env.SSH_AUTH_SOCK = ${
+            if pkgs.stdenv.isDarwin then
+              ''$"(${lib.getExe pkgs.getconf} DARWIN_USER_TEMP_DIR)/${cfg.socket}"''
+            else
+              ''$"($env.XDG_RUNTIME_DIR)/${cfg.socket}"''
+          }";
+        };
       };
 
       systemd.user.services.proton-pass-agent = {

--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -60,24 +60,27 @@ in
 
   config = lib.mkIf cfg.enable {
 
-    sshAuthSock.initialization =
-      let
-        socketPath =
-          if pkgs.stdenv.isDarwin then
-            "$(${lib.getExe pkgs.getconf} DARWIN_USER_TEMP_DIR)/${cfg.socket}"
-          else
-            "$XDG_RUNTIME_DIR/${cfg.socket}";
-      in
-      {
-        bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
-        fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
-        nushell = "$env.SSH_AUTH_SOCK = ${
-          if pkgs.stdenv.isDarwin then
-            ''$"(${lib.getExe pkgs.getconf} DARWIN_USER_TEMP_DIR)/${cfg.socket}"''
-          else
-            ''$"($env.XDG_RUNTIME_DIR)/${cfg.socket}"''
-        }";
-      };
+    sshAuthSock = {
+      enable = true;
+      initialization =
+        let
+          socketPath =
+            if pkgs.stdenv.isDarwin then
+              "$(${lib.getExe pkgs.getconf} DARWIN_USER_TEMP_DIR)/${cfg.socket}"
+            else
+              "$XDG_RUNTIME_DIR/${cfg.socket}";
+        in
+        {
+          bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
+          fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
+          nushell = "$env.SSH_AUTH_SOCK = ${
+            if pkgs.stdenv.isDarwin then
+              ''$"(${lib.getExe pkgs.getconf} DARWIN_USER_TEMP_DIR)/${cfg.socket}"''
+            else
+              ''$"($env.XDG_RUNTIME_DIR)/${cfg.socket}"''
+          }";
+        };
+    };
 
     systemd.user.services.ssh-agent = {
       Install.WantedBy = [ "default.target" ];

--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -80,6 +80,7 @@ in
               ''$"($env.XDG_RUNTIME_DIR)/${cfg.socket}"''
           }";
         };
+      systemd.socketProviderUnit = "ssh-agent.service";
     };
 
     systemd.user.services.ssh-agent = {

--- a/modules/services/ssh-tpm-agent.nix
+++ b/modules/services/ssh-tpm-agent.nix
@@ -73,10 +73,13 @@ in
 
     # Override ssh-agent's $SSH_AUTH_SOCK definition since ssh-tpm-agent is a
     # proxy to it.
-    sshAuthSock.initialization = lib.mkOverride 90 {
-      bash = ''export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'';
-      fish = ''set -x SSH_AUTH_SOCK "$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'';
-      nushell = ''$env.SSH_AUTH_SOCK = $"($env.XDG_RUNTIME_DIR)/ssh-tpm-agent.sock"'';
+    sshAuthSock = {
+      enable = true;
+      initialization = lib.mkOverride 90 {
+        bash = ''export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'';
+        fish = ''set -x SSH_AUTH_SOCK "$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'';
+        nushell = ''$env.SSH_AUTH_SOCK = $"($env.XDG_RUNTIME_DIR)/ssh-tpm-agent.sock"'';
+      };
     };
 
     systemd.user = {

--- a/modules/services/ssh-tpm-agent.nix
+++ b/modules/services/ssh-tpm-agent.nix
@@ -80,6 +80,7 @@ in
         fish = ''set -x SSH_AUTH_SOCK "$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'';
         nushell = ''$env.SSH_AUTH_SOCK = $"($env.XDG_RUNTIME_DIR)/ssh-tpm-agent.sock"'';
       };
+      systemd.socketProviderUnit = lib.mkOverride 90 "ssh-tpm-agent.socket";
     };
 
     systemd.user = {

--- a/modules/services/yubikey-agent.nix
+++ b/modules/services/yubikey-agent.nix
@@ -22,24 +22,27 @@ in
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    sshAuthSock.initialization =
-      let
-        socketPath =
-          if pkgs.stdenv.isDarwin then
-            "/tmp/yubikey-agent.sock"
-          else
-            "\${XDG_RUNTIME_DIR:-/run/user/$UID}/yubikey-agent/yubikey-agent.sock";
-      in
-      {
-        bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
-        fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
-        nushell = "$env.SSH_AUTH_SOCK = ${
-          if pkgs.stdenv.isDarwin then
-            "/tmp/yubikey-agent.sock"
-          else
-            ''$"($env.XDG_RUNTIME_DIR | default $"/run/user/(id -u)")/yubikey-agent/yubikey-agent.sock"''
-        }";
-      };
+    sshAuthSock = {
+      enable = true;
+      initialization =
+        let
+          socketPath =
+            if pkgs.stdenv.isDarwin then
+              "/tmp/yubikey-agent.sock"
+            else
+              "\${XDG_RUNTIME_DIR:-/run/user/$UID}/yubikey-agent/yubikey-agent.sock";
+        in
+        {
+          bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
+          fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
+          nushell = "$env.SSH_AUTH_SOCK = ${
+            if pkgs.stdenv.isDarwin then
+              "/tmp/yubikey-agent.sock"
+            else
+              ''$"($env.XDG_RUNTIME_DIR | default $"/run/user/(id -u)")/yubikey-agent/yubikey-agent.sock"''
+          }";
+        };
+    };
 
     systemd.user.services.yubikey-agent = {
       Unit = {

--- a/modules/services/yubikey-agent.nix
+++ b/modules/services/yubikey-agent.nix
@@ -42,6 +42,7 @@ in
               ''$"($env.XDG_RUNTIME_DIR | default $"/run/user/(id -u)")/yubikey-agent/yubikey-agent.sock"''
           }";
         };
+      systemd.socketProviderUnit = "yubikey-agent.socket";
     };
 
     systemd.user.services.yubikey-agent = {

--- a/tests/modules/misc/ssh-auth-sock/default.nix
+++ b/tests/modules/misc/ssh-auth-sock/default.nix
@@ -1,3 +1,4 @@
 {
-  sshAuthSock-initialization = ./initialization.nix;
+  sshAuthSock-disabled = ./disabled.nix;
+  sshAuthSock-enabled = ./enabled.nix;
 }

--- a/tests/modules/misc/ssh-auth-sock/disabled.nix
+++ b/tests/modules/misc/ssh-auth-sock/disabled.nix
@@ -1,0 +1,23 @@
+{
+  programs.bash.enable = true;
+  programs.fish.enable = true;
+  programs.nushell.enable = true;
+  programs.zsh.enable = true;
+
+  sshAuthSock.enable = false;
+
+  nmt.script = ''
+    assertFileNotRegex \
+      home-files/.profile \
+      'SSH_AUTH_SOCK'
+    assertFileNotRegex \
+      home-files/.config/fish/config.fish \
+      'SSH_AUTH_SOCK'
+    assertFileNotRegex \
+      home-files/.config/nushell/config.nu \
+      'SSH_AUTH_SOCK'
+    assertFileNotRegex \
+      home-files/.zshenv \
+      'SSH_AUTH_SOCK'
+  '';
+}

--- a/tests/modules/misc/ssh-auth-sock/disabled.nix
+++ b/tests/modules/misc/ssh-auth-sock/disabled.nix
@@ -19,5 +19,7 @@
     assertFileNotRegex \
       home-files/.zshenv \
       'SSH_AUTH_SOCK'
+
+    assertPathNotExists home-files/.config/systemd/user/set-SSH_AUTH_SOCK.service
   '';
 }

--- a/tests/modules/misc/ssh-auth-sock/enabled.nix
+++ b/tests/modules/misc/ssh-auth-sock/enabled.nix
@@ -1,3 +1,5 @@
+{ config, lib, ... }:
+
 {
   programs.bash.enable = true;
   programs.fish.enable = true;
@@ -11,6 +13,7 @@
       fish = "echo fish";
       nushell = "echo nushell";
     };
+    systemd.socketProviderUnit = "foo.socket";
   };
 
   nmt.script = ''
@@ -26,5 +29,10 @@
     assertFileContains \
       home-files/.zshenv \
       'if [ -z "$SSH_AUTH_SOCK" -o -z "$SSH_CONNECTION" ]; then'
+  ''
+  + lib.optionalString config.systemd.user.enable ''
+    assertFileExists home-files/.config/systemd/user/set-SSH_AUTH_SOCK.service
+    assertFileContains home-files/.config/systemd/user/set-SSH_AUTH_SOCK.service 'Before=foo.socket'
+    assertFileContains home-files/.config/systemd/user/set-SSH_AUTH_SOCK.service 'WantedBy=foo.socket'
   '';
 }

--- a/tests/modules/misc/ssh-auth-sock/enabled.nix
+++ b/tests/modules/misc/ssh-auth-sock/enabled.nix
@@ -4,10 +4,13 @@
   programs.nushell.enable = true;
   programs.zsh.enable = true;
 
-  sshAuthSock.initialization = {
-    bash = "echo bash/zsh";
-    fish = "echo fish";
-    nushell = "echo nushell";
+  sshAuthSock = {
+    enable = true;
+    initialization = {
+      bash = "echo bash/zsh";
+      fish = "echo fish";
+      nushell = "echo nushell";
+    };
   };
 
   nmt.script = ''


### PR DESCRIPTION
### Description

`SSH_AUTH_SOCK` is exported in shells only, which systemd does not inherit from. With this commit, it is also set in systemd such that systemd-managed applications can access the SSH agent by declaring dependencies onto `sshAuthSock.systemd.socketProviderUnit`.

Since the `sshAuthSock.systemd.socketProviderUnit` option is meant to be consumed by users, the `sshAuthSock` module is hereby no longer internal.

Furthermore, the `sshAuthSock.initialization` option is not nullable any more but guarded by a `sshAuthSock.enable` toggle like in other modules. This type change is backwards-compatible since the module has previously been internal.

To round the publication of the module up, there is a new `sshAuthSock.initialization.zsh` option to make transparent that the Zsh initialization code defaults to the Bash initialization code while also enabling overrides.

Closes #7971.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
