### PR TITLE
lib.hm.dag: performance improvements

### DIFF
--- a/modules/lib/dag.nix
+++ b/modules/lib/dag.nix
@@ -24,12 +24,20 @@ let
     tail
     toposort
     ;
+
+  inherit (hm.dag)
+    empty
+    entriesBetween
+    entryAfter
+    entryBetween
+    isEntry
+    ;
 in
 {
   empty = { };
 
   isEntry = e: e ? data && e ? after && e ? before;
-  isDag = dag: isAttrs dag && all hm.dag.isEntry (attrValues dag);
+  isDag = dag: isAttrs dag && all isEntry (attrValues dag);
 
   # Takes an attribute set containing entries built by entryAnywhere,
   # entryAfter, and entryBefore to a topologically sorted list of
@@ -114,10 +122,10 @@ in
   entryBetween = before: after: data: { inherit data before after; };
 
   # Create a DAG entry with no particular dependency information.
-  entryAnywhere = hm.dag.entryBetween [ ] [ ];
+  entryAnywhere = entryBetween [ ] [ ];
 
-  entryAfter = hm.dag.entryBetween [ ];
-  entryBefore = before: hm.dag.entryBetween before [ ];
+  entryAfter = entryBetween [ ];
+  entryBefore = before: entryBetween before [ ];
 
   # Given a list of entries, this function places them in order within the DAG.
   # Each entry is labeled "${tag}-${entry index}" and other DAG entries can be
@@ -131,24 +139,24 @@ in
       go =
         i: before: after: entries:
         if entries == [ ] then
-          hm.dag.empty
+          empty
         else
           let
             name = "${tag}-${toString i}";
           in
           if length entries == 1 then
             {
-              "${name}" = hm.dag.entryBetween before after (head entries);
+              "${name}" = entryBetween before after (head entries);
             }
           else
             {
-              "${name}" = hm.dag.entryAfter after (head entries);
+              "${name}" = entryAfter after (head entries);
             }
             // go (i + 1) before [ name ] (tail entries);
     in
     go 0;
 
-  entriesAnywhere = tag: hm.dag.entriesBetween tag [ ] [ ];
-  entriesAfter = tag: hm.dag.entriesBetween tag [ ];
-  entriesBefore = tag: before: hm.dag.entriesBetween tag before [ ];
+  entriesAnywhere = tag: entriesBetween tag [ ] [ ];
+  entriesAfter = tag: entriesBetween tag [ ];
+  entriesBefore = tag: before: entriesBetween tag before [ ];
 }

--- a/modules/lib/dag.nix
+++ b/modules/lib/dag.nix
@@ -12,9 +12,13 @@
 let
   inherit (lib)
     all
+    attrNames
+    attrValues
+    elem
     filterAttrs
     head
     hm
+    isAttrs
     mapAttrs
     length
     tail
@@ -25,7 +29,7 @@ in
   empty = { };
 
   isEntry = e: e ? data && e ? after && e ? before;
-  isDag = dag: builtins.isAttrs dag && all hm.dag.isEntry (builtins.attrValues dag);
+  isDag = dag: isAttrs dag && all hm.dag.isEntry (attrValues dag);
 
   # Takes an attribute set containing entries built by entryAnywhere,
   # entryAfter, and entryBefore to a topologically sorted list of
@@ -86,14 +90,14 @@ in
   topoSort =
     dag:
     let
-      dagBefore = dag: name: builtins.attrNames (filterAttrs (_n: v: builtins.elem name v.before) dag);
+      dagBefore = dag: name: attrNames (filterAttrs (_n: v: elem name v.before) dag);
       normalizedDag = mapAttrs (n: v: {
         name = n;
         inherit (v) data;
         after = v.after ++ dagBefore dag n;
       }) dag;
