### PR TITLE
zellij: add support for plugins

### DIFF
--- a/modules/misc/news/2026/06/2026-06-04_19-10-21.nix
+++ b/modules/misc/news/2026/06/2026-06-04_19-10-21.nix
@@ -1,0 +1,8 @@
+{ config, ... }:
+{
+  time = "2026-06-04T17:10:21+00:00";
+  condition = config.programs.zellij.enable;
+  message = ''
+    Added support for Zellij plugins using `programs.zellij.plugins`.
+  '';
+}

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -31,6 +31,15 @@ in
 
     package = lib.mkPackageOption pkgs "zellij" { };
 
+    finalPackage = mkOption {
+      type = types.package;
+      visible = false;
+      readOnly = true;
+      description = ''
+        The zellij package with all plugin dependencies.
+      '';
+    };
+
     layouts = lib.mkOption {
       type = types.attrsOf (
         types.oneOf [
@@ -137,6 +146,15 @@ in
         See <https://zellij.dev/documentation> for the full
         list of options.
       '';
+    };
+
+    plugins = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      example = lib.literalExpression ''
+        with pkgs.zellijPlugins; [ jbz vim-plugins-navigator zjstatus ]
+      '';
+      description = "List of Zellij plugins";
     };
 
     settings = lib.mkOption {
@@ -263,9 +281,23 @@ in
       shellIntegrationEnabled = (
         cfg.enableBashIntegration || cfg.enableZshIntegration || cfg.enableFishIntegration
       );
+      pluginsWithNames = lib.map (plugin: {
+        inherit plugin;
+        name = lib.removePrefix "zellij-" plugin.pname;
+      }) cfg.plugins;
+      pluginRuntimeDeps = lib.concatLists (
+        lib.map ({ plugin, ... }: plugin.runtimeDeps or [ ]) pluginsWithNames
+      );
     in
     mkIf cfg.enable {
-      home.packages = [ cfg.package ];
+      home.packages = [ cfg.finalPackage ];
+      programs.zellij.finalPackage =
+        if pluginRuntimeDeps != [ ] then
+          cfg.package.override {
+            extraPackages = pluginRuntimeDeps;
+          }
+        else
+          cfg.package;
 
       # Zellij switched from yaml to KDL in version 0.32.0:
       # https://github.com/zellij-org/zellij/releases/tag/v0.32.0
@@ -273,14 +305,15 @@ in
         {
 
           "zellij/config.yaml" =
-            mkIf ((lib.versionOlder cfg.package.version "0.32.0") && cfg.settings != { })
+            mkIf ((lib.versionOlder cfg.finalPackage.version "0.32.0") && cfg.settings != { })
               {
                 source = yamlFormat.generate "zellij.yaml" cfg.settings;
               };
           "zellij/config.kdl" =
             mkIf
               (
-                (lib.versionAtLeast cfg.package.version "0.32.0") && (cfg.settings != { } || cfg.extraConfig != "")
+                (lib.versionAtLeast cfg.finalPackage.version "0.32.0")
+                && (cfg.settings != { } || cfg.extraConfig != "")
               )
               {
                 text =
@@ -321,20 +354,57 @@ in
                 );
           }
         ) cfg.themes)
+
+        # on every plugin update, zellij asks for permissions again, because
+        # the plugin path has changed (=/nix/store path has changed)
+        # to avoid that, we symlink all plugins to `.config/zellij/plugins` and
+        # use those paths
+        (lib.listToAttrs (
+          lib.map (
+            { plugin, name }:
+            {
+              name = "zellij/plugins/${name}.wasm";
+              value.source = plugin;
+            }
+          ) pluginsWithNames
+        ))
       ];
+      programs.zellij.settings = {
+        # define plugin aliases
+        plugins = mkIf (pluginsWithNames != [ ]) (
+          lib.listToAttrs (
+            lib.map (
+              { name, ... }:
+              {
+                inherit name;
+                value._props.location = "file:${config.xdg.configHome}/zellij/plugins/${name}.wasm";
+              }
+            ) pluginsWithNames
+          )
+        );
+        # auto-load plugins on start
+        load_plugins = mkIf (pluginsWithNames != [ ]) {
+          _children = lib.map (
+            { name, ... }:
+            {
+              ${name} = [ ];
+            }
+          ) pluginsWithNames;
+        };
+      };
 
       programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-        eval "$(${lib.getExe cfg.package} setup --generate-auto-start bash)"
