### PR TITLE
broot: fix nushell integration br command

### DIFF
--- a/modules/programs/broot.nix
+++ b/modules/programs/broot.nix
@@ -139,9 +139,14 @@ let
     # manipulations of the prompt.
     lib.mkAfter ''
       source ${
-        pkgs.runCommand "br.${shell}" {
-          nativeBuildInputs = [ cfg.package ];
-        } "broot --print-shell-function ${shell} > $out"
+        pkgs.runCommand "br.${shell}" { nativeBuildInputs = [ cfg.package ]; } (
+          if shell == "nushell" then
+            # broot >= 1.51 exports `main` instead of `br`.
+            # Rename back to `br` to keep `source` working.
+            "broot --print-shell-function ${shell} | sed 's/export def --env main/export def --env br/' > $out"
+          else
+            "broot --print-shell-function ${shell} > $out"
+        )
       }
     '';
 in

--- a/tests/modules/programs/broot/broot.nix
+++ b/tests/modules/programs/broot/broot.nix
@@ -3,9 +3,20 @@
 {
   programs.broot = {
     enable = true;
+    enableBashIntegration = true;
+    enableNushellIntegration = true;
     package = (
       config.lib.test.mkStubPackage {
         name = "broot";
+        # Mimic broot >= 1.51, whose nushell shell function is named `main`.
+        buildScript = ''
+          mkdir -p $out/bin
+          cat > $out/bin/broot <<'EOF'
+          #!/bin/sh
+          echo 'export def --env main ['
+          EOF
+          chmod +x $out/bin/broot
+        '';
         extraAttrs = {
           src = config.lib.test.mkStubPackage {
             name = "broot-src";
@@ -21,8 +32,21 @@
     settings.modal = true;
   };
 
+  programs.bash.enable = true;
+  programs.nushell.enable = true;
+
   nmt.script = ''
     assertFileExists home-files/.config/broot/conf.hjson
     assertFileContains home-files/.config/broot/conf.hjson '"modal": true'
+    assertFileRegex home-files/.bashrc 'source /nix/store/.*-br\.bash'
+    assertFileRegex home-files/.config/nushell/config.nu \
+      'source /nix/store/.*-br\.nushell'
+
+    brNushell=$(
+      sed -n 's/^[[:space:]]*source \(\/nix\/store\/.*-br\.nushell\)$/\1/p' \
+        "$(_abs home-files/.config/nushell/config.nu)"
+    )
+    assertFileRegex "$brNushell" 'export def --env br \['
+    assertFileNotRegex "$brNushell" 'export def --env main \['
   '';
 }


### PR DESCRIPTION
broot 1.51 renamed the printed nushell entry point from `br` to `main`, intended to be loaded with `use` where the command takes the module's name. Home Manager sources the snippet with `source`, so it began defining a global `main` instead of `br`, breaking the `br` command in nushell.

Rewrite the definition line back to `br` for the nushell shell function so `source` keeps exposing `br` globally. Other shells are unaffected.

Fixes #9392

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
