### PR TITLE
alacritty: fix toml escape generation

### DIFF
--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -100,8 +100,20 @@ in
         _finalAttrs: prevAttrs: {
           buildCommand = lib.concatStringsSep "\n" [
             prevAttrs.buildCommand
-            # TODO: why is this needed? Is there a better way to retain escape sequences?
-            "substituteInPlace $out --replace-quiet '\\\\' '\\'"
+            # Nix cannot spell TOML escape sequences like "\u001d" directly:
+            # "\\u001d" is a literal backslash-u string, while fromJSON creates
+            # a control character and fails for "\u0000". Normalize both TOML
+            # generator outputs to the Alacritty escape form:
+            #   chars = "\\u001d" -> chars = "\u001d"
+            #   chars = '\u001d'  -> chars = "\u001d"
+            ''
+              sed \
+                -E \
+                -e "s/= \"\\\\\\\\u([0-9a-fA-F]{4})\"\$/= \"\\\\u\1\"/" \
+                -e "s/= '\\\\u([0-9a-fA-F]{4})'\$/= \"\\\\u\1\"/" \
+                "$out" > "$TMPDIR/alacritty.toml"
+              cp "$TMPDIR/alacritty.toml" "$out"
+            ''
           ];
         }
       );

--- a/tests/modules/programs/alacritty/settings-merging.nix
+++ b/tests/modules/programs/alacritty/settings-merging.nix
@@ -15,6 +15,11 @@
           mods = "Control";
           chars = "\\u000c";
         }
+        {
+          key = "RBracket";
+          mods = "Alt";
+          chars = "\\u001d";
+        }
       ];
 
       font =

--- a/tests/modules/programs/alacritty/settings-toml-expected.toml
+++ b/tests/modules/programs/alacritty/settings-toml-expected.toml
@@ -9,6 +9,11 @@ chars = "\u000c"
 key = "K"
 mods = "Control"
 
+[[keyboard.bindings]]
+chars = "\u001d"
+key = "RBracket"
+mods = "Alt"
+
 [window.dimensions]
 columns = 200
 lines = 3

--- a/tests/modules/programs/alacritty/toml-config.nix
+++ b/tests/modules/programs/alacritty/toml-config.nix
@@ -13,6 +13,11 @@
           mods = "Control";
           chars = "\\u000c";
         }
+        {
+          key = "RBracket";
+          mods = "Alt";
+          chars = "\\u001d";
+        }
       ];
 
       font = {


### PR DESCRIPTION
### Description
Related https://github.com/NixOS/nixpkgs/pull/513796#issuecomment-4607461838

cc @PedroHLC 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
