### PR TITLE
treewide: eval tuning tweaks

### DIFF
--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -10,11 +10,11 @@
     let
       inherit (lib)
         all
+        any
         concatMapStringsSep
         concatStrings
         concatStringsSep
         filterAttrs
-        foldl
         generators
         hasPrefix
         isAttrs
@@ -29,8 +29,7 @@
       toHyprconf' =
         indent: attrs:
         let
-          isImportantField =
-            n: _: foldl (acc: prev: if hasPrefix prev n then true else acc) false importantPrefixes;
+          isImportantField = n: _: any (prev: hasPrefix prev n) importantPrefixes;
           importantFields = filterAttrs isImportantField attrs;
           withoutImportantFields = fields: removeAttrs fields (attrNames importantFields);
 

--- a/modules/programs/browserpass.nix
+++ b/modules/programs/browserpass.nix
@@ -32,7 +32,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.file = lib.foldl' (a: b: a // b) { } (
+    home.file = lib.mergeAttrsList (
       lib.concatMap (
         x:
         with pkgs.stdenv;

--- a/modules/programs/getmail/default.nix
+++ b/modules/programs/getmail/default.nix
@@ -64,7 +64,7 @@ in
       (lib.hm.assertions.assertPlatform "programs.getmail" pkgs lib.platforms.linux)
     ];
 
-    home.file = lib.foldl' (a: b: a // b) { } (
+    home.file = lib.mergeAttrsList (
       map (a: { "${renderConfigFilepath a}".text = renderAccountConfig a; }) accounts
     );
   };

--- a/modules/programs/go.nix
+++ b/modules/programs/go.nix
@@ -161,7 +161,7 @@ in
 
               mkSrc = n: v: { "${mainGoPath}/src/${n}".source = v; };
             in
-            lib.foldl' (a: b: a // b) { } (lib.mapAttrsToList mkSrc cfg.packages)
+            lib.mergeAttrsList (lib.mapAttrsToList mkSrc cfg.packages)
           );
         }
 

--- a/modules/programs/neomutt/default.nix
+++ b/modules/programs/neomutt/default.nix
@@ -498,7 +498,7 @@ in
           "${accountFilename account}".text = accountStr account;
         };
       in
-      lib.foldl' (a: b: a // b) { } (map rcFile neomuttAccounts);
+      lib.mergeAttrsList (map rcFile neomuttAccounts);
 
     xdg.configFile."neomutt/neomuttrc" = mkIf (neomuttAccounts != [ ]) {
       text =

--- a/modules/programs/neovim/default.nix
+++ b/modules/programs/neovim/default.nix
@@ -556,7 +556,7 @@ in
         generatedConfigs =
           let
             grouped = lib.groupBy (x: x.type) pluginsNormalized;
-            configsOnly = lib.foldl (acc: p: if p.config != null then acc ++ [ p.config ] else acc) [ ];
+            configsOnly = ps: map (p: p.config) (lib.filter (p: p.config != null) ps);
           in
           lib.mapAttrs (_name: vals: lib.concatStringsSep "\n" (configsOnly vals)) grouped;
 

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -263,16 +263,14 @@ let
     // optionalAttrs (account.ews != null && account.ews.authentication != null) {
       "mail.server.server_${id}.authMethod" = toThunderbirdAuthMethod account.ews.authentication;
     }
-    // builtins.foldl' (a: b: a // b) { } (map (address: toThunderbirdSMTP account address) addresses)
+    // lib.mergeAttrsList (map (address: toThunderbirdSMTP account address) addresses)
     // optionalAttrs (account.smtp != null && account.primary) {
       "mail.smtp.defaultserver" = "smtp_${id}";
     }
     // optionalAttrs (account.smtp == null && account.ews != null && account.primary) {
       "mail.smtp.defaultserver" = "ews_${id}";
     }
-    // builtins.foldl' (a: b: a // b) { } (
-      map (address: toThunderbirdIdentity account address) addresses
-    )
+    // lib.mergeAttrsList (map (address: toThunderbirdIdentity account address) addresses)
     // account.thunderbird.settings id;
 
   toThunderbirdCalendar =
@@ -1176,7 +1174,7 @@ in
                 );
             in
             {
-              text = mkUserJs (builtins.foldl' (a: b: a // b) { } (
+              text = mkUserJs (lib.mergeAttrsList (
                 [
                   cfg.settings
 

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -60,7 +60,7 @@ let
   profilesWithId = lib.imap0 (i: v: v // { id = toString i; }) (attrValues cfg.profiles);
 
   profilesIni =
-    lib.foldl lib.recursiveUpdate
+    lib.foldl' lib.recursiveUpdate
       {
         General = {
           StartWithLastProfile = 1;

--- a/modules/programs/zsh/plugins/default.nix
+++ b/modules/programs/zsh/plugins/default.nix
@@ -108,7 +108,7 @@ in
     ) options.programs.zsh.plugins.definitionsWithLocations;
 
     home.file = lib.mkIf cfg.enable (
-      lib.foldl' (a: b: a // b) { } (
+      lib.mergeAttrsList (
         map (plugin: { "${pluginsDir}/${plugin.name}".source = plugin.src; }) cfg.plugins
       )
     );

--- a/modules/services/fusuma.nix
+++ b/modules/services/fusuma.nix
@@ -57,10 +57,6 @@ let
     '';
   };
 
-  makeBinPath =
-    packages:
-    lib.foldl (a: b: if a == "" then b else "${a}:${b}") "" (map (pkg: "${pkg}/bin") packages);
-
 in
 {
   meta.maintainers = [ lib.maintainers.iosmanthus ];
@@ -127,7 +123,7 @@ in
       };
 
       Service = {
-        Environment = "PATH=${makeBinPath cfg.extraPackages}";
+        Environment = "PATH=${lib.makeBinPath cfg.extraPackages}";
         ExecStart = "${cfg.package}/bin/fusuma";
       };
 


### PR DESCRIPTION
Misc eval tuning tweaks just targeted to small performance / eval gains. 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
