### PR TITLE
feat: mutable configs

### DIFF
--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -13,6 +13,7 @@ rec {
   gvariant = import ./gvariant.nix { inherit lib; };
   maintainers = import ./maintainers.nix;
   mcp = import ./mcp.nix { inherit lib; };
+  mutableConfig = import ./mutable-config.nix;
   strings = import ./strings.nix { inherit lib; };
   types = import ./types.nix { inherit gvariant lib; };
 

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -16,7 +16,15 @@ let
     types
     ;
 in
-{
+rec {
+  # Normalizes absolute paths
+  normalizeAbsPath =
+    { path, basePath }:
+    let
+      absPath = if hasPrefix "/" path then path else "${basePath}/${path}";
+    in
+    removePrefix (homeDirectory + "/") absPath;
+
   # Constructs a type suitable for a `home.file` like option. The
   # target path may be either absolute or relative, in which case it
   # is relative the `basePath` argument (which itself must be an
@@ -45,10 +53,10 @@ in
               type = types.nonEmptyStr;
               apply =
                 p:
-                let
-                  absPath = if hasPrefix "/" p then p else "${basePath}/${p}";
-                in
-                removePrefix (homeDirectory + "/") absPath;
+                normalizeAbsPath {
+                  inherit basePath;
+                  path = p;
+                };
               defaultText = literalExpression "name";
               description = ''
                 Path to target file relative to ${basePathDesc}.

--- a/modules/lib/mutable-config.nix
+++ b/modules/lib/mutable-config.nix
@@ -1,0 +1,19 @@
+let
+  actionKey = "__homeManagerMutableConfig_action";
+in
+{
+  remove = {
+    ${actionKey} = "remove";
+  };
+
+  union = items: {
+    ${actionKey} = "union";
+    inherit items;
+  };
+
+  mergeBy = keys: items: {
+    ${actionKey} = "mergeBy";
+    keys = if builtins.isList keys then keys else [ keys ];
+    inherit items;
+  };
+}

--- a/modules/misc/mutable-config.nix
+++ b/modules/misc/mutable-config.nix
@@ -1,0 +1,209 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    attrNames
+    attrValues
+    concatStringsSep
+    elem
+    filter
+    filterAttrs
+    hasSuffix
+    literalExpression
+    mapAttrsToList
+    mkIf
+    mkOption
+    toLower
+    types
+    ;
+
+  inherit (config.home) homeDirectory;
+
+  inherit
+    (
+      (import ../lib/file-type.nix {
+        inherit homeDirectory lib pkgs;
+      })
+    )
+    normalizeAbsPath
+    ;
+
+  cfg = config.home.mutableConfig;
+  enabledEntries = filterAttrs (_: entry: entry.enable && entry.data != { }) cfg;
+  enabledPaths = attrNames enabledEntries;
+  homeFileTargets = map (file: file.target) (attrValues config.home.file);
+  homeFileConflicts = filter (
+    path:
+    elem (normalizeAbsPath {
+      inherit path;
+      basePath = homeDirectory;
+    }) homeFileTargets
+  ) enabledPaths;
+
+  inferFormat =
+    path:
+    let
+      lower = toLower path;
+    in
+    if hasSuffix ".toml" lower then
+      "toml"
+    else if hasSuffix ".json" lower || hasSuffix ".jsonc" lower then
+      "json"
+    else if hasSuffix ".ini" lower || hasSuffix ".cfg" lower then
+      "ini"
+    else
+      throw "cannot infer mutable config format for ${path}; set format explicitly";
+in
+{
+  options.home.mutableConfig = mkOption {
+    type = types.attrsOf (
+      types.submodule {
+        options = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Whether to manage this file.";
+          };
+
+          format = mkOption {
+            type = types.enum [
+              "auto"
+              "toml"
+              "json"
+              "ini"
+            ];
+            default = "auto";
+            description = ''
+              File format of the file. If unspecified or "auto",
+              format is detected based on file extension.
+            '';
+          };
+
+          data = mkOption {
+            type = types.anything;
+            default = { };
+            example = literalExpression ''
+              {
+                # This key will be overwritten by home-manager.
+                managedKey = "managed value";
+
+                # Other fields on nestedObject will be preserved.
+                nestedObject = {
+                  justOne = "managed field";
+                };
+
+                # This key will be removed, if it exists.
+                staleKey = config.lib.mutableConfig.remove;
+
+                # The list contained in this key will have an element appended
+                # if it doesn't have that element.
+                listKey = config.lib.mutableConfig.union [ "managed item" ];
+
+                # For a list of objects, this will look up an existing object by
+                # the "label" key and deep merge the inner fields.
+                # If no object matches `label=Format`, a new one will be inserted.
+                tasks = config.lib.mutableConfig.mergeBy "label" [
+                  {
+                    label = "Format";
+                    command = "nix";
+                    # NOTE: the merge is recursive, so we could use another
+                    #       `union` right here, for example.
+                    args = [ "fmt" ];
+                  }
+                ];
+              }
+            '';
+            description = ''
+              Data to merge into the existing file.
+              For object and table files, keys not present here are preserved.
+
+              Specific keys can be removed explicitly by using the `remove`
+              sentinel. For lists and arrays, you can use the `union` operator
+              to ensure values will be added if not already present.
+              For lists of objects, `mergeBy` is available - it finds the object
+              in the list by looking up a specific key, then merging in the other
+              properties. If no record by that key exists, it gets appended.
+
+              For top-level JSON arrays, use
+              {option}`config.lib.mutableConfig.union` or
+              {option}`config.lib.mutableConfig.mergeBy`.
+            '';
+          };
+
+          failOnInvalid = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Whether to fail activation when the existing file cannot be parsed.";
+          };
+
+          onInvalid = mkOption {
+            type = types.enum [
+              "skip"
+              "initialize"
+            ];
+            default = "skip";
+            description = ''
+              How to handle an invalid existing file when {option}`failOnInvalid`
+              is disabled. The value `skip` leaves the file untouched, while
+              `initialize` treats it as an empty file and applies managed keys.
+            '';
+          };
+        };
+      }
+    );
+    default = { };
+    description = ''
+      Patch specific properties on complex or mutable structured configuration files.
+      This manages only a subset of values of the overall file.
+
+      Unlike {option}`home.file` and {option}`xdg.configFile`, these files are
+      plain files in the home directory. Home Manager manages only the keys
+      declared in {option}`data`, so applications may continue to modify other settings.
+    '';
+  };
+
+  config = lib.mkMerge [
+    {
+      assertions = [
+        {
+          assertion = homeFileConflicts == [ ];
+          message = "home.mutableConfig conflicts with home.file for paths: ${concatStringsSep ", " homeFileConflicts}";
+        }
+      ];
+    }
+
+    (mkIf (enabledPaths != [ ]) (
+      let
+        python = pkgs.python3.withPackages (ps: [
+          ps.json5
+          ps.tomlkit
+        ]);
+
+        manifestJson = builtins.toJSON (
+          mapAttrsToList (path: entry: {
+            path = normalizeAbsPath {
+              inherit path;
+              basePath = homeDirectory;
+            };
+            format = if entry.format == "auto" then inferFormat path else entry.format;
+            fail_on_invalid = entry.failOnInvalid;
+            on_invalid = entry.onInvalid;
+            managed = entry.data;
+          }) enabledEntries
+        );
+
+        manifestFile = pkgs.writeText "hm-mutable-config-manifest.json" manifestJson;
+      in
+      {
+        home.activation.mutableConfigMerge = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+          ${python}/bin/python ${./mutable-config.py} ${manifestFile} ${lib.escapeShellArg homeDirectory}
+        '';
+      }
+    ))
+  ];
+}

