### PR TITLE
lib: escape backslash in `lib.hm.generators.toKDL`

### DIFF
--- a/docs/release-notes/rl-2611.md
+++ b/docs/release-notes/rl-2611.md
@@ -12,3 +12,11 @@ This release has the following notable changes:
 The state version in this release includes the changes below. These
 changes are only active if the `home.stateVersion` option is set to
 "26.11" or later.
+
+- The KDL options under `programs.zellij` will now correctly escape backslashes
+  in string values. For example, the Nix string `"\\"` will now correctly
+  generate the KDL string `"\\"`. Previously, this would have generated `"\"`,
+  which is invalid KDL. The following options are affected:
+  - `programs.zellij.settings`
+  - `programs.zellij.themes`
+  - `programs.zellij.layouts`

--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -67,7 +67,9 @@
     toHyprconf' initialIndent attrs;
 
   toKDL =
-    _:
+    {
+      escapeBackslashes ? false,
+    }:
     let
       inherit (lib)
         concatStringsSep
@@ -89,7 +91,22 @@
         stringsWithNewlines: indentAll (unlines (lines stringsWithNewlines));
 
       # String -> String
-      sanitizeString = replaceStrings [ "\n" ''"'' ] [ "\\n" ''\"'' ];
+      sanitizeString =
+        replaceStrings
+          (
+            [
+              "\n"
+              ''"''
+            ]
+            ++ (lib.optional escapeBackslashes "\\")
+          )
+          (
+            [
+              "\\n"
+              ''\"''
+            ]
+            ++ (lib.optional escapeBackslashes "\\\\")
+          );
 
       # OneOf [Int Float String Bool Null] -> String
       literalValueToString =

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -288,6 +288,9 @@ in
       pluginRuntimeDeps = lib.concatLists (
         lib.map ({ plugin, ... }: plugin.runtimeDeps or [ ]) pluginsWithNames
       );
+      toKDL = lib.hm.generators.toKDL {
+        escapeBackslashes = lib.versionAtLeast config.home.stateVersion "26.11";
+      };
     in
     mkIf cfg.enable {
       home.packages = [ cfg.finalPackage ];
@@ -317,7 +320,7 @@ in
               )
               {
                 text =
-                  (lib.hm.generators.toKDL { } cfg.settings)
+                  (toKDL cfg.settings)
                   + lib.optionalString (cfg.extraConfig != "") (
                     ''
 
@@ -336,9 +339,7 @@ in
               if builtins.isPath value || lib.isStorePath value then
                 value
               else
-                pkgs.writeText "zellij-layout-${name}" (
-                  if lib.isString value then value else lib.hm.generators.toKDL { } value
-                );
+                pkgs.writeText "zellij-layout-${name}" (if lib.isString value then value else toKDL value);
           }
         ) cfg.layouts)
 
@@ -349,9 +350,7 @@ in
               if builtins.isPath value || lib.isStorePath value then
                 value
               else
-                pkgs.writeText "zellij-theme-${name}" (
-                  if lib.isString value then value else lib.hm.generators.toKDL { } value
-                );
+                pkgs.writeText "zellij-theme-${name}" (if lib.isString value then value else toKDL value);
           }
         ) cfg.themes)
 

--- a/tests/lib/generators/tokdl-result-escape-backslashes.txt
+++ b/tests/lib/generators/tokdl-result-escape-backslashes.txt
@@ -4,7 +4,7 @@ a 1
 argsAndProps 1 2 a=3
 b "string"
 bigFlatItems 23847590283751 1.239000 "multiline \" \" \"\nstring\n" null
-c "multiline string\nwith special characters:\n	 \\" \" \\n"
+c "multiline string\nwith special characters:\n	 \\\" \" \\\n"
 duplicateChildren {
 	child 2
 	child 1
@@ -45,4 +45,4 @@ nested {
 	- 
 	- null
 }
-unsafeString " \" \n 	 \"
+unsafeString " \" \n 	 \\"

--- a/tests/lib/generators/tokdl.nix
+++ b/tests/lib/generators/tokdl.nix
@@ -1,15 +1,14 @@
 { lib, ... }:
-
-{
-  home.file."tokdl-result.txt".text = lib.hm.generators.toKDL { } {
+let
+  testData = {
     a = 1;
     b = "string";
     c = ''
       multiline string
       with special characters:
-      \t \n \" "
+      ''\t \" " \
     '';
-    unsafeString = " \" \n 	 ";
+    unsafeString = " \" \n 	 \\";
     flatItems = [
       1
       2
@@ -81,10 +80,21 @@
       list2 = [ { a = 8; } ];
     };
   };
+in
+
+{
+  home.file."tokdl-result.txt".text = lib.hm.generators.toKDL { } testData;
+  home.file."tokdl-result-escape-backslashes.txt".text = lib.hm.generators.toKDL {
+    escapeBackslashes = true;
+  } testData;
 
   nmt.script = ''
     assertFileContent \
       home-files/tokdl-result.txt \
       ${./tokdl-result.txt}
+
+    assertFileContent \
+      home-files/tokdl-result-escape-backslashes.txt \
+      ${./tokdl-result-escape-backslashes.txt}
   '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

According to the [KDL spec](https://kdl.dev/spec/#name-quoted-string), backslashes need to be escaped in quoted strings. The existing KDL generator doesn't have any special handling for backslashes, so it can generate invalid KDL if a string in the input contains a backslash.

This change is not backwards compatible because it changes the behavior of the KDL generator. Can someone advise me on how I should proceed with a backwards incompatible change like this?

I removed the the escaped newline from the multiline string test due to unintuitive behavior in nix: https://github.com/NixOS/nix/issues/16011 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
