### PR TITLE
launchd: add agent domain option

### DIFF
--- a/docs/release-notes/rl-2611.md
+++ b/docs/release-notes/rl-2611.md
@@ -14,6 +14,12 @@ This release has the following notable changes:
   and `programs.uv.python.prune` / `programs.uv.tool.prune` make the managed set
   fully declarative by removing versions and tools that are no longer listed.
 
+- On Darwin, Home Manager launchd agents now support
+  [](#opt-launchd.agents._name_.domain) to choose either the user's GUI or
+  background launchd domain. Background services provided by Home Manager now
+  use the user domain, which allows activations from contexts such as SSH
+  sessions without requiring an active graphical login session.
+
 ## State Version Changes {#sec-release-26.11-state-version-changes}
 
 The state version in this release includes the changes below. These

--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -18,6 +18,22 @@ let
     {
       options = {
         enable = lib.mkEnableOption name;
+        domain = lib.mkOption {
+          type = lib.types.enum [
+            "gui"
+            "user"
+          ];
+          default = "gui";
+          example = "user";
+          description = ''
+            The launchd domain to bootstrap this agent into.
+
+            The `gui` domain is appropriate for agents that need the user's
+            Aqua session, such as window managers, hotkey daemons, and other
+            graphical tools. The `user` domain is appropriate for background
+            services that do not require a graphical login session.
+          '';
+        };
         config = lib.mkOption {
           type = lib.types.submodule (import ./launchd.nix);
           default = { };
@@ -74,6 +90,13 @@ let
     _n: v: lib.nameValuePair "${v.config.Label}.plist" (toAgent v.config)
   ) (lib.filterAttrs (_n: v: v.enable) cfg.agents);
 
+  agentDomains = lib.mapAttrs' (
+    _n: v:
+    lib.nameValuePair "${v.config.Label}.domain" (
+      pkgs.writeText "${v.config.Label}.domain" "${v.domain}\n"
+    )
+  ) (lib.filterAttrs (_n: v: v.enable) cfg.agents);
+
   agentsDrv = pkgs.runCommand "home-manager-agents" { } ''
     mkdir -p "$out"
 
@@ -84,6 +107,20 @@ let
 
     for dest in "''${!plists[@]}"; do
       src="''${plists[$dest]}"
+      ln -s "$src" "$out/$dest"
+    done
+  '';
+
+  agentDomainsDrv = pkgs.runCommand "home-manager-agent-domains" { } ''
+    mkdir -p "$out"
+
+    declare -A domains
+    domains=(${
+      lib.concatStringsSep " " (lib.mapAttrsToList (name: value: "['${name}']='${value}'") agentDomains)
+    })
+
+    for dest in "''${!domains[@]}"; do
+      src="''${domains[$dest]}"
       ln -s "$src" "$out/$dest"
     done
   '';
@@ -129,6 +166,7 @@ in
     (lib.mkIf isDarwin {
       home.extraBuilderCommands = ''
         ln -s "${agentsDrv}" $out/LaunchAgents
+        ln -s "${agentDomainsDrv}" $out/LaunchAgentDomains
       '';
 
       # NOTE: Launch Agent configurations can't be symlinked from the Nix store
@@ -138,6 +176,40 @@ in
           ''
             # Disable errexit to ensure we process all agents even if some fail
             set +e
+
+            readAgentDomain() {
+              local domainsDir="$1"
+              local agentName="$2"
+              local domainFile="$domainsDir/$agentName.domain"
+
+              if [[ -n "$domainsDir" && -f "$domainFile" ]]; then
+                local domainName
+                domainName="$(<"$domainFile")"
+                case "$domainName" in
+                  gui|user)
+                    printf '%s\n' "$domainName"
+                    ;;
+                  *)
+                    printf 'gui\n'
+                    ;;
+                esac
+              else
+                printf 'gui\n'
+              fi
+            }
+
+            resolveDomain() {
+              local domainName="$1"
+
+              case "$domainName" in
+                gui)
+                  printf 'gui/%s\n' "$UID"
+                  ;;
+                user)
+                  printf 'user/%s\n' "$UID"
+                  ;;
+              esac
+            }
 
             # Stop an agent if it's running
             bootoutAgent() {
@@ -190,26 +262,36 @@ in
             processAgent() {
               local srcPath="$1"
               local dstDir="$2"
-              local domain="$3"
+              local oldDomainsDir="$3"
+              local newDomainsDir="$4"
 
               local agentFile="''${srcPath##*/}"
               local agentName="''${agentFile%.plist}"
               local dstPath="$dstDir/$agentFile"
+              local oldDomainName
+              local newDomainName
+              local oldDomain
+              local newDomain
+
+              oldDomainName="$(readAgentDomain "$oldDomainsDir" "$agentName")"
+              newDomainName="$(readAgentDomain "$newDomainsDir" "$agentName")"
+              oldDomain="$(resolveDomain "$oldDomainName")"
+              newDomain="$(resolveDomain "$newDomainName")"
 
               # Skip if unchanged
-              if cmp -s "$srcPath" "$dstPath"; then
-                verboseEcho "Agent '$agentName' is already up-to-date"
+              if cmp -s "$srcPath" "$dstPath" && [[ "$oldDomainName" == "$newDomainName" ]]; then
+                verboseEcho "Agent '$newDomain/$agentName' is already up-to-date"
                 return 0
               fi
 
-              verboseEcho "Processing agent '$agentName'"
+              verboseEcho "Processing agent '$newDomain/$agentName'"
 
               # Stop/Unload agent if it's already running
               if [[ -f "$dstPath" ]]; then
-                bootoutAgent "$domain" "$agentName"
+                bootoutAgent "$oldDomain" "$agentName"
               fi
 
-              installAndBootstrapAgent "$srcPath" "$dstPath" "$domain" "$agentName"
+              installAndBootstrapAgent "$srcPath" "$dstPath" "$newDomain" "$agentName"
               # Note: We continue processing even if this agent fails
               return 0
             }
@@ -218,11 +300,16 @@ in
               local srcPath="$1"
               local dstDir="$2"
               local newDir="$3"
-              local domain="$4"
+              local oldDomainsDir="$4"
 
               local agentFile="''${srcPath##*/}"
               local agentName="''${agentFile%.plist}"
               local dstPath="$dstDir/$agentFile"
+              local domainName
+              local domain
+
+              domainName="$(readAgentDomain "$oldDomainsDir" "$agentName")"
+              domain="$(resolveDomain "$domainName")"
 
               if [[ -e "$newDir/$agentFile" ]]; then
                 verboseEcho "Agent '$agentName' still exists in new generation, skipping cleanup"
@@ -253,11 +340,11 @@ in
             }
 
             setupLaunchAgents() {
-              local oldDir newDir dstDir domain
+              local oldDir newDir oldDomainsDir newDomainsDir dstDir
 
               newDir="$(readlink -m "$newGenPath/LaunchAgents")"
+              newDomainsDir="$(readlink -m "$newGenPath/LaunchAgentDomains")"
               dstDir=${lib.escapeShellArg dstDir}
-              domain="gui/$UID"
 
               if [[ -n "''${oldGenPath:-}" ]]; then
                 oldDir="$(readlink -m "$oldGenPath/LaunchAgents")"
@@ -265,8 +352,14 @@ in
                   verboseEcho "No previous LaunchAgents directory found"
                   oldDir=""
                 fi
+
+                oldDomainsDir="$(readlink -m "$oldGenPath/LaunchAgentDomains")"
+                if [[ ! -d "$oldDomainsDir" ]]; then
+                  oldDomainsDir=""
+                fi
               else
                 oldDir=""
+                oldDomainsDir=""
               fi
 
               verboseEcho "Setting up LaunchAgents in $dstDir"
@@ -274,7 +367,7 @@ in
 
               verboseEcho "Processing new/updated LaunchAgents..."
               find -L "$newDir" -maxdepth 1 -name '*.plist' -type f | while read -r srcPath; do
-                processAgent "$srcPath" "$dstDir" "$domain"
+                processAgent "$srcPath" "$dstDir" "$oldDomainsDir" "$newDomainsDir"
               done
 
               # Skip cleanup if there's no previous generation
@@ -285,7 +378,7 @@ in
 
               verboseEcho "Cleaning up removed LaunchAgents..."
               find -L "$oldDir" -maxdepth 1 -name '*.plist' -type f | while read -r srcPath; do
-                removeAgent "$srcPath" "$dstDir" "$newDir" "$domain"
+                removeAgent "$srcPath" "$dstDir" "$newDir" "$oldDomainsDir"
               done
             }
 

