### PR TITLE
antigravity-cli: robust rename support

### DIFF
--- a/modules/programs/antigravity-cli.nix
+++ b/modules/programs/antigravity-cli.nix
@@ -1,11 +1,31 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
 let
   cfg = config.programs.antigravity-cli;
+
+  renamedGeminiOptions = [
+    "commands"
+    "context"
+    "defaultModel"
+    "enable"
+    "enableMcpIntegration"
+    "mcpServers"
+    "package"
+    "permissions"
+    "policies"
+    "settings"
+    "skills"
+    "useLegacyGeminiConfig"
+  ];
+
+  oldGeminiCliDefined = lib.any (
+    name: (lib.getAttrFromPath [ "programs" "gemini-cli" name ] options).isDefined
+  ) renamedGeminiOptions;
 
   jsonFormat = pkgs.formats.json { };
   tomlFormat = pkgs.formats.toml { };
@@ -31,9 +51,23 @@ in
 {
   meta.maintainers = [ lib.maintainers.rrvsh ];
 
-  imports = [
-    (lib.mkRenamedOptionModule [ "programs" "gemini-cli" ] [ "programs" "antigravity-cli" ])
-  ];
+  imports =
+    let
+      renamedGeminiOption =
+        name:
+        lib.mkRenamedOptionModule
+          [
+            "programs"
+            "gemini-cli"
+            name
+          ]
+          [
+            "programs"
+            "antigravity-cli"
+            name
+          ];
+    in
+    map renamedGeminiOption renamedGeminiOptions;
 
   options.programs.antigravity-cli = {
     enable = lib.mkEnableOption "Antigravity CLI";
@@ -353,6 +387,12 @@ in
     in
     lib.mkIf cfg.enable (
       lib.mkMerge [
+        (lib.mkIf oldGeminiCliDefined {
+          programs.antigravity-cli = {
+            package = lib.mkDefault pkgs.gemini-cli;
+            useLegacyGeminiConfig = lib.mkDefault true;
+          };
+        })
         {
           home = {
             packages = lib.mkIf (cfg.package != null) [ cfg.package ];

--- a/tests/modules/programs/antigravity-cli-legacy/context.nix
+++ b/tests/modules/programs/antigravity-cli-legacy/context.nix
@@ -5,6 +5,20 @@
   ...
 }:
 
+let
+  renamedWarning =
+    name:
+    "The option `programs.gemini-cli.${name}' defined in ${
+      lib.showFiles (
+        lib.getAttrFromPath [
+          "programs"
+          "gemini-cli"
+          name
+          "files"
+        ] options
+      )
+    } has been renamed to `programs.antigravity-cli.${name}'.";
+in
 {
   programs.gemini-cli = {
     enable = true;
@@ -37,8 +51,11 @@
       ];
     };
   };
-  test.asserts.warnings.expected = [
-    "The option `programs.gemini-cli' defined in ${lib.showFiles options.programs.gemini-cli.files} has been renamed to `programs.antigravity-cli'."
+  test.asserts.warnings.expected = map renamedWarning [
+    "settings"
+    "package"
+    "enable"
+    "context"
   ];
 
   nmt.script = ''

--- a/tests/modules/programs/antigravity-cli-legacy/mcp.nix
+++ b/tests/modules/programs/antigravity-cli-legacy/mcp.nix
@@ -5,12 +5,26 @@
   ...
 }:
 
+let
+  renamedWarning =
+    name:
+    "The option `programs.gemini-cli.${name}' defined in ${
+      lib.showFiles (
+        lib.getAttrFromPath [
+          "programs"
+          "gemini-cli"
+          name
+          "files"
+        ] options
+      )
+    } has been renamed to `programs.antigravity-cli.${name}'.";
+in
 {
   programs = {
     gemini-cli = {
       enable = true;
       package = pkgs.writeShellScriptBin "gemini-cli" "";
-      enableMcpIntegration = true;
+      enableMcpIntegration = lib.mkIf true true;
       settings = {
         theme = "Default";
         vimMode = true;
@@ -58,8 +72,11 @@
       };
     };
   };
-  test.asserts.warnings.expected = [
-    "The option `programs.gemini-cli' defined in ${lib.showFiles options.programs.gemini-cli.files} has been renamed to `programs.antigravity-cli'."
+  test.asserts.warnings.expected = map renamedWarning [
+    "settings"
+    "package"
+    "enableMcpIntegration"
+    "enable"
   ];
 
   nmt.script = ''

--- a/tests/modules/programs/antigravity-cli-legacy/policies.nix
+++ b/tests/modules/programs/antigravity-cli-legacy/policies.nix
@@ -1,14 +1,35 @@
 {
-  pkgs,
   lib,
   options,
   ...
 }:
 
+let
+  renamedWarning =
+    name:
+    "The option `programs.gemini-cli.${name}' defined in ${
+      lib.showFiles (
+        lib.getAttrFromPath [
+          "programs"
+          "gemini-cli"
+          name
+          "files"
+        ] options
+      )
+    } has been renamed to `programs.antigravity-cli.${name}'.";
+in
 {
+  test.stubs.gemini-cli = {
+    name = "gemini-cli";
+    outPath = null;
+    buildScript = ''
+      mkdir -p $out/bin
+      touch $out/bin/gemini
+    '';
+  };
+
   programs.gemini-cli = {
     enable = true;
-    package = pkgs.writeShellScriptBin "gemini-cli" "";
     policies = {
       "my-rules" = {
         rule = [
@@ -24,11 +45,14 @@
     };
   };
 
-  test.asserts.warnings.expected = [
-    "The option `programs.gemini-cli' defined in ${lib.showFiles options.programs.gemini-cli.files} has been renamed to `programs.antigravity-cli'."
+  test.asserts.warnings.expected = map renamedWarning [
+    "policies"
+    "enable"
   ];
 
   nmt.script = ''
+    assertFileExists home-path/bin/gemini
+
     assertFileExists home-files/.gemini/policies/my-rules.toml
     assertFileRegex home-files/.gemini/policies/my-rules.toml \
       'toolName = "run_shell_command"'

--- a/tests/modules/programs/antigravity-cli-legacy/settings.nix
+++ b/tests/modules/programs/antigravity-cli-legacy/settings.nix
@@ -5,6 +5,20 @@
   ...
 }:
 
