### PR TITLE
difftastic: fix typo in example

### DIFF
--- a/modules/programs/difftastic.nix
+++ b/modules/programs/difftastic.nix
@@ -83,7 +83,7 @@ in
         attrsOf (either atom (listOf atom));
       default = { };
       example = {
-        color = "dark";
+        color = "always";
         sort-paths = true;
         tab-width = 8;
       };


### PR DESCRIPTION
The **"dark"** value actually applies to the `background` setting (which I’ve omitted here since **"dark"** is its default value.)

I’ve given `color` the value **"always"**, which will preserve colorization when using `less` as a pager.

Extracted from `difft --help`¹:

```
Options:
...
        --color <WHEN>
            When to use color output.

            [env: DFT_COLOR=]
            [default: auto]
            [possible values: always, auto, never]

        --background <BACKGROUND>
            Set the background brightness. Difftastic will prefer brighter colours on dark backgrounds.

            [env: DFT_BACKGROUND=]
            [default: dark]
            [possible values: dark, light]
```

¹: which seems to be the authoritative source of documentation, as per https://difftastic.wilfred.me.uk/usage.html#configuration-options

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
