### PR TITLE
zellij: Avoid starting on dumb terminals

### DIFF
--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -394,17 +394,23 @@ in
       };
 
       programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-        eval "$(${lib.getExe cfg.finalPackage} setup --generate-auto-start bash)"
+        if [[ "$TERM" != "dumb" ]]; then
+            eval "$(${lib.getExe cfg.finalPackage} setup --generate-auto-start bash)"
+        fi
       '';
 
       programs.zsh.initContent = mkIf cfg.enableZshIntegration (
         lib.mkOrder 200 ''
-          eval "$(${lib.getExe cfg.finalPackage} setup --generate-auto-start zsh)"
+          if [[ "$TERM" != "dumb" ]]; then
+              eval "$(${lib.getExe cfg.finalPackage} setup --generate-auto-start zsh)"
+          fi
         ''
       );
 
       programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-        eval (${lib.getExe cfg.finalPackage} setup --generate-auto-start fish | string collect)
+        if test "$TERM" != "dumb"
+            eval (${lib.getExe cfg.finalPackage} setup --generate-auto-start fish | string collect)
+        end
       '';
 
       home.sessionVariables = mkIf shellIntegrationEnabled {


### PR DESCRIPTION
This avoids https://github.com/zellij-org/zellij/issues/3824

### Description

Using a dumb terminal for automated interactive shells is broken as zellij is started regardless and trips all scrappy dumb terminals.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
  - Ran `nix run .#tests -- zellij` instead and it passed.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module
  - It doesn't
- If this PR adds an exciting new feature or contains a breaking change.
  - It doesn't