--- a/modules/misc/mutable-config.py
+++ b/modules/misc/mutable-config.py
@@ -1,0 +1,313 @@
+import configparser
+import io
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import MutableMapping
+
+import json5
+import tomlkit
+
+
+ACTION_KEY = "__homeManagerMutableConfig_action"
+INI_TOP_LEVEL_SECTION = "__homeManagerMutableConfig_topLevel"
+
+
+def new_ini_parser():
+    parser = configparser.ConfigParser(
+        allow_no_value=True,
+        delimiters=("=",),
+        default_section="__homeManagerMutableConfig_defaults",
+        interpolation=None,
+        strict=False,
+    )
+    parser.optionxform = str
+    return parser
+
+
+def parse_ini(raw):
+    parser = new_ini_parser()
+    parser.read_string(f"[{INI_TOP_LEVEL_SECTION}]\n{raw}")
+
+    data = {}
+    for key, value in parser.items(INI_TOP_LEVEL_SECTION, raw=True):
+        data[key] = value
+
+    for section in parser.sections():
+        if section == INI_TOP_LEVEL_SECTION:
+            continue
+        data[section] = dict(parser.items(section, raw=True))
+
+    return data
+
+
+def render_ini_value(value):
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    return str(value)
+
+
+def dump_ini(data):
+    parser = new_ini_parser()
+    top_level = [(key, value) for key, value in data.items() if not isinstance(value, MutableMapping)]
+    sections = [(key, value) for key, value in data.items() if isinstance(value, MutableMapping)]
+
+    if top_level:
+        parser.add_section(INI_TOP_LEVEL_SECTION)
+        for key, value in top_level:
+            parser.set(INI_TOP_LEVEL_SECTION, key, None if value is None else render_ini_value(value))
+
+    for section_name, items in sections:
+        parser.add_section(section_name)
+        for key, value in items.items():
+            if isinstance(value, MutableMapping):
+                raise ValueError(f"INI section [{section_name}] key {key!r} cannot be a nested table")
+            parser.set(section_name, key, None if value is None else render_ini_value(value))
+
+    output = io.StringIO()
+    parser.write(output, space_around_delimiters=False)
+    rendered = output.getvalue()
+    if top_level:
+        rendered = rendered.split("\n", 1)[1]
+    return rendered.rstrip("\n") + "\n"
+
+
+def parse_content(raw, fmt):
+    if raw.strip() == "":
+        return {}
+    if fmt == "toml":
+        return tomlkit.parse(raw)
+    if fmt == "json":
+        return json5.loads(raw)
+    if fmt == "ini":
+        return parse_ini(raw)
+    raise ValueError(f"unsupported format {fmt}")
+
+
+def dump_content(data, fmt):
+    if fmt == "toml":
+        return tomlkit.dumps(data)
+    if fmt == "json":
+        return json.dumps(data, indent=2) + "\n"
+    if fmt == "ini":
+        return dump_ini(data)
+    raise ValueError(f"unsupported format {fmt}")
+
+
+def is_sentinel(value, action):
+    return isinstance(value, dict) and value.get(ACTION_KEY) == action
+
+
+def identity_for(item, keys):
+    if not isinstance(item, MutableMapping):
+        return None
+    values = []
+    for key in keys:
+        values.append(json.dumps(item.get(key), sort_keys=True, separators=(",", ":")))
+    return tuple(values)
+
+
+def merge_by(existing, managed, keys):
+    if not isinstance(existing, list):
+        return managed
+
+    index = {}
+    for pos, item in enumerate(existing):
+        identity = identity_for(item, keys)
+        if identity is not None and identity not in index:
+            index[identity] = pos
+
+    for managed_item in managed:
+        identity = identity_for(managed_item, keys)
+        if identity is not None and identity in index:
+            existing[index[identity]] = merge(existing[index[identity]], managed_item)
+        elif managed_item not in existing:
+            existing.append(managed_item)
+
+    return existing
+
+
+def merge(existing, managed):
+    if is_sentinel(managed, "union"):
+        items = managed["items"]
+        if isinstance(existing, list):
+            for item in items:
+                if item not in existing:
+                    existing.append(item)
+            return existing
+        return items
+
+    if is_sentinel(managed, "mergeBy"):
+        return merge_by(existing, managed["items"], managed["keys"])
+
+    if isinstance(existing, MutableMapping) and isinstance(managed, MutableMapping):
+        for key, managed_value in managed.items():
+            if is_sentinel(managed_value, "remove"):
+                existing.pop(key, None)
+            elif is_sentinel(managed_value, "union"):
+                items = managed_value["items"]
+                if key in existing and isinstance(existing[key], list):
+                    for item in items:
+                        if item not in existing[key]:
+                            existing[key].append(item)
+                else:
+                    existing[key] = items
+            elif is_sentinel(managed_value, "mergeBy"):
+                items = managed_value["items"]
+                keys = managed_value["keys"]
+                if key in existing:
+                    existing[key] = merge_by(existing[key], items, keys)
+                else:
+                    existing[key] = items
+            elif key in existing:
+                existing[key] = merge(existing[key], managed_value)
+            else:
+                existing[key] = managed_value
+        return existing
+
+    return managed
+
+
+def fail_or_warn(message, fail):
+    if fail:
+        print(message, file=sys.stderr)
+        raise SystemExit(1)
+    print(f"warning: {message}", file=sys.stderr)
+
+
+def remove_backup(path):
+    if not os.path.lexists(path):
+        return
+    if os.path.isdir(path) and not os.path.islink(path):
+        raise IsADirectoryError(f"backup path {path} is a directory")
+    os.unlink(path)
+
+
+def backup_existing(path, command_path=None):
+    backup_command = os.environ.get("HOME_MANAGER_BACKUP_COMMAND")
+    backup_ext = os.environ.get("HOME_MANAGER_BACKUP_EXT")
+
+    if backup_command:
+        command = f"{backup_command} {shlex.quote(command_path or path)}"
+        try:
+            subprocess.run(command, shell=True, check=True)
+        except subprocess.CalledProcessError as exc:
+            raise SystemExit(exc.returncode) from exc
+        return
+
+    if backup_ext:
+        backup_path = f"{path}.{backup_ext}"
+        if os.path.lexists(backup_path):
+            if os.environ.get("HOME_MANAGER_BACKUP_OVERWRITE") is None:
+                print(
+                    f"existing backup path {backup_path!r} would be clobbered",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
+            remove_backup(backup_path)
+        shutil.copy2(path, backup_path)
+        return
+
+    shutil.copy2(path, path + ".bak")
+
+
+def merge_entry(entry, home_directory):
+    target = entry.get("target")
+    if target is None:
+        path = entry["path"]
+        if os.path.isabs(path):
+            target = path
+        elif home_directory is not None:
+            target = os.path.join(home_directory, path)
+        else:
+            raise ValueError(f"relative path {path!r} requires a home directory")
+
+    fail_on_invalid = entry["fail_on_invalid"]
+    on_invalid = entry["on_invalid"]
+    fmt = entry["format"]
+
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+
+    orig_mode = None
+    raw_existing = None
+    if os.path.exists(target):
+        try:
+            orig_mode = os.stat(target).st_mode
+            with open(target, "r", encoding="utf-8") as existing_file:
+                raw_existing = existing_file.read()
+            existing = parse_content(raw_existing, fmt)
+        except Exception as exc:
+            message = f"failed to parse {target}: {exc}"
+            if fail_on_invalid:
+                fail_or_warn(message, True)
+                return
+            if on_invalid == "initialize":
+                print(f"warning: {message}; treating as empty", file=sys.stderr)
+                existing = {}
+            else:
+                fail_or_warn(message, False)
+                return
+    else:
+        existing = {}
+
+    managed = entry["managed"]
+
+    if not isinstance(existing, MutableMapping) and not (
+        is_sentinel(managed, "union") or is_sentinel(managed, "mergeBy")
+    ):
+        fail_or_warn(
+            f"top-level value in {target} is not an object/table; got {type(existing).__name__}",
+            fail_on_invalid,
+        )
+        return
+
+    existing = merge(existing, managed)
+
+    try:
+        rendered = dump_content(existing, fmt)
+    except Exception as exc:
+        fail_or_warn(f"failed to serialize {target}: {exc}", True)
+        return
+
+    if rendered == raw_existing:
+        return
+
+    write_target = os.path.realpath(target) if os.path.islink(target) else target
+
+    if raw_existing is not None:
+        backup_existing(target, command_path=write_target)
+
+    target_dir = os.path.dirname(write_target)
+    fd, tmp_path = tempfile.mkstemp(prefix="home-manager.", dir=target_dir)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            tmp_file.write(rendered)
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+        if orig_mode is not None:
+            os.chmod(tmp_path, orig_mode & 0o7777)
+        os.replace(tmp_path, write_target)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} manifest.json home-directory", file=sys.stderr)
+        raise SystemExit(2)
+
+    with open(sys.argv[1], "r", encoding="utf-8") as manifest_file:
+        entries = json.load(manifest_file)
+    home_directory = sys.argv[2]
+
+    for entry in entries:
+        merge_entry(entry, home_directory)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -38,6 +38,7 @@ let
       ./misc/gtk.nix
       ./misc/lib.nix
       ./misc/mozilla-messaging-hosts.nix
