### PR TITLE
kiro-cli: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -552,6 +552,12 @@
     github = "SunOfLife1";
     githubId = 30405063;
   };
+  superflash41 = {
+    name = "Saymon Nicho";
+    email = "saymon.nicho@pucp.edu.pe";
+    github = "superflash41";
+    githubId = 102434258;
+  };
   yarn = {
     name = "yarncat";
     email = "30006414+yaaaarn@users.noreply.github.com";

--- a/modules/misc/news/2026/06/2026-06-09_12-00-00.nix
+++ b/modules/misc/news/2026/06/2026-06-09_12-00-00.nix
@@ -1,0 +1,11 @@
+{ config, ... }:
+{
+  time = "2026-06-09T12:00:00+00:00";
+  condition = config.programs.kiro-cli.enable;
+  message = ''
+    A new module is available: `programs.kiro-cli`.
+
+    It installs the kiro-cli package and provides optional shell
+    integration for Bash and Zsh.
+  '';
+}

--- a/modules/programs/kiro-cli.nix
+++ b/modules/programs/kiro-cli.nix
@@ -1,0 +1,50 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.kiro-cli;
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.superflash41 ];
+
+  options.programs.kiro-cli = {
+    enable = lib.mkEnableOption "kiro-cli, the command-line interface for Kiro";
+
+    package = lib.mkPackageOption pkgs "kiro-cli" { };
+
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
+
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs = {
+      bash.initExtra = lib.mkIf cfg.enableBashIntegration (
+        lib.mkMerge [
+          (lib.mkBefore ''
+            eval "$(${lib.getExe cfg.package} init bash pre)"
+          '')
+          (lib.mkAfter ''
+            eval "$(${lib.getExe cfg.package} init bash post)"
+          '')
+        ]
+      );
+
+      zsh.initContent = lib.mkIf cfg.enableZshIntegration (
+        lib.mkMerge [
+          (lib.mkBefore ''
+            eval "$(${lib.getExe cfg.package} init zsh pre)"
+          '')
+          (lib.mkAfter ''
+            eval "$(${lib.getExe cfg.package} init zsh post)"
+          '')
+        ]
+      );
+    };
+  };
+}

--- a/tests/modules/programs/kiro-cli/bash.nix
+++ b/tests/modules/programs/kiro-cli/bash.nix
@@ -1,0 +1,24 @@
+{
+  programs = {
+    kiro-cli.enable = true;
+    bash.enable = true;
+  };
+
+  test.stubs.kiro-cli = {
+    name = "kiro-cli";
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileContains home-files/.bashrc \
+      'eval "$(@kiro-cli@/bin/kiro-cli init bash pre)"'
+    assertFileContains home-files/.bashrc \
+      'eval "$(@kiro-cli@/bin/kiro-cli init bash post)"'
+
+    preLine=$(grep -n 'init bash pre' $TESTED/home-files/.bashrc | head -n1 | cut -d: -f1)
+    postLine=$(grep -n 'init bash post' $TESTED/home-files/.bashrc | head -n1 | cut -d: -f1)
+    if [[ "$preLine" -ge "$postLine" ]]; then
+      fail "kiro-cli 'pre' snippet (line $preLine) must appear before 'post' snippet (line $postLine) in .bashrc"
+    fi
+  '';
+}

--- a/tests/modules/programs/kiro-cli/default.nix
+++ b/tests/modules/programs/kiro-cli/default.nix
@@ -1,0 +1,4 @@
+{
+  kiro-cli-bash = ./bash.nix;
+  kiro-cli-zsh = ./zsh.nix;
+}

--- a/tests/modules/programs/kiro-cli/zsh.nix
+++ b/tests/modules/programs/kiro-cli/zsh.nix
@@ -1,0 +1,24 @@
+{
+  programs = {
+    kiro-cli.enable = true;
+    zsh.enable = true;
+  };
+
+  test.stubs.kiro-cli = {
+    name = "kiro-cli";
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+    assertFileContains home-files/.zshrc \
+      'eval "$(@kiro-cli@/bin/kiro-cli init zsh pre)"'
+    assertFileContains home-files/.zshrc \
+      'eval "$(@kiro-cli@/bin/kiro-cli init zsh post)"'
+
+    preLine=$(grep -n 'init zsh pre' $TESTED/home-files/.zshrc | head -n1 | cut -d: -f1)
+    postLine=$(grep -n 'init zsh post' $TESTED/home-files/.zshrc | head -n1 | cut -d: -f1)
+    if [[ "$preLine" -ge "$postLine" ]]; then
+      fail "kiro-cli 'pre' snippet (line $preLine) must appear before 'post' snippet (line $postLine) in .zshrc"
+    fi
+  '';
+}


### PR DESCRIPTION
### Description

Adds a `programs.kiro-cli` module for [Kiro CLI](https://kiro.dev), the command-line interface for the Kiro IDE.

The module supports shell integration for Bash and Zsh. Both shells require injecting a pre and a post eval, which this module handles via `programs.bash.initExtra` and `programs.zsh.initContent`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
