### PR TITLE
nixpkgs-disabled: show offending definition locations in warning

### DIFF
--- a/modules/misc/nixpkgs-disabled.nix
+++ b/modules/misc/nixpkgs-disabled.nix
@@ -1,5 +1,6 @@
 {
   config,
+  options,
   lib,
   pkgs,
   ...
@@ -8,6 +9,14 @@
 let
 
   cfg = config.nixpkgs;
+  opt = options.nixpkgs;
+
+  # Locations of the offending `nixpkgs.config`/`nixpkgs.overlays` definitions,
+  # so users can find what set them.
+  offendingFiles = lib.unique (
+    lib.optionals (cfg.config != null) opt.config.files
+    ++ lib.optionals (cfg.overlays != null) opt.overlays.files
+  );
 
   # Copied from nixpkgs.nix.
   isConfig = x: builtins.isAttrs x || builtins.isFunction x;
@@ -82,6 +91,7 @@ in
         assertion = cfg.config == null || cfg.overlays == null;
         message = ''
           `nixpkgs` options are disabled when `home-manager.useGlobalPkgs` is enabled.
+          Definitions found in ${lib.showFiles offendingFiles}.
         '';
       }
     ];
@@ -89,6 +99,7 @@ in
     warnings = lib.optional ((cfg.config != null) || (cfg.overlays != null)) ''
       You have set either `nixpkgs.config` or `nixpkgs.overlays` while using `home-manager.useGlobalPkgs`.
       This will soon not be possible. Please remove all `nixpkgs` options when using `home-manager.useGlobalPkgs`.
+      Definitions found in ${lib.showFiles offendingFiles}.
     '';
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -187,6 +187,7 @@ import nmtSrc {
           ./modules/misc/news
           ./modules/misc/nix
           ./modules/misc/nix-remote-build
+          ./modules/misc/nixpkgs-disabled
           ./modules/misc/specialisation
           ./modules/misc/ssh-auth-sock/default.nix
           ./modules/misc/xdg

--- a/tests/modules/misc/nixpkgs-disabled/assertion.nix
+++ b/tests/modules/misc/nixpkgs-disabled/assertion.nix
@@ -1,0 +1,34 @@
+{ lib, pkgs, ... }:
+let
+  # Both options set trips the assertion; it should list both locations.
+  eval = lib.evalModules {
+    modules = [
+      ../../../../modules/misc/nixpkgs-disabled.nix
+      (pkgs.path + "/nixos/modules/misc/assertions.nix")
+      (pkgs.path + "/nixos/modules/misc/meta.nix")
+      { _module.args.pkgs = pkgs; }
+      ./offending-overlay.nix
+      ./offending-config.nix
+    ];
+  };
+
+  files = lib.showFiles (
+    lib.unique (eval.options.nixpkgs.config.files ++ eval.options.nixpkgs.overlays.files)
+  );
+
+  failed = map (a: a.message) (lib.filter (a: !a.assertion) eval.config.assertions);
+in
+{
+  nmt.script =
+    let
+      expected = pkgs.writeText "nixpkgs-disabled-assertion.expected" ''
+        `nixpkgs` options are disabled when `home-manager.useGlobalPkgs` is enabled.
+        Definitions found in ${files}.
+      '';
+
+      actual = pkgs.writeText "nixpkgs-disabled-assertion.actual" (lib.concatStringsSep "\n--\n" failed);
+    in
+    ''
+      assertFileContent ${actual} ${expected}
+    '';
+}

--- a/tests/modules/misc/nixpkgs-disabled/default.nix
+++ b/tests/modules/misc/nixpkgs-disabled/default.nix
@@ -1,0 +1,4 @@
+{
+  nixpkgs-disabled-warning = ./warning.nix;
+  nixpkgs-disabled-assertion = ./assertion.nix;
+}

--- a/tests/modules/misc/nixpkgs-disabled/offending-config.nix
+++ b/tests/modules/misc/nixpkgs-disabled/offending-config.nix
@@ -1,0 +1,3 @@
+{
+  nixpkgs.config.allowUnfree = true;
+}

--- a/tests/modules/misc/nixpkgs-disabled/offending-overlay.nix
+++ b/tests/modules/misc/nixpkgs-disabled/offending-overlay.nix
@@ -1,0 +1,3 @@
+{
+  nixpkgs.overlays = [ (_self: _super: { }) ];
+}

--- a/tests/modules/misc/nixpkgs-disabled/warning.nix
+++ b/tests/modules/misc/nixpkgs-disabled/warning.nix
@@ -1,0 +1,33 @@
+{ lib, pkgs, ... }:
+let
+  # nixpkgs-disabled.nix only loads under `useGlobalPkgs` (useNixpkgsModule =
+  # false), which the standard harness can't toggle; evaluate it standalone.
+  eval = lib.evalModules {
+    modules = [
+      ../../../../modules/misc/nixpkgs-disabled.nix
+      (pkgs.path + "/nixos/modules/misc/assertions.nix")
+      (pkgs.path + "/nixos/modules/misc/meta.nix")
+      { _module.args.pkgs = pkgs; }
+      ./offending-overlay.nix
+    ];
+  };
+
+  files = lib.showFiles eval.options.nixpkgs.overlays.files;
+in
+{
+  nmt.script =
+    let
+      expected = pkgs.writeText "nixpkgs-disabled-warning.expected" ''
+        You have set either `nixpkgs.config` or `nixpkgs.overlays` while using `home-manager.useGlobalPkgs`.
+        This will soon not be possible. Please remove all `nixpkgs` options when using `home-manager.useGlobalPkgs`.
+        Definitions found in ${files}.
+      '';
+
+      actual = pkgs.writeText "nixpkgs-disabled-warning.actual" (
+        lib.concatStringsSep "\n--\n" eval.config.warnings
+      );
+    in
+    ''
+      assertFileContent ${actual} ${expected}
+    '';
+}


### PR DESCRIPTION
Surface the files that defined `nixpkgs.config`/`nixpkgs.overlays` in the `useGlobalPkgs` warning and assertion, so users can find what set them without inspecting `options.*.files` in the repl.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
