### PR TITLE
mise: add bash completion to bash integration

### DIFF
--- a/modules/programs/mise.nix
+++ b/modules/programs/mise.nix
@@ -102,7 +102,11 @@ in
           The shell integration will not be added.
         '';
 
-    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [
+      cfg.package
+      # The generated completions call the `usage` CLI at completion time.
+      pkgs.usage
+    ];
 
     xdg.configFile = {
       "mise/config.toml" = mkIf (cfg.globalConfig != { }) {

--- a/modules/programs/mise.nix
+++ b/modules/programs/mise.nix
@@ -111,9 +111,17 @@ in
     };
 
     programs = {
-      bash.initExtra = mkIf (cfg.enableBashIntegration && cfg.package != null) ''
-        eval "$(${getExe cfg.package} activate bash)"
-      '';
+      bash.initExtra =
+        let
+          # TODO: Upstream to nixpkgs
+          bashCompletion = pkgs.runCommand "mise-bash-completion.bash" { } ''
+            ${getExe cfg.package} completion bash --include-bash-completion-lib > $out
+          '';
+        in
+        mkIf (cfg.enableBashIntegration && cfg.package != null) ''
+          eval "$(${getExe cfg.package} activate bash)"
+          source ${bashCompletion}
+        '';
 
       zsh.initContent = mkIf (cfg.enableZshIntegration && cfg.package != null) ''
         eval "$(${getExe cfg.package} activate zsh)"

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -194,6 +194,7 @@ let
     "topgrade"
     "translate-shell"
     "tray-tui"
+    "usage"
     "vesktop"
     "vifm"
     "vim-vint"

--- a/tests/modules/programs/mise/bash-integration.nix
+++ b/tests/modules/programs/mise/bash-integration.nix
@@ -1,8 +1,12 @@
-{ config, ... }:
+{ pkgs, ... }:
 {
   programs = {
     mise = {
-      package = config.lib.test.mkStubPackage { name = "mise"; };
+      package = pkgs.writeShellScriptBin "mise" ''
+        if [ "$1" = "completion" ]; then
+          echo "complete -F _mise mise"
+        fi
+      '';
       enable = true;
       enableBashIntegration = true;
     };
@@ -12,5 +16,7 @@
 
   nmt.script = ''
     assertFileRegex home-files/.bashrc 'eval "$(/nix/store/.*mise.*/bin/mise activate bash)"'
+    assertFileRegex home-files/.bashrc \
+      '^source /nix/store/[0-9a-z]*-mise-bash-completion.bash$'
   '';
 }


### PR DESCRIPTION
The bash integration previously only ran `mise activate bash`, so tab
completion for `mise` was never set up. Source the generated completion
script via `mise completion bash --include-bash-completion-lib`; the
flag self-bundles the bash-completion helpers so it also works on
systems whose bash-completion predates `_comp_initialize`.

Fixes #8539

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
