### PR TITLE
services/openclaw: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -434,6 +434,12 @@
     github = "natecox";
     githubId = 2782695;
   };
+  nikhilmaddirala = {
+    name = "Nikhil Maddirala";
+    email = "nikhil.maddirala@gmail.com";
+    github = "nikhilmaddirala";
+    githubId = 4138581;
+  };
   nikp123 = {
     name = "nikp123";
     email = "nikp123@users.noreply.github.com";

--- a/modules/misc/news/2026/06/2026-06-11_11-23-14.nix
+++ b/modules/misc/news/2026/06/2026-06-11_11-23-14.nix
@@ -1,0 +1,9 @@
+{
+  time = "2026-06-11T11:23:14+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `services.openclaw`.
+
+    This module manages OpenClaw as a per-user gateway runtime service.
+  '';
+}

--- a/modules/services/openclaw/README.md
+++ b/modules/services/openclaw/README.md
@@ -1,0 +1,48 @@
+# OpenClaw Home Manager Service
+
+This module manages OpenClaw as a per-user gateway runtime service: it installs
+the OpenClaw package, manages the live OpenClaw JSON settings file, and keeps
+`openclaw gateway run` running as a user service.
+
+## Runtime Service
+
+- `services.openclaw.enable` installs OpenClaw and enables the module.
+- `services.openclaw.package` selects the OpenClaw package to install.
+- The module creates a user service for `openclaw gateway run`: systemd on
+  Linux and launchd on macOS.
+- `services.openclaw.gateway.port` passes `--port` to the gateway command.
+- `services.openclaw.gateway.tailscale` passes `--tailscale on` or
+  `--tailscale off` to the gateway command.
+
+## Settings
+
+- `services.openclaw.settings` contains Nix-declared OpenClaw JSON settings.
+- When `settings` is empty, Home Manager does not manage OpenClaw's live config
+  file.
+- When `settings` is non-empty, Home Manager writes
+  `~/.openclaw/openclaw.json` during activation.
+
+## Mutable Settings
+
+- `services.openclaw.mutableSettings = true` is the default.
+- In mutable mode, Home Manager merges declared settings into the live OpenClaw
+  config file and preserves unknown keys written by OpenClaw or plugins at
+  runtime.
+- This mode is useful when OpenClaw owns some runtime state and Home Manager
+  owns only the declared subset.
+
+## Authoritative Settings
+
+- Set `services.openclaw.mutableSettings = false` when the declared settings
+  should be authoritative.
+- In authoritative mode, Home Manager replaces the live config file with the
+  declared settings during activation.
+- This avoids symlinking the OpenClaw config file while still supporting an
+  immutable-style workflow.
+
+## Acknowledgements
+
+The `mutableSettings` option is inspired by the Zed Home Manager module's
+mutable settings options, which let users choose whether Home Manager should
+coexist with application-managed settings or fully own the generated settings
+file.

--- a/modules/services/openclaw/default.nix
+++ b/modules/services/openclaw/default.nix
@@ -1,0 +1,177 @@
+# Home Manager module for OpenClaw's per-user gateway runtime.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.openclaw;
+
+  jsonFormat = pkgs.formats.json { };
+  settingsMergeFilter = pkgs.writeText "openclaw-settings-merge.jq" (import ./settings-merge.nix);
+  declaredSettingsFile = jsonFormat.generate "openclaw-declared-settings.json" cfg.settings;
+  hasSettings = cfg.settings != { };
+  liveConfigPath = "${config.home.homeDirectory}/.openclaw/openclaw.json";
+  gatewayArgs = [
+    "${cfg.package}/bin/openclaw"
+    "gateway"
+    "run"
+  ]
+  ++ lib.optionals (cfg.gateway.port != null) [
+    "--port"
+    (toString cfg.gateway.port)
+  ]
+  ++ [
+    "--tailscale"
+    (if cfg.gateway.tailscale then "on" else "off")
+  ];
+
+  openclawSettingsCommand =
+    let
+      prepareDestination = ''
+        live_dst=${lib.escapeShellArg liveConfigPath}
+        declared=${lib.escapeShellArg (toString declaredSettingsFile)}
+        mkdir -p "$(dirname "$live_dst")"
+      '';
+
+      mergeSettings = ''
+        tmp=$(mktemp "''${TMPDIR:-/tmp}/openclaw-settings.XXXXXX")
+        live_src="$live_dst"
+
+        if [ -L "$live_dst" ]; then
+          live_src=$(mktemp "''${TMPDIR:-/tmp}/openclaw-live-settings.XXXXXX")
+          if [ -e "$live_dst" ]; then
+            cp "$live_dst" "$live_src"
+          else
+            install -m 0600 ${pkgs.writeText "empty-openclaw.json" "{}"} "$live_src"
+          fi
+          rm -f "$live_dst"
+        fi
+
+        if [ ! -e "$live_src" ]; then
+          install -m 0600 ${pkgs.writeText "empty-openclaw.json" "{}"} "$live_src"
+        fi
+
+        if ! ${pkgs.jq}/bin/jq empty "$live_src" >/dev/null 2>&1; then
+          backup="$live_dst.invalid.$(date +%Y%m%d%H%M%S)"
+          cp "$live_src" "$backup"
+          rm -f "$tmp"
+          if [ "$live_src" != "$live_dst" ]; then
+            rm -f "$live_src"
+          fi
+          echo "Invalid OpenClaw JSON in $live_dst; backed up to $backup" >&2
+          exit 1
+        fi
+
+        ${pkgs.jq}/bin/jq -s -f ${lib.escapeShellArg (toString settingsMergeFilter)} "$live_src" "$declared" > "$tmp"
+        install -m 0600 "$tmp" "$live_dst"
+        rm -f "$tmp"
+        if [ "$live_src" != "$live_dst" ]; then
+          rm -f "$live_src"
+        fi
+      '';
+
+      replaceSettings = ''
+        if [ -L "$live_dst" ]; then
+          rm -f "$live_dst"
+        fi
+        install -m 0600 "$declared" "$live_dst"
+      '';
+    in
+    lib.optionalString hasSettings ''
+      ${prepareDestination}
+      ${if cfg.mutableSettings then mergeSettings else replaceSettings}
+    '';
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.nikhilmaddirala ];
+
+  options.services.openclaw = {
+    enable = lib.mkEnableOption "OpenClaw gateway user service and runtime files";
+
+    package = lib.mkPackageOption pkgs "openclaw" { };
+
+    settings = lib.mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      description = ''
+        Nix-declared OpenClaw settings. When empty, Home Manager does not manage
+        OpenClaw's config file. When non-empty, Home Manager writes the
+        declared settings to {file}`~/.openclaw/openclaw.json`, using
+        {option}`services.openclaw.mutableSettings` to choose between preserving
+        or replacing existing runtime settings.
+      '';
+    };
+
+    mutableSettings = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whether OpenClaw's config file may retain settings written outside Home
+        Manager. When enabled, Home Manager merges declared settings into the
+        live {file}`~/.openclaw/openclaw.json` file while preserving unknown
+        runtime keys. When disabled, Home Manager replaces that file with the
+        declared settings.
+      '';
+    };
+
+    gateway = {
+      port = lib.mkOption {
+        type = lib.types.nullOr lib.types.port;
+        default = null;
+        description = "Optional loopback port for this user's OpenClaw gateway. When unset, OpenClaw's CLI default is used.";
+      };
+
+      tailscale = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether the gateway should use OpenClaw's built-in Tailscale exposure.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.optional (cfg.package != null) cfg.package;
+
+    home.activation.openclawSettings = lib.mkIf (openclawSettingsCommand != "") (
+      lib.hm.dag.entryAfter [ "writeBoundary" ] openclawSettingsCommand
+    );
+
+    systemd.user.services.openclaw-gateway = {
+      Unit = {
+        Description = "OpenClaw gateway";
+        After = [ "network-online.target" ];
+        Wants = [ "network-online.target" ];
+      };
+
+      Service = {
+        Type = "simple";
+        WorkingDirectory = config.home.homeDirectory;
+        Environment = [
+          "PATH=${config.home.profileDirectory}/bin:/run/current-system/sw/bin:/usr/bin:/bin"
+        ];
+        ExecStart = lib.escapeShellArgs gatewayArgs;
+        Restart = "always";
+        RestartSec = "10s";
+      };
+
+      Install.WantedBy = [ "default.target" ];
+    };
+
+    launchd.agents.openclaw-gateway = {
+      enable = true;
+      config = {
+        ProgramArguments = gatewayArgs;
+        WorkingDirectory = config.home.homeDirectory;
+        KeepAlive = {
+          Crashed = true;
+          SuccessfulExit = false;
+        };
+        ProcessType = "Background";
+        RunAtLoad = true;
+      };
+    };
+  };
+}

