### PR TITLE
nushell: add abbreviations option

### DIFF
--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -191,6 +191,21 @@ in
       '';
     };
 
+    abbreviations = lib.mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        ll = "ls -l";
+        gs = "git status";
+      };
+      description = ''
+        An attribute set that maps each abbreviation (the top level attribute
+        names in this option) to its expansion. Unlike aliases, abbreviations
+        are expanded inline in the line editor when a space or enter is pressed,
+        so the expanded command is what ends up in the command history.
+      '';
+    };
+
     environmentVariables = lib.mkOption {
       type = types.attrsOf lib.hm.types.nushellValue;
       default = { };
@@ -232,11 +247,16 @@ in
             || cfg.extraConfig != ""
             || aliasesStr != ""
             || cfg.settings != { }
+            || cfg.abbreviations != { }
             || cfg.environmentVariables != { };
 
           aliasesStr = lib.concatLines (
             lib.mapAttrsToList (k: v: "alias ${toNushell { } k} = ${v}") cfg.shellAliases
           );
+
+          abbreviationsStr =
+            lib.optionalString (cfg.abbreviations != { })
+              "$env.config.abbreviations = ${toNushell { } cfg.abbreviations}";
         in
         lib.mkIf writeConfig {
           "${cfg.configDir}/config.nu".text = lib.mkMerge [
@@ -275,6 +295,7 @@ in
             (lib.mkIf (cfg.configFile != null) cfg.configFile.text)
             cfg.extraConfig
             aliasesStr
+            abbreviationsStr
           ];
         }
       )

--- a/tests/modules/programs/nushell/config-expected.nu
+++ b/tests/modules/programs/nushell/config-expected.nu
@@ -29,3 +29,8 @@ let config = {
 alias "ll" = ls -a
 alias "multi word alias" = cd -
 alias "z" = __zoxide_z
+
+$env.config.abbreviations = {
+    "gs": "git status"
+    "ll": "ls -l"
+}

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -38,6 +38,11 @@
       "z" = "__zoxide_z";
     };
 
+    abbreviations = {
+      "gs" = "git status";
+      "ll" = "ls -l";
+    };
+
     settings = {
       show_banner = false;
       display_errors.exit_code = false;


### PR DESCRIPTION
## Description

Adds `programs.nushell.abbreviations`, mirroring the existing `shellAliases` option, to declaratively configure [fish-style abbreviations](https://github.com/nushell/nushell/pull/18197) (available in nushell 0.113.0+).

Abbreviations differ from aliases: they are expanded inline in the line editor when a space or `enter` is pressed, so the *expanded* command is what gets recorded in history. This parallels `programs.fish.shellAbbrs`, which already exists in home-manager.

```nix
programs.nushell.abbreviations = {
  ll = "ls -l";
  gs = "git status";
};
```

becomes, in `config.nu`:

```nushell
$env.config.abbreviations = {
    "gs": "git status"
    "ll": "ls -l"
}
```

## Checklist

- [x] Tested (extended `tests/modules/programs/nushell` — `nix-build tests -A build.nushell-example-settings` passes).
- [x] Formatted with `nixfmt`.
- [x] Commit follows `nushell: ...` convention.