### PR TITLE
modules/kdeconnect: stop overriding PATH, remove support for prehistoric versions

### DIFF
--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -48,12 +48,7 @@ in
         };
 
         Service = {
-          Environment = [ "PATH=${config.home.profileDirectory}/bin" ];
-          ExecStart =
-            if lib.strings.versionAtLeast (lib.versions.majorMinor cfg.package.version) "24.05" then
-              "${cfg.package}/bin/kdeconnectd"
-            else
-              "${cfg.package}/libexec/kdeconnectd";
+          ExecStart = "${cfg.package}/bin/kdeconnectd";
           Restart = "on-abort";
         };
       };
@@ -80,7 +75,6 @@ in
         };
 
         Service = {
-          Environment = [ "PATH=${config.home.profileDirectory}/bin" ];
           ExecStart = "${cfg.package}/bin/kdeconnect-indicator";
           Restart = "on-abort";
         };


### PR DESCRIPTION
Bad. No. Why.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
