### PR TITLE
antigravity-cli: update skills deployment path

### DIFF
--- a/modules/misc/news/2026/05/2026-05-20_12-00-00.nix
+++ b/modules/misc/news/2026/05/2026-05-20_12-00-00.nix
@@ -10,6 +10,6 @@
     and emit rename warnings. The Antigravity CLI module writes settings and
     permissions to `~/.gemini/antigravity-cli`, MCP server configuration to
     `~/.gemini/config/mcp_config.json`, and skills to
-    `~/.gemini/config/skills`.
+    `~/.gemini/antigravity-cli/skills`.
   '';
 }

--- a/modules/programs/antigravity-cli.nix
+++ b/modules/programs/antigravity-cli.nix
@@ -356,13 +356,13 @@ in
 
         If an attribute set is used, the attribute name becomes the
         skill directory name, and the value is either:
-        - Inline content as a string (creates `~/.gemini/config/skills/<name>/SKILL.md`)
-        - A path to a file (creates `~/.gemini/config/skills/<name>/SKILL.md`)
-        - A path to a directory (symlinks `~/.gemini/config/skills/<name>/` to that directory)
+        - Inline content as a string (creates `~/.gemini/antigravity-cli/skills/<name>/SKILL.md`)
+        - A path to a file (creates `~/.gemini/antigravity-cli/skills/<name>/SKILL.md`)
+        - A path to a directory (symlinks `~/.gemini/antigravity-cli/skills/<name>/` to that directory)
 
         If a path is used, it is expected to contain one folder per
         skill name, each containing a {file}`SKILL.md`. The directory is
-        symlinked to {file}`~/.gemini/config/skills/`.
+        symlinked to {file}`~/.gemini/antigravity-cli/skills/`.
       '';
     };
   };
@@ -371,7 +371,7 @@ in
     let
       useGeminiConfig =
         cfg.useLegacyGeminiConfig || (cfg.package != null && lib.getName cfg.package == "gemini-cli");
-      antigravitySkillsDir = ".gemini/config/skills";
+      antigravitySkillsDir = ".gemini/antigravity-cli/skills";
       geminiSkillsDir = ".gemini/skills";
       antigravitySettings = lib.recursiveUpdate (lib.optionalAttrs (cfg.permissions != null) {
         inherit (cfg) permissions;

--- a/tests/modules/programs/antigravity-cli/gemini-package-paths.nix
+++ b/tests/modules/programs/antigravity-cli/gemini-package-paths.nix
@@ -33,7 +33,7 @@
     assertFileExists home-files/.gemini/commands/review.toml
     assertFileExists home-files/.gemini/skills/audit/SKILL.md
     assertFileExists home-files/.gemini/policies/commands.toml
-    assertPathNotExists home-files/.gemini/config/skills/review/SKILL.md
+    assertPathNotExists home-files/.gemini/antigravity-cli/skills/review/SKILL.md
     assertPathNotExists home-files/.gemini/config/mcp_config.json
   '';
 }

--- a/tests/modules/programs/antigravity-cli/legacy-gemini-config.nix
+++ b/tests/modules/programs/antigravity-cli/legacy-gemini-config.nix
@@ -19,6 +19,6 @@
     assertFileRegex home-files/.gemini/settings.json '"github"'
     assertPathNotExists home-files/.gemini/antigravity-cli/settings.json
     assertPathNotExists home-files/.gemini/config/mcp_config.json
-    assertPathNotExists home-files/.gemini/config/skills/review/SKILL.md
+    assertPathNotExists home-files/.gemini/antigravity-cli/skills/review/SKILL.md
   '';
 }

--- a/tests/modules/programs/antigravity-cli/settings.nix
+++ b/tests/modules/programs/antigravity-cli/settings.nix
@@ -33,15 +33,15 @@
     assertFileExists home-files/.gemini/antigravity-cli/settings.json
     assertFileContent home-files/.gemini/antigravity-cli/settings.json \
       ${./settings.json}
-    assertFileExists home-files/.gemini/config/skills/changelog/SKILL.md
-    assertFileRegex home-files/.gemini/config/skills/changelog/SKILL.md \
+    assertFileExists home-files/.gemini/antigravity-cli/skills/changelog/SKILL.md
+    assertFileRegex home-files/.gemini/antigravity-cli/skills/changelog/SKILL.md \
       'name: changelog'
-    assertFileRegex home-files/.gemini/config/skills/changelog/SKILL.md \
+    assertFileRegex home-files/.gemini/antigravity-cli/skills/changelog/SKILL.md \
       "Adds a new entry to the project's CHANGELOG.md file."
-    assertFileExists home-files/.gemini/config/skills/git:fix/SKILL.md
-    assertFileRegex home-files/.gemini/config/skills/git:fix/SKILL.md \
+    assertFileExists home-files/.gemini/antigravity-cli/skills/git:fix/SKILL.md
+    assertFileRegex home-files/.gemini/antigravity-cli/skills/git:fix/SKILL.md \
       'name: git:fix'
