### PR TITLE
fontconfig: add explicit font packages

### DIFF
--- a/modules/misc/fontconfig.nix
+++ b/modules/misc/fontconfig.nix
@@ -196,6 +196,19 @@ in
         '';
       };
 
+      packages = lib.mkOption {
+        type = with lib.types; listOf path;
+        default = [ ];
+        example = lib.literalExpression "[ pkgs.nerd-fonts.open-dyslexic ]";
+        description = ''
+          List of font packages to add directly to Fontconfig's search paths.
+
+          These packages are not added to {option}`home.packages`. Use this
+          option for font packages that should be discovered through direct
+          immutable store paths rather than through the Home Manager profile.
+        '';
+      };
+
       defaultFonts = {
         monospace = lib.mkOption {
           type = with lib.types; listOf str;
@@ -366,7 +379,7 @@ in
               "${config.home.path}/etc/fonts/conf.d"
               "${config.home.path}/etc/fonts/fonts.conf"
             ];
-            dir = [
+            dir = map (fontPackage: "${fontPackage}") cfg.packages ++ [
               "${config.home.path}/lib/X11/fonts"
               "${config.home.path}/share/fonts"
               "${config.home.profileDirectory}/lib/X11/fonts"

--- a/modules/misc/fontconfig.nix
+++ b/modules/misc/fontconfig.nix
@@ -446,9 +446,12 @@ in
     };
 
     xdg.configFile = lib.mapAttrs' (
-      _name: config:
+      name: config:
       lib.nameValuePair "fontconfig/conf.d/${config.target}" {
         inherit (config) enable source;
+        onChange = lib.optionalString (name == "fonts") ''
+          run ${lib.getExe' pkgs.fontconfig "fc-cache"} -f $VERBOSE_ARG
+        '';
       }
     ) cfg.configFile;
   };

--- a/modules/misc/news/2026/06/2026-06-19_19-56-26.nix
+++ b/modules/misc/news/2026/06/2026-06-19_19-56-26.nix
@@ -1,0 +1,11 @@
+{ config, ... }:
+{
+  time = "2026-06-19T19:56:26+00:00";
+  condition = config.fonts.fontconfig.enable;
+  message = ''
+    There is a new `fonts.fontconfig.packages` option to add font packages
+    directly to Fontconfig's search paths. This can be useful for fonts that
+    need deterministic discovery through immutable store paths rather than the
+    Home Manager profile.
+  '';
+}

--- a/tests/modules/misc/fontconfig/default.nix
+++ b/tests/modules/misc/fontconfig/default.nix
@@ -8,6 +8,7 @@
   fontconfig-custom-rendering = ./custom-rendering.nix;
   fontconfig-extra-config-files = ./extra-config-files.nix;
   fontconfig-fonts = ./fonts.nix;
+  fontconfig-font-packages = ./font-packages.nix;
 
   fontconfig-legacy-default-configFile-toggle = ./legacy-default-configFile-toggle.nix;
 }

--- a/tests/modules/misc/fontconfig/font-packages.nix
+++ b/tests/modules/misc/fontconfig/font-packages.nix
@@ -1,0 +1,79 @@
+{
+  config,
+  pkgs,
+  realPkgs,
+  ...
+}:
+
+let
+  configFile = "home-files/.config/fontconfig/conf.d/10-hm-fonts.conf";
+  fontPackage = pkgs.runCommandLocal "hm-fontconfig-test-font" { } ''
+    mkdir -p $out/share/fonts/misc
+    cat > $out/share/fonts/misc/hm-test-font.bdf <<'EOF'
+    STARTFONT 2.1
+    FONT -HM-Test-Font-Medium-R-Normal--8-80-75-75-C-50-ISO10646-1
+    SIZE 8 75 75
+    FONTBOUNDINGBOX 5 8 0 -1
+    STARTPROPERTIES 8
+    FONT_ASCENT 7
+    FONT_DESCENT 1
+    FOUNDRY "HM"
+    FAMILY_NAME "HM Test Font"
+    WEIGHT_NAME "Medium"
+    SLANT "R"
+    SETWIDTH_NAME "Normal"
+    CHARSET_REGISTRY "ISO10646"
+    CHARSET_ENCODING "1"
+    ENDPROPERTIES
+    CHARS 1
+    STARTCHAR A
+    ENCODING 65
+    SWIDTH 500 0
+    DWIDTH 5 0
+    BBX 5 7 0 0
+    BITMAP
+    70
+    88
+    88
+    F8
+    88
+    88
+    88
+    ENDCHAR
+    ENDFONT
+    EOF
+  '';
+in
+{
+  fonts.fontconfig = {
+    enable = true;
+    packages = [ fontPackage ];
+  };
+
+  # Use `realPkgs` here since the discovery check relies on the `fc-list`
+  # binary. The font package itself is generated locally by this test.
+  test.unstubs = [ (_self: _super: { inherit (realPkgs) fontconfig; }) ];
+
+  nmt.script = ''
+    assertFileExists ${configFile}
+    assertFileContent ${configFile} ${pkgs.writeText "font-packages.conf" ''
+      <?xml version="1.0" encoding="utf-8"?>
+      <fontconfig>
+        <cachedir>${config.home.path}/lib/fontconfig/cache</cachedir>
+        <description>Add fonts in the Nix user profile</description>
+        <dir>${fontPackage}</dir>
+        <dir>${config.home.path}/lib/X11/fonts</dir>
+        <dir>${config.home.path}/share/fonts</dir>
+        <dir>${config.home.profileDirectory}/lib/X11/fonts</dir>
+        <dir>${config.home.profileDirectory}/share/fonts</dir>
+        <include ignore_missing="yes">${config.home.path}/etc/fonts/conf.d</include>
+        <include ignore_missing="yes">${config.home.path}/etc/fonts/fonts.conf</include>
+      </fontconfig>
+    ''}
+
+    XDG_CACHE_HOME="$TMPDIR" \
+      FONTCONFIG_FILE="$TESTED/${configFile}" \
+      ${realPkgs.fontconfig}/bin/fc-list \
+      | grep -F "${fontPackage}/share/fonts/misc/hm-test-font.bdf" >/dev/null
+  '';
+}

--- a/tests/modules/misc/fontconfig/font-packages.nix
+++ b/tests/modules/misc/fontconfig/font-packages.nix
@@ -56,6 +56,7 @@ in
 
   nmt.script = ''
     assertFileExists ${configFile}
+    assertFileRegex activate 'run .*/bin/fc-cache -f'
     assertFileContent ${configFile} ${pkgs.writeText "font-packages.conf" ''
       <?xml version="1.0" encoding="utf-8"?>
       <fontconfig>


### PR DESCRIPTION
### Description

Add `fonts.fontconfig.packages` so Home Manager can point Fontconfig at explicit font package store paths, while keeping existing profile discovery for compatibility. Also refresh Fontconfig cache during activation.

Closes #4048.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