+        eval "$(${lib.getExe cfg.finalPackage} setup --generate-auto-start bash)"
       '';
 
       programs.zsh.initContent = mkIf cfg.enableZshIntegration (
         lib.mkOrder 200 ''
-          eval "$(${lib.getExe cfg.package} setup --generate-auto-start zsh)"
+          eval "$(${lib.getExe cfg.finalPackage} setup --generate-auto-start zsh)"
         ''
       );
 
       programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-        eval (${lib.getExe cfg.package} setup --generate-auto-start fish | string collect)
+        eval (${lib.getExe cfg.finalPackage} setup --generate-auto-start fish | string collect)
       '';
 
       home.sessionVariables = mkIf shellIntegrationEnabled {

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -22,6 +22,7 @@ in
 {
   meta.maintainers = [
     lib.maintainers.khaneliman
+    lib.maintainers.PerchunPak
     lib.hm.maintainers.mainrs
   ];
 

--- a/tests/modules/programs/zellij/default.nix
+++ b/tests/modules/programs/zellij/default.nix
@@ -4,5 +4,6 @@
   zellij-config-extra_config = ./config-extra_config.nix;
   zellij-enable-shells = ./enable-shells.nix;
   zellij-layout = ./layout.nix;
+  zellij-plugins = ./plugins.nix;
   zellij-theme = ./theme.nix;
 }

--- a/tests/modules/programs/zellij/plugins-config.kdl
+++ b/tests/modules/programs/zellij/plugins-config.kdl
@@ -1,0 +1,12 @@
+load_plugins {
+	foo 
+	bar 
+	baz 
+}
+plugins {
+	bar location="file:/home/hm-user/.config/zellij/plugins/bar.wasm" {
+		foo 123
+	}
+	baz location="file:/home/hm-user/.config/zellij/plugins/baz.wasm"
+	foo location="file:/home/hm-user/.config/zellij/plugins/foo.wasm"
+}

--- a/tests/modules/programs/zellij/plugins.nix
+++ b/tests/modules/programs/zellij/plugins.nix
@@ -1,0 +1,59 @@
+{ config, ... }:
+let
+  zellijPackage = config.lib.test.mkStubPackage {
+    name = "zellij";
+    version = "0.44.3";
+    extraAttrs.override =
+      args:
+      zellijPackage
+      // {
+        extraPackages = args.extraPackages or [ ];
+      };
+  };
+
+  runtimeDep = config.lib.test.mkStubPackage {
+    name = "just";
+  };
+
+  mkPlugin =
+    name: deps:
+    config.lib.test.mkStubPackage {
+      name = "zellij-${name}";
+      outPath = null;
+      buildScript = ''
+        echo wasm > "$out"
+      '';
+      extraAttrs = {
+        pname = "zellij-${name}";
+        runtimeDeps = deps;
+      };
+    };
+in
+{
+  programs.zellij = {
+    enable = true;
+    package = zellijPackage;
+    plugins = [
+      (mkPlugin "foo" [ ])
+      (mkPlugin "bar" [ ])
+      (mkPlugin "baz" [ runtimeDep ])
+    ];
+
+    settings = {
+      plugins.bar.foo = 123;
+    };
+  };
+
+  nmt.script =
+    assert builtins.elem runtimeDep config.programs.zellij.finalPackage.extraPackages;
+    # sh
+    ''
+      assertFileExists home-files/.config/zellij/plugins/foo.wasm
+      assertFileExists home-files/.config/zellij/plugins/bar.wasm
+      assertFileExists home-files/.config/zellij/plugins/baz.wasm
+
+      assertFileContent \
+        home-files/.config/zellij/config.kdl \
+        ${./plugins-config.kdl}
+    '';
+}


### PR DESCRIPTION
### Description

Nixpkgs PR: https://github.com/NixOS/nixpkgs/pull/511825

I couldn't include tests because home-manager replaces plugins with stubs, and this module needs to symlink plugin derivations.

<details>
<summary>Tests patch</summary>

