### PR TITLE
fzf: add nushell integration

### DIFF
--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -188,11 +188,19 @@ in
     enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+
+    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    assertions = [
+      {
+        assertion = cfg.enableNushellIntegration -> lib.versionAtLeast cfg.package.version "0.73.0";
+        message = "fzf package version must be 0.73.0 or greater for nushell integration";
+      }
+    ];
 
+    home.packages = [ cfg.package ];
     home.sessionVariables = lib.mapAttrs (_n: toString) (
       lib.filterAttrs (_n: v: v != [ ] && v != null) {
         FZF_ALT_C_COMMAND = cfg.changeDirWidgetCommand;
@@ -221,5 +229,16 @@ in
     programs.zsh.initContent = mkIf cfg.enableZshIntegration (mkOrder 910 zshIntegration);
 
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration (mkOrder 200 fishIntegration);
+
+    programs.nushell = lib.mkIf cfg.enableNushellIntegration {
+      extraConfig = ''
+        source ${
+          pkgs.runCommand "nushell-fzf-integration.nu" { } ''
+            ${lib.getExe cfg.package} --nushell > $out
+          ''
+        }
+      '';
+    };
+
   };
 }

--- a/tests/modules/programs/fzf/all-options.nix
+++ b/tests/modules/programs/fzf/all-options.nix
@@ -1,0 +1,59 @@
+{
+  programs.fzf = {
+    enable = true;
+    defaultCommand = "fd --type f";
+    defaultOptions = [
+      "--height 40%"
+      "--border"
+    ];
+    fileWidgetCommand = "fd --type f";
+    fileWidgetOptions = [ "--preview 'head {}'" ];
+    changeDirWidgetCommand = "fd --type d";
+    changeDirWidgetOptions = [ "--preview 'tree -C {} | head -200'" ];
+    historyWidgetOptions = [
+      "--sort"
+      "--exact"
+    ];
+    colors = {
+      bg = "#1e1e1e";
+    };
+    tmux = {
+      enableShellIntegration = true;
+      shellIntegrationOptions = [ "-d 40%" ];
+    };
+  };
+
+  nmt.script = ''
+    # Test default options
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_DEFAULT_COMMAND="fd --type f"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_DEFAULT_OPTS="--height 40% --border --color'
+
+    # Test file widget
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_CTRL_T_COMMAND="fd --type f"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_CTRL_T_OPTS="--preview'
+
+    # Test change dir widget
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_ALT_C_COMMAND="fd --type d"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_ALT_C_OPTS="--preview'
+
+    # Test history widget
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_CTRL_R_OPTS="--sort --exact"'
+
+    # Test tmux
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_TMUX="1"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_TMUX_OPTS="-d 40%"'
+
+    # Test colors are exported
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_DEFAULT_OPTS=.*--color'
+  '';
+}

--- a/tests/modules/programs/fzf/bash-integration.nix
+++ b/tests/modules/programs/fzf/bash-integration.nix
@@ -1,0 +1,27 @@
+{ config, ... }:
+
+{
+  programs.fzf = {
+    enable = true;
+    enableBashIntegration = true;
+
+    package = config.lib.test.mkStubPackage {
+      name = "fzf";
+      version = "0.73.0";
+      buildScript = ''
+        mkdir -p $out/bin $out/share/fzf
+        cat > $out/bin/fzf << 'EOF'
+        #!/bin/sh
+        echo "Stub fzf"
+        EOF
+      '';
+    };
+  };
+
+  programs.bash.enable = true;
+
+  nmt.script = ''
+    assertFileRegex home-files/.bashrc \
+      'eval.*fzf.*bash'
+  '';
+}

--- a/tests/modules/programs/fzf/default.nix
+++ b/tests/modules/programs/fzf/default.nix
@@ -1,0 +1,8 @@
+{
+  fzf-disabled = ./disabled.nix;
+  fzf-options = ./all-options.nix;
+  fzf-bash-integration = ./bash-integration.nix;
+  fzf-zsh-integration = ./zsh-integration.nix;
+  fzf-fish-integration = ./fish-integration.nix;
+  fzf-nushell-integration = ./nushell-integration.nix;
+}

--- a/tests/modules/programs/fzf/disabled.nix
+++ b/tests/modules/programs/fzf/disabled.nix
@@ -1,0 +1,7 @@
+{
+  programs.fzf.enable = false;
+
+  nmt.script = ''
+    assertPathNotExists home-files/.bashrc
+  '';
+}

--- a/tests/modules/programs/fzf/fish-integration.nix
+++ b/tests/modules/programs/fzf/fish-integration.nix
@@ -1,0 +1,28 @@
+{ config, ... }:
+
+{
+  programs.fzf = {
+    enable = true;
+    enableFishIntegration = true;
+
+    package = config.lib.test.mkStubPackage {
+      name = "fzf";
+      version = "0.73.0";
+      buildScript = ''
+        mkdir -p $out/bin
+        cat > $out/bin/fzf << 'EOF'
+        #!/bin/sh
+        echo "Stub fzf"
+        EOF
+        chmod +x $out/bin/fzf
+      '';
+    };
+  };
+
+  programs.fish.enable = true;
+
+  nmt.script = ''
+    assertFileRegex home-files/.config/fish/config.fish \
+      'fzf.*--fish.*source'
+  '';
+}

--- a/tests/modules/programs/fzf/nushell-integration.nix
+++ b/tests/modules/programs/fzf/nushell-integration.nix
@@ -1,0 +1,37 @@
+{ config, pkgs, ... }:
+
+{
+  programs.fzf = {
+    enable = true;
+    enableNushellIntegration = true;
+
+    package = config.lib.test.mkStubPackage {
+      name = "fzf";
+      version = "0.73.0";
+      buildScript = ''
+        mkdir -p $out/bin
+        cat > $out/bin/fzf << 'EOF'
+        #!/bin/sh
+        echo "Stub fzf"
+        EOF
+        chmod +x $out/bin/fzf
+      '';
+    };
+  };
+
+  programs.nushell.enable = true;
+
+  nmt.script =
+    let
+      nushellConfigFile =
+        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+          "home-files/Library/Application Support/nushell/config.nu"
+        else
+          "home-files/.config/nushell/config.nu";
+    in
+    ''
+      assertFileExists "${nushellConfigFile}"
+      assertFileRegex "${nushellConfigFile}" \
+        'source.*nushell-fzf-integration'
+    '';
+}

--- a/tests/modules/programs/fzf/zsh-integration.nix
+++ b/tests/modules/programs/fzf/zsh-integration.nix
@@ -1,0 +1,27 @@
+{ config, ... }:
+
+{
+  programs.fzf = {
+    enable = true;
+    enableZshIntegration = true;
+
+    package = config.lib.test.mkStubPackage {
+      name = "fzf";
+      version = "0.73.0";
+      buildScript = ''
+        mkdir -p $out/bin $out/share/fzf
+        cat > $out/bin/fzf << 'EOF'
+        #!/bin/sh
+        echo "Stub fzf"
+        EOF
+      '';
+    };
+  };
+
+  programs.zsh.enable = true;
+
+  nmt.script = ''
+    assertFileRegex home-files/.zshrc \
+      'source.*fzf.*zsh'
+  '';
+}


### PR DESCRIPTION
### Description

Introduces support for the newly added nushell keybindings for fzf.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
