### PR TITLE
nixgl: preserve `__functionArgs` when forwarding `.override`

### DIFF
--- a/modules/targets/generic-linux/nixgl.nix
+++ b/modules/targets/generic-linux/nixgl.nix
@@ -303,7 +303,9 @@ in
             # wouldn't know what to do with them. So, we rewrite the override
             # function to instead forward the arguments to the package's own
             # override function.
-            override = args: makePackageWrapper vendor environment (pkg.override args);
+            override = lib.setFunctionArgs (args: makePackageWrapper vendor environment (pkg.override args)) (
+              lib.functionArgs (pkg.override or (_: { }))
+            );
           };
 
       # Note, if you add/remove/alter attribute names here you need to make a


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Forwarding `.override` calls strips the attached metadata, which leads to unexpected behavior in some modules.

Closes #9494

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