+      ./misc/mutable-config.nix
       ./misc/news.nix
       ./misc/nix-remote-build.nix
       ./misc/nix.nix

--- a/modules/programs/t3code.nix
+++ b/modules/programs/t3code.nix
@@ -15,19 +15,7 @@ let
 
   cfg = config.programs.t3code;
   jsonFormat = pkgs.formats.json { };
-  json5 = pkgs.python3Packages.toPythonApplication pkgs.python3Packages.json5;
-
-  impureConfigMerger = empty: jqOperation: path: staticSettings: ''
-    mkdir -p "$(dirname -- ${lib.escapeShellArg path})"
-    if [ ! -e ${lib.escapeShellArg path} ]; then
-      echo ${lib.escapeShellArg empty} > ${lib.escapeShellArg path}
-    fi
-    dynamic="$(${lib.getExe json5} --as-json ${lib.escapeShellArg path})"
-    static="$(cat ${lib.escapeShellArg staticSettings})"
-    config="$(${lib.getExe pkgs.jq} -n ${lib.escapeShellArg jqOperation} --argjson dynamic "$dynamic" --argjson static "$static")"
-    printf '%s\n' "$config" > ${lib.escapeShellArg path}
-    unset config
-  '';
+  mutableConfig = config.lib.mutableConfig;
 
   userDataDir = "${config.home.homeDirectory}/.t3/userdata";
 in
