### PR TITLE
antigravity-cli: fix programs.mcp.servers integration for remote servers

### DIFF
--- a/modules/programs/antigravity-cli.nix
+++ b/modules/programs/antigravity-cli.nix
@@ -474,19 +474,6 @@ in
                   lib.hm.mcp.transformMcpServer {
                     inherit server;
                     extraTransforms = [
-                      (
-                        s:
-                        removeAttrs s [
-                          "httpUrl"
-                          "url"
-                        ]
-                        // lib.optionalAttrs (s ? httpUrl) {
-                          serverUrl = s.httpUrl;
-                        }
-                        // lib.optionalAttrs (s ? url) {
-                          serverUrl = s.url;
-                        }
-                      )
                       lib.hm.mcp.addType
                       (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
                       (s: lib.mapAttrs (_: lib.mkDefault) s)

--- a/tests/modules/programs/antigravity-cli/mcp.nix
+++ b/tests/modules/programs/antigravity-cli/mcp.nix
@@ -50,6 +50,12 @@
             DATABASE_URL = "postgresql://user:pass@localhost:5432/db";
           };
         };
+        remote-server = {
+          url = "https://remote.example/mcp";
+          headers = {
+            "Authorization" = "Bearer token";
+          };
+        };
       };
     };
   };
@@ -62,5 +68,8 @@
     assertFileRegex home-files/.gemini/config/mcp_config.json '"filesystem"'
     assertFileRegex home-files/.gemini/config/mcp_config.json '"database"'
     assertFileNotRegex home-files/.gemini/config/mcp_config.json '"other-tmp"'
+    assertFileRegex home-files/.gemini/config/mcp_config.json '"remote-server"'
+    assertFileRegex home-files/.gemini/config/mcp_config.json '"serverUrl": "https://remote.example/mcp"'
+    assertFileRegex home-files/.gemini/config/mcp_config.json '"type": "http"'
   '';
 }


### PR DESCRIPTION
### Description

This PR fixes a bug in the `antigravity-cli` module where remote MCP servers imported from `programs.mcp.servers` are generated as broken configurations with an incorrect `type = "stdio"` and their `serverUrl` field completely removed.

#### Issue Analysis
When `enableMcpIntegration` is enabled, the module calls `lib.hm.mcp.transformMcpServer` and passes an `extraTransforms` block that renames `url`/`httpUrl` to `serverUrl`:
```nix
(
  s:
  removeAttrs s [ "httpUrl" "url" ]
  // lib.optionalAttrs (s ? httpUrl) { serverUrl = s.httpUrl; }
  // lib.optionalAttrs (s ? url) { serverUrl = s.url; }
)
```

However:
1. Since the `url` attribute is renamed to `serverUrl` early inside the `extraTransforms` pipeline, the subsequent `lib.hm.mcp.addType` helper does not see the `url` field and incorrectly defaults the server type to `"stdio"`.
2. Furthermore, once all transforms complete, `lib.hm.mcp.transformMcpServer` performs a final cleanup which explicitly runs `removeAttrs withRenderedEnv [ "disabled" "serverUrl" ]`. This completely erases the `"serverUrl"` field from the output.

#### Solution
The module already has a local helper `transformMcpServers` that runs during config generation to convert `url` to `serverUrl`. Deferring the renaming to this step fixes the issue. We simply remove the early renaming from `lib.hm.mcp.transformMcpServer`'s `extraTransforms` list, allowing the core library to correctly identify the server type and preserve the attributes during normalization.

I have also added a remote HTTP server test case to `tests/modules/programs/antigravity-cli/mcp.nix` to prevent regressions.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt`.
- [x] Code tested through `nix run .#tests -- test-all`.
- [x] Test cases updated/added.
- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```
