### PR TITLE
podman: generate v2 registries.conf

### DIFF
--- a/modules/misc/news/2026/06/2026-06-18_15-00-50.nix
+++ b/modules/misc/news/2026/06/2026-06-18_15-00-50.nix
@@ -1,0 +1,23 @@
+{ config, ... }:
+{
+  time = "2026-06-18T13:00:50+00:00";
+  condition =
+    config.services.podman.enable
+    && (
+      config.services.podman.settings.registries.insecure != [ ]
+      || config.services.podman.settings.registries.block != [ ]
+    );
+  message = ''
+    `services.podman.settings.registries` now generates `registries.conf` v2
+    format.
+
+    The new per-registry option
+    {option}`services.podman.settings.registries.registry` was added. Use
+    entries like `{ location = "registry.example"; insecure = true; }` or
+    `{ location = "registry.example"; blocked = true; }`.
+
+    Legacy {option}`services.podman.settings.registries.insecure` and
+    {option}`services.podman.settings.registries.block` are still supported
+    but deprecated, and now emit a warning.
+  '';
+}

--- a/modules/services/podman/default.nix
+++ b/modules/services/podman/default.nix
@@ -8,15 +8,60 @@ let
   cfg = config.services.podman;
   toml = pkgs.formats.toml { };
 
+  registriesCfg = cfg.settings.registries;
+
+  legacyRegistryEntries =
+    (map (location: {
+      inherit location;
+      insecure = true;
+    }) registriesCfg.insecure)
+    ++ (map (location: {
+      inherit location;
+      blocked = true;
+    }) registriesCfg.block);
+
+  registryEntries = lib.mapAttrsToList (
+    location: entries:
+    let
+      merged =
+        builtins.foldl'
+          (acc: entry: {
+            inherit location;
+            insecure = if entry ? insecure && entry.insecure != null then entry.insecure else acc.insecure;
+            blocked = if entry ? blocked && entry.blocked != null then entry.blocked else acc.blocked;
+          })
+          {
+            inherit location;
+            insecure = null;
+            blocked = null;
+          }
+          entries;
+    in
+    {
+      inherit (merged) location;
+    }
+    // lib.optionalAttrs (merged.insecure != null) {
+      inherit (merged) insecure;
+    }
+    // lib.optionalAttrs (merged.blocked != null) {
+      inherit (merged) blocked;
+    }
+  ) (lib.groupBy (entry: entry.location) (legacyRegistryEntries ++ registriesCfg.registry));
+
+  registriesConfSettings = {
+    unqualified-search-registries = registriesCfg.search;
+  }
+  // lib.optionalAttrs (registryEntries != [ ]) {
+    registry = registryEntries;
+  };
+
   configFiles = {
     "policy.json" =
       if cfg.settings.policy != { } then
         pkgs.writeText "policy.json" (builtins.toJSON cfg.settings.policy)
       else
         "${pkgs.skopeo.policy}/default-policy.json";
-    "registries.conf" = toml.generate "registries.conf" {
-      registries = lib.mapAttrs (_n: v: { registries = v; }) cfg.settings.registries;
-    };
+    "registries.conf" = toml.generate "registries.conf" registriesConfSettings;
     "storage.conf" = toml.generate "storage.conf" cfg.settings.storage;
     "containers.conf" = toml.generate "containers.conf" cfg.settings.containers;
   }
@@ -91,6 +136,35 @@ in
             List of blocked repositories.
           '';
         };