@@ -147,28 +135,27 @@ in
   config = mkIf cfg.enable {
     home.packages = mkIf (cfg.package != null) [ cfg.package ];
 
-    home.activation = mkMerge [
+    home.mutableConfig = mkMerge [
       (mkIf (cfg.mutableUserSettings && cfg.userSettings != { }) {
-        t3codeSettingsActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-          impureConfigMerger "{}" "$dynamic * $static" "${userDataDir}/settings.json" (
-            jsonFormat.generate "t3code-user-settings" cfg.userSettings
-          )
-        );
+        "${userDataDir}/settings.json" = {
+          data = cfg.userSettings;
+          failOnInvalid = true;
+        };
       })
       (mkIf (cfg.mutableKeybindings && cfg.keybindings != [ ]) {
-        t3codeKeybindingsActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-          impureConfigMerger "[]"
-            "$dynamic + $static | group_by([.key, .when]) | map(reduce .[] as $item ({}; . * $item))"
-            "${userDataDir}/keybindings.json"
-            (jsonFormat.generate "t3code-user-keybindings" cfg.keybindings)
-        );
+        "${userDataDir}/keybindings.json" = {
+          data = mutableConfig.mergeBy [
+            "key"
+            "when"
+          ] cfg.keybindings;
+          failOnInvalid = true;
+        };
       })
       (mkIf (cfg.mutableClientSettings && cfg.clientSettings != { }) {
-        t3codeClientSettingsActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-          impureConfigMerger "{}" "$dynamic * $static" "${userDataDir}/client-settings.json" (
-            jsonFormat.generate "t3code-client-settings" cfg.clientSettings
-          )
-        );
+        "${userDataDir}/client-settings.json" = {
+          data = cfg.clientSettings;
+          failOnInvalid = true;
+        };
       })
     ];
 

--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -15,19 +15,7 @@ let
 
   cfg = config.programs.zed-editor;
   jsonFormat = pkgs.formats.json { };
-  json5 = pkgs.python3Packages.toPythonApplication pkgs.python3Packages.json5;
-  impureConfigMerger = empty: jqOperation: path: staticSettings: ''
-    mkdir -p $(dirname ${lib.escapeShellArg path})
-    if [ ! -e ${lib.escapeShellArg path} ]; then
-      # No file? Create it
-      echo ${lib.escapeShellArg empty} > ${lib.escapeShellArg path}
-    fi
-    dynamic="$(${lib.getExe json5} --as-json ${lib.escapeShellArg path} 2>/dev/null || echo ${lib.escapeShellArg empty})"
-    static="$(cat ${lib.escapeShellArg staticSettings})"
-    config="$(${lib.getExe pkgs.jq} -n ${lib.escapeShellArg jqOperation} --argjson dynamic "$dynamic" --argjson static "$static")"
-    printf '%s\n' "$config" > ${lib.escapeShellArg path}
-    unset config
-  '';
+  mutableConfig = config.lib.mutableConfig;
 
   transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
     lib.mapAttrs (
@@ -307,37 +295,30 @@ in
       }
     );
 
