### PR TITLE
sshAuthSock: avoid cycles for socket providers

### DIFF
--- a/modules/misc/ssh-auth-sock.nix
+++ b/modules/misc/ssh-auth-sock.nix
@@ -7,6 +7,8 @@
 
 let
   cfg = config.sshAuthSock;
+  socketProviderIsSocket = lib.hasSuffix ".socket" cfg.systemd.socketProviderUnit;
+  orderedProviderUnits = lib.optional (!socketProviderIsSocket) cfg.systemd.socketProviderUnit;
 in
 {
   meta.maintainers = [ lib.maintainers.bmrips ];
@@ -102,7 +104,9 @@ in
       systemd.user.services.set-SSH_AUTH_SOCK = {
         Unit = {
           Description = "Sets SSH_AUTH_SOCK in the D-BUS daemon and systemd";
-          Before = [ cfg.systemd.socketProviderUnit ];
+          # Socket units are ordered before sockets.target by systemd. Ordering
+          # this service before them creates a cycle through basic.target.
+          Before = orderedProviderUnits;
         };
         Service = {
           Type = "oneshot";
@@ -113,8 +117,8 @@ in
         };
         Install.WantedBy = [
           "default.target"
-          cfg.systemd.socketProviderUnit
-        ];
+        ]
+        ++ orderedProviderUnits;
       };
     };
 }

--- a/tests/modules/misc/ssh-auth-sock/default.nix
+++ b/tests/modules/misc/ssh-auth-sock/default.nix
@@ -1,4 +1,5 @@
 {
   sshAuthSock-disabled = ./disabled.nix;
   sshAuthSock-enabled = ./enabled.nix;
+  sshAuthSock-socket-provider = ./socket-provider.nix;
 }

--- a/tests/modules/misc/ssh-auth-sock/enabled.nix
+++ b/tests/modules/misc/ssh-auth-sock/enabled.nix
@@ -13,7 +13,7 @@
       fish = "echo fish";
       nushell = "echo nushell";
     };
-    systemd.socketProviderUnit = "foo.socket";
+    systemd.socketProviderUnit = "foo.service";
   };
 
   nmt.script = ''
@@ -32,7 +32,7 @@
   ''
   + lib.optionalString config.systemd.user.enable ''
     assertFileExists home-files/.config/systemd/user/set-SSH_AUTH_SOCK.service
-    assertFileContains home-files/.config/systemd/user/set-SSH_AUTH_SOCK.service 'Before=foo.socket'
-    assertFileContains home-files/.config/systemd/user/set-SSH_AUTH_SOCK.service 'WantedBy=foo.socket'
+    assertFileContains home-files/.config/systemd/user/set-SSH_AUTH_SOCK.service 'Before=foo.service'
+    assertFileContains home-files/.config/systemd/user/set-SSH_AUTH_SOCK.service 'WantedBy=foo.service'
   '';
 }

--- a/tests/modules/misc/ssh-auth-sock/socket-provider.nix
+++ b/tests/modules/misc/ssh-auth-sock/socket-provider.nix
@@ -1,0 +1,22 @@
+{ config, lib, ... }:
+
+{
+  sshAuthSock = {
+    enable = true;
+    initialization = {
+      bash = "echo bash/zsh";
+      fish = "echo fish";
+      nushell = "echo nushell";
+    };
+    systemd.socketProviderUnit = "foo.socket";
+  };
+
+  nmt.script = lib.optionalString config.systemd.user.enable ''
+    serviceFile=home-files/.config/systemd/user/set-SSH_AUTH_SOCK.service
+
+    assertFileExists $serviceFile
+    assertFileContains $serviceFile 'WantedBy=default.target'
+    assertFileNotRegex $serviceFile 'Before=foo\.socket'
+    assertFileNotRegex $serviceFile 'WantedBy=foo\.socket'
+  '';
+}


### PR DESCRIPTION
PR #9420 added set-SSH_AUTH_SOCK.service and ordered it before sshAuthSock.systemd.socketProviderUnit. When that provider is a socket unit, systemd default dependencies already order the socket before sockets.target while service defaults place set-SSH_AUTH_SOCK.service after basic.target. That creates a sockets.target -> basic.target -> set-SSH_AUTH_SOCK.service -> provider.socket -> sockets.target cycle.

For gpg-agent this makes systemd drop gpg-agent-ssh.socket, leaving SSH_AUTH_SOCK pointing at the expected S.gpg-agent.ssh path but with no socket listening there.

Only order and install the environment service against non-socket providers. Socket providers still get SSH_AUTH_SOCK imported through default.target.

Fixes #9432.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