+
+        registry = lib.mkOption {
+          default = [ ];
+          type = lib.types.listOf (
+            lib.types.submodule {
+              options = {
+                location = lib.mkOption {
+                  type = lib.types.str;
+                  description = "Registry location.";
+                };
+                insecure = lib.mkOption {
+                  type = lib.types.nullOr lib.types.bool;
+                  default = null;
+                  description = "Whether the registry is insecure.";
+                };
+                blocked = lib.mkOption {
+                  type = lib.types.nullOr lib.types.bool;
+                  default = null;
+                  description = "Whether the registry is blocked.";
+                };
+              };
+            }
+          );
+          description = ''
+            List of per-registry configuration entries.
+
+            Prefer this over the deprecated `insecure` and `block` lists.
+          '';
+        };
       };
 
       policy = lib.mkOption {
@@ -119,33 +193,49 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        home.packages = [ cfg.package ];
 
-    services.podman.settings.storage.storage.driver = lib.mkDefault "overlay";
+        services.podman.settings.storage.storage.driver = lib.mkDefault "overlay";
 
-    # On Linux, podman reads its configuration directly from
-    # `$XDG_CONFIG_HOME/containers`. On Darwin the same files are placed there
-    # as real files by an activation script and bind-mounted into the podman
-    # machine VM (see darwin.nix).
-    xdg.configFile = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
-      lib.mapAttrs' (name: src: lib.nameValuePair "containers/${name}" { source = src; }) cfg._configFiles
-    );
-    home.activation.podmanContainersConfig = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (
-      lib.hm.dag.entryBetween [ "podmanMachines" ] [ "linkGeneration" ] ''
-        run mkdir -p "$HOME/.config/containers"
+        # On Linux, podman reads its configuration directly from
+        # `$XDG_CONFIG_HOME/containers`. On Darwin the same files are placed there
+        # as real files by an activation script and bind-mounted into the podman
+        # machine VM (see darwin.nix).
+        xdg.configFile = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
+          lib.mapAttrs' (name: src: lib.nameValuePair "containers/${name}" { source = src; }) cfg._configFiles
+        );
+        home.activation.podmanContainersConfig = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (
+          lib.hm.dag.entryBetween [ "podmanMachines" ] [ "linkGeneration" ] ''
+            run mkdir -p "$HOME/.config/containers"
 
-        # Remove only files this module manages.
-        for f in ${lib.escapeShellArgs (builtins.attrNames cfg._configFiles)}; do
-          run rm -f "$HOME/.config/containers/$f"
-        done
+            # Remove only files this module manages.
+            for f in ${lib.escapeShellArgs (builtins.attrNames cfg._configFiles)}; do
+              run rm -f "$HOME/.config/containers/$f"
+            done
 
-        ${lib.concatStringsSep "\n" (
-          lib.mapAttrsToList (
-            name: src: ''run install -m 0644 ${src} "$HOME/.config/containers/${name}"''
-          ) cfg._configFiles
-        )}
-      ''
-    );
-  };
+            ${lib.concatStringsSep "\n" (
+              lib.mapAttrsToList (
+                name: src: ''run install -m 0644 ${src} "$HOME/.config/containers/${name}"''
+              ) cfg._configFiles
+            )}
+          ''
+        );
+      }
+      (lib.mkIf (registriesCfg.insecure != [ ] || registriesCfg.block != [ ]) {
+        warnings = [
+          ''
+            `services.podman.settings.registries.insecure` and
+            `services.podman.settings.registries.block` are deprecated and will be
+            removed in a future release.
+
+            Use `services.podman.settings.registries.registry` entries with
+            `location`, `insecure`, and `blocked` instead.
+          ''
+        ];
+      })
+    ]
+  );
 }

--- a/tests/modules/services/podman/configuration-registries-expected.conf
+++ b/tests/modules/services/podman/configuration-registries-expected.conf
@@ -1,8 +1,18 @@
-[registries.block]
-registries = ["ghcr.io", "gallery.ecr.aws"]
+unqualified-search-registries = ["docker.io"]
 
-[registries.insecure]
-registries = ["quay.io"]
+[[registry]]
+blocked = false
+location = "gallery.ecr.aws"
 
-[registries.search]
-registries = ["docker.io"]
+[[registry]]
+blocked = true
+location = "ghcr.io"
+
+[[registry]]
+blocked = true
+insecure = true
+location = "quay.io"
+
+[[registry]]
+insecure = true
+location = "registry.fedoraproject.org"

--- a/tests/modules/services/podman/configuration.nix
+++ b/tests/modules/services/podman/configuration.nix
@@ -25,12 +25,26 @@
         };
       };
       registries = {
+        search = [ "docker.io" ];
         block = [
           "ghcr.io"
           "gallery.ecr.aws"
         ];
         insecure = [ "quay.io" ];
-        search = [ "docker.io" ];
+        registry = [
+          {
+            location = "quay.io";
+            blocked = true;
+          }
+          {
+            location = "gallery.ecr.aws";
+            blocked = false;
+          }
+          {
+            location = "registry.fedoraproject.org";
+            insecure = true;
+          }
+        ];
       };
       policy = {
         default = [ { type = "insecureAcceptAnything"; } ];
@@ -38,6 +52,17 @@
       mounts = [ "/usr/share/secrets:/run/secrets" ];
     };
   };
+
+  test.asserts.warnings.expected = [
+    ''
+      `services.podman.settings.registries.insecure` and
+      `services.podman.settings.registries.block` are deprecated and will be
+      removed in a future release.
+
+      Use `services.podman.settings.registries.registry` entries with
+      `location`, `insecure`, and `blocked` instead.
+    ''
+  ];
 
   nmt.script =
     if pkgs.stdenv.hostPlatform.isDarwin then


### PR DESCRIPTION
### Description

Convert `services.podman.settings.registries` output to v2 format.
Keep legacy `insecure` and `block` inputs, add `registry` entries,
and warn when legacy options are used.

Update podman configuration tests and expected registries.conf output.

Resolves #9501

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
