### PR TITLE
mkFirefoxModule: add warning for dropped options on wrapped packages

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -195,23 +195,20 @@ let
     if package == null then
       null
     else if isWrapped then
-      let
-        acceptsCfg = lib.functionArgs package.override ? cfg;
-        droppedPolicies = cfg.policies != { } && (!isDarwin || cfg.darwinDefaultsId == null);
-        droppedOptions = droppedPolicies || cfg.pkcs11Modules != [ ] || cfg.enableGnomeExtensions;
-      in
-      lib.warnIf (!acceptsCfg && droppedOptions)
-        "${moduleName}: '${browserName}' cannot be reconfigured; 'policies', 'pkcs11Modules', and 'enableGnomeExtensions' will not be applied."
-        (
-          package.override (
-            old:
-            lib.optionalAttrs acceptsCfg {
-              cfg = old.cfg or { } // fcfg;
-              extraPolicies = (old.extraPolicies or { }) // cfg.policies;
-              pkcs11Modules = (old.pkcs11Modules or [ ]) ++ cfg.pkcs11Modules;
-            }
-          )
-        )
+      if lib.functionArgs package.override ? cfg then
+        package.override (old: {
+          cfg = old.cfg or { } // fcfg;
+          extraPolicies = (old.extraPolicies or { }) // cfg.policies;
+          pkcs11Modules = (old.pkcs11Modules or [ ]) ++ cfg.pkcs11Modules;
+        })
+      else
+        let
+          droppedPolicies = cfg.policies != { } && (!isDarwin || cfg.darwinDefaultsId == null);
+          droppedOptions = droppedPolicies || cfg.pkcs11Modules != [ ] || cfg.enableGnomeExtensions;
+        in
+        lib.warnIf droppedOptions
+          "${moduleName}: '${browserName}' cannot be reconfigured; 'policies', 'pkcs11Modules', and 'enableGnomeExtensions' will not be applied."
+          package
     else
       (pkgs.wrapFirefox.override { config = bcfg; }) package { };
 

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -195,14 +195,22 @@ let
     if package == null then
       null
     else if isWrapped then
-      package.override (
-        old:
-        lib.optionalAttrs (lib.functionArgs package.override ? cfg) {
-          cfg = old.cfg or { } // fcfg;
-          extraPolicies = (old.extraPolicies or { }) // cfg.policies;
-          pkcs11Modules = (old.pkcs11Modules or [ ]) ++ cfg.pkcs11Modules;
-        }
-      )
+      let
+        acceptsCfg = lib.functionArgs package.override ? cfg;
+        droppedOptions = cfg.policies != { } || cfg.pkcs11Modules != [ ] || cfg.enableGnomeExtensions;
+      in
+      lib.warnIf (!acceptsCfg && droppedOptions)
+        "${moduleName}: '${browserName}' cannot be reconfigured; 'policies', 'pkcs11Modules', and 'enableGnomeExtensions' will not be applied."
+        (
+          package.override (
+            old:
+            lib.optionalAttrs acceptsCfg {
+              cfg = old.cfg or { } // fcfg;
+              extraPolicies = (old.extraPolicies or { }) // cfg.policies;
+              pkcs11Modules = (old.pkcs11Modules or [ ]) ++ cfg.pkcs11Modules;
+            }
+          )
+        )
     else
       (pkgs.wrapFirefox.override { config = bcfg; }) package { };
 

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -197,7 +197,8 @@ let
     else if isWrapped then
       let
         acceptsCfg = lib.functionArgs package.override ? cfg;
-        droppedOptions = cfg.policies != { } || cfg.pkcs11Modules != [ ] || cfg.enableGnomeExtensions;
+        droppedPolicies = cfg.policies != { } && (!isDarwin || cfg.darwinDefaultsId == null);
+        droppedOptions = droppedPolicies || cfg.pkcs11Modules != [ ] || cfg.enableGnomeExtensions;
       in
       lib.warnIf (!acceptsCfg && droppedOptions)
         "${moduleName}: '${browserName}' cannot be reconfigured; 'policies', 'pkcs11Modules', and 'enableGnomeExtensions' will not be applied."


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Warns only if the package lacks a `cfg` override and relevant options are configured.

References
#9486

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
