### PR TITLE
voxtype: fix output mode `paste`

### DIFF
--- a/modules/services/voxtype.nix
+++ b/modules/services/voxtype.nix
@@ -141,7 +141,10 @@ in
       Service =
         let
           runtimePath = makeBinPath (
-            [ pkgs.which ]
+            [
+              pkgs.coreutils
+              pkgs.which
+            ]
             ++ optionals (cfg.x11.display != null) [ pkgs.xclip ]
             ++ optionals (cfg.wayland.display != null) [
               pkgs.wl-clipboard

--- a/tests/modules/services/voxtype/basic-configuration.nix
+++ b/tests/modules/services/voxtype/basic-configuration.nix
@@ -31,7 +31,7 @@
       WantedBy=default.target
 
       [Service]
-      Environment=PATH=@which@/bin:@wl-clipboard@/bin:@wtype@/bin
+      Environment=PATH=/nix/store/00000000000000000000000000000000-coreutils/bin:@which@/bin:@wl-clipboard@/bin:@wtype@/bin
       Environment=XDG_RUNTIME_DIR=%t
       Environment=WAYLAND_DISPLAY=wayland-1
       Environment=VOXTYPE_TEST_ENV=1


### PR DESCRIPTION
### Description

Voxtype requires the command `cat` from coreutils when using the output mode `paste`, but fails with the current configuration because it cannot find `cat`.

```
WARN paste (clipboard + keystroke) failed: Text injection failed: wl-copy exited with error, trying next
```

This PR adds `coreutils` to the runtime path to resolve the path to `cat`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