--- a/modules/services/openclaw/settings-merge.nix
+++ b/modules/services/openclaw/settings-merge.nix
@@ -1,0 +1,40 @@
+''
+  def mergeOpenClawSettings($live; $declared):
+    if ($live | type) == "object" and ($declared | type) == "object" then
+      reduce (($live + $declared) | keys_unsorted[]) as $key
+        ({};
+          .[$key] =
+            if ($live | has($key)) and ($declared | has($key)) then
+              mergeOpenClawSettings($live[$key]; $declared[$key])
+            elif ($declared | has($key)) then
+              $declared[$key]
+            else
+              $live[$key]
+            end
+        )
+    elif ($live | type) == "array" and ($declared | type) == "array" then
+      if
+        (all($live[]?; type == "object" and has("id")))
+        and (all($declared[]?; type == "object" and has("id")))
+      then
+        ($live | map({ key: (.id | tostring), value: . }) | from_entries) as $liveById
+        | [
+            $declared[]? as $item
+            | if $liveById | has($item.id | tostring) then
+                mergeOpenClawSettings($liveById[$item.id | tostring]; $item)
+              else
+                $item
+              end
+          ] as $mergedDeclared
+        | reduce ($live[]?) as $item
+            ($mergedDeclared; if any(.[]; .id == $item.id) then . else . + [$item] end)
+      else
+        reduce ($live[]?) as $item
+          ($declared; if any(.[]; . == $item) then . else . + [$item] end)
+      end
+    else
+      $declared
+    end;
+
+  mergeOpenClawSettings(.[0]; .[1])
+''

