### PR TITLE
docs: update release notes for 26.05

### DIFF
--- a/docs/release-notes/rl-2605.md
+++ b/docs/release-notes/rl-2605.md
@@ -6,41 +6,141 @@ The 26.05 release branch became stable in May, 2026.
 
 This release has the following notable changes:
 
-- WezTerm now supports declarative configuration via
-  [](#opt-programs.wezterm.settings). Settings are expressed as a Nix
-  attribute set and serialized to Lua using `lib.generators.toLua`.
-  Raw Lua expressions such as `wezterm.font` and `wezterm.action.*`
-  can be embedded using `lib.generators.mkLuaInline`. The existing
-  [](#opt-programs.wezterm.extraConfig) option remains fully supported
-  and can be combined with [](#opt-programs.wezterm.settings).
+- Home Manager now supports RFC 42-style SSH configuration through
+  [](#opt-programs.ssh.settings). The legacy `programs.ssh.matchBlocks` format
+  is deprecated and migrated automatically.
 
-- The [](#opt-programs.anki.uiScale) option now expects a value in the
-  range 1.0–2.0, previously it erroneously expected values in the
-  range `0.0–1.0`.
+- The new `home-manager.startAsUserService` option runs user activation on
+  demand at login instead of doing all setup during system boot, which helps on
+  systems where home directories are mounted later (for example, pam_mount).
+
+- New options were added for `services.podman.useDefaultMachine` and podman
+  machine management on Darwin.
+
+- The [](#opt-programs.rclone.enable) module now supports launchd-backed config,
+  mount, and serve agents on Darwin. The new
+  `programs.rclone.remotes.<name>.serve` option can manage `rclone serve`
+  sidecar services on both Linux and Darwin. On non-systemd platforms,
+  `programs.rclone.requiresUnit` is read-only and always `null` because there is
+  no systemd ordering unit to depend on.
+
+- The Syncthing credentials flow now uses `services.syncthing.guiCredentials`
+  instead of the removed `services.syncthing.passwordFile` option.
+
+- Firefox extensions are now managed per-profile through the
+  `programs.firefox.profiles.<name>.extensions.packages` and
+  `programs.firefox.profiles.<name>.extensions.settings` options. The top-level
+  `programs.firefox.extensions = [ ... ]` list was removed; migrate it to
+  `programs.firefox.profiles.<name>.extensions.packages`.
+
+- Thunderbird now supports `accounts.email.accounts.<name>.ews`, the
+  `outlook.office365.com-ews` account flavor, declarative language packs, and
+  enterprise policies. Thunderbird accounts using the `outlook.office365.com`
+  flavor now default IMAP and SMTP authentication to OAuth2 when the account
+  does not set an authentication method explicitly.
+
+- A new `systemd.user.packages` option provides a user-level equivalent of
+  `systemd.packages` for installing unit files from packages.
+
+- WezTerm now supports declarative configuration via
+  [](#opt-programs.wezterm.settings). Settings are expressed as a Nix attribute
+  set and serialized to Lua using `lib.generators.toLua`. Raw Lua expressions
+  such as `wezterm.font` and `wezterm.action.*` can be embedded using
+  `lib.generators.mkLuaInline`. The existing
+  [](#opt-programs.wezterm.extraConfig) option remains fully supported and can
+  be combined with [](#opt-programs.wezterm.settings).
+
+- The [](#opt-programs.anki.uiScale) option now expects a value in the range
+  1.0–2.0, previously it erroneously expected values in the range `0.0–1.0`.
+  Anki sync options moved from `programs.anki.sync.*` to
+  `programs.anki.profiles."User 1".sync.*`, and
+  `programs.anki.sync.passwordFile` is migrated to
+  `programs.anki.profiles."User 1".sync.keyFile`.
 
 - New [](#opt-home.services) namespace for nixpkgs
   [modular services](https://nixos.org/manual/nixos/unstable/#modular-services).
   Service modules shipped with packages (e.g.
-  `pkgs.<name>.passthru.services.default`) drop in unchanged and are
-  lifted to user systemd units. See
-  [Modular Services](#sec-usage-modular-services) for details.
+  `pkgs.<name>.passthru.services.default`) drop in unchanged and are lifted to
+  user systemd units. See [Modular Services](#sec-usage-modular-services) for
+  details.
+
+- Dedicated modules were added for several VSCode forks (`programs.cursor`,
+  `programs.vscodium`, `programs.windsurf`, `programs.kiro`, and
+  `programs.antigravity`), built from a shared `mkVscodeModule` factory. Each
+  fork can now be configured independently and simultaneously. Users who
+  previously selected a fork by setting `programs.vscode.package` should migrate
+  to the matching module; the `programs.vscode.pname` option was removed.
+
+- The AI coding-assistant modules ([](#opt-programs.claude-code.enable),
+  [](#opt-programs.codex.enable), and [](#opt-programs.opencode.enable)) now
+  share a unified `context` option for providing global instructions. The
+  previous per-module options (`claude-code.memory`,
+  `codex.custom-instructions`, and `opencode.rules`) are deprecated and migrated
+  automatically. MCP server configuration via `programs.mcp.servers` was also
+  extended to more assistant and editor modules through an
+  `enableMcpIntegration` option.
+
+- The `programs.man` module was split so the man viewer can be selected through
+  the [](#opt-programs.man.man-db.enable) and
+  [](#opt-programs.man.mandoc.enable) submodules, which are mutually exclusive.
+
+- The `programs.neovim.extraLuaConfig` option was renamed to
+  [](#opt-programs.neovim.initLua). Home Manager now writes generated Lua
+  initialization to {file}`$XDG_CONFIG_HOME/nvim/init.lua` by default. If you
+  manage that file outside Home Manager, set
+  [](#opt-programs.neovim.sideloadInitLua) to `true` to load the generated Lua
+  through the Neovim wrapper instead.
+
+- A new [](#opt-sshAuthSock.enable) module manages the `SSH_AUTH_SOCK`
+  environment variable. It is implicitly enabled and configured by the
+  SSH-agent-providing modules (e.g. `services.ssh-agent`, `services.gpg-agent`).
+  The old `services.ssh-agent.enable{Bash,Zsh,Fish,Nushell}Integration` options
+  were removed; shell initialization is now provided through `sshAuthSock`.
+
+- A new [](#opt-services.pipewire.enable) module provides client-side
+  configuration for PipeWire, WirePlumber, and the PulseAudio/JACK compatibility
+  layers. It does not install or manage the PipeWire daemon itself.
+
+- The `services.swww` module was renamed to [](#opt-services.awww.enable)
+  following the upstream project rename. The `enable`, `package`, and
+  `extraArgs` options are migrated automatically from `services.swww.*` to
+  `services.awww.*`.
+
+- Several modules dropped their freeform `extraConfig` escape hatches in favor
+  of RFC 42-style `settings`: `programs.aerospace.extraConfig` (and
+  `userSettings`) and `programs.aria2.extraConfig` were removed.
+  `programs.mise.settings` was renamed to `programs.mise.globalConfig.settings`.
+  The `programs.eww.configDir` and
+  `programs.eww.enable{Bash,Zsh,Fish}Integration` options were removed; use
+  [](#opt-programs.eww.yuckConfig) and [](#opt-programs.eww.scssConfig) for
+  declarative Eww config files. The `programs.niriswitcher` options were also
+  removed.
+
+- Darwin integration received several behavior changes. Home Manager launchd
+  agents now wait for `/nix/store` before starting and use
+  `launchctl bootout --wait` when replacing agents. nix-darwin activations now
+  propagate dry-run mode into Home Manager user activations. On Darwin, Home
+  Manager also exports `TERMINFO_DIRS` so terminfo entries from Home
+  Manager-installed packages are visible to shells.
+
+- The [](#opt-nix.assumeXdg) option was added for installations where Nix is
+  configured to use XDG base directories outside Home Manager. Home Manager also
+  detects `osConfig.nix.settings.use-xdg-base-directories` when deciding where
+  to place declarative channel entries.
 
 ## State Version Changes {#sec-release-26.05-state-version-changes}
 
-The state version in this release includes the changes below. These
-changes are only active if the `home.stateVersion` option is set to
-\"26.05\" or later.
+The state version in this release includes the changes below. These changes are
+only active if the `home.stateVersion` option is set to \"26.05\" or later.
 
-- The [](#opt-gtk.gtk4.theme) option does not mirror
-  [](#opt-gtk.theme) by default anymore.
+- The [](#opt-gtk.gtk4.theme) option does not mirror [](#opt-gtk.theme) by
+  default anymore.
 
-- The [](#opt-programs.zsh.dotDir) option now defaults to the XDG
-  configuration directory (usually `~/.config/zsh`) when
-  [](#opt-xdg.enable) is true.
+- The [](#opt-programs.zsh.dotDir) option now defaults to the XDG configuration
+  directory (usually `~/.config/zsh`) when [](#opt-xdg.enable) is true.
 
-- The [](#opt-programs.yazi.shellWrapperName) option now defaults to
-  `y` instead of `yy`. For users with older `home.stateVersion` values,
-  the legacy default `yy` is retained.
+- The [](#opt-programs.yazi.shellWrapperName) option now defaults to `y` instead
+  of `yy`.
 
 - The [](#opt-xdg.userDirs.setSessionVariables) option now defaults to `false`
   instead of `true`.
@@ -51,21 +151,39 @@ changes are only active if the `home.stateVersion` option is set to
   `DESKTOP`. Home Manager 26.05 introduced a warning when the `XDG_<name>_DIR`
   form is used.
 
-- The [](#opt-programs.man.package) option now defaults to `null` on
-  Darwin because the GNU `man` from nixpkgs ships `apropos`/`man -k`
-  and `whatis`/`man -f` binaries that don't work on Darwin. Nix-installed
-  manual pages still work with macOS's built-in `man` via
+- The [](#opt-programs.man.package) option now defaults to `null` on Darwin
+  because the GNU `man` from nixpkgs ships `apropos`/`man -k` and
+  `whatis`/`man -f` binaries that don't work on Darwin. Nix-installed manual
+  pages still work with macOS's built-in `man` via
   [](#opt-home.extraOutputsToInstall).
 
 - The options [](#opt-programs.neovim.withPython3) and
-  [](#opt-programs.neovim.withRuby) now default to `false` following nixpkgs
+  [](#opt-programs.neovim.withRuby) now default to `false` following nixpkgs.
+
+- Neovim plugin `config` fragments are assumed to be Lua by default through
+  `programs.neovim.plugins.<name>.type = "lua"`, instead of the previous `viml`
+  default.
 
 - On Linux, `programs.firefox.configPath` now defaults to
-  `"${config.xdg.configHome}/mozilla/firefox"` for `home.stateVersion = "26.05"` and later.
-  Older state versions keep the legacy default of `".mozilla/firefox"`.
+  `"${config.xdg.configHome}/mozilla/firefox"`, instead of the legacy
+  `".mozilla/firefox"`.
 
-- The [](#opt-wayland.windowManager.hyprland.configType) option now
-  defaults to `"lua"` for `home.stateVersion = "26.05"` and later.
-  Older state versions keep the legacy `"hyprlang"` default. Set
-  `wayland.windowManager.hyprland.configType = "hyprlang"` to keep
-  generating {file}`$XDG_CONFIG_HOME/hypr/hyprland.conf`.
+- The [](#opt-wayland.windowManager.hyprland.configType) option now defaults to
+  `"lua"`, instead of the legacy `"hyprlang"`. Set
+  `wayland.windowManager.hyprland.configType = "hyprlang"` to keep generating
+  {file}`$XDG_CONFIG_HOME/hypr/hyprland.conf`.
+
+- The [](#opt-programs.docker-cli.configDir) option now defaults to
+  `"${config.xdg.configHome}/docker"` when [](#opt-xdg.enable) is true, instead
+  of `~/.docker`. Similarly, [](#opt-services.colima.profiles) now sets
+  `$DOCKER_HOST` for the default context.
+
+- The [](#opt-services.home-manager.autoUpgrade.preSwitchCommands) option now
+  defaults to an empty list. Previously, when
+  [](#opt-services.home-manager.autoUpgrade.useFlake) was `true`, it defaulted
+  to `[ "nix flake update" ]`. Set `preSwitchCommands = [ "nix flake update" ]`
+  to keep updating flake inputs before each automatic switch.
+
+- The [](#opt-programs.mergiraf.enableGitIntegration) and
+  [](#opt-programs.mergiraf.enableJujutsuIntegration) options now default to
+  `false`, so the integrations must be enabled explicitly.


### PR DESCRIPTION
Lots of missing information about major changes throughout the last release.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
