### PR TITLE
maintainers: dump aguirre-matteo from almost all modules

### DIFF
--- a/modules/programs/abaddon.nix
+++ b/modules/programs/abaddon.nix
@@ -16,7 +16,6 @@ let
   iniFormat = pkgs.formats.ini { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.abaddon = {
     enable = mkEnableOption "abaddon";
     package = mkPackageOption pkgs "abaddon" { nullable = true; };

--- a/modules/programs/acd-cli.nix
+++ b/modules/programs/acd-cli.nix
@@ -16,7 +16,6 @@ let
   iniFormat = pkgs.formats.ini { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.acd-cli = {
     enable = mkEnableOption "acd-cli";
     package = mkPackageOption pkgs "acd-cli" { nullable = true; };

--- a/modules/programs/ahoviewer.nix
+++ b/modules/programs/ahoviewer.nix
@@ -16,7 +16,6 @@ let
   cfg = config.programs.ahoviewer;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.ahoviewer = {
     enable = mkEnableOption "ahoviewer";
     package = mkPackageOption pkgs "ahoviewer" { nullable = true; };

--- a/modules/programs/aiac.nix
+++ b/modules/programs/aiac.nix
@@ -16,7 +16,6 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.aiac = {
     enable = mkEnableOption "aiac";
     package = mkPackageOption pkgs "aiac" { nullable = true; };

--- a/modules/programs/aider-chat.nix
+++ b/modules/programs/aider-chat.nix
@@ -16,7 +16,6 @@ let
   yamlFormat = pkgs.formats.yaml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.aider-chat = {
     enable = mkEnableOption "aider-chat";
     package = mkPackageOption pkgs "aider-chat" { nullable = true; };

--- a/modules/programs/airlift.nix
+++ b/modules/programs/airlift.nix
@@ -16,7 +16,6 @@ let
   yamlFormat = pkgs.formats.yaml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.airlift = {
     enable = mkEnableOption "airlift";
     package = mkPackageOption pkgs "airlift" { nullable = true; };

--- a/modules/programs/algia.nix
+++ b/modules/programs/algia.nix
@@ -16,7 +16,6 @@ let
   jsonFormat = pkgs.formats.json { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.algia = {
     enable = mkEnableOption "algia";
     package = mkPackageOption pkgs "algia" { nullable = true; };

--- a/modules/programs/aliae.nix
+++ b/modules/programs/aliae.nix
@@ -24,7 +24,6 @@ let
   yamlFormat = pkgs.formats.yaml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.aliae = {
     enable = mkEnableOption "aliae";
     package = mkPackageOption pkgs "aliae" { nullable = true; };

--- a/modules/programs/alistral.nix
+++ b/modules/programs/alistral.nix
@@ -16,7 +16,6 @@ let
   jsonFormat = pkgs.formats.json { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.alistral = {
     enable = mkEnableOption "alistral";
     package = mkPackageOption pkgs "alistral" { nullable = true; };

--- a/modules/programs/am2rlauncher.nix
+++ b/modules/programs/am2rlauncher.nix
@@ -16,7 +16,6 @@ let
   cfg = config.programs.am2rlauncher;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.am2rlauncher = {
     enable = mkEnableOption "am2rlauncher";
     package = mkPackageOption pkgs "am2rlauncher" { nullable = true; };

--- a/modules/programs/amber.nix
+++ b/modules/programs/amber.nix
@@ -16,7 +16,6 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.amber = {
     enable = mkEnableOption "amber";
     package = mkPackageOption pkgs "amber" { nullable = true; };

--- a/modules/programs/amfora.nix
+++ b/modules/programs/amfora.nix
@@ -17,7 +17,6 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.amfora = {
     enable = mkEnableOption "amfora";
     package = mkPackageOption pkgs "amfora" { nullable = true; };

--- a/modules/programs/amoco.nix
+++ b/modules/programs/amoco.nix
@@ -16,7 +16,6 @@ let
   cfg = config.programs.amoco;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.amoco = {
     enable = mkEnableOption "amoco";
     package = mkPackageOption pkgs "amoco" { nullable = true; };

--- a/modules/programs/amp.nix
+++ b/modules/programs/amp.nix
@@ -16,7 +16,6 @@ let
   yamlFormat = pkgs.formats.yaml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.amp = {
     enable = mkEnableOption "amp";
     package = mkPackageOption pkgs "amp" { nullable = true; };

--- a/modules/programs/andcli.nix
+++ b/modules/programs/andcli.nix
@@ -16,7 +16,6 @@ let
   yamlFormat = pkgs.formats.yaml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.andcli = {
     enable = mkEnableOption "andcli";
     package = mkPackageOption pkgs "andcli" { nullable = true; };

--- a/modules/programs/animdl.nix
+++ b/modules/programs/animdl.nix
@@ -16,7 +16,6 @@ let
   yamlFormat = pkgs.formats.yaml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.animdl = {
     enable = mkEnableOption "animdl";
     package = mkPackageOption pkgs "animdl" { nullable = true; };

--- a/modules/programs/anime-downloader.nix
+++ b/modules/programs/anime-downloader.nix
@@ -16,7 +16,6 @@ let
   jsonFormat = pkgs.formats.json { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.anime-downloader = {
     enable = mkEnableOption "anime-downloader";
     package = mkPackageOption pkgs "anime-downloader" { nullable = true; };

--- a/modules/programs/anup.nix
+++ b/modules/programs/anup.nix
@@ -16,7 +16,6 @@ let
   cfg = config.programs.anup;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.anup = {
     enable = mkEnableOption "anup";
     package = mkPackageOption pkgs "anup" { nullable = true; };

--- a/modules/programs/anvil-editor.nix
+++ b/modules/programs/anvil-editor.nix
@@ -17,7 +17,6 @@ let
   jsonFormat = pkgs.formats.json { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.anvil-editor = {
     enable = mkEnableOption "anvil-editor";
     package = mkPackageOption pkgs "anvil-editor" { nullable = true; };

--- a/modules/programs/aperture.nix
+++ b/modules/programs/aperture.nix
@@ -16,7 +16,6 @@ let
   yamlFormat = pkgs.formats.yaml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.aperture = {
     enable = mkEnableOption "aperture";

--- a/modules/programs/aphorme.nix
+++ b/modules/programs/aphorme.nix
@@ -16,7 +16,6 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.aphorme = {
     enable = mkEnableOption "aphorme";

--- a/modules/programs/calibre.nix
+++ b/modules/programs/calibre.nix
@@ -16,7 +16,6 @@ let
   cfg = config.programs.calibre;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.calibre = {
     enable = mkEnableOption "calibre";
     package = mkPackageOption pkgs "calibre" { nullable = true; };

--- a/modules/programs/cudatext.nix
+++ b/modules/programs/cudatext.nix
@@ -20,7 +20,6 @@ let
   jsonFormat = pkgs.formats.json { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.cudatext = {
     enable = mkEnableOption "cudatext";
     package = mkPackageOption pkgs "cudatext" { nullable = true; };

--- a/modules/programs/element-desktop.nix
+++ b/modules/programs/element-desktop.nix
@@ -21,7 +21,6 @@ let
     if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else config.xdg.configHome;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.element-desktop = {
     enable = mkEnableOption "element-desktop";

--- a/modules/programs/fabric-ai.nix
+++ b/modules/programs/fabric-ai.nix
@@ -19,7 +19,6 @@ let
   cfg = config.programs.fabric-ai;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.fabric-ai = {
     enable = mkEnableOption "Fabric AI";
     package = mkPackageOption pkgs "fabric-ai" { nullable = true; };

--- a/modules/programs/formiko.nix
+++ b/modules/programs/formiko.nix
@@ -16,7 +16,6 @@ let
   iniFormat = pkgs.formats.ini { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.formiko = {
     enable = mkEnableOption "formiko";
     package = mkPackageOption pkgs "formiko" { nullable = true; };

--- a/modules/programs/halloy.nix
+++ b/modules/programs/halloy.nix
@@ -18,7 +18,6 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.halloy = {
     enable = mkEnableOption "halloy";

--- a/modules/programs/i3bar-river.nix
+++ b/modules/programs/i3bar-river.nix
@@ -16,7 +16,6 @@ let
   formatter = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.i3bar-river = {
     enable = mkEnableOption "i3bar-river";

--- a/modules/programs/intelli-shell.nix
+++ b/modules/programs/intelli-shell.nix
@@ -24,7 +24,6 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.intelli-shell = {
     enable = mkEnableOption "intelli-shell";
     package = mkPackageOption pkgs "intelli-shell" { nullable = true; };

--- a/modules/programs/kickoff.nix
+++ b/modules/programs/kickoff.nix
@@ -17,7 +17,6 @@ let
   formatter = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.kickoff = {
     enable = mkEnableOption "kickoff";

--- a/modules/programs/lazysql.nix
+++ b/modules/programs/lazysql.nix
@@ -17,7 +17,6 @@ let
   formatter = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.lazysql = {
     enable = mkEnableOption "lazysql";

--- a/modules/programs/lazyworktree.nix
+++ b/modules/programs/lazyworktree.nix
@@ -15,7 +15,6 @@ let
   yamlFormat = pkgs.formats.yaml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.lazyworktree = {
     enable = mkEnableOption "lazyworktree";
 

--- a/modules/programs/mpvpaper.nix
+++ b/modules/programs/mpvpaper.nix
@@ -16,7 +16,6 @@ let
   cfg = config.programs.mpvpaper;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.mpvpaper = {
     enable = mkEnableOption "mpvpaper";

--- a/modules/programs/nyxt.nix
+++ b/modules/programs/nyxt.nix
@@ -17,7 +17,6 @@ let
   cfg = config.programs.nyxt;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.nyxt = {
     enable = mkEnableOption "Nyxt";

--- a/modules/programs/onagre.nix
+++ b/modules/programs/onagre.nix
@@ -16,7 +16,6 @@ let
   cfg = config.programs.onagre;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.onagre = {
     enable = mkEnableOption "onagre";

--- a/modules/programs/onedrive.nix
+++ b/modules/programs/onedrive.nix
@@ -20,7 +20,6 @@ let
   };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.onedrive = {
     enable = mkEnableOption "onedrive";

--- a/modules/programs/radio-cli.nix
+++ b/modules/programs/radio-cli.nix
@@ -16,7 +16,6 @@ let
   jsonFormat = pkgs.formats.json { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.radio-cli = {
     enable = mkEnableOption "radio-cli";

--- a/modules/programs/retext.nix
+++ b/modules/programs/retext.nix
@@ -16,7 +16,6 @@ let
   iniFormat = pkgs.formats.ini { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.retext = {
     enable = mkEnableOption "retext";
     package = mkPackageOption pkgs "retext" { nullable = true; };

--- a/modules/programs/rmpc.nix
+++ b/modules/programs/rmpc.nix
@@ -16,7 +16,6 @@ let
   cfg = config.programs.rmpc;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.rmpc = {
     enable = mkEnableOption "rmpc";

--- a/modules/programs/screen.nix
+++ b/modules/programs/screen.nix
@@ -16,7 +16,6 @@ let
   cfg = config.programs.screen;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.screen = {
     enable = mkEnableOption "screen";
     package = mkPackageOption pkgs "screen" { nullable = true; };

--- a/modules/programs/swappy.nix
+++ b/modules/programs/swappy.nix
@@ -16,7 +16,6 @@ let
   iniFormat = pkgs.formats.ini { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.swappy = {
     enable = mkEnableOption "swappy";

--- a/modules/programs/sway-easyfocus.nix
+++ b/modules/programs/sway-easyfocus.nix
@@ -16,7 +16,6 @@ let
   formatter = pkgs.formats.yaml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.sway-easyfocus = {
     enable = mkEnableOption "sway-easyfocus";

--- a/modules/programs/tray-tui.nix
+++ b/modules/programs/tray-tui.nix
@@ -16,7 +16,6 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.tray-tui = {
     enable = mkEnableOption "tray-tui";

--- a/modules/programs/trippy.nix
+++ b/modules/programs/trippy.nix
@@ -17,7 +17,6 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.trippy = {
     enable = mkEnableOption "trippy";

--- a/modules/programs/twitch-tui.nix
+++ b/modules/programs/twitch-tui.nix
@@ -16,7 +16,6 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.twitch-tui = {
     enable = mkEnableOption "twitch-tui";

--- a/modules/programs/visidata.nix
+++ b/modules/programs/visidata.nix
@@ -16,7 +16,6 @@ let
   cfg = config.programs.visidata;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.visidata = {
     enable = mkEnableOption "Visidata";

--- a/modules/programs/vivid.nix
+++ b/modules/programs/vivid.nix
@@ -27,7 +27,6 @@ let
 in
 {
   meta.maintainers = [
-    lib.hm.maintainers.aguirre-matteo
     lib.maintainers.arunoruto
   ];
 

--- a/modules/programs/waveterm.nix
+++ b/modules/programs/waveterm.nix
@@ -17,7 +17,6 @@ let
   formatter = pkgs.formats.json { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.waveterm = {
     enable = mkEnableOption "waveterm";

--- a/modules/programs/yofi.nix
+++ b/modules/programs/yofi.nix
@@ -18,7 +18,6 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.yofi = {
     enable = mkEnableOption "yofi";

--- a/modules/programs/zapzap.nix
+++ b/modules/programs/zapzap.nix
@@ -16,7 +16,6 @@ let
   cfg = config.programs.zapzap;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
   options.programs.zapzap = {
     enable = mkEnableOption "zapzap";
     package = mkPackageOption pkgs "zapzap" { nullable = true; };

--- a/modules/services/clipcat.nix
+++ b/modules/services/clipcat.nix
@@ -18,7 +18,6 @@ let
   formatter = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.services.clipcat = {
     enable = mkEnableOption "clipcat";

--- a/modules/services/hyprlauncher.nix
+++ b/modules/services/hyprlauncher.nix
@@ -15,7 +15,6 @@ let
   cfg = config.services.hyprlauncher;
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.services.hyprlauncher = {
     enable = mkEnableOption "hyprlauncher";

--- a/modules/services/hyprshell.nix
+++ b/modules/services/hyprshell.nix
@@ -18,7 +18,6 @@ let
   jsonFormat = pkgs.formats.json { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.services.hyprshell = {
     enable = mkEnableOption "hyprshell";

--- a/modules/services/walker.nix
+++ b/modules/services/walker.nix
@@ -18,7 +18,6 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.services.walker = {
     enable = mkEnableOption "walker";


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

These couple of months I've been really busy, not only because of school but also some responsibilities I have acquired. That's the reason I'm not willing to maintain that large amount of modules but only Distrobox and Onlyoffice.
 
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
