### PR TITLE
pimsync: have type be the first directive in storage blocks

### DIFF
--- a/modules/programs/pimsync/default.nix
+++ b/modules/programs/pimsync/default.nix
@@ -53,10 +53,10 @@
         name = "storage";
         params = [ "${if calendar then "calendar" else "contacts"}-${name}-local" ];
         children =
-          (attrsToDirectives {
+          (attrsToDirectives { type = if calendar then "vdir/icalendar" else "vdir/vcard"; })
+          ++ (attrsToDirectives {
             inherit (acc.local) path;
             fileext = acc.local.fileExt;
-            type = if calendar then "vdir/icalendar" else "vdir/vcard";
           })
           ++ acc.pimsync.extraLocalStorageDirectives;
       };
@@ -66,8 +66,6 @@
         params = [ "${if calendar then "calendar" else "contacts"}-${name}-remote" ];
         children =
           (attrsToDirectives {
-            inherit (acc.remote) url;
-            username = acc.remote.userName;
             type =
               if !calendar then
                 "carddav"
@@ -75,6 +73,10 @@
                 acc.remote.type
               else
                 "webcal";
+          })
+          ++ (attrsToDirectives {
+            inherit (acc.remote) url;
+            username = acc.remote.userName;
           })
           ++ lib.optional (acc.remote.passwordCommand != null) {
             name = "password";

--- a/tests/modules/programs/pimsync/basic.scfg
+++ b/tests/modules/programs/pimsync/basic.scfg
@@ -1,12 +1,12 @@
 storage calendar-http-local {
+	type vdir/icalendar
 	fileext .ics
 	path /home/hm-user/.local/state/calendar/http
-	type vdir/icalendar
 }
 storage calendar-mine-local {
+	type vdir/icalendar
 	fileext .ics
 	path /home/hm-user/.local/state/calendar/mine
-	type vdir/icalendar
 }
 storage calendar-http-remote {
 	type webcal
@@ -29,9 +29,9 @@ pair calendar-mine {
 	storage_b calendar-mine-remote
 }
 storage contacts-mine-local {
+	type vdir/vcard
 	fileext .vcf
 	path /home/hm-user/.local/state/contact/mine
-	type vdir/vcard
 }
 storage contacts-mine-remote {
 	type carddav


### PR DESCRIPTION
### Description

pimsync 0.5.10 introduced a change to config parsing which now mandates that the type directive is the first one in each storage block.



<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
