### PR TITLE
difftastic: support difftool-only git integration

### DIFF
--- a/modules/misc/news/2026/06/2026-06-10_16-05-00.nix
+++ b/modules/misc/news/2026/06/2026-06-10_16-05-00.nix
@@ -1,0 +1,20 @@
+{ config, ... }:
+{
+  time = "2026-06-10T16:05:00+00:00";
+  condition = config.programs.difftastic.enable;
+  message = ''
+    The git integration of 'programs.difftastic' now uses a new option
+    'programs.difftastic.git.mode' to select how difftastic is wired into
+    git:
+
+    - "external" (default): set 'diff.external' so 'git diff' uses
+      difftastic.
+    - "difftool": only configure difftastic as a git difftool, leaving
+      'git diff' untouched.
+    - "both": configure both.
+
+    The boolean option 'programs.difftastic.git.diffToolMode' is deprecated;
+    existing configurations are migrated automatically ('true' becomes
+    "both" and 'false' becomes "external").
+  '';
+}

--- a/modules/programs/difftastic.nix
+++ b/modules/programs/difftastic.nix
@@ -29,9 +29,15 @@ in
       [ "programs" "git" "difftastic" "package" ]
       [ "programs" "difftastic" "package" ]
     )
-    (lib.mkRenamedOptionModule
+    (lib.mkChangedOptionModule
       [ "programs" "git" "difftastic" "enableAsDifftool" ]
+      [ "programs" "difftastic" "git" "mode" ]
+      (config: if config.programs.git.difftastic.enableAsDifftool then "both" else "external")
+    )
+    (lib.mkChangedOptionModule
       [ "programs" "difftastic" "git" "diffToolMode" ]
+      [ "programs" "difftastic" "git" "mode" ]
+      (config: if config.programs.difftastic.git.diffToolMode then "both" else "external")
     )
     (lib.mkRenamedOptionModule
       [ "programs" "git" "difftastic" "options" ]
@@ -91,19 +97,29 @@ in
         description = ''
           Whether to enable git integration for difftastic.
 
-          When enabled, difftastic will be configured as git's external diff tool or difftool
-          depending on the value of {option}`programs.difftastic.git.diffToolMode`.
+          When enabled, difftastic will be configured as git's external diff
+          command, as a git difftool, or both, depending on the value of
+          {option}`programs.difftastic.git.mode`.
         '';
       };
 
-      diffToolMode = mkOption {
-        type = types.bool;
-        default = false;
+      mode = mkOption {
+        type = types.enum [
+          "external"
+          "difftool"
+          "both"
+        ];
+        default = "external";
+        example = "difftool";
         description = ''
-          Whether to additionally configure difftastic as a git difftool.
+          How difftastic integrates with git.
 
-          When `false`, only `diff.external` is set (used for `git diff`).
-          When `true`, both `diff.external` and difftool config are set (supporting both `git diff` and `git difftool`).
+          - `"external"`: set `diff.external` so {command}`git diff` uses
+            difftastic by default.
+          - `"difftool"`: only configure difftastic as a git difftool
+            (`diff.tool` and `difftool.difftastic.cmd`), leaving
+            {command}`git diff` untouched.
+          - `"both"`: configure both `diff.external` and the difftool.
         '';
       };
     };
@@ -145,13 +161,25 @@ in
               difftCommand = "${lib.getExe cfg.package} ${lib.cli.toCommandLineShellGNU { } cfg.options}";
             in
             mkMerge [
-              {
-                diff.external = difftCommand;
-              }
-              (mkIf cfg.git.diffToolMode {
-                diff.tool = lib.mkDefault "difftastic";
-                difftool.difftastic.cmd = "${difftCommand} $LOCAL $REMOTE";
-              })
+              (mkIf
+                (lib.elem cfg.git.mode [
+                  "external"
+                  "both"
+                ])
+                {
+                  diff.external = difftCommand;
+                }
+              )
+              (mkIf
+                (lib.elem cfg.git.mode [
+                  "difftool"
+                  "both"
+                ])
+                {
+                  diff.tool = lib.mkDefault "difftastic";
+                  difftool.difftastic.cmd = "${difftCommand} $LOCAL $REMOTE";
+                }
+              )
             ];
         };
       })

--- a/tests/modules/programs/difftastic/default.nix
+++ b/tests/modules/programs/difftastic/default.nix
@@ -3,5 +3,7 @@
   difftastic-with-git-integration = ./difftastic-with-git-integration.nix;
   difftastic-with-git-external-diff = ./difftastic-with-git-external-diff.nix;
   difftastic-with-git-difftool = ./difftastic-with-git-difftool.nix;
+  difftastic-with-git-both = ./difftastic-with-git-both.nix;
+  difftastic-legacy-diff-tool-mode = ./difftastic-legacy-diff-tool-mode.nix;
   difftastic-migration = ./difftastic-migration.nix;
 }

--- a/tests/modules/programs/difftastic/difftastic-legacy-diff-tool-mode.nix
+++ b/tests/modules/programs/difftastic/difftastic-legacy-diff-tool-mode.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  options,
+  ...
+}:
+
+{
+  programs.difftastic = {
+    enable = true;
+    git = {
+      enable = true;
+      diffToolMode = true;
+    };
+    options = {
+      color = "always";
+      display = "side-by-side";
+    };
+  };
+
+  programs.git.enable = true;
+
+  test.asserts.warnings.expected = [
+    "The option `programs.difftastic.git.diffToolMode' defined in ${lib.showFiles options.programs.difftastic.git.diffToolMode.files} has been changed to `programs.difftastic.git.mode' that has a different type. Please read `programs.difftastic.git.mode' documentation and update your configuration accordingly."
+  ];
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContains home-files/.config/git/config '[diff]'
+    # Legacy diffToolMode = true should map to mode = "both"
+    assertFileContains home-files/.config/git/config "external = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side'\""
+    assertFileContains home-files/.config/git/config 'tool = "difftastic"'
+    assertFileContains home-files/.config/git/config '[difftool "difftastic"]'
+    assertFileContains home-files/.config/git/config "cmd = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side' \$LOCAL \$REMOTE\""
+  '';
+}

