### PR TITLE
lib: separate eval config file

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -2,38 +2,5 @@
 {
   inherit ((import ../modules/lib/stdlib-extended.nix lib)) hm;
 
-  homeManagerConfiguration =
-    {
-      check ? true,
-      extraSpecialArgs ? { },
-      lib ? pkgs.lib,
-      modules ? [ ],
-      pkgs,
-      minimal ? false,
-    }:
-    import ../modules {
-      inherit
-        check
-        extraSpecialArgs
-        lib
-        pkgs
-        minimal
-        ;
-      configuration = {
-        imports = modules ++ [
-          {
-            programs.home-manager.path = builtins.path {
-              path = ../.;
-              name = "source";
-            };
-          }
-        ];
-
-        nixpkgs = {
-          config = lib.mkDefault pkgs.config;
-
-          inherit (pkgs) overlays;
-        };
-      };
-    };
+  homeManagerConfiguration = import ./eval-config.nix;
 }

--- a/lib/eval-config.nix
+++ b/lib/eval-config.nix
@@ -1,0 +1,33 @@
+{
+  check ? true,
+  extraSpecialArgs ? { },
+  lib ? pkgs.lib,
+  modules ? [ ],
+  pkgs,
+  minimal ? false,
+}:
+import ../modules {
+  inherit
+    check
+    extraSpecialArgs
+    lib
+    pkgs
+    minimal
+    ;
+  configuration = {
+    imports = modules ++ [
+      {
+        programs.home-manager.path = builtins.path {
+          path = ../.;
+          name = "source";
+        };
+      }
+    ];
+
+    nixpkgs = {
+      config = lib.mkDefault pkgs.config;
+
+      inherit (pkgs) overlays;
+    };
+  };
+}


### PR DESCRIPTION
### Description

Move the `homeManagerConfiguration` function into its own file to allow importing without passing an unused `lib` argument. This aligns with how the `nixosSystem` function is defined in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/nixos/lib/eval-config.nix)

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
