### PR TITLE
shikane: make config file RW

### DIFF
--- a/modules/services/shikane.nix
+++ b/modules/services/shikane.nix
@@ -67,9 +67,14 @@ in
 
     home.packages = [ cfg.package ];
 
-    xdg.configFile."shikane/config.toml" = lib.mkIf (cfg.settings != { }) {
-      source = tomlFormat.generate "shikane-config" cfg.settings;
-    };
+    # shikane >=1.1.0 opens config.toml O_RDWR|O_CREAT;
+    # https://gitlab.com/w0lff/shikane/-/blob/b242dcd1c05f6e902f82ba45fc56165f538696f8/CHANGELOG.md
+    home.activation.shikaneConfig = lib.mkIf (cfg.settings != { }) (
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        run install -Dm644 ${tomlFormat.generate "shikane-config" cfg.settings} \
+          "${config.xdg.configHome}/shikane/config.toml"
+      ''
+    );
 
     systemd.user.services.shikane = {
       Unit = {

--- a/tests/modules/services/shikane/basic-configuration.nix
+++ b/tests/modules/services/shikane/basic-configuration.nix
@@ -37,11 +37,18 @@
     };
 
     nmt.script = ''
-      serviceFile=home-files/.config/systemd/user/shikane.service
-      assertFileExists $serviceFile
+      assertFileExists home-files/.config/systemd/user/shikane.service
 
-      assertFileExists home-files/.config/shikane/config.toml
-      assertFileContent home-files/.config/shikane/config.toml ${./expected.toml}
+      # shikane >=1.1.0 opens config.toml O_RDWR, so HM installs it as a writable
+      # file at activation time rather than a read-only home-files symlink.
+      assertFileRegex activate 'install -Dm644 /nix/store/[^ ]*-shikane-config'
+
+      # Validate the generated TOML via the store path the activation installs from.
+      storePath=$(grep -oE '/nix/store/[^ "]*-shikane-config' "$TESTED/activate" | head -n1)
+      if ! cmp -s "$storePath" ${./expected.toml}; then
+        fail "shikane config.toml content mismatch:
+      $(diff -u "$storePath" ${./expected.toml})"
+      fi
     '';
   };
 }


### PR DESCRIPTION

### Description

shikane 1.1.0 opens the config file with [O_RDWR|O_CREAT](https://gitlab.com/w0lff/shikane/-/blob/b242dcd1c05f6e902f82ba45fc56165f538696f8/CHANGELOG.md).

this creates an rw file instead of symlinking into the nix store.

a bit unsure if my usage of `lib.hm.dag.entryAfter` is correct?

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