-    assertFileRegex home-files/.gemini/config/skills/git:fix/SKILL.md \
+    assertFileRegex home-files/.gemini/antigravity-cli/skills/git:fix/SKILL.md \
       'Generates a fix for a given GitHub issue.'
 
     assertFileExists home-path/etc/profile.d/hm-session-vars.sh

--- a/tests/modules/programs/antigravity-cli/skills-dir.nix
+++ b/tests/modules/programs/antigravity-cli/skills-dir.nix
@@ -8,19 +8,19 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.gemini/config/skills/xlsx/SKILL.md
-    assertLinkExists home-files/.gemini/config/skills/xlsx/SKILL.md
-    assertFileContent home-files/.gemini/config/skills/xlsx/SKILL.md \
+    assertFileExists home-files/.gemini/antigravity-cli/skills/xlsx/SKILL.md
+    assertLinkExists home-files/.gemini/antigravity-cli/skills/xlsx/SKILL.md
+    assertFileContent home-files/.gemini/antigravity-cli/skills/xlsx/SKILL.md \
       ${./skills/xlsx/SKILL.md}
 
-    assertFileExists home-files/.gemini/config/skills/data-analysis/SKILL.md
-    assertLinkExists home-files/.gemini/config/skills/data-analysis/SKILL.md
-    assertFileContent home-files/.gemini/config/skills/data-analysis/SKILL.md \
+    assertFileExists home-files/.gemini/antigravity-cli/skills/data-analysis/SKILL.md
+    assertLinkExists home-files/.gemini/antigravity-cli/skills/data-analysis/SKILL.md
+    assertFileContent home-files/.gemini/antigravity-cli/skills/data-analysis/SKILL.md \
       ${./skills/data-analysis/SKILL.md}
 
-    assertFileExists home-files/.gemini/config/skills/pdf-processing/SKILL.md
-    assertLinkExists home-files/.gemini/config/skills/pdf-processing/SKILL.md
-    assertFileContent home-files/.gemini/config/skills/pdf-processing/SKILL.md \
+    assertFileExists home-files/.gemini/antigravity-cli/skills/pdf-processing/SKILL.md
+    assertLinkExists home-files/.gemini/antigravity-cli/skills/pdf-processing/SKILL.md
+    assertFileContent home-files/.gemini/antigravity-cli/skills/pdf-processing/SKILL.md \
       ${./skills/pdf-processing/SKILL.md}
   '';
 }

--- a/tests/modules/programs/antigravity-cli/skills-store-path-dir.nix
+++ b/tests/modules/programs/antigravity-cli/skills-store-path-dir.nix
@@ -13,9 +13,9 @@ in
   };
 
   nmt.script = ''
-    assertFileExists home-files/.gemini/config/skills/external-skill/SKILL.md
-    assertLinkExists home-files/.gemini/config/skills/external-skill/SKILL.md
-    assertFileContent home-files/.gemini/config/skills/external-skill/SKILL.md \
+    assertFileExists home-files/.gemini/antigravity-cli/skills/external-skill/SKILL.md
+    assertLinkExists home-files/.gemini/antigravity-cli/skills/external-skill/SKILL.md
+    assertFileContent home-files/.gemini/antigravity-cli/skills/external-skill/SKILL.md \
       "${src}/skills/external-skill/SKILL.md"
   '';
 }

--- a/tests/modules/programs/antigravity-cli/skills.nix
+++ b/tests/modules/programs/antigravity-cli/skills.nix
@@ -29,16 +29,16 @@
     };
   };
   nmt.script = ''
-    assertFileExists home-files/.gemini/config/skills/xlsx/SKILL.md
-    assertFileContent home-files/.gemini/config/skills/xlsx/SKILL.md \
+    assertFileExists home-files/.gemini/antigravity-cli/skills/xlsx/SKILL.md
+    assertFileContent home-files/.gemini/antigravity-cli/skills/xlsx/SKILL.md \
       ${./skills/xlsx/SKILL.md}
 
-    assertFileExists home-files/.gemini/config/skills/data-analysis/SKILL.md
-    assertFileContent home-files/.gemini/config/skills/data-analysis/SKILL.md \
+    assertFileExists home-files/.gemini/antigravity-cli/skills/data-analysis/SKILL.md
+    assertFileContent home-files/.gemini/antigravity-cli/skills/data-analysis/SKILL.md \
       ${./skills/data-analysis/SKILL.md}
 
-    assertFileExists home-files/.gemini/config/skills/pdf-processing/SKILL.md
-    assertFileContent home-files/.gemini/config/skills/pdf-processing/SKILL.md \
+    assertFileExists home-files/.gemini/antigravity-cli/skills/pdf-processing/SKILL.md
+    assertFileContent home-files/.gemini/antigravity-cli/skills/pdf-processing/SKILL.md \
       ${./skills/pdf-processing/SKILL.md}
   '';
 }


### PR DESCRIPTION
The skills folder deployment path has been updated to '~/.gemini/antigravity-cli/skills/' to align with the application's configuration path structure from docs. I think the other path is just a weird compatibility shim that app supports. strace shows it will search it, but it also checks the documented path.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
