### PR TITLE
ssh: document DAG ordering patterns

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -678,13 +678,29 @@ in
       );
       default = { };
       example = literalExpression ''
-        {
-          "github.com" = {
-            HostName = "github.com";
+        # Tagged hosts must appear before Match blocks that select those tags.
+        lib.hm.dag.entriesBefore "corp-host" [ "corp-match" ] [
+          {
+            header = "Host build.corp";
+            HostName = "build.corp.example.org";
+            User = "builder";
+            Tag = "corp";
+          }
+
+          {
+            header = "Host git.corp";
+            HostName = "git.corp.example.org";
             User = "git";
-            IdentityFile = "~/.ssh/github";
+            Tag = "corp";
+          }
+        ]
+        // {
+          # Bare attribute names become Host patterns.
+          "*.internal.example.org" = {
+            User = "internal";
           };
 
+          # Literal Host headers can use the full OpenSSH syntax.
           "Host *.example.org" = lib.hm.dag.entryBefore [ "github.com" ] {
             IdentityFile = "~/.ssh/example";
             LocalForward = [
@@ -698,7 +714,20 @@ in
             DynamicForward = "127.0.0.1:1080";
           };
 
-          "Match host *.corp exec \"test -f ~/.corp\"" = {
+          # Literal Match headers can be ordered by their attribute name.
+          "Match host *.vpn.example.org" = lib.hm.dag.entryAfter [ "github.com" ] {
+            ProxyJump = "vpn";
+          };
+
+          "github.com" = {
+            HostName = "github.com";
+            User = "git";
+            IdentityFile = "~/.ssh/github";
+          };
+
+          # Keep long or dynamic SSH headers out of DAG references.
+          corp-match = lib.hm.dag.entryAfter [ "github.com" ] {
+            header = "Match tagged corp exec \"test -f ~/.corp\"";
             ProxyJump = "bastion";
             RemoteForward = {
               bind.port = 8081;
@@ -707,6 +736,13 @@ in
             };
           };
         }
+        # Generated groups can also be placed after named blocks.
+        // lib.hm.dag.entriesAfter "corp-fallback" [ "corp-match" ] [
+          {
+            header = "Host *.corp";
+            User = "corp";
+          }
+        ]
       '';
       description = ''
         OpenSSH client configuration blocks written to
@@ -716,7 +752,10 @@ in
         start with `Host ` or `Match `, in which case they are written
         literally as block headers. If the order of rules matter then
         use the DAG functions to express the dependencies as shown in
-        the example.
+        the example. Use {option}`programs.ssh.settings.<name>.header`
+        when the block should have a short stable name for DAG ordering,
+        and use `lib.hm.dag.entriesBefore` or
+        `lib.hm.dag.entriesAfter` to order generated groups of blocks.
 
         See
         {manpage}`ssh_config(5)`


### PR DESCRIPTION
### Description

Expand the `programs.ssh.settings` example to show ordered Host and Match blocks with both single-entry and list-shaped DAG helpers.

This documents and tests:

- plain attribute names as Host patterns
- literal `Host ...` and `Match ...` headers
- stable DAG names with `programs.ssh.settings.<name>.header`
- `lib.hm.dag.entryBefore` / `entryAfter`
- `lib.hm.dag.entriesBefore` / `entriesAfter`

Closes #9523

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

  Targeted SSH suite passed: `nix run path:.#tests -- ssh -- --show-trace`.
  Docs build passed: `nix-build -A docs.html`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

  N/A - no new module.

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

  N/A - documentation/test coverage only.
