### PR TITLE
keepassxc: Support macOS KeePassXC configuration

### DIFF
--- a/modules/programs/keepassxc.nix
+++ b/modules/programs/keepassxc.nix
@@ -9,6 +9,8 @@ let
   cfg = config.programs.keepassxc;
 
   iniFormat = pkgs.formats.ini { };
+
+  settingsFile = iniFormat.generate "keepassxc-settings" cfg.settings;
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -99,10 +101,18 @@ in
         xdg.autostart.entries = lib.mkIf cfg.autostart [
           "${cfg.package}/share/applications/org.keepassxc.KeePassXC.desktop"
         ];
-        xdg.configFile."keepassxc/keepassxc.ini" = lib.mkIf (cfg.settings != { }) {
-          source = iniFormat.generate "keepassxc-settings" cfg.settings;
-        };
       }
+
+      (lib.mkIf (cfg.settings != { }) {
+        xdg.configFile."keepassxc/keepassxc.ini" = {
+          enable = !pkgs.stdenv.hostPlatform.isDarwin;
+          source = settingsFile;
+        };
+        home.file."Library/Application Support/KeePassXC/keepassxc.ini" = {
+          enable = pkgs.stdenv.hostPlatform.isDarwin;
+          source = settingsFile;
+        };
+      })
 
       (lib.mkIf (cfg.package != null) {
         home.packages = [ cfg.package ];

--- a/tests/modules/programs/keepassxc/default-settings.nix
+++ b/tests/modules/programs/keepassxc/default-settings.nix
@@ -1,3 +1,12 @@
+{ pkgs, ... }:
+
+let
+  configFile =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "home-files/Library/Application Support/KeePassXC/keepassxc.ini"
+    else
+      "home-files/.config/keepassxc/keepassxc.ini";
+in
 {
   programs.keepassxc = {
     enable = true;
@@ -6,6 +15,6 @@
   test.stubs.keepassxc = { };
 
   nmt.script = ''
-    assertPathNotExists home-files/.config/keepassxc/keepassxc.ini
+    assertPathNotExists "${configFile}"
   '';
 }

--- a/tests/modules/programs/keepassxc/example-settings.nix
+++ b/tests/modules/programs/keepassxc/example-settings.nix
@@ -1,3 +1,12 @@
+{ pkgs, ... }:
+
+let
+  configFile =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "home-files/Library/Application Support/KeePassXC/keepassxc.ini"
+    else
+      "home-files/.config/keepassxc/keepassxc.ini";
+in
 {
   programs.keepassxc = {
     enable = true;
@@ -16,7 +25,6 @@
   test.stubs.keepassxc = { };
 
   nmt.script = ''
-    configFile=home-files/.config/keepassxc/keepassxc.ini
-    assertFileContent $configFile ${./keepassxc-example-config.ini}
+    assertFileContent "${configFile}" ${./keepassxc-example-config.ini}
   '';
 }


### PR DESCRIPTION
Refactor configuration for KeePassXC settings based on platform.

### Description

Support KeePassXC configuration file on macOS

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
