### PR TITLE
alacritty: normalize key binding escape sequences

### DIFF
--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -96,27 +96,37 @@ in
       };
 
     xdg.configFile."alacritty/alacritty.toml" = lib.mkIf (cfg.settings != { }) {
-      source = (tomlFormat.generate "alacritty.toml" cfg.settings).overrideAttrs (
-        _finalAttrs: prevAttrs: {
-          buildCommand = lib.concatStringsSep "\n" [
-            prevAttrs.buildCommand
-            # Nix cannot spell TOML escape sequences like "\u001d" directly:
-            # "\\u001d" is a literal backslash-u string, while fromJSON creates
-            # a control character and fails for "\u0000". Normalize both TOML
-            # generator outputs to the Alacritty escape form:
-            #   chars = "\\u001d" -> chars = "\u001d"
-            #   chars = '\u001d'  -> chars = "\u001d"
-            ''
-              sed \
-                -E \
-                -e "s/= \"\\\\\\\\u([0-9a-fA-F]{4})\"\$/= \"\\\\u\1\"/" \
-                -e "s/= '\\\\u([0-9a-fA-F]{4})'\$/= \"\\\\u\1\"/" \
-                "$out" > "$TMPDIR/alacritty.toml"
-              cp "$TMPDIR/alacritty.toml" "$out"
-            ''
-          ];
-        }
-      );
+      source =
+        let
+          # `pkgs.formats.toml` escapes backslashes and cannot emit raw
+          # control characters (NUL cannot even appear in a Nix string), so a
+          # `chars` escape like "\u001d" generates as literal "\\u001d",
+          # which Alacritty rejects. Stash each escape behind a placeholder that
+          # survives generation, then restore "\u" in the build command.
+          unicodeEscapePrefix = "__home_manager_alacritty_unicode_escape_";
+
+          normalizeAlacrittyEscapes =
+            value:
+            if builtins.isAttrs value then
+              lib.mapAttrs (_: normalizeAlacrittyEscapes) value
+            else if builtins.isList value then
+              map normalizeAlacrittyEscapes value
+            else if !builtins.isString value then
+              value
+            else
+              # Normalize the "\^[" caret form to "\u001b", then replace every
+              # "\uXXXX" with the placeholder.
+              lib.concatMapStrings (
+                chunk: if builtins.isList chunk then unicodeEscapePrefix + builtins.head chunk else chunk
+              ) (builtins.split "\\\\u([0-9a-fA-F]{4})" (builtins.replaceStrings [ "\\^[" ] [ "\\u001b" ] value));
+        in
+        (tomlFormat.generate "alacritty.toml" (normalizeAlacrittyEscapes cfg.settings)).overrideAttrs
+          (prevAttrs: {
+            buildCommand = lib.concatStringsSep "\n" [
+              prevAttrs.buildCommand
+              ''substituteInPlace $out --replace-quiet '${unicodeEscapePrefix}' '\u' ''
+            ];
+          });
     };
   };
 }

--- a/tests/modules/programs/alacritty/settings-merging.nix
+++ b/tests/modules/programs/alacritty/settings-merging.nix
@@ -20,6 +20,36 @@
           mods = "Alt";
           chars = "\\u001d";
         }
+        {
+          key = "Back";
+          mods = "Shift";
+          chars = "\\u001b[3~";
+        }
+        {
+          key = "Delete";
+          mods = "Shift";
+          chars = "\\^[[3~";
+        }
+        {
+          key = "A";
+          mods = "Control";
+          chars = "\\u0000";
+        }
+        {
+          key = "Up";
+          mods = "Control";
+          chars = "\\u001b\\u001b";
+        }
+        {
+          key = "Down";
+          mods = "Control";
+          chars = "OK\\u001b";
+        }
+        {
+          key = "Left";
+          mods = "Control";
+          chars = "\\^[\\^[";
+        }
       ];
 
       font =

--- a/tests/modules/programs/alacritty/settings-toml-expected.toml
+++ b/tests/modules/programs/alacritty/settings-toml-expected.toml
@@ -14,6 +14,36 @@ chars = "\u001d"
 key = "RBracket"
 mods = "Alt"
 
+[[keyboard.bindings]]
+chars = "\u001b[3~"
+key = "Back"
+mods = "Shift"
+
+[[keyboard.bindings]]
+chars = "\u001b[3~"
+key = "Delete"
+mods = "Shift"
+
+[[keyboard.bindings]]
+chars = "\u0000"
+key = "A"
+mods = "Control"
+
+[[keyboard.bindings]]
+chars = "\u001b\u001b"
+key = "Up"
+mods = "Control"
+
+[[keyboard.bindings]]
+chars = "OK\u001b"
+key = "Down"
+mods = "Control"
+
+[[keyboard.bindings]]
+chars = "\u001b\u001b"
+key = "Left"
+mods = "Control"
+
 [window.dimensions]
 columns = 200
 lines = 3

--- a/tests/modules/programs/alacritty/toml-config.nix
+++ b/tests/modules/programs/alacritty/toml-config.nix
@@ -18,6 +18,36 @@
           mods = "Alt";
           chars = "\\u001d";
         }
+        {
+          key = "Back";
+          mods = "Shift";
+          chars = "\\u001b[3~";
+        }
+        {
+          key = "Delete";
+          mods = "Shift";
+          chars = "\\^[[3~";
+        }
+        {
+          key = "A";
+          mods = "Control";
+          chars = "\\u0000";
+        }
+        {
+          key = "Up";
+          mods = "Control";
+          chars = "\\u001b\\u001b";
+        }
+        {
+          key = "Down";
+          mods = "Control";
+          chars = "OK\\u001b";
+        }
+        {
+          key = "Left";
+          mods = "Control";
+          chars = "\\^[\\^[";
+        }
       ];
 
       font = {


### PR DESCRIPTION
`pkgs.formats.toml` escapes backslashes and cannot emit raw control characters, so key-binding `chars` written as escape text (e.g. "\uXXXX" or the "\^[" caret form) ended up as invalid literals in the generated config. Rewrite each escape to a placeholder before generation and restore it to "\u" afterward.

Use `builtins.split` so escapes are handled anywhere in the value, including when repeated or mixed with other text.

Closes https://github.com/nix-community/home-manager/issues/9482

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
