### PR TITLE
fish: extract completion generator from the fish binary

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -658,17 +658,21 @@ in
                 ++ lib.filter (p: p != null) (
                   map (outName: package.${outName} or null) config.home.extraOutputsToInstall
                 );
-                nativeBuildInputs = [ pkgs.python3 ];
-                buildInputs = [ cfg.package ];
+                nativeBuildInputs = [
+                  pkgs.python3
+                  cfg.package
+                ];
                 preferLocalBuild = true;
               }
               ''
+                # The generator script is embedded in the fish binary, so extract it.
+                generator=$PWD/create_manpage_completions.py
+                fish --no-config -c 'status get-file tools/create_manpage_completions.py' > "$generator"
+
                 mkdir -p $out
                 for src in $srcs; do
                   if [ -d $src/share/man ]; then
-                    find -L $src/share/man -type f \
-                      -exec python ${cfg.package}/share/fish/tools/create_manpage_completions.py --directory $out {} + \
-                      > /dev/null
+                    find -L $src/share/man -type f -exec python "$generator" --directory $out {} + > /dev/null
                   fi
                 done
               '';


### PR DESCRIPTION
### Description

fish 4.8.0 stops installing `share/fish/tools/` and embeds the generator script in the binary instead, which breaks `programs.fish.generateCompletions`. Extract it via `status get-file` (available since fish 4.1).

See NixOS/nixpkgs#534907.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
