### PR TITLE
docs: fix sshAuthSock reference in rl-2605

### DIFF
--- a/docs/release-notes/rl-2605.md
+++ b/docs/release-notes/rl-2605.md
@@ -91,8 +91,8 @@ This release has the following notable changes:
   [](#opt-programs.neovim.sideloadInitLua) to `true` to load the generated Lua
   through the Neovim wrapper instead.
 
-- A new [](#opt-sshAuthSock.enable) module manages the `SSH_AUTH_SOCK`
-  environment variable. It is implicitly enabled and configured by the
+- A new `sshAuthSock` module manages the `SSH_AUTH_SOCK`
+  environment variable. It is implicitly configured by the
   SSH-agent-providing modules (e.g. `services.ssh-agent`, `services.gpg-agent`).
   The old `services.ssh-agent.enable{Bash,Zsh,Fish,Nushell}Integration` options
   were removed; shell initialization is now provided through `sshAuthSock`.


### PR DESCRIPTION
### Description

The `rl-2605.md` link to `#opt-sshAuthSock.enable` breaks the manual
build on `release-26.05` — the `enable` option only exists on master, so
the anchor resolves to nothing there. Drop the broken reference and the
inaccurate "enabled and" wording. To be backported to `release-26.05`.

Docs-only change; verified `nix-build -A docs.html` succeeds on both
master and `release-26.05`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
