### PR TITLE
xdg-portal: remove broken NIX_XDG_DESKTOP_PORTAL_DIR

### DIFF
--- a/modules/misc/xdg-portal.nix
+++ b/modules/misc/xdg-portal.nix
@@ -50,11 +50,6 @@ in
       description = ''
         List of additional portals that should be added to the environment.
 
-        The directory where the portal definitions have been merged together
-        (likely `~/.nix-profile/share/xdg-desktop-portal/portals`) will get
-        passed to `xdg-desktop-portal.service` via the
-        `NIX_XDG_DESKTOP_PORTAL_DIR` environment variable.
-
         Portals allow interaction with system, like choosing files or taking
         screenshots. At minimum, a desktop portal implementation should be
         listed.
@@ -124,7 +119,6 @@ in
     let
       cfg = config.xdg.portal;
       packages = [ pkgs.xdg-desktop-portal ] ++ cfg.extraPortals;
-      portalsDir = "${config.home.profileDirectory}/share/xdg-desktop-portal/portals";
     in
     mkIf cfg.enable {
       assertions = [
@@ -172,11 +166,7 @@ in
         packages = packages ++ cfg.configPackages;
         sessionVariables = mkMerge [
           (mkIf cfg.xdgOpenUsePortal { NIXOS_XDG_OPEN_USE_PORTAL = "1"; })
-          { NIX_XDG_DESKTOP_PORTAL_DIR = portalsDir; }
         ];
-      };
-      systemd.user.sessionVariables = {
-        NIX_XDG_DESKTOP_PORTAL_DIR = portalsDir;
       };
 
       xdg.configFile = lib.concatMapAttrs (


### PR DESCRIPTION
### Description

This removes the broken NIX_XDG_DESKTOP_PORTAL_DIR.
It is a companion to https://github.com/NixOS/nixpkgs/pull/529088.

It is meant to fix 
https://github.com/nix-community/home-manager/issues/7124

The patch that nixpkgs made to xdg-desktop-portal meant that it only looks in NIX_XDG_DESKTOP_PORTAL_DIR.
Both NixOS and HM then set NIX_XDG_DESKTOP_PORTAL_DIR.
HM overwrites NixOS.

However, non of this is necessary since xdg-desktop-portal searches `XDG_DATA_DIRS`, where both 
`/etc/profiles/per-user/rasmus/share/` and `/run/current-system/sw/share/` are.

links:
https://discourse.nixos.org/t/hyprland-home-manager-module-breaks-portal-discovery-for-other-desktop-environments/78042/4

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