```diff
diff --git a/tests/modules/programs/zellij/default.nix b/tests/modules/programs/zellij/default.nix
index 90b939ce8..b36eabd8c 100644
--- a/tests/modules/programs/zellij/default.nix
+++ b/tests/modules/programs/zellij/default.nix
@@ -4,5 +4,6 @@
   zellij-config-extra_config = ./config-extra_config.nix;
   zellij-enable-shells = ./enable-shells.nix;
   zellij-layout = ./layout.nix;
+  zellij-plugins = ./plugins.nix;
   zellij-theme = ./theme.nix;
 }
diff --git a/tests/modules/programs/zellij/plugins-config.kdl b/tests/modules/programs/zellij/plugins-config.kdl
new file mode 100644
index 000000000..9683d778a
--- /dev/null
+++ b/tests/modules/programs/zellij/plugins-config.kdl
@@ -0,0 +1,12 @@
+load_plugins {
+  jbz 
+  vim-zellij-navigator 
+  zjstatus 
+}
+plugins {
+	jbz location="file:@jbz@" {
+		foo 123
+	}
+	vim-zellij-navigator location="file:@vim-zellij-navigator@"
+	zjstatus location="file:@zjstatus@"
+}
diff --git a/tests/modules/programs/zellij/plugins.nix b/tests/modules/programs/zellij/plugins.nix
new file mode 100644
index 000000000..296941d26
--- /dev/null
+++ b/tests/modules/programs/zellij/plugins.nix
@@ -0,0 +1,21 @@
+{ pkgs, ... }:
+{
+  programs.zellij = {
+    enable = true;
+    plugins = with pkgs.zellijPlugins; [
+      jbz
+      vim-zellij-navigator
+      zjstatus
+    ];
+
+    settings = {
+      plugins.jbz.foo = 123;
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/zellij/config.kdl \
+      ${./plugins-config.kdl}
+  '';
+}
```
</details>

<details>
<summary>Tests log</summary>

```
~/dev/home-manager zellij-plugins *1 +3 ❯ nix run .#tests -- zellij-plugins
warning: Git tree '/home/perchun/dev/home-manager' is dirty
ℹ️ Discovering tests...
ℹ️ Running 1 test(s)...

--- Running test 1/1: test-zellij-plugins ---
❌ Test failed: test-zellij-plugins
path "/home/perchun/dev/home-manager/tests" does not contain a 'flake.nix', searching up
warning: Git tree '/home/perchun/dev/home-manager' is dirty
warning: not writing modified lock file of flake 'git+file:///home/perchun/dev/home-manager':
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/4100e830e085863741bc69b156ec4ccd53ab5be0?narHash=sha256-NOF9NAREhxr50bbBfVcVOq%2BArCMSoe8dP79Pk2uyARk%3D' (2026-05-27)
  → 'path:/nix/store/1jcvn8vajx22lvl0cv6biw10q2cl0pgn-source?lastModified=0&narHash=sha256-NOF9NAREhxr50bbBfVcVOq%2BArCMSoe8dP79Pk2uyARk%3D' (1970-01-01)
error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nmt-test-zellij-plugins'
         whose name attribute is located at /nix/store/1jcvn8vajx22lvl0cv6biw10q2cl0pgn-source/pkgs/stdenv/generic/make-derivation.nix:647:11

       … while evaluating attribute 'buildCommand' of derivation 'nmt-test-zellij-plugins'
         at /nix/store/1jcvn8vajx22lvl0cv6biw10q2cl0pgn-source/pkgs/build-support/trivial-builders/default.nix:81:17:
           80|         enableParallelBuilding = true;
           81|         inherit buildCommand name;
             |                 ^
           82|         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);

       … while evaluating the option `home.file."/home/hm-user/.config/zellij/plugins/jbz.wasm".source':

       … while evaluating definitions from `/nix/store/mwvdz6hq0n11r04by8lw6fj4syqamlsw-source/modules/misc/xdg.nix':

       … while evaluating the option `xdg.configFile."zellij/plugins/jbz.wasm".source':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: A definition for option `xdg.configFile."zellij/plugins/jbz.wasm".source' is not of type `absolute path'. Definition values:
       - In `/nix/store/mwvdz6hq0n11r04by8lw6fj4syqamlsw-source/modules/programs/zellij.nix': <derivation zellij-plugin-jbz-0.39.0.wasm>


--- Summary ---
❌ 1 of 1 test(s) failed:
  - test-zellij-plugins
``` 
</details>

### Check

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
