### PR TITLE
docs: clarify new module news conditions

### DIFF
--- a/docs/manual/contributing/news.md
+++ b/docs/manual/contributing/news.md
@@ -34,11 +34,12 @@ but you should follow some basic guidelines:
     This will create a new file inside the `modules/misc/news` directory
     with some placeholder information that you can edit.
 
--   The entry condition should be as specific as possible. For example,
-    if you are changing or deprecating a specific option then you could
-    restrict the news to those users who actually use this option.
-    Prefer a targeted condition over skipping useful news only to avoid
-    notifying unaffected users.
+-   The entry condition should be as specific as possible for changes
+    affecting existing functionality. For example, if you are changing
+    or deprecating a specific option then you could restrict the news to
+    those users who actually use this option. Prefer a targeted
+    condition over skipping useful news only to avoid notifying
+    unaffected users.
 
 -   Wrap the news message so that it will fit in the typical terminal,
     that is, at most 80 characters wide. Ideally a bit less.
@@ -64,9 +65,9 @@ but you should follow some basic guidelines:
 
         A new module is available: 'services.foo'.
 
-    Since this news is specific to the module, its condition should use
-    the module enable option to avoid spamming non-users of the module,
-    for example `condition = config.services.foo.enable;`.
+    Since this news announces newly available functionality, its
+    condition should not require `config.services.foo.enable`; otherwise
+    users who may want the new module will not see the news.
 
     If the module is platform specific, e.g., a service module using
     systemd, then a condition like
@@ -75,7 +76,6 @@ but you should follow some basic guidelines:
     condition = hostPlatform.isLinux;
     ```
 
-    should be added, either by itself for platform-scoped news or in
-    combination with the module enable option. Use the `create-news-entry`
-    generator described above to scaffold this entry as part of your
-    contribution.
+    should be added to avoid showing the news on unsupported platforms.
+    Use the `create-news-entry` generator described above to scaffold
+    this entry as part of your contribution.


### PR DESCRIPTION
### Description

Clarifies the news-entry guidelines so targeted enable-option conditions apply to changes in existing functionality, not to new-module announcements.

New-module news needs to remain visible to users who have not enabled the module yet; otherwise the announcement cannot help with discovery. Platform-specific module news should still be gated to supported platforms.

Validation:

- `nix fmt`
- `git diff --check`
- `nix-build -A docs.html`

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