--- a/tests/modules/programs/difftastic/difftastic-migration.nix
+++ b/tests/modules/programs/difftastic/difftastic-migration.nix
@@ -9,6 +9,7 @@
     enable = true;
     difftastic = {
       enable = true;
+      enableAsDifftool = true;
       options = {
         color = "always";
         display = "side-by-side";
@@ -18,6 +19,7 @@
 
   test.asserts.warnings.expected = [
     "The option `programs.git.difftastic.options' defined in ${lib.showFiles options.programs.git.difftastic.options.files} has been renamed to `programs.difftastic.options'."
+    "The option `programs.git.difftastic.enableAsDifftool' defined in ${lib.showFiles options.programs.git.difftastic.enableAsDifftool.files} has been changed to `programs.difftastic.git.mode' that has a different type. Please read `programs.difftastic.git.mode' documentation and update your configuration accordingly."
     "The option `programs.git.difftastic.enable' defined in ${lib.showFiles options.programs.git.difftastic.enable.files} has been renamed to `programs.difftastic.enable'."
     "`programs.difftastic.git.enable` automatic enablement is deprecated. Please explicitly set `programs.difftastic.git.enable = true`."
   ];
@@ -27,5 +29,9 @@
     assertFileExists home-files/.config/git/config
     assertFileContains home-files/.config/git/config '[diff]'
     assertFileContains home-files/.config/git/config "external = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side'\""
+    # Legacy enableAsDifftool = true maps to mode = "both", so difftool is also configured
+    assertFileContains home-files/.config/git/config 'tool = "difftastic"'
+    assertFileContains home-files/.config/git/config '[difftool "difftastic"]'
+    assertFileContains home-files/.config/git/config "cmd = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side' \$LOCAL \$REMOTE\""
   '';
 }

--- a/tests/modules/programs/difftastic/difftastic-with-git-both.nix
+++ b/tests/modules/programs/difftastic/difftastic-with-git-both.nix
@@ -3,7 +3,7 @@
     enable = true;
     git = {
       enable = true;
-      mode = "difftool";
+      mode = "both";
     };
     options = {
       color = "always";
@@ -15,11 +15,11 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/git/config
-    # Should have difftool config only, leaving `git diff` untouched
+    assertFileContains home-files/.config/git/config '[diff]'
+    # Should have BOTH diff.external AND difftool config when mode is "both"
+    assertFileContains home-files/.config/git/config "external = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side'\""
     assertFileContains home-files/.config/git/config 'tool = "difftastic"'
     assertFileContains home-files/.config/git/config '[difftool "difftastic"]'
     assertFileContains home-files/.config/git/config "cmd = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side' \$LOCAL \$REMOTE\""
-    # Should NOT have diff.external when mode is "difftool"
-    assertFileNotRegex home-files/.config/git/config 'external = .*/difft'
   '';
 }

--- a/tests/modules/programs/difftastic/difftastic-with-git-external-diff.nix
+++ b/tests/modules/programs/difftastic/difftastic-with-git-external-diff.nix
@@ -3,7 +3,7 @@
     enable = true;
     git = {
       enable = true;
-      diffToolMode = false;
+      mode = "external";
     };
     options = {
       color = "always";
@@ -22,7 +22,7 @@
     assertFileContains home-files/.config/git/config '[diff]'
     # Should have diff.external set
     assertFileContains home-files/.config/git/config "external = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side' '--override=*.mill:Scala' '--override=*.yuck:Emacs Lisp'\""
-    # Should NOT have difftool config when diffToolMode is explicitly false
+    # Should NOT have difftool config when mode is "external"
     assertFileNotRegex home-files/.config/git/config 'tool = "difftastic"'
     assertFileNotRegex home-files/.config/git/config '\[difftool "difftastic"\]'
   '';

--- a/tests/modules/programs/difftastic/difftastic-with-git-integration.nix
+++ b/tests/modules/programs/difftastic/difftastic-with-git-integration.nix
@@ -15,7 +15,7 @@
     assertFileContains home-files/.config/git/config '[diff]'
     # Should have diff.external set
     assertFileContains home-files/.config/git/config "external = \"@difftastic@/bin/difft '--color=always' '--display=side-by-side'\""
-    # Should NOT have difftool config since diffToolMode is false
+    # Should NOT have difftool config in the default external mode
     assertFileNotRegex home-files/.config/git/config 'tool = "difftastic"'
     assertFileNotRegex home-files/.config/git/config '\[difftool "difftastic"\]'
   '';


### PR DESCRIPTION
Splitting git diff tools into the separate programs.difftastic module made it impossible to register difftastic as a git difftool without also forcing it as diff.external, since the boolean git.diffToolMode only toggled between "external" and "external + difftool".

Replace git.diffToolMode with a git.mode enum ("external", "difftool", "both") so difftastic can be wired as the difftool only, leaving `git diff` untouched. The deprecated boolean is migrated automatically via mkChangedOptionModule (true -> "both", false -> "external"), preserving existing behavior.

Fixes #8592

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