+let
+  renamedWarning =
+    name:
+    "The option `programs.gemini-cli.${name}' defined in ${
+      lib.showFiles (
+        lib.getAttrFromPath [
+          "programs"
+          "gemini-cli"
+          name
+          "files"
+        ] options
+      )
+    } has been renamed to `programs.antigravity-cli.${name}'.";
+in
 {
   programs.gemini-cli = {
     enable = true;
@@ -34,8 +48,13 @@
       ask = [ "command(*)" ];
     };
   };
-  test.asserts.warnings.expected = [
-    "The option `programs.gemini-cli' defined in ${lib.showFiles options.programs.gemini-cli.files} has been renamed to `programs.antigravity-cli'."
+  test.asserts.warnings.expected = map renamedWarning [
+    "settings"
+    "permissions"
+    "package"
+    "enable"
+    "defaultModel"
+    "commands"
   ];
 
   nmt.script = ''

--- a/tests/modules/programs/antigravity-cli-legacy/skills-dir.nix
+++ b/tests/modules/programs/antigravity-cli-legacy/skills-dir.nix
@@ -5,6 +5,20 @@
   ...
 }:
 
+let
+  renamedWarning =
+    name:
+    "The option `programs.gemini-cli.${name}' defined in ${
+      lib.showFiles (
+        lib.getAttrFromPath [
+          "programs"
+          "gemini-cli"
+          name
+          "files"
+        ] options
+      )
+    } has been renamed to `programs.antigravity-cli.${name}'.";
+in
 {
   programs.gemini-cli = {
     enable = true;
@@ -12,8 +26,10 @@
     skills = ./skills;
   };
 
-  test.asserts.warnings.expected = [
-    "The option `programs.gemini-cli' defined in ${lib.showFiles options.programs.gemini-cli.files} has been renamed to `programs.antigravity-cli'."
+  test.asserts.warnings.expected = map renamedWarning [
+    "skills"
+    "package"
+    "enable"
   ];
 
   nmt.script = ''