-    home.activation = mkMerge [
+    home.mutableConfig = mkMerge [
       (mkIf (cfg.mutableUserSettings && mergedSettings != { }) {
-        zedSettingsActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-          impureConfigMerger "{}" "$dynamic * $static" "${config.xdg.configHome}/zed/settings.json" (
-            jsonFormat.generate "zed-user-settings" mergedSettings
-          )
-        );
+        "${config.xdg.configHome}/zed/settings.json" = {
+          data = mergedSettings;
+          onInvalid = "initialize";
+        };
       })
       (mkIf (cfg.mutableUserKeymaps && cfg.userKeymaps != [ ]) {
-        zedKeymapActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-          impureConfigMerger "[]"
-            "$dynamic + $static | group_by(.context) | map(reduce .[] as $item ({}; . * $item))"
-            "${config.xdg.configHome}/zed/keymap.json"
-            (jsonFormat.generate "zed-user-keymaps" cfg.userKeymaps)
-        );
+        "${config.xdg.configHome}/zed/keymap.json" = {
+          data = mutableConfig.mergeBy "context" cfg.userKeymaps;
+          onInvalid = "initialize";
+        };
       })
       (mkIf (cfg.mutableUserTasks && cfg.userTasks != [ ]) {
-        zedTasksActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-          impureConfigMerger "[]"
-            "$dynamic + $static | group_by(.label) | map(reduce .[] as $item ({}; . * $item))"
-            "${config.xdg.configHome}/zed/tasks.json"
-            (jsonFormat.generate "zed-user-tasks" cfg.userTasks)
-        );
+        "${config.xdg.configHome}/zed/tasks.json" = {
+          data = mutableConfig.mergeBy "label" cfg.userTasks;
+          onInvalid = "initialize";
+        };
       })
       (mkIf (cfg.mutableUserDebug && cfg.userDebug != [ ]) {
-        zedDebugActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-          impureConfigMerger "[]"
-            "$dynamic + $static | group_by(.label) | map(reduce .[] as $item ({}; . * $item))"
-            "${config.xdg.configHome}/zed/debug.json"
-            (jsonFormat.generate "zed-user-debug" cfg.userDebug)
-        );
+        "${config.xdg.configHome}/zed/debug.json" = {
+          data = mutableConfig.mergeBy "label" cfg.userDebug;
+          onInvalid = "initialize";
+        };
       })
     ];
 

--- a/tests/modules/programs/t3code/settings.nix
+++ b/tests/modules/programs/t3code/settings.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -147,13 +146,13 @@
         [
           {
             "key": "mod+d",
-            "command": "diff.toggle",
-            "when": "!terminalFocus"
+            "command": "terminal.split",
+            "when": "terminalFocus"
           },
           {
             "key": "mod+d",
-            "command": "terminal.split",
-            "when": "terminalFocus"
+            "command": "diff.toggle",
+            "when": "!terminalFocus"
           },
           {
             "key": "mod+j",
@@ -181,9 +180,6 @@
       settingsPath = ".t3/userdata/settings.json";
       keybindingsPath = ".t3/userdata/keybindings.json";
       clientSettingsPath = ".t3/userdata/client-settings.json";
-      settingsActivation = pkgs.writeScript "settings-activation" config.home.activation.t3codeSettingsActivation.data;
-      keybindingsActivation = pkgs.writeScript "keybindings-activation" config.home.activation.t3codeKeybindingsActivation.data;
-      clientSettingsActivation = pkgs.writeScript "client-settings-activation" config.home.activation.t3codeClientSettingsActivation.data;
     in
     ''
       export HOME=$TMPDIR/hm-user
@@ -193,25 +189,13 @@
       cat ${preexistingKeybindings} > $HOME/${keybindingsPath}
       cat ${preexistingClientSettings} > $HOME/${clientSettingsPath}
 
-      substitute ${settingsActivation} $TMPDIR/settings-activate --subst-var TMPDIR
-      chmod +x $TMPDIR/settings-activate
-      $TMPDIR/settings-activate
-
-      substitute ${keybindingsActivation} $TMPDIR/keybindings-activate --subst-var TMPDIR
-      chmod +x $TMPDIR/keybindings-activate
-      $TMPDIR/keybindings-activate
-
-      substitute ${clientSettingsActivation} $TMPDIR/client-settings-activate --subst-var TMPDIR
-      chmod +x $TMPDIR/client-settings-activate
-      $TMPDIR/client-settings-activate
+      ${config.lib.test.runMutableConfig}
 
       assertFileContent "$HOME/${settingsPath}" "${expectedSettings}"
       assertFileContent "$HOME/${keybindingsPath}" "${expectedKeybindings}"
       assertFileContent "$HOME/${clientSettingsPath}" "${expectedClientSettings}"
 
-      $TMPDIR/settings-activate
-      $TMPDIR/keybindings-activate
-      $TMPDIR/client-settings-activate
+      $TMPDIR/mutable-config-activation
 
       assertFileContent "$HOME/${settingsPath}" "${expectedSettings}"
       assertFileContent "$HOME/${keybindingsPath}" "${expectedKeybindings}"

--- a/tests/modules/programs/zed-editor/debug-empty.nix
+++ b/tests/modules/programs/zed-editor/debug-empty.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -39,6 +38,12 @@
         [
           {
             "adapter": "Xdebug",
+            "label": "PHP: Listen to Xdebug",
+            "port": 9003,
+            "request": "launch"
+          },
+          {
+            "adapter": "Xdebug",
             "args": [
               "--filter",
               "$ZED_SYMBOL"
@@ -46,38 +51,14 @@
             "label": "PHP: Debug this test",
             "program": "vendor/bin/phpunit",
             "request": "launch"
-          },
-          {
-            "adapter": "Xdebug",
-            "label": "PHP: Listen to Xdebug",
-            "port": 9003,
-            "request": "launch"
           }
         ]
       '';
 
       debugPath = ".config/zed/debug.json";
-      activationScript = pkgs.writeScript "activation" config.home.activation.zedDebugActivation.data;
     in
-    ''
-      export HOME=$TMPDIR/hm-user
-
-      # Simulate preexisting debug
-      mkdir -p $HOME/.config/zed
-      cat ${preexistingDebug} > $HOME/${debugPath}
-
-      # Run the activation script
-      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
-      chmod +x $TMPDIR/activate
-      $TMPDIR/activate
-
-      # Validate the merged debug
-      assertFileExists "$HOME/${debugPath}"
-      assertFileContent "$HOME/${debugPath}" "${expectedContent}"
-
-      # Test idempotency
-      $TMPDIR/activate
-      assertFileExists "$HOME/${debugPath}"
-      assertFileContent "$HOME/${debugPath}" "${expectedContent}"
-    '';
+    config.lib.test.runMutableConfigTest {
+      files.${debugPath} = preexistingDebug;
+      expected.${debugPath} = expectedContent;
+    };
 }

--- a/tests/modules/programs/zed-editor/debug.nix
+++ b/tests/modules/programs/zed-editor/debug.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -56,6 +55,12 @@
           },
           {
             "adapter": "Xdebug",
+            "label": "PHP: Listen to Xdebug",
+            "port": 9003,
+            "request": "launch"
+          },
+          {
+            "adapter": "Xdebug",
             "args": [
               "--filter",
               "$ZED_SYMBOL"
@@ -63,38 +68,14 @@
             "label": "PHP: Debug this test",
             "program": "vendor/bin/phpunit",
             "request": "launch"
-          },
-          {
-            "adapter": "Xdebug",
-            "label": "PHP: Listen to Xdebug",
-            "port": 9003,
-            "request": "launch"
           }
         ]
       '';
 
       debugPath = ".config/zed/debug.json";
-      activationScript = pkgs.writeScript "activation" config.home.activation.zedDebugActivation.data;
     in
-    ''
-      export HOME=$TMPDIR/hm-user
-
-      # Simulate preexisting debug
-      mkdir -p $HOME/.config/zed
-      cat ${preexistingDebug} > $HOME/${debugPath}
-
-      # Run the activation script
-      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
-      chmod +x $TMPDIR/activate
-      $TMPDIR/activate
-
-      # Validate the merged debug
-      assertFileExists "$HOME/${debugPath}"
-      assertFileContent "$HOME/${debugPath}" "${expectedContent}"
-
-      # Test idempotency
-      $TMPDIR/activate
-      assertFileExists "$HOME/${debugPath}"
-      assertFileContent "$HOME/${debugPath}" "${expectedContent}"
-    '';
+    config.lib.test.runMutableConfigTest {
+      files.${debugPath} = preexistingDebug;
+      expected.${debugPath} = expectedContent;
+    };
 }

