### PR TITLE
vicinae: add firefox mesaging host

### DIFF
--- a/modules/programs/vicinae/default.nix
+++ b/modules/programs/vicinae/default.nix
@@ -53,6 +53,12 @@ in
         instead.
       '';
     };
+    enableFirefoxIntegration = lib.mkOption {
+      default = true;
+      description = ''
+        Whether to install the messaging host so that the firefox extension <https://addons.mozilla.org/en-US/firefox/addon/vicinae/> works.
+      '';
+    };
 
     extensions = lib.mkOption {
       type = lib.types.listOf lib.types.package;
@@ -212,6 +218,25 @@ in
           verboseEcho "Refreshing the vicinae app list"
           run --silence ${lib.getExe config.programs.vicinae.package} deeplink vicinae://launch/core/refresh-apps || verboseEcho "Failed to refresh the vicinae app list"
         ''
+      );
+      mozilla = lib.mkIf (cfg.enableFirefoxIntegration && cfg.package != null) (
+        let
+          vicinaeNativeMessagingHost =
+            pkgs.writeTextDir "lib/mozilla/native-messaging-hosts/com.vicinae.vicinae.json"
+              (
+                builtins.toJSON {
+                  name = "com.vicinae.vicinae";
+                  description = "Vicinae Native Messaging Host";
+                  path = "${cfg.package}/libexec/vicinae/vicinae-browser-link";
+                  type = "stdio";
+                  allowed_extensions = [ "firefox@vicinae.com" ];
+                }
+              );
+        in
+        {
+          firefoxNativeMessagingHosts = [ vicinaeNativeMessagingHost ];
+          librewolfNativeMessagingHosts = [ vicinaeNativeMessagingHost ];
+        }
       );
 
       systemd.user.services.vicinae = lib.mkIf (cfg.systemd.enable && cfg.package != null) {


### PR DESCRIPTION
### Description

This adds support for connecting vicinae to firefox.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