-      before = a: b: builtins.elem a.name b.after;
-      sorted = toposort before (builtins.attrValues normalizedDag);
+      before = a: b: elem a.name b.after;
+      sorted = toposort before (attrValues normalizedDag);
     in
     if sorted ? result then
       {

--- a/modules/lib/dag.nix
+++ b/modules/lib/dag.nix
@@ -88,6 +88,9 @@ in
   #              }
   #    true
   topoSort =
+    let
+      before = a: b: elem a.name b.after;
+    in
     dag:
     let
       dagBefore = dag: name: attrNames (filterAttrs (_n: v: elem name v.before) dag);
@@ -96,7 +99,6 @@ in
         inherit (v) data;
         after = v.after ++ dagBefore dag n;
       }) dag;
-      before = a: b: elem a.name b.after;
       sorted = toposort before (attrValues normalizedDag);
     in
     if sorted ? result then

--- a/modules/lib/dag.nix
+++ b/modules/lib/dag.nix
@@ -130,20 +130,21 @@ in
     let
       go =
         i: before: after: entries:
-        let
-          name = "${tag}-${toString i}";
-        in
         if entries == [ ] then
           hm.dag.empty
-        else if length entries == 1 then
-          {
-            "${name}" = hm.dag.entryBetween before after (head entries);
-          }
         else
-          {
-            "${name}" = hm.dag.entryAfter after (head entries);
-          }
-          // go (i + 1) before [ name ] (tail entries);
+          let
+            name = "${tag}-${toString i}";
+          in
+          if length entries == 1 then
+            {
+              "${name}" = hm.dag.entryBetween before after (head entries);
+            }
+          else
+            {
+              "${name}" = hm.dag.entryAfter after (head entries);
+            }
+            // go (i + 1) before [ name ] (tail entries);
     in
     go 0;
 

--- a/modules/lib/dag.nix
+++ b/modules/lib/dag.nix
@@ -15,7 +15,7 @@ let
     attrNames
     attrValues
     elem
-    filterAttrs
+    filter
     head
     hm
     isAttrs
@@ -101,11 +101,12 @@ in
     in
     dag:
     let
-      dagBefore = dag: name: attrNames (filterAttrs (_n: v: elem name v.before) dag);
+      names = attrNames dag;
+      dagBefore = name: filter (n: elem name dag.${n}.before) names;
       normalizedDag = mapAttrs (n: v: {
         name = n;
         inherit (v) data;
-        after = v.after ++ dagBefore dag n;
+        after = v.after ++ dagBefore n;
       }) dag;
       sorted = toposort before (attrValues normalizedDag);
     in


### PR DESCRIPTION
### Description

DAGs aren't load-bearing at all in HM, but I'd like them to be generally sane. I used this code as a benchmark:
```nix
let
  lib = import ~/Documents/repos/nixpkgs/lib;
  inherit (lib) toString genList listToAttrs;

  hm = (import ./lib/default.nix { inherit lib; }).hm;
  inherit (hm.dag)
    entryAnywhere
    entryAfter
    topoSort
    ;

  data = listToAttrs (
    genList (n: {
      name = toString n;
      value = if n == 0 then entryAnywhere 0 else entryAfter [ (toString (n - 1)) ] n;
    }) 2000
  );
in
builtins.deepSeq (topoSort data) null
```

Profiling with hyperfine:
```sh
# before this PR
Benchmark 1: nix-instantiate --eval --strict ./benchmark.nix
  Time (mean ± σ):      1.890 s ±  0.006 s    [User: 1.692 s, System: 0.222 s]
  Range (min … max):    1.879 s …  1.902 s    20 runs

# after this PR
Benchmark 2: nix-instantiate --eval --strict ./benchmark.nix
  Time (mean ± σ):     764.3 ms ±   7.2 ms    [User: 547.7 ms, System: 211.5 ms]
  Range (min … max):   750.3 ms … 778.1 ms    20 runs
```

I originally added a new toposort function to this PR as well. The nixpkgs implementation relies on a comparator function and appears to be O(n^3) in the worst case, while we can trivially achieve O(n^2) in the case of a DAG. However, I got some really odd results, where the new toposort consistently grew by the expected O(n^2) growth factor, but the nixpkgs toposort showed odd bumps in its growth rate. For now, I'll table it until I can figure out what's going on.

### Checklist


- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
