### PR TITLE
claude-code: omit unsupported mcp enabled field

### DIFF
--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -19,17 +19,29 @@ let
 
   upstreamConfigDir = "${config.home.homeDirectory}/.claude";
 
+  isMcpServerEnabled =
+    server:
+    let
+      enabled = server.enabled or null;
+      disabled = (server.disabled or false) == true;
+    in
+    enabled != false && !disabled;
+
+  transformMcpServer =
+    name: server:
+    lib.hm.mcp.transformMcpServer {
+      inherit server;
+      exclude = [ "enabled" ];
+      extraTransforms = [
+        lib.hm.mcp.addType
+        (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; }) # envFiles currently still need wrapping https://github.com/anthropics/claude-code/issues/28942
+      ];
+    };
+
   transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
-    lib.mapAttrs (
-      name: server:
-      lib.hm.mcp.transformMcpServer {
-        inherit server;
-        extraTransforms = [
-          lib.hm.mcp.addType
-          (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; }) # envFiles currently still need wrapping https://github.com/anthropics/claude-code/issues/28942
-        ];
-      }
-    ) config.programs.mcp.servers
+    lib.mapAttrs transformMcpServer (
+      lib.filterAttrs (_: isMcpServerEnabled) config.programs.mcp.servers
+    )
   );
 
   mkContentOption =
@@ -632,7 +644,9 @@ in
 
       programs.claude-code.finalPackage =
         let
-          mergedMcpServers = transformedMcpServers // lib.mapAttrs (_: lib.hm.mcp.addType) cfg.mcpServers;
+          mergedMcpServers =
+            transformedMcpServers
+            // lib.mapAttrs (_: server: removeAttrs (lib.hm.mcp.addType server) [ "enabled" ]) cfg.mcpServers;
           pluginFiles =
             lib.optional (mergedMcpServers != { }) {
               name = ".mcp.json";

--- a/tests/modules/programs/claude-code/mcp-integration.nix
+++ b/tests/modules/programs/claude-code/mcp-integration.nix
@@ -19,6 +19,7 @@
         github = {
           type = "http";
           url = "https://api.githubcopilot.com/mcp/";
+          enabled = true;
         };
         filesystem = {
           type = "stdio";
@@ -61,6 +62,11 @@
           customOption = "value";
           timeout = 5000;
         };
+        disabled-server = {
+          command = "echo";
+          args = [ "test" ];
+          disabled = true;
+        };
       };
     };
   };
@@ -73,10 +79,7 @@
     pluginDir=$(grep -o -- '--plugin-dir /nix/store/[^ ]*' "$wrapperPath")
     pluginDir="''${pluginDir#--plugin-dir }"
     assertFileContent "$pluginDir/.claude-plugin/plugin.json" ${./expected-plugin-manifest.json}
-    assertFileRegex "$pluginDir/.mcp.json" '"github"'
-    assertFileRegex "$pluginDir/.mcp.json" '"database"'
-    assertFileRegex "$pluginDir/.mcp.json" '"/tmp"'
-    (! grep -q -- '/other-tmp' "$pluginDir/.mcp.json")
+    assertFileContent "$pluginDir/.mcp.json" ${./expected-mcp-plugin.json}
     assertPathNotExists "$pluginDir/.lsp.json"
   '';
 }


### PR DESCRIPTION
### Description
Follow up to https://github.com/nix-community/home-manager/pull/9081#issuecomment-4670644844

Claude Code upstream docs do not document `enabled` as an MCP server config field. Server approval/rejection is managed by Claude Code (`claude mcp list`, `claude mcp get`, `/mcp`) rather than `.mcp.json`, and documented `.mcp.json` examples only use fields such as `command`, `args`, `env`, `type`, `url`, `headers`, and `timeout`.

So this follow-up strips `enabled` from generated Claude Code MCP config and filters disabled shared servers instead of emitting `enabled = false`, which Claude Code ignores.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