--- a/tests/modules/services/openclaw/default.nix
+++ b/tests/modules/services/openclaw/default.nix
@@ -1,0 +1,265 @@
+_:
+
+{
+  openclaw-basic =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+
+    let
+      fakeOpenclaw = pkgs.writeShellScriptBin "openclaw" ''
+        echo fake-openclaw "$@"
+      '';
+    in
+    {
+      services.openclaw = {
+        enable = true;
+        package = fakeOpenclaw;
+        gateway.port = 18789;
+        settings = {
+          gateway = {
+            port = 18789;
+            bind = "loopback";
+          };
+          runtime.declared = true;
+        };
+      };
+
+      home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+      nmt.script =
+        let
+          preexistingSettings = builtins.toFile "preexisting-openclaw.json" ''
+            {
+              "gateway": {
+                "port": 19999,
+                "runtimeOnly": true
+              },
+              "runtime": {
+                "live": true
+              }
+            }
+          '';
+
+          expectedSettings = builtins.toFile "expected-openclaw.json" ''
+            {
+              "gateway": {
+                "bind": "loopback",
+                "port": 18789,
+                "runtimeOnly": true
+              },
+              "runtime": {
+                "declared": true,
+                "live": true
+              }
+            }
+          '';
+
+          activationScript = pkgs.writeScript "activation" config.home.activation.openclawSettings.data;
+        in
+        ''
+          assertFileExists home-path/bin/openclaw
+
+          ${lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
+            serviceFile=home-files/.config/systemd/user/openclaw-gateway.service
+            serviceFile=$(normalizeStorePaths "$serviceFile")
+            assertFileRegex "$serviceFile" '^ExecStart=.*/bin/openclaw gateway run --port 18789 --tailscale off$'
+            assertFileRegex "$serviceFile" '^WorkingDirectory=/@TMPDIR@/hm-user$'
+            assertFileRegex "$serviceFile" '^Restart=always$'
+          ''}
+
+          ${lib.optionalString pkgs.stdenv.hostPlatform.isDarwin ''
+            serviceFile=LaunchAgents/org.nix-community.home.openclaw-gateway.plist
+            serviceFile=$(normalizeStorePaths "$serviceFile")
+            assertFileRegex "$serviceFile" '<string>org.nix-community.home.openclaw-gateway</string>'
+            assertFileRegex "$serviceFile" '<key>KeepAlive</key>'
+            assertFileRegex "$serviceFile" '<key>Crashed</key>'
+            assertFileRegex "$serviceFile" '<true/>'
+            assertFileRegex "$serviceFile" '<key>SuccessfulExit</key>'
+            assertFileRegex "$serviceFile" '<false/>'
+            assertFileRegex "$serviceFile" '<key>ProcessType</key>'
+            assertFileRegex "$serviceFile" '<string>Background</string>'
+            assertFileRegex "$serviceFile" '<key>ProgramArguments</key>'
+            assertFileRegex "$serviceFile" '<string>/bin/sh</string>'
+            assertFileRegex "$serviceFile" '<string>-c</string>'
+            assertFileRegex "$serviceFile" '<string>/bin/wait4path /nix/store &amp;&amp; exec .*/bin/openclaw gateway run --port 18789 --tailscale off</string>'
+            assertFileRegex "$serviceFile" '<key>RunAtLoad</key>'
+            assertFileRegex "$serviceFile" '<key>WorkingDirectory</key>'
+            assertFileRegex "$serviceFile" '<string>/@TMPDIR@/hm-user</string>'
+          ''}
+
+          export HOME=$TMPDIR/hm-user
+          configPath=$HOME/.openclaw/openclaw.json
+
+          mkdir -p "$(dirname "$configPath")"
+          cat ${preexistingSettings} > "$configPath"
+
+          substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+          chmod +x $TMPDIR/activate
+          $TMPDIR/activate
+
+          ${pkgs.jq}/bin/jq -S . "$configPath" > $TMPDIR/actual.json
+          ${pkgs.jq}/bin/jq -S . ${expectedSettings} > $TMPDIR/expected.json
+          assertFileContent $TMPDIR/actual.json $TMPDIR/expected.json
+
+          $TMPDIR/activate
+          ${pkgs.jq}/bin/jq -S . "$configPath" > $TMPDIR/actual-idempotent.json
+          assertFileContent $TMPDIR/actual-idempotent.json $TMPDIR/expected.json
+        '';
+    };
+
+  openclaw-immutable-settings =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+
+    let
+      fakeOpenclaw = pkgs.writeShellScriptBin "openclaw" ''
+        echo fake-openclaw "$@"
+      '';
+    in
+    {
+      services.openclaw = {
+        enable = true;
+        package = fakeOpenclaw;
+        mutableSettings = false;
+        settings = {
+          gateway = {
+            port = 18789;
+            bind = "loopback";
+          };
+          runtime.declared = true;
+        };
+      };
+
+      home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+      nmt.script =
+        let
+          preexistingSettings = builtins.toFile "preexisting-openclaw.json" ''
+            {
+              "gateway": {
+                "port": 19999,
+                "runtimeOnly": true
+              },
+              "runtime": {
+                "live": true
+              }
+            }
+          '';
+
+          expectedSettings = builtins.toFile "expected-openclaw.json" ''
+            {
+              "gateway": {
+                "bind": "loopback",
+                "port": 18789
+              },
+              "runtime": {
+                "declared": true
+              }
+            }
+          '';
+
+          activationScript = pkgs.writeScript "activation" config.home.activation.openclawSettings.data;
+        in
+        ''
+          export HOME=$TMPDIR/hm-user
+          configPath=$HOME/.openclaw/openclaw.json
+
+          mkdir -p "$(dirname "$configPath")"
+          cat ${preexistingSettings} > "$configPath"
+
+          substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+          chmod +x $TMPDIR/activate
+          $TMPDIR/activate
+
+          ${pkgs.jq}/bin/jq -S . "$configPath" > $TMPDIR/actual.json
+          ${pkgs.jq}/bin/jq -S . ${expectedSettings} > $TMPDIR/expected.json
+          assertFileContent $TMPDIR/actual.json $TMPDIR/expected.json
+        '';
+    };
+
+  openclaw-mutable-symlink-settings =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+
+    let
+      fakeOpenclaw = pkgs.writeShellScriptBin "openclaw" ''
+        echo fake-openclaw "$@"
+      '';
+    in
+    {
+      services.openclaw = {
+        enable = true;
+        package = fakeOpenclaw;
+        settings = {
+          gateway.port = 18789;
+          runtime.declared = true;
+        };
+      };
+
+      home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+      nmt.script =
+        let
+          preexistingSettings = builtins.toFile "preexisting-openclaw.json" ''
+            {
+              "gateway": {
+                "runtimeOnly": true
+              },
+              "runtime": {
+                "live": true
+              }
+            }
+          '';
+
+          expectedSettings = builtins.toFile "expected-openclaw.json" ''
+            {
+              "gateway": {
+                "port": 18789,
+                "runtimeOnly": true
+              },
+              "runtime": {
+                "declared": true,
+                "live": true
+              }
+            }
+          '';
+
+          activationScript = pkgs.writeScript "activation" config.home.activation.openclawSettings.data;
+        in
+        ''
+          export HOME=$TMPDIR/hm-user
+          configPath=$HOME/.openclaw/openclaw.json
+          externalPath=$TMPDIR/external-openclaw.json
+
+          mkdir -p "$(dirname "$configPath")"
+          cat ${preexistingSettings} > "$externalPath"
+          ln -s "$externalPath" "$configPath"
+
+          substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+          chmod +x $TMPDIR/activate
+          $TMPDIR/activate
+
+          if [ -L "$configPath" ]; then
+            fail "expected activation to replace symlinked OpenClaw config with a regular file"
+          fi
+
+          ${pkgs.jq}/bin/jq -S . "$configPath" > $TMPDIR/actual.json
+          ${pkgs.jq}/bin/jq -S . ${expectedSettings} > $TMPDIR/expected.json
+          assertFileContent $TMPDIR/actual.json $TMPDIR/expected.json
+        '';
+    };
+
+  openclaw-settings-merge = ./settings-merge.nix;
+}