--- a/tests/modules/programs/zed-editor/extensions.nix
+++ b/tests/modules/programs/zed-editor/extensions.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -43,27 +42,9 @@
 
       settingsPath = ".config/zed/settings.json";
 
-      activationScript = pkgs.writeScript "activation" config.home.activation.zedSettingsActivation.data;
     in
-    ''
-      export HOME=$TMPDIR/hm-user
-
-      # Simulate preexisting settings
-      mkdir -p $HOME/.config/zed
-      cat ${preexistingSettings} > $HOME/${settingsPath}
-
-      # Run the activation script
-      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
-      chmod +x $TMPDIR/activate
-      $TMPDIR/activate
-
-      # Validate the merged settings
-      assertFileExists "$HOME/${settingsPath}"
-      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
-
-      # Test idempotency
-      $TMPDIR/activate
-      assertFileExists "$HOME/${settingsPath}"
-      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
-    '';
+    config.lib.test.runMutableConfigTest {
+      files.${settingsPath} = preexistingSettings;
+      expected.${settingsPath} = expectedContent;
+    };
 }

--- a/tests/modules/programs/zed-editor/keymap-empty.nix
+++ b/tests/modules/programs/zed-editor/keymap-empty.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -48,27 +47,9 @@
       '';
 
       keymapPath = ".config/zed/keymap.json";
-      activationScript = pkgs.writeScript "activation" config.home.activation.zedKeymapActivation.data;
     in
-    ''
-      export HOME=$TMPDIR/hm-user
-
-      # Simulate preexisting keymaps
-      mkdir -p $HOME/.config/zed
-      cat ${preexistingKeymaps} > $HOME/${keymapPath}
-
-      # Run the activation script
-      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
-      chmod +x $TMPDIR/activate
-      $TMPDIR/activate
-
-      # Validate the merged keymaps
-      assertFileExists "$HOME/${keymapPath}"
-      assertFileContent "$HOME/${keymapPath}" "${expectedContent}"
-
-      # Test idempotency
-      $TMPDIR/activate
-      assertFileExists "$HOME/${keymapPath}"
-      assertFileContent "$HOME/${keymapPath}" "${expectedContent}"
-    '';
+    config.lib.test.runMutableConfigTest {
+      files.${keymapPath} = preexistingKeymaps;
+      expected.${keymapPath} = expectedContent;
+    };
 }

--- a/tests/modules/programs/zed-editor/keymap.nix
+++ b/tests/modules/programs/zed-editor/keymap.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -63,42 +62,24 @@
           },
           {
             "bindings": {
+              "down": "select"
+            },
+            "context": "Terminal"
+          },
+          {
+            "bindings": {
               "enter": "newline",
               "escape": "editor::Cancel"
             },
             "context": "Editor"
-          },
-          {
-            "bindings": {
-              "down": "select"
-            },
-            "context": "Terminal"
           }
         ]
       '';
 
       keymapPath = ".config/zed/keymap.json";
-      activationScript = pkgs.writeScript "activation" config.home.activation.zedKeymapActivation.data;
     in
-    ''
-      export HOME=$TMPDIR/hm-user
-
-      # Simulate preexisting keymaps
-      mkdir -p $HOME/.config/zed
-      cat ${preexistingKeymaps} > $HOME/${keymapPath}
-
-      # Run the activation script
-      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
-      chmod +x $TMPDIR/activate
-      $TMPDIR/activate
-
-      # Validate the merged keymaps
-      assertFileExists "$HOME/${keymapPath}"
-      assertFileContent "$HOME/${keymapPath}" "${expectedContent}"
-
-      # Test idempotency
-      $TMPDIR/activate
-      assertFileExists "$HOME/${keymapPath}"
-      assertFileContent "$HOME/${keymapPath}" "${expectedContent}"
-    '';
+    config.lib.test.runMutableConfigTest {
+      files.${keymapPath} = preexistingKeymaps;
+      expected.${keymapPath} = expectedContent;
+    };
 }