--- a/tests/modules/programs/antigravity-cli-legacy/skills-path-not-directory.nix
+++ b/tests/modules/programs/antigravity-cli-legacy/skills-path-not-directory.nix
@@ -5,6 +5,20 @@
   ...
 }:
 
+let
+  renamedWarning =
+    name:
+    "The option `programs.gemini-cli.${name}' defined in ${
+      lib.showFiles (
+        lib.getAttrFromPath [
+          "programs"
+          "gemini-cli"
+          name
+          "files"
+        ] options
+      )
+    } has been renamed to `programs.antigravity-cli.${name}'.";
+in
 {
   programs.gemini-cli = {
     enable = true;
@@ -12,8 +26,10 @@
     skills = ./skills/xlsx/SKILL.md;
   };
 
-  test.asserts.warnings.expected = [
-    "The option `programs.gemini-cli' defined in ${lib.showFiles options.programs.gemini-cli.files} has been renamed to `programs.antigravity-cli'."
+  test.asserts.warnings.expected = map renamedWarning [
+    "skills"
+    "package"
+    "enable"
   ];
 
   test.asserts.assertions.expected = [

--- a/tests/modules/programs/antigravity-cli-legacy/skills-store-path-dir.nix
+++ b/tests/modules/programs/antigravity-cli-legacy/skills-store-path-dir.nix
@@ -6,6 +6,18 @@
 }:
 
 let
+  renamedWarning =
+    name:
+    "The option `programs.gemini-cli.${name}' defined in ${
+      lib.showFiles (
+        lib.getAttrFromPath [
+          "programs"
+          "gemini-cli"
+          name
+          "files"
+        ] options
+      )
+    } has been renamed to `programs.antigravity-cli.${name}'.";
   src = pkgs.writeTextDir "skills/external-skill/SKILL.md" ''
     # External Skill
   '';
@@ -17,8 +29,10 @@ in
     skills = "${src}/skills";
   };
 
-  test.asserts.warnings.expected = [
-    "The option `programs.gemini-cli' defined in ${lib.showFiles options.programs.gemini-cli.files} has been renamed to `programs.antigravity-cli'."
+  test.asserts.warnings.expected = map renamedWarning [
+    "skills"
+    "package"
+    "enable"
   ];
 
   nmt.script = ''

--- a/tests/modules/programs/antigravity-cli-legacy/skills.nix
+++ b/tests/modules/programs/antigravity-cli-legacy/skills.nix
@@ -5,6 +5,20 @@
   ...
 }:
 
+let
+  renamedWarning =
+    name:
+    "The option `programs.gemini-cli.${name}' defined in ${
+      lib.showFiles (
+        lib.getAttrFromPath [
+          "programs"
+          "gemini-cli"
+          name
+          "files"
+        ] options
+      )
+    } has been renamed to `programs.antigravity-cli.${name}'.";
+in
 {
   programs.gemini-cli = {
     enable = true;
@@ -33,8 +47,10 @@
       '';
     };
   };
-  test.asserts.warnings.expected = [
-    "The option `programs.gemini-cli' defined in ${lib.showFiles options.programs.gemini-cli.files} has been renamed to `programs.antigravity-cli'."
+  test.asserts.warnings.expected = map renamedWarning [
+    "skills"
+    "package"
+    "enable"
   ];
 
   nmt.script = ''


### PR DESCRIPTION
Handle module system merge priority resolution issues with suboptions.

Fixes eval / assertion issues with users of old gemini module. 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
