### PR TITLE
git-credentials-keepassxc: add unlock option

### DIFF
--- a/modules/misc/news/2026/06/2026-06-16_21-53-22.nix
+++ b/modules/misc/news/2026/06/2026-06-16_21-53-22.nix
@@ -1,0 +1,10 @@
+{ config, ... }:
+{
+  time = "2026-06-16T19:53:22+00:00";
+  condition = config.programs.git-credential-keepassxc.enable;
+  # if behavior changed, explain how to restore previous behavior.
+  message = ''
+    'programs.git-credential-keepassxc.unlock' was added
+    to automatically ask for a login when required.
+  '';
+}

--- a/modules/programs/git-credential-keepassxc.nix
+++ b/modules/programs/git-credential-keepassxc.nix
@@ -31,6 +31,21 @@ in
       example = [ "https://github.com" ];
       description = "Hosts for which {command}`git-credential-keepassxc` is enabled.";
     };
+    unlock = {
+      enable = lib.mkEnableOption "automatic database unlock prompt.";
+      retries = lib.mkOption {
+        type = lib.types.int;
+        default = 0;
+        example = 3;
+        description = "Number of unlocking attempts (0 means infinite retries)";
+      };
+      interval = lib.mkOption {
+        type = with lib.types; nullOr int;
+        default = null;
+        example = 1000;
+        description = "Number of ms between attempts, null uses the default value";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -46,7 +61,16 @@ in
                 lib.concatStringsSep " " (map (g: "--group ${g}") cfg.groups);
           in
           {
-            helper = "${cfg.package}/bin/git-credential-keepassxc ${groups}";
+            helper = lib.concatStringsSep " " (
+              [
+                "${cfg.package}/bin/git-credential-keepassxc"
+                groups
+              ]
+              ++ lib.optional cfg.unlock.enable (
+                "--unlock ${toString cfg.unlock.retries}"
+                + lib.optionalString (cfg.unlock.interval != null) ",${toString cfg.unlock.interval}"
+              )
+            );
           };
       in
       if cfg.hosts == [ ] then

--- a/tests/modules/programs/git-credential-keepassxc/default.nix
+++ b/tests/modules/programs/git-credential-keepassxc/default.nix
@@ -2,4 +2,6 @@
   git-credential-keepassxc-default-config = ./default-config.nix;
   git-credential-keepassxc-custom-groups = ./custom-groups.nix;
   git-credential-keepassxc-custom-hosts = ./custom-hosts.nix;
+  git-credential-keepassxc-unlock = ./unlock.nix;
+  git-credential-keepassxc-unlock-set-timeout = ./unlock-set-timeout.nix;
 }

--- a/tests/modules/programs/git-credential-keepassxc/unlock-set-timeout.nix
+++ b/tests/modules/programs/git-credential-keepassxc/unlock-set-timeout.nix
@@ -1,0 +1,16 @@
+{
+  programs.git.enable = true;
+  programs.git-credential-keepassxc = {
+    enable = true;
+    unlock = {
+      enable = true;
+      retries = 5;
+      interval = 3000;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileRegex home-files/.config/git/config 'helper = "\S*/bin/git-credential-keepassxc --git-groups --unlock 5,3000"'
+  '';
+}

--- a/tests/modules/programs/git-credential-keepassxc/unlock.nix
+++ b/tests/modules/programs/git-credential-keepassxc/unlock.nix
@@ -1,0 +1,14 @@
+{
+  programs.git.enable = true;
+  programs.git-credential-keepassxc = {
+    enable = true;
+    unlock = {
+      enable = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileRegex home-files/.config/git/config 'helper = "\S*/bin/git-credential-keepassxc --git-groups --unlock 0"'
+  '';
+}


### PR DESCRIPTION
### Description

Add option to automatically unlock keepassxc

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
