### PR TITLE
zed-editor: fix programs.mcp.servers compatibility

### DIFF
--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -32,20 +32,22 @@ let
   transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
     lib.mapAttrs (
       name: server:
-      # See: https://zed.dev/docs/ai/mcp & https://github.com/zed-industries/zed/discussions/53780
-      lib.hm.mcp.transformMcpServer {
+      # See:
+      #
+      # - https://zed.dev/docs/ai/mcp
+      # - https://github.com/zed-industries/zed/discussions/53780
+      # - https://github.com/zed-industries/zed/blob/v1.6.3/crates/project/src/project_settings.rs#L182
+      (lib.optionalAttrs (server.command != null) { args = [ ]; })
+      // (lib.hm.mcp.transformMcpServer {
         inherit server;
         extraTransforms = [
-          lib.hm.mcp.addType
           (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
         ];
-      }
+      })
     ) config.programs.mcp.servers
   );
 
-  settingMcpServers = lib.mapAttrs (_: lib.hm.mcp.addType) (
-    lib.attrByPath [ "context_servers" ] { } cfg.userSettings
-  );
+  settingMcpServers = lib.attrByPath [ "context_servers" ] { } cfg.userSettings;
   mergedMcpServers = transformedMcpServers // settingMcpServers;
 
   mergedSettings =

--- a/tests/modules/programs/zed-editor/mcp-integration-with-override.nix
+++ b/tests/modules/programs/zed-editor/mcp-integration-with-override.nix
@@ -16,6 +16,9 @@
           "@modelcontextprotocol/server-everything"
         ];
       };
+      server-no-args = {
+        command = "echo";
+      };
     };
   };
 
@@ -55,7 +58,6 @@
               "headers": {
                 "Authorization": "Bearer token"
               },
-              "type": "http",
               "url": "https://custom.example.com/mcp"
             },
             "everything": {
@@ -63,8 +65,11 @@
                 "-y",
                 "@modelcontextprotocol/server-everything"
               ],
-              "command": "npx",
-              "type": "stdio"
+              "command": "npx"
+            },
+            "server-no-args": {
+              "args": [],
+              "command": "echo"
             }
           }
         }

--- a/tests/modules/programs/zed-editor/mcp-integration.json
+++ b/tests/modules/programs/zed-editor/mcp-integration.json
@@ -4,7 +4,6 @@
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       },
-      "type": "http",
       "url": "https://mcp.context7.com/mcp"
     },
     "disabled-server": {
@@ -12,16 +11,18 @@
         "test"
       ],
       "command": "echo",
-      "enabled": false,
-      "type": "stdio"
+      "enabled": false
     },
     "everything": {
       "args": [
         "-y",
         "@modelcontextprotocol/server-everything"
       ],
-      "command": "npx",
-      "type": "stdio"
+      "command": "npx"
+    },
+    "server-no-args": {
+      "args": [],
+      "command": "echo"
     }
   }
 }

--- a/tests/modules/programs/zed-editor/mcp-integration.nix
+++ b/tests/modules/programs/zed-editor/mcp-integration.nix
@@ -16,6 +16,9 @@
           "@modelcontextprotocol/server-everything"
         ];
       };
+      server-no-args = {
+        command = "echo";
+      };
       context7 = {
         url = "https://mcp.context7.com/mcp";
         headers = {
@@ -47,7 +50,6 @@
               "headers": {
                 "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
               },
-              "type": "http",
               "url": "https://mcp.context7.com/mcp"
             },
             "disabled-server": {
@@ -55,16 +57,18 @@
                 "test"
               ],
               "command": "echo",
-              "enabled": false,
-              "type": "stdio"
+              "enabled": false
             },
             "everything": {
               "args": [
                 "-y",
                 "@modelcontextprotocol/server-everything"
               ],
-              "command": "npx",
-              "type": "stdio"
+              "command": "npx"
+            },
+            "server-no-args": {
+              "args": [],
+              "command": "echo"
             }
           }
         }


### PR DESCRIPTION
### Description

Default `args` to an empty list on `stdio` servers as it's a `Vec<String>`, and loading the configuration fails if it's missing. This cannot be done in `extraTransforms` due to the final `filterAttrs`.

Remove `addType` call as `ContextServerSettings` doesn't use type to differentiate server types.

Link: https://github.com/zed-industries/zed/blob/601ecb3ee5c16940191818ee7f244837abf6983c/crates/settings_content/src/project.rs#L484
Link: https://github.com/zed-industries/zed/blob/601ecb3ee5c16940191818ee7f244837abf6983c/crates/project/src/project_settings.rs#L182

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
