### PR TITLE
nushell: remove redundant abbreviations option

### DIFF
--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -191,21 +191,6 @@ in
       '';
     };
 
-    abbreviations = lib.mkOption {
-      type = types.attrsOf types.str;
-      default = { };
-      example = {
-        ll = "ls -l";
-        gs = "git status";
-      };
-      description = ''
-        An attribute set that maps each abbreviation (the top level attribute
-        names in this option) to its expansion. Unlike aliases, abbreviations
-        are expanded inline in the line editor when a space or enter is pressed,
-        so the expanded command is what ends up in the command history.
-      '';
-    };
-
     environmentVariables = lib.mkOption {
       type = types.attrsOf lib.hm.types.nushellValue;
       default = { };
@@ -247,16 +232,11 @@ in
             || cfg.extraConfig != ""
             || aliasesStr != ""
             || cfg.settings != { }
-            || cfg.abbreviations != { }
             || cfg.environmentVariables != { };
 
           aliasesStr = lib.concatLines (
             lib.mapAttrsToList (k: v: "alias ${toNushell { } k} = ${v}") cfg.shellAliases
           );
-
-          abbreviationsStr =
-            lib.optionalString (cfg.abbreviations != { })
-              "$env.config.abbreviations = ${toNushell { } cfg.abbreviations}";
         in
         lib.mkIf writeConfig {
           "${cfg.configDir}/config.nu".text = lib.mkMerge [
@@ -295,7 +275,6 @@ in
             (lib.mkIf (cfg.configFile != null) cfg.configFile.text)
             cfg.extraConfig
             aliasesStr
-            abbreviationsStr
           ];
         }
       )

--- a/tests/modules/programs/nushell/config-expected.nu
+++ b/tests/modules/programs/nushell/config-expected.nu
@@ -13,6 +13,8 @@ load-env {
     "PROMPT_COMMAND": ({|| "> "})
 }
 
+$env.config.abbreviations.gs = "git status"
+$env.config.abbreviations.ll = "ls -l"
 $env.config.display_errors.exit_code = false
 $env.config.hooks.pre_execution = [
     ({|| "pre_execution hook"})
@@ -29,8 +31,3 @@ let config = {
 alias "ll" = ls -a
 alias "multi word alias" = cd -
 alias "z" = __zoxide_z
-
-$env.config.abbreviations = {
-    "gs": "git status"
-    "ll": "ls -l"
-}

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -38,12 +38,11 @@
       "z" = "__zoxide_z";
     };
 
-    abbreviations = {
-      "gs" = "git status";
-      "ll" = "ls -l";
-    };
-
     settings = {
+      abbreviations = {
+        "gs" = "git status";
+        "ll" = "ls -l";
+      };
       show_banner = false;
       display_errors.exit_code = false;
       hooks.pre_execution = [ (lib.hm.nushell.mkNushellInline ''{|| "pre_execution hook"}'') ];


### PR DESCRIPTION
### Description

Reverts #9433. Nushell abbreviations are regular settings, so native config already works:

```nix
programs.nushell.settings.abbreviations = {
  gs = "git status";
  ll = "ls -l";
};
```

This emits existing flattened settings output:

```nu
$env.config.abbreviations.gs = "git status"
$env.config.abbreviations.ll = "ls -l"
```

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

Tested focused path: `nix run .#tests -- nushell-example-settings`.
