### PR TITLE
mkFirefoxModule: assert managed package for global extensions

### DIFF
--- a/modules/misc/news/2026/06/2026-06-18_12-40-40.nix
+++ b/modules/misc/news/2026/06/2026-06-18_12-40-40.nix
@@ -1,0 +1,26 @@
+{ config, pkgs, ... }:
+let
+  requiresManagedBrowserPackage =
+    browserCfg:
+    browserCfg.globalExtensions != [ ]
+    && browserCfg.package == null
+    && (!pkgs.stdenv.hostPlatform.isDarwin || browserCfg.darwinDefaultsId == null);
+in
+{
+  time = "2026-06-18T17:40:40+00:00";
+  condition =
+    requiresManagedBrowserPackage config.programs.firefox
+    || requiresManagedBrowserPackage config.programs.floorp
+    || requiresManagedBrowserPackage config.programs.librewolf;
+  message = ''
+    The `programs.firefox.globalExtensions`,
+    `programs.floorp.globalExtensions`, and
+    `programs.librewolf.globalExtensions` options now assert that the browser
+    package is managed by Home Manager. On Darwin, setting
+    `programs.<browser>.darwinDefaultsId` also satisfies this requirement.
+
+    If you used `globalExtensions` with `package = null`, set `package` to a
+    non-null browser package or switch back to
+    `profiles.<name>.extensions.packages`.
+  '';
+}

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -1065,6 +1065,15 @@ in
         }
 
         {
+          assertion =
+            cfg.globalExtensions == [ ] || cfg.package != null || (isDarwin && cfg.darwinDefaultsId != null);
+          message =
+            "'${moduleName}.globalExtensions' requires '${moduleName}.package'"
+            + " to be set to a non-null value unless"
+            + " '${moduleName}.darwinDefaultsId' is set on Darwin.";
+        }
+
+        {
           assertion = builtins.all (
             elem:
             let

--- a/tests/modules/programs/firefox/global-extensions-assertions.nix
+++ b/tests/modules/programs/firefox/global-extensions-assertions.nix
@@ -1,5 +1,10 @@
 modulePath:
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   firefoxMockOverlay = import ./setup-firefox-mock-overlay.nix modulePath;
@@ -14,12 +19,17 @@ in
   config = lib.mkIf config.test.enableBig (
     lib.setAttrByPath modulePath {
       enable = true;
+      package = lib.mkIf pkgs.stdenv.hostPlatform.isLinux null;
       globalExtensions = [ extensionWithoutAddonId ];
     }
     // {
-      test.asserts.assertions.expected = [
-        "${lib.showOption modulePath}.globalExtensions requires each package to expose addonId in passthru."
-      ];
+      test.asserts.assertions.expected =
+        lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+          "'${lib.showOption modulePath}.globalExtensions' requires '${lib.showOption modulePath}.package' to be set to a non-null value unless '${lib.showOption modulePath}.darwinDefaultsId' is set on Darwin."
+        ]
+        ++ [
+          "${lib.showOption modulePath}.globalExtensions requires each package to expose addonId in passthru."
+        ];
     }
   );
 }


### PR DESCRIPTION
### Description

Follow-up to #8009 to alert users when `globalExtensions` cannot actually be applied.

This adds a clear assertion for `package = null` setups that have no managed policy carrier, adds regression coverage for Firefox/Floorp/LibreWolf, and includes a targeted news entry explaining how affected users can fix their configuration.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