--- a/tests/modules/programs/zed-editor/mcp-integration-with-override.nix
+++ b/tests/modules/programs/zed-editor/mcp-integration-with-override.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -71,22 +70,9 @@
       '';
 
       settingsPath = ".config/zed/settings.json";
-      activationScript = pkgs.writeScript "activation" config.home.activation.zedSettingsActivation.data;
     in
-    ''
-      export HOME=$TMPDIR/hm-user
-
-      # Simulate preexisting settings
-      mkdir -p $HOME/.config/zed
-      cat ${preexistingSettings} > $HOME/${settingsPath}
-
-      # Run the activation script
-      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
-      chmod +x $TMPDIR/activate
-      $TMPDIR/activate
-
-      # Validate the settings file exists and contains both MCP servers
-      assertFileExists "$HOME/${settingsPath}"
-      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
-    '';
+    config.lib.test.runMutableConfigTest {
+      files.${settingsPath} = preexistingSettings;
+      expected.${settingsPath} = expectedContent;
+    };
 }

--- a/tests/modules/programs/zed-editor/mcp-integration.nix
+++ b/tests/modules/programs/zed-editor/mcp-integration.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -71,18 +70,8 @@
       '';
 
       settingsPath = ".config/zed/settings.json";
-      activationScript = pkgs.writeScript "activation" config.home.activation.zedSettingsActivation.data;
     in
-    ''
-      export HOME=$TMPDIR/hm-user
-
-      # Run the activation script
-      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
-      chmod +x $TMPDIR/activate
-      $TMPDIR/activate
-
-      # Validate the settings file exists and contains MCP servers
-      assertFileExists "$HOME/${settingsPath}"
-      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
-    '';
+    config.lib.test.runMutableConfigTest {
+      expected.${settingsPath} = expectedContent;
+    };
 }

--- a/tests/modules/programs/zed-editor/settings-empty.nix
+++ b/tests/modules/programs/zed-editor/settings-empty.nix
@@ -2,7 +2,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -41,27 +40,9 @@
       '';
 
       settingsPath = ".config/zed/settings.json";
-      activationScript = pkgs.writeScript "activation" config.home.activation.zedSettingsActivation.data;
     in
-    ''
-      export HOME=$TMPDIR/hm-user
-
-      # Simulate preexisting settings
-      mkdir -p $HOME/.config/zed
-      cat ${preexistingSettings} > $HOME/${settingsPath}
-
-      # Run the activation script
-      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
-      chmod +x $TMPDIR/activate
-      $TMPDIR/activate
-
-      # Validate the merged settings
-      assertFileExists "$HOME/${settingsPath}"
-      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
-
-      # Test idempotency
-      $TMPDIR/activate
-      assertFileExists "$HOME/${settingsPath}"
-      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
-    '';
+    config.lib.test.runMutableConfigTest {
+      files.${settingsPath} = preexistingSettings;
+      expected.${settingsPath} = expectedContent;
+    };
 }

--- a/tests/modules/programs/zed-editor/settings.nix
+++ b/tests/modules/programs/zed-editor/settings.nix
@@ -2,7 +2,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -53,27 +52,15 @@
       '';
 
       settingsPath = ".config/zed/settings.json";
-      activationScript = pkgs.writeScript "activation" config.home.activation.zedSettingsActivation.data;
     in
-    ''
-      export HOME=$TMPDIR/hm-user
-
-      # Simulate preexisting settings
-      mkdir -p $HOME/.config/zed
-      cat ${preexistingSettings} > $HOME/${settingsPath}
-
-      # Run the activation script
-      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
-      chmod +x $TMPDIR/activate
-      $TMPDIR/activate
-
-      # Validate the merged settings
-      assertFileExists "$HOME/${settingsPath}"
-      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
-
-      # Test idempotency
-      $TMPDIR/activate
-      assertFileExists "$HOME/${settingsPath}"
-      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
-    '';
+    config.lib.test.runMutableConfigTest {
+      files.${settingsPath} = preexistingSettings;
+      expected.${settingsPath} = expectedContent;
+      setup = ''
+        chmod 600 "$HOME/${settingsPath}"
+      '';
+      assertions = ''
+        test "$(stat -c '%a' "$HOME/${settingsPath}")" = 600
+      '';
+    };
 }

--- a/tests/modules/programs/zed-editor/tasks-empty.nix
+++ b/tests/modules/programs/zed-editor/tasks-empty.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -43,27 +42,9 @@
       '';
 
       taskPath = ".config/zed/tasks.json";
-      activationScript = pkgs.writeScript "activation" config.home.activation.zedTasksActivation.data;
     in
-    ''
-      export HOME=$TMPDIR/hm-user
-
-      # Simulate preexisting tasks
-      mkdir -p $HOME/.config/zed
-      cat ${preexistingTasks} > $HOME/${taskPath}
-
-      # Run the activation script
-      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
-      chmod +x $TMPDIR/activate
-      $TMPDIR/activate
-
-      # Validate the merged tasks
-      assertFileExists "$HOME/${taskPath}"
-      assertFileContent "$HOME/${taskPath}" "${expectedContent}"
-
-      # Test idempotency
-      $TMPDIR/activate
-      assertFileExists "$HOME/${taskPath}"
-      assertFileContent "$HOME/${taskPath}" "${expectedContent}"
-    '';
+    config.lib.test.runMutableConfigTest {
+      files.${taskPath} = preexistingTasks;
+      expected.${taskPath} = expectedContent;
+    };
 }