--- a/modules/misc/news/2026/06/2026-06-18_02-02-00.nix
+++ b/modules/misc/news/2026/06/2026-06-18_02-02-00.nix
@@ -1,0 +1,15 @@
+{ config, pkgs, ... }:
+
+{
+  time = "2026-06-18T02:02:00+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin && config.launchd.enable;
+  message = ''
+
+    Home Manager launchd agents now support the
+    `launchd.agents.<name>.domain` option. Background services provided by Home
+    Manager use the user launchd domain by default, so they can be managed from
+    SSH and other non-graphical sessions. Set
+    `launchd.agents.<name>.domain = "gui"` for agents that need the graphical
+    session.
+  '';
+}

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -298,6 +298,7 @@ in
 
           launchd.agents.atuin-daemon = {
             enable = true;
+            domain = lib.mkDefault "user";
             config = {
               ProgramArguments = [ (lib.getExe cfg.package) ] ++ daemonArgs;
               EnvironmentVariables = lib.optionalAttrs (daemonCfg.logLevel != null) {

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -609,6 +609,7 @@ in
           {
             "git-maintenance-hourly" = {
               enable = true;
+              domain = lib.mkDefault "user";
               config = {
                 ProgramArguments = baseArguments ++ [ "--schedule=hourly" ];
                 StartCalendarInterval = map (hour: {
@@ -619,6 +620,7 @@ in
             };
             "git-maintenance-daily" = {
               enable = true;
+              domain = lib.mkDefault "user";
               config = {
                 ProgramArguments = baseArguments ++ [ "--schedule=daily" ];
                 StartCalendarInterval = map (weekday: {
@@ -630,6 +632,7 @@ in
             };
             "git-maintenance-weekly" = {
               enable = true;
+              domain = lib.mkDefault "user";
               config = {
                 ProgramArguments = baseArguments ++ [ "--schedule=weekly" ];
                 StartCalendarInterval = [

--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -151,6 +151,7 @@ in
 
     launchd.agents.nh-clean = lib.mkIf cfg.clean.enable {
       enable = true;
+      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           "${lib.getExe cfg.package}"

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -626,6 +626,7 @@ in
     launchd.agents = mkIf webCfg.enable {
       opencode-web = {
         enable = true;
+        domain = lib.mkDefault "user";
         config = {
           ProgramArguments =
             let

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -160,6 +160,7 @@ let
     in
     {
       enable = true;
+      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           (lib.getExe rcloneSidecarWrapper)
@@ -619,6 +620,7 @@ in
       mkLaunchdConfigService = lib.mkIf (cfg.remotes != { }) {
         rclone-config = {
           enable = true;
+          domain = lib.mkDefault "user";
           config = {
             ProgramArguments = [ (lib.getExe rcloneConfigScript) ];
             RunAtLoad = true;

--- a/modules/services/borgmatic.nix
+++ b/modules/services/borgmatic.nix
@@ -87,6 +87,7 @@ in
 
     launchd.agents.borgmatic = {
       enable = true;
+      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           (lib.getExe programConfig.package)

--- a/modules/services/colima.nix
+++ b/modules/services/colima.nix
@@ -265,6 +265,7 @@ in
         name: profile:
         lib.nameValuePair "colima-${name}" {
           enable = true;
+          domain = lib.mkDefault "user";
           config = {
             ProgramArguments = [
               "${lib.getExe cfg.package}"

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -218,6 +218,7 @@ in
 
     launchd.agents.emacs = {
       enable = true;
+      domain = lib.mkDefault (if cfg.startWithUserSession == "graphical" then "gui" else "user");
       config = {
         ProgramArguments = [
           "${cfg.package}/bin/emacs"

--- a/modules/services/exo.nix
+++ b/modules/services/exo.nix
@@ -60,6 +60,7 @@ in
 
     launchd.agents.exo = {
       enable = true;
+      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [ (lib.getExe cfg.package) ] ++ cfg.extraArgs;
         EnvironmentVariables = cfg.environmentVariables;

--- a/modules/services/git-sync.nix
+++ b/modules/services/git-sync.nix
@@ -108,6 +108,7 @@ in
     launchd.agents = services (
       _name: repo: {
         enable = true;
+        domain = lib.mkDefault "user";
         config = {
           StartInterval = repo.interval;
           ProcessType = "Background";

--- a/modules/services/glance.nix
+++ b/modules/services/glance.nix
@@ -78,13 +78,16 @@ in
 
     xdg.configFile."glance/glance.yml" = {
       source = settingsFile;
-      onChange = mkIf pkgs.stdenv.hostPlatform.isDarwin ''
-        /bin/launchctl kickstart -k "gui/$(id -u)/org.nix-community.home.glance" 2>/dev/null || true
+      onChange = mkIf (pkgs.stdenv.hostPlatform.isDarwin && cfg.package != null) ''
+        domain="${config.launchd.agents.glance.domain}/$(id -u)"
+        /bin/launchctl kickstart -k "$domain/org.nix-community.home.glance" \
+          2>/dev/null || true
       '';
     };
 
     launchd.agents.glance = mkIf (cfg.package != null) {
       enable = true;
+      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           (getExe cfg.package)

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -454,6 +454,7 @@ in
 
     launchd.agents.gpg-agent = {
       enable = true;
+      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           "${gpgPkg}/bin/gpg-agent"

--- a/modules/services/home-manager-auto-expire.nix
+++ b/modules/services/home-manager-auto-expire.nix
@@ -105,6 +105,7 @@ in
 
     launchd.agents.home-manager-auto-expire = {
       enable = true;
+      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [ (toString script) ];
         ProcessType = "Background";

--- a/modules/services/imapnotify/default.nix
+++ b/modules/services/imapnotify/default.nix
@@ -65,6 +65,7 @@ let
       name = "imapnotify-${name}";
       value = {
         enable = true;
+        domain = lib.mkDefault "user";
         config = {
           # Use the nix store path for config to ensure service restarts when it changes
           ProgramArguments = [

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -254,6 +254,7 @@ in
 
       launchd.agents.mpd = {
         enable = true;
+        domain = lib.mkDefault "user";
         config = {
           ProgramArguments = [
             (lib.getExe cfg.package)

--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -121,6 +121,7 @@ in
 
     launchd.agents.nix-gc = {
       enable = true;
+      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           "${nixPackage}/bin/nix-collect-garbage"

--- a/modules/services/ollama.nix
+++ b/modules/services/ollama.nix
@@ -107,6 +107,7 @@ in
 
     launchd.agents.ollama = {
       enable = true;
+      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           "${lib.getExe ollamaPackage}"

--- a/modules/services/podman/darwin.nix
+++ b/modules/services/podman/darwin.nix
@@ -311,6 +311,7 @@ in
           name: machine:
           nameValuePair "podman-machine-${name}" {
             enable = true;
+            domain = lib.mkDefault "user";
             config = {
               ProgramArguments = [ "${mkWatchdogScript name machine}" ];
               KeepAlive = {

--- a/modules/services/proton-pass-agent.nix
+++ b/modules/services/proton-pass-agent.nix
@@ -104,6 +104,7 @@ in
 
       launchd.agents.proton-pass-agent = {
         enable = true;
+        domain = lib.mkDefault "user";
         config = {
           ProgramArguments = [
             (lib.getExe pkgs.bash)

--- a/modules/services/pueue.nix
+++ b/modules/services/pueue.nix
@@ -57,6 +57,7 @@ in
 
     launchd.agents.pueued = lib.mkIf (cfg.package != null) {
       enable = true;
+      domain = lib.mkDefault "user";
 
       config = {
         ProgramArguments = [

--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -105,6 +105,7 @@ in
 
     launchd.agents.ssh-agent = {
       enable = true;
+      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           (lib.getExe pkgs.bash)

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -912,6 +912,7 @@ in
       launchd.agents = {
         syncthing = {
           enable = true;
+          domain = lib.mkDefault "user";
           config = {
             ProgramArguments = [
               "${pkgs.writers.writeBash "syncthing-wrapper" ''

--- a/modules/services/tldr-update.nix
+++ b/modules/services/tldr-update.nix
@@ -62,6 +62,7 @@ in
 
     launchd.agents.tldr-update = {
       enable = true;
+      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           (lib.getExe cfg.package)

--- a/modules/services/yubikey-agent.nix
+++ b/modules/services/yubikey-agent.nix
@@ -82,6 +82,7 @@ in
 
     launchd.agents.yubikey-agent = {
       enable = true;
+      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           "${cfg.package}/bin/yubikey-agent"

--- a/tests/modules/launchd/agent-domain.nix
+++ b/tests/modules/launchd/agent-domain.nix
@@ -1,0 +1,20 @@
+{
+  config = {
+    launchd.agents."user-service" = {
+      enable = true;
+      domain = "user";
+      config.ProgramArguments = [
+        "/some/command"
+      ];
+    };
+
+    nmt.script = ''
+      serviceFile=LaunchAgents/org.nix-community.home.user-service.plist
+      assertFileExists $serviceFile
+
+      domainFile=LaunchAgentDomains/org.nix-community.home.user-service.domain
+      assertFileExists $domainFile
+      assertFileContent $domainFile ${builtins.toFile "expected-domain" "user\n"}
+    '';
+  };
+}

--- a/tests/modules/launchd/agents.nix
+++ b/tests/modules/launchd/agents.nix
@@ -22,6 +22,16 @@
       serviceFile=LaunchAgents/org.nix-community.home.test-service.plist
       assertFileExists $serviceFile
       assertFileContent $serviceFile ${./expected-agent.plist}
+
+      domainFile=LaunchAgentDomains/org.nix-community.home.test-service.domain
+      assertFileExists $domainFile
+      assertFileContent $domainFile ${builtins.toFile "expected-domain" "gui\n"}
+
+      assertFileExists activate
+      assertFileContains activate 'readAgentDomain'
+      assertFileContains activate 'resolveDomain'
+      assertFileContains activate "printf 'gui/%s"
+      assertFileContains activate "printf 'user/%s"
     '';
   };
 }

--- a/tests/modules/launchd/default.nix
+++ b/tests/modules/launchd/default.nix
@@ -1,1 +1,4 @@
-{ launchd-agents = ./agents.nix; }
+{
+  launchd-agent-domain = ./agent-domain.nix;
+  launchd-agents = ./agents.nix;
+}

--- a/tests/modules/services/glance/default-settings.nix
+++ b/tests/modules/services/glance/default-settings.nix
@@ -18,6 +18,11 @@
       serviceFile=$(normalizeStorePaths $serviceFile)
       assertFileExists "$serviceFile"
       assertFileContent "$serviceFile" ${./glance.plist}
+
+      domainFile=LaunchAgentDomains/org.nix-community.home.glance.domain
+      assertFileContent "$domainFile" ${builtins.toFile "expected-domain" "user\n"}
+      assertFileContains activate 'domain="user/$(id -u)"'
+      assertFileContains activate 'launchctl kickstart -k "$domain/org.nix-community.home.glance"'
     '')
   ];
 }

--- a/tests/modules/services/glance/default.nix
+++ b/tests/modules/services/glance/default.nix
@@ -1,4 +1,5 @@
 {
+  glance-domain-override = ./domain-override.nix;
   glance-default-settings = ./default-settings.nix;
   glance-example-settings = ./example-settings.nix;
 }

--- a/tests/modules/services/glance/domain-override.nix
+++ b/tests/modules/services/glance/domain-override.nix
@@ -1,0 +1,14 @@
+{ lib, pkgs, ... }:
+
+{
+  services.glance.enable = true;
+  launchd.agents.glance.domain = "gui";
+
+  nmt.script = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin ''
+    domainFile=LaunchAgentDomains/org.nix-community.home.glance.domain
+    assertFileExists "$domainFile"
+    assertFileContent "$domainFile" ${builtins.toFile "expected-domain" "gui\n"}
+    assertFileContains activate 'domain="gui/$(id -u)"'
+    assertFileContains activate 'launchctl kickstart -k "$domain/org.nix-community.home.glance"'
+  '';
+}


### PR DESCRIPTION
Allow Darwin LaunchAgents to target either the GUI or user launchd domain while preserving gui as the compatibility default.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
