### PR TITLE
attic-client: init module

### DIFF
--- a/modules/misc/news/2026/07/2026-07-06_00-46-00.nix
+++ b/modules/misc/news/2026/07/2026-07-06_00-46-00.nix
@@ -1,0 +1,9 @@
+{
+  time = "2026-07-06T00:46:00+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.attic-client`.
+
+    It manages the client configuration for the Attic Nix binary cache.
+  '';
+}

--- a/modules/programs/attic-client.nix
+++ b/modules/programs/attic-client.nix
@@ -1,0 +1,97 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkOption
+    types
+    ;
+
+  cfg = config.programs.attic-client;
+
+  settingsFormat = pkgs.formats.toml { };
+in
+{
+  options.programs.attic-client = {
+    enable = lib.mkEnableOption "the attic binary cache client";
+
+    package = lib.mkPackageOption pkgs "attic-client" {
+      nullable = true;
+    };
+
+    settings = mkOption {
+      inherit (settingsFormat) type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          default-server = "myserver";
+          servers.myserver = {
+            endpoint = "https://myserver.org";
+            token-file = "/run/secrets/attic-token";
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/attic/config.toml`.
+
+        See <https://github.com/zhaofengli/attic> for the available options.
+      '';
+    };
+
+    watchStore = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "mycacheserver:mycache" ];
+      description = ''
+        Caches to push new store paths to via `attic watch-store`.
+        Format: `server:cache` (or just `cache` to use the default server).
+
+        This relies on systemd and is only supported on Linux.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.watchStore == [ ] || pkgs.stdenv.hostPlatform.isLinux;
+        message = "programs.attic-client.watchStore requires systemd and is only supported on Linux.";
+      }
+      {
+        assertion = cfg.watchStore == [ ] || cfg.package != null;
+        message = "programs.attic-client.watchStore requires programs.attic-client.package to be set.";
+      }
+    ];
+
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."attic/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = settingsFormat.generate "attic-config.toml" cfg.settings;
+    };
+
+    systemd.user.services = lib.mkIf (cfg.watchStore != [ ]) (
+      lib.listToAttrs (
+        map (
+          cache:
+          lib.nameValuePair "attic-watch-store--${lib.replaceStrings [ ":" ] [ "-" ] cache}" {
+            Unit.Description = "Push new store paths to the attic cache ${cache}";
+
+            Install.WantedBy = [ "default.target" ];
+
+            Service = {
+              ExecStart = "${lib.getExe cfg.package} watch-store ${cache}";
+              Restart = "always";
+              RestartSec = 30;
+            };
+          }
+        ) cfg.watchStore
+      )
+    );
+  };
+
+  meta.maintainers = [ lib.maintainers.swarsel ];
+}

--- a/tests/modules/programs/attic-client/attic-client-basic-config.nix
+++ b/tests/modules/programs/attic-client/attic-client-basic-config.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (pkgs.stdenv.hostPlatform) isLinux;
+in
+{
+  programs.attic-client = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "attic";
+      outPath = "@attic@";
+    };
+    settings = {
+      default-server = "myserver";
+      servers = {
+        myserver = {
+          endpoint = "https://myserver.org";
+          token-file = "/run/secrets/attic-token";
+        };
+        myotherserver = {
+          endpoint = "https://myotherserver.org";
+          token-file = "/run/secrets/attic-token";
+        };
+      };
+    };
+    watchStore = lib.optionals isLinux [ "myserver:mycache" ];
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/attic/config.toml \
+      ${builtins.toFile "expected.config" ''
+        default-server = "myserver"
+
+        [servers.myotherserver]
+        endpoint = "https://myotherserver.org"
+        token-file = "/run/secrets/attic-token"
+
+        [servers.myserver]
+        endpoint = "https://myserver.org"
+        token-file = "/run/secrets/attic-token"
+      ''}
+  ''
+  + lib.optionalString isLinux ''
+    assertFileContent \
+      home-files/.config/systemd/user/attic-watch-store--myserver-mycache.service \
+      ${builtins.toFile "expected.service" ''
+        [Install]
+        WantedBy=default.target
+
+        [Service]
+        ExecStart=@attic@/bin/attic watch-store myserver:mycache
+        Restart=always
+        RestartSec=30
+
+        [Unit]
+        Description=Push new store paths to the attic cache myserver:mycache
+      ''}
+  '';
+}

--- a/tests/modules/programs/attic-client/default.nix
+++ b/tests/modules/programs/attic-client/default.nix
@@ -1,0 +1,3 @@
+{
+  attic-client-basic-config = ./attic-client-basic-config.nix;
+}


### PR DESCRIPTION
### Description
This adds support for `attic`.

The testcase might be a bit wild - I wanted to test the secret rendering as well without looking too much into integration tests. Let me know if that is an issue.
<!--

Please provide a brief description of your change.

-->

### Checklist


<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