--- a/tests/modules/programs/zed-editor/tasks.nix
+++ b/tests/modules/programs/zed-editor/tasks.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -44,10 +43,6 @@
       expectedContent = builtins.toFile "expected.json" ''
         [
           {
-            "label": "Compile",
-            "command": "make"
-          },
-          {
             "label": "Format Code",
             "allow_concurrent_runs": false,
             "args": [
@@ -55,32 +50,18 @@
               "$ZED_WORKTREE_ROOT"
             ],
             "command": "nix"
+          },
+          {
+            "label": "Compile",
+            "command": "make"
           }
         ]
       '';
 
       taskPath = ".config/zed/tasks.json";
-      activationScript = pkgs.writeScript "activation" config.home.activation.zedTasksActivation.data;
     in
-    ''
-      export HOME=$TMPDIR/hm-user
-
-      # Simulate preexisting tasks
-      mkdir -p $HOME/.config/zed
-      cat ${preexistingTasks} > $HOME/${taskPath}
-
-      # Run the activation script
-      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
-      chmod +x $TMPDIR/activate
-      $TMPDIR/activate
-
-      # Validate the merged tasks
-      assertFileExists "$HOME/${taskPath}"
-      assertFileContent "$HOME/${taskPath}" "${expectedContent}"
-
-      # Test idempotency
-      $TMPDIR/activate
-      assertFileExists "$HOME/${taskPath}"
-      assertFileContent "$HOME/${taskPath}" "${expectedContent}"
-    '';
+    config.lib.test.runMutableConfigTest {
+      files.${taskPath} = preexistingTasks;
+      expected.${taskPath} = expectedContent;
+    };
 }

--- a/tests/stubs.nix
+++ b/tests/stubs.nix
@@ -93,6 +93,72 @@ let
     in
     stubbedPkg;
 
+  runActivation =
+    name: activation:
+    let
+      activationScript = pkgs.writeScript name activation.data;
+    in
+    ''
+      substitute ${activationScript} $TMPDIR/${name} --subst-var TMPDIR
+      chmod +x $TMPDIR/${name}
+      $TMPDIR/${name}
+    '';
+
+  runMutableConfigTest =
+    {
+      home ? "$TMPDIR/hm-user",
+      files ? { },
+      expected ? { },
+      setup ? "",
+      assertions ? "",
+      idempotent ? true,
+      idempotentPaths ? lib.attrNames expected,
+    }:
+    let
+      seedFiles = lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (path: source: ''
+          mkdir -p "$(dirname "$HOME/${path}")"
+          cat ${source} > "$HOME/${path}"
+        '') files
+      );
+
+      assertExpected = lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (path: expectedContent: ''
+          assertFileExists "$HOME/${path}"
+          assertFileContent "$HOME/${path}" "${expectedContent}"
+        '') expected
+      );
+
+      idempotentFiles = lib.concatStringsSep " " (map (path: ''"$HOME/${path}"'') idempotentPaths);
+    in
+    ''
+      export HOME=${home}
+
+      ${seedFiles}
+      ${setup}
+
+      ${runActivation "mutable-config-activation" config.home.activation.mutableConfigMerge}
+
+      ${assertExpected}
+      ${assertions}
+
+      ${lib.optionalString (idempotent && idempotentPaths != [ ]) ''
+        pre_hashes="$(sha256sum ${idempotentFiles})"
+        pre_inodes="$(stat -c '%i %n' ${idempotentFiles})"
+
+        $TMPDIR/mutable-config-activation
+
+        post_hashes="$(sha256sum ${idempotentFiles})"
+        post_inodes="$(stat -c '%i %n' ${idempotentFiles})"
+
+        test "$pre_hashes" = "$post_hashes"
+        test "$pre_inodes" = "$post_inodes"
+
+        ${assertExpected}
+        ${assertions}
+      ''}
+    '';
+
 in
 {
   options.test = {
@@ -116,6 +182,9 @@ in
 
   config = {
     lib.test.mkStubPackage = mkStubPackage;
+    lib.test.runActivation = runActivation;
+    lib.test.runMutableConfig = runActivation "mutable-config-activation" config.home.activation.mutableConfigMerge;
+    lib.test.runMutableConfigTest = runMutableConfigTest;
 
     test.stubOverlays =
       lib.optional (config.test.stubs != { }) (


### PR DESCRIPTION
### Description

Patch specific properties on complex or mutable structured configuration files.
This manages only a subset of values of the overall file.

Unlike {option}`home.file` and {option}`xdg.configFile`, these files are
plain files in the home directory. Home Manager manages only the keys
declared in {option}`data`, so applications may continue to modify other settings.

Example:

```nix
{
  # This key will be overwritten by home-manager.
  managedKey = "managed value";

  # Other fields on nestedObject will be preserved.
  nestedObject = {
    justOne = "managed field";
  };

  # This key will be removed, if it exists.
  staleKey = config.lib.mutableConfig.remove;

  # The list contained in this key will have an element appended
  # if it doesn't have that element.
  listKey = config.lib.mutableConfig.union [ "managed item" ];

  # For a list of objects, this will look up an existing object by
  # the "label" key and deep merge the inner fields.
  # If no object matches `label=Format`, a new one will be inserted.
  tasks = config.lib.mutableConfig.mergeBy "label" [
    {
      label = "Format";
      command = "nix";
      # NOTE: the merge is recursive, so we could use another
      #       `union` right here, for example.
      args = [ "fmt" ];
    }
  ];
}

```


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

---

Not a new module, but I think it could be worthy of a news entry?

Not sure about the docs on options. IMO, this is useful on files that need to be writable, or cannot be a symlink, or have too many ever-changing properties to manage through HM. My trigger was the zed-editor so I refactored its HM module to use this capability.