### PR TITLE
darcs: add defaults

### DIFF
--- a/modules/programs/darcs.nix
+++ b/modules/programs/darcs.nix
@@ -37,6 +37,19 @@ in
         ];
         description = "File patterns to ignore";
       };
+
+      defaults = lib.mkOption {
+        type = lib.types.nullOr lib.types.lines;
+        default = "";
+        example = ''
+          ALL ignore-times
+        '';
+        description = ''
+          Default values for Darcs commands.
+
+          See <https://darcs.net/Using/Configuration#defaults> for details.
+        '';
+      };
     };
   };
 
@@ -52,6 +65,9 @@ in
         home.file.".darcs/boring".text = lib.concatMapStrings (x: x + "\n") cfg.boring;
       })
 
+      (lib.mkIf (cfg.defaults != null) {
+        home.file.".darcs/defaults".text = cfg.defaults;
+      })
     ]
   );
 }

--- a/tests/modules/programs/darcs/default.nix
+++ b/tests/modules/programs/darcs/default.nix
@@ -1,4 +1,5 @@
 {
   darcs-author = ./author.nix;
   darcs-boring = ./boring.nix;
+  darcs-defaults = ./defaults.nix;
 }

--- a/tests/modules/programs/darcs/defaults.nix
+++ b/tests/modules/programs/darcs/defaults.nix
@@ -1,0 +1,19 @@
+{
+  programs.darcs = {
+    enable = true;
+    defaults = ''
+      ALL ignore-times
+      send sign-as AAAAAAAAAAAAAAAA
+      push prehook darcs-hooks run pre-push
+    '';
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.darcs/defaults \
+      ${builtins.toFile "expected-defaults" ''
+        ALL ignore-times
+        send sign-as AAAAAAAAAAAAAAAA
+        push prehook darcs-hooks run pre-push
+      ''}
+  '';
+}


### PR DESCRIPTION
### Description

This adds support for specifying default values for Darcs commands.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)