### PR TITLE
voxtype: restart service when configuration changes

### DIFF
--- a/modules/services/voxtype.nix
+++ b/modules/services/voxtype.nix
@@ -129,6 +129,9 @@ in
       Unit = {
         Description = "Voxtype speech-to-text daemon";
         PartOf = [ "default.target" ];
+        X-Restart-Triggers = mkIf (cfg.settings != { }) [
+          "${config.xdg.configFile."voxtype/config.toml".source}"
+        ];
       }
       // optionalAttrs (cfg.loadModels != [ ]) {
         Wants = [ "voxtype-model-loader.service" ];

--- a/tests/modules/services/voxtype/basic-configuration.nix
+++ b/tests/modules/services/voxtype/basic-configuration.nix
@@ -25,11 +25,26 @@
     assertFileExists "$serviceFile"
     assertFileExists "$configFile"
 
-    assertFileRegex "$serviceFile" 'ExecStart=@voxtype@/bin/dummy daemon --verbose'
-    assertFileRegex "$serviceFile" 'Environment=PATH=.*/bin'
-    assertFileRegex "$serviceFile" 'Environment=WAYLAND_DISPLAY=wayland-1'
-    assertFileRegex "$serviceFile" 'Environment=VOXTYPE_TEST_ENV=1'
-    assertFileRegex "$serviceFile" 'X-Restart-Triggers=/nix/store/.*-voxtype-config.toml'
+    serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+    assertFileContent "$serviceFileNormalized" ${builtins.toFile "expected.service" ''
+      [Install]
+      WantedBy=default.target
+
+      [Service]
+      Environment=PATH=@which@/bin:@wl-clipboard@/bin:@wtype@/bin
+      Environment=XDG_RUNTIME_DIR=%t
+      Environment=WAYLAND_DISPLAY=wayland-1
+      Environment=VOXTYPE_TEST_ENV=1
+      ExecStart=@voxtype@/bin/dummy daemon --verbose
+      Restart=on-failure
+      RestartSec=5s
+      Type=exec
+
+      [Unit]
+      Description=Voxtype speech-to-text daemon
+      PartOf=default.target
+      X-Restart-Triggers=/nix/store/00000000000000000000000000000000-voxtype-config.toml
+    ''}
 
     assertFileContent "$configFile" ${./expected-config.toml}
   '';

--- a/tests/modules/services/voxtype/basic-configuration.nix
+++ b/tests/modules/services/voxtype/basic-configuration.nix
@@ -29,6 +29,7 @@
     assertFileRegex "$serviceFile" 'Environment=PATH=.*/bin'
     assertFileRegex "$serviceFile" 'Environment=WAYLAND_DISPLAY=wayland-1'
     assertFileRegex "$serviceFile" 'Environment=VOXTYPE_TEST_ENV=1'
+    assertFileRegex "$serviceFile" 'X-Restart-Triggers=/nix/store/.*-voxtype-config.toml'
 
     assertFileContent "$configFile" ${./expected-config.toml}
   '';


### PR DESCRIPTION
Add the rendered config path to X-Restart-Triggers so the service restarts whenever the configuration changes.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
