### PR TITLE
flake: gate development outputs to supported systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,9 +45,19 @@
     }
     // (
       let
-        forAllPkgs =
-          f:
-          nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (system: f nixpkgs.legacyPackages.${system});
+        supportedSystems = [
+          "aarch64-darwin"
+          "aarch64-linux"
+          "i686-linux"
+          "x86_64-darwin"
+          "x86_64-linux"
+        ];
+
+        forSystems = systems: f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+
+        forAllPkgs = forSystems nixpkgs.lib.systems.flakeExposed;
+
+        forSupportedPkgs = forSystems supportedSystems;
 
         forCI = nixpkgs.lib.genAttrs [
           "aarch64-darwin"
@@ -156,7 +166,7 @@
           lib.mapAttrs' renameTestPkg tests;
       in
       {
-        formatter = forAllPkgs (pkgs: pkgs.callPackage ./home-manager/formatter.nix { });
+        formatter = forSupportedPkgs (pkgs: pkgs.callPackage ./home-manager/formatter.nix { });
 
         # TODO: increase buildbot testing scope
         buildbot = forCI (
@@ -187,6 +197,8 @@
           {
             default = hmPkg;
             home-manager = hmPkg;
+          }
+          // nixpkgs.lib.optionalAttrs (nixpkgs.lib.elem pkgs.stdenv.hostPlatform.system supportedSystems) {
 
             ci-parse = pkgs.callPackage ./ci/parse.nix { nix = pkgs.nixVersions.latest; };
             ci-parse-lix = pkgs.callPackage ./ci/parse.nix {
@@ -212,11 +224,11 @@
           }
         );
 
-        devShells = forAllPkgs (pkgs: {
+        devShells = forSupportedPkgs (pkgs: {
           default = pkgs.callPackage ./home-manager/devShell.nix { };
         });
 
-        legacyPackages = forAllPkgs (
+        legacyPackages = forSupportedPkgs (
           pkgs:
           let
             inherit (pkgs.stdenv.hostPlatform) system;


### PR DESCRIPTION
Keep the home-manager package exposed for all nixpkgs flakeExposed systems, but only expose formatter, devShell, docs, tests, CI helpers, and legacy test packages on supported Home Manager systems.

This prevents nix flake check --all-systems from forcing unavailable formatter toolchains such as GHC on riscv64-linux and x86_64-freebsd.

Fixes #9389.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