--- a/tests/modules/services/openclaw/settings-merge.nix
+++ b/tests/modules/services/openclaw/settings-merge.nix
@@ -1,0 +1,241 @@
+{ pkgs, ... }:
+let
+  filter = pkgs.writeText "openclaw-settings-merge.jq" (
+    import ../../../../modules/services/openclaw/settings-merge.nix
+  );
+in
+{
+  nmt.script = ''
+    set -euo pipefail
+
+    jq_bin=${pkgs.jq}/bin/jq
+    filter=${filter}
+    tmpdir=$(mktemp -d "''${TMPDIR:-/tmp}/openclaw-settings-merge-test.XXXXXX")
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    case_no=0
+
+    assert_case() {
+      local name=$1
+      local live=$2
+      local declared=$3
+      local expected=$4
+      local actual=$tmpdir/$case_no-actual.json
+
+      "$jq_bin" -s -f "$filter" "$live" "$declared" >"$actual"
+      "$jq_bin" -S . "$expected" >"$tmpdir/$case_no-expected.sorted.json"
+      "$jq_bin" -S . "$actual" >"$tmpdir/$case_no-actual.sorted.json"
+      if ! diff -u "$tmpdir/$case_no-expected.sorted.json" "$tmpdir/$case_no-actual.sorted.json"; then
+        echo "settings merge case failed: $name" >&2
+        exit 1
+      fi
+    }
+
+    next_case() {
+      case_no=$((case_no + 1))
+      case_dir=$tmpdir/case-$case_no
+      mkdir -p "$case_dir"
+    }
+
+    next_case
+    cat >"$case_dir/live.json" <<'EOF'
+    {
+      "gateway": {
+        "port": 19999,
+        "runtimeOnly": true,
+        "nested": {
+          "runtime": "keep",
+          "override": "runtime"
+        }
+      },
+      "session": {
+        "idleMinutes": 12345
+      },
+      "scalar": "runtime"
+    }
+    EOF
+    cat >"$case_dir/declared.json" <<'EOF'
+    {
+      "gateway": {
+        "port": 18789,
+        "bind": "loopback",
+        "nested": {
+          "override": "declared",
+          "declared": "add"
+        }
+      },
+      "scalar": "declared"
+    }
+    EOF
+    cat >"$case_dir/expected.json" <<'EOF'
+    {
+      "gateway": {
+        "port": 18789,
+        "runtimeOnly": true,
+        "bind": "loopback",
+        "nested": {
+          "runtime": "keep",
+          "override": "declared",
+          "declared": "add"
+        }
+      },
+      "session": {
+        "idleMinutes": 12345
+      },
+      "scalar": "declared"
+    }
+    EOF
+    assert_case "recursive objects and scalar override" "$case_dir/live.json" "$case_dir/declared.json" "$case_dir/expected.json"
+
+    next_case
+    cat >"$case_dir/live.json" <<'EOF'
+    {
+      "plugins": {
+        "enabled": [
+          "runtime-only",
+          "declared-existing"
+        ]
+      },
+      "agents": {
+        "list": [
+          {
+            "id": "runtime-agent"
+          },
+          {
+            "id": "declared-agent"
+          }
+        ]
+      }
+    }
+    EOF
+    cat >"$case_dir/declared.json" <<'EOF'
+    {
+      "plugins": {
+        "enabled": [
+          "declared-existing",
+          "declared-new"
+        ]
+      },
+      "agents": {
+        "list": [
+          {
+            "id": "declared-agent"
+          }
+        ]
+      }
+    }
+    EOF
+    cat >"$case_dir/expected.json" <<'EOF'
+    {
+      "plugins": {
+        "enabled": [
+          "declared-existing",
+          "declared-new",
+          "runtime-only"
+        ]
+      },
+      "agents": {
+        "list": [
+          {
+            "id": "declared-agent"
+          },
+          {
+            "id": "runtime-agent"
+          }
+        ]
+      }
+    }
+    EOF
+    assert_case "declared-first arrays preserve runtime additions" "$case_dir/live.json" "$case_dir/declared.json" "$case_dir/expected.json"
+
+    next_case
+    cat >"$case_dir/live.json" <<'EOF'
+    {
+      "agents": {
+        "list": [
+          {
+            "id": "main",
+            "default": true,
+            "runtime": {
+              "lastSession": "keep"
+            },
+            "skills": ["old"],
+            "theme": "runtime"
+          },
+          {
+            "id": "runtime-agent",
+            "default": false
+          }
+        ]
+      }
+    }
+    EOF
+    cat >"$case_dir/declared.json" <<'EOF'
+    {
+      "agents": {
+        "list": [
+          {
+            "id": "main",
+            "default": true,
+            "model": "declared",
+            "skills": ["new"],
+            "theme": "declared"
+          }
+        ]
+      }
+    }
+    EOF
+    cat >"$case_dir/expected.json" <<'EOF'
+    {
+      "agents": {
+        "list": [
+          {
+            "id": "main",
+            "default": true,
+            "model": "declared",
+            "runtime": {
+              "lastSession": "keep"
+            },
+            "skills": ["new", "old"],
+            "theme": "declared"
+          },
+          {
+            "id": "runtime-agent",
+            "default": false
+          }
+        ]
+      }
+    }
+    EOF
+    assert_case "object arrays with id merge matching objects and append runtime objects" "$case_dir/live.json" "$case_dir/declared.json" "$case_dir/expected.json"
+
+    next_case
+    cat >"$case_dir/live.json" <<'EOF'
+    {
+      "gateway": {
+        "port": 19999
+      },
+      "tools": [
+        "runtime"
+      ]
+    }
+    EOF
+    cat >"$case_dir/declared.json" <<'EOF'
+    {
+      "gateway": false,
+      "tools": {
+        "profile": "declared"
+      }
+    }
+    EOF
+    cat >"$case_dir/expected.json" <<'EOF'
+    {
+      "gateway": false,
+      "tools": {
+        "profile": "declared"
+      }
+    }
+    EOF
+    assert_case "declared type replaces runtime type" "$case_dir/live.json" "$case_dir/declared.json" "$case_dir/expected.json"
+  '';
+}


