### PR TITLE
tests: fix integration tests

### DIFF
--- a/tests/integration/standalone/alice-flake-init.nix
+++ b/tests/integration/standalone/alice-flake-init.nix
@@ -11,7 +11,7 @@
   };
 
   outputs =
-    inputs@{ nixpkgs, home-manager, ... }:
+    { nixpkgs, home-manager, ... }:
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
@@ -24,7 +24,8 @@
         # the path to your home.nix.
         modules = [ ./home.nix ];
 
-        extraSpecialArgs = { inherit inputs; };
+        # Optionally use extraSpecialArgs
+        # to pass through arguments to home.nix
       };
     };
 }

--- a/tests/integration/standalone/alice-home-init.nix
+++ b/tests/integration/standalone/alice-home-init.nix
@@ -1,3 +1,5 @@
+{ config, pkgs, ... }:
+
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.
@@ -11,7 +13,7 @@
   # You should not change this value, even if you update Home Manager. If you do
   # want to update the value, then make sure to first check the Home Manager
   # release notes.
-  home.stateVersion = "25.11"; # Please read the comment before changing.
+  home.stateVersion = "26.05"; # Please read the comment before changing.
 
   # The home.packages option allows you to install Nix packages into your
   # environment.

--- a/tests/integration/standalone/home-with-symbols-init.nix
+++ b/tests/integration/standalone/home-with-symbols-init.nix
@@ -1,3 +1,5 @@
+{ config, pkgs, ... }:
+
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.
@@ -11,7 +13,7 @@
   # You should not change this value, even if you update Home Manager. If you do
   # want to update the value, then make sure to first check the Home Manager
   # release notes.
-  home.stateVersion = "25.11"; # Please read the comment before changing.
+  home.stateVersion = "26.05"; # Please read the comment before changing.
 
   # The home.packages option allows you to install Nix packages into your
   # environment.

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -8,11 +8,13 @@ includes = [ "*.nix" ]
 [formatter.statix]
 command = "treefmt-statix"
 includes = [ "*.nix" ]
+excludes = [ "tests/integration/standalone/*-init.nix" ]
 
 [formatter.deadnix]
 command = "deadnix"
 options = [ "--edit" ]
 includes = [ "*.nix" ]
+excludes = [ "tests/integration/standalone/*-init.nix" ]
 
 [formatter.nixf-diagnose]
 command = "nixf-diagnose"


### PR DESCRIPTION
### Description

This updates the integration tests so that they pass.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