### PR DESCRIPTION
### Description

Adds a new `services.openclaw` module for managing OpenClaw as a per-user gateway runtime.

The module supports:

- installing the `openclaw` package through Home Manager
- running `openclaw gateway run` as a user service
- Linux service management through `systemd.user.services.openclaw-gateway`
- macOS service management through `launchd.agents.openclaw-gateway`
- optional gateway port and Tailscale mode
- declarative settings written to `~/.openclaw/openclaw.json`
- mutable settings by default, merging declared settings into the live
  OpenClaw config while preserving unknown runtime-owned keys
- authoritative settings with `mutableSettings = false`, replacing the live
  config file with the declared settings

The mutable settings merge is intended for OpenClaw's runtime-owned config model. It preserves unknown runtime keys, lets declared values win on conflicts, recursively merges objects, and recursively merges arrays of objects keyed by `id`.

Focused NMT coverage is included for basic service generation, authoritative settings, mutable settings merging, preexisting symlinked config files, and same-`id` object array merges.

~~I did not add a news entry in this contributor PR because the Home Manager news guidelines say that, for a contributed new module, the merger will create the entry.~~ (Update: added news entry)

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

### Validation

Focused validation run locally:

```console
$ nix fmt
$ nix run .#tests -- openclaw
$ git diff --check
```

Result:

- `nix fmt`: completed
- `test-openclaw-basic`: passed
- `test-openclaw-immutable-settings`: passed
- `test-openclaw-mutable-symlink-settings`: passed
- `test-openclaw-settings-merge`: passed
- `git diff --check`: passed

I have not run the full `test-all` suite locally for this PR.

### Disclosure

AI assistance: this PR was prepared with Codex assistance and reviewed/tested by the author.
