### PR TITLE
github-copilot-cli: preserve args for local-type MCP servers

### DIFF
--- a/modules/programs/github-copilot-cli.nix
+++ b/modules/programs/github-copilot-cli.nix
@@ -19,14 +19,15 @@ let
 
   upstreamConfigDir = "${config.home.homeDirectory}/.copilot";
 
+  # Applied after transformMcpServer so that args = [] is not filtered out.
   forCopilotFormat =
     server:
     let
-      isLocal = server.type == "stdio";
+      isLocal = server.type == "stdio" || server.type == "local";
     in
     server
     // {
-      type = if server.type == "stdio" then "local" else server.type or "local";
+      type = if isLocal then "local" else server.type;
     }
     // lib.optionalAttrs isLocal {
       args = server.args or [ ];
@@ -43,14 +44,15 @@ let
     if cfg.enableMcpIntegration && config.programs.mcp.enable && enabledServers != { } then
       lib.mapAttrs (
         name: server:
-        lib.hm.mcp.transformMcpServer {
-          inherit server;
-          extraTransforms = [
-            lib.hm.mcp.addType
-            (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
-            forCopilotFormat
-          ];
-        }
+        forCopilotFormat (
+          lib.hm.mcp.transformMcpServer {
+            inherit server;
+            extraTransforms = [
+              lib.hm.mcp.addType
+              (lib.hm.mcp.wrapEnvFilesCommand { inherit pkgs name; })
+            ];
+          }
+        )
       ) enabledServers
     else
       { };
@@ -59,16 +61,17 @@ let
     transformedMcpServers
     // lib.mapAttrs (
       name: server:
-      lib.hm.mcp.transformMcpServer {
-        inherit server;
-        extraTransforms = [
-          lib.hm.mcp.addType
-          (lib.hm.mcp.wrapEnvFilesCommand {
-            inherit pkgs name;
-          })
-          forCopilotFormat
-        ];
-      }
+      forCopilotFormat (
+        lib.hm.mcp.transformMcpServer {
+          inherit server;
+          extraTransforms = [
+            lib.hm.mcp.addType
+            (lib.hm.mcp.wrapEnvFilesCommand {
+              inherit pkgs name;
+            })
+          ];
+        }
+      )
     ) cfg.mcpServers;
 in
 {

--- a/tests/modules/programs/github-copilot-cli/expected-mcp-integration-config.json
+++ b/tests/modules/programs/github-copilot-cli/expected-mcp-integration-config.json
@@ -15,6 +15,7 @@
       "type": "local"
     },
     "fetch": {
+      "args": [],
       "command": "mcp-server-fetch",
       "tools": [
         "*"


### PR DESCRIPTION
### Description

forCopilotFormat only checked for type == "stdio" to add back args, missing the case where a server already has `type = "local"` (e.g. set directly by a third-party module). This caused args to be absent in the generated mcp-config.json, failing validation.

Also, running `forCopilotFormat` as an `extraTransform` meant it ran inside `transformMcpServer`, which then filtered out `args = []` in its cleanup pass. Move `forCopilotFormat` to run after `transformMcpServer` so the empty args list is preserved in the output.

(I hope this is not just a me problem, as i pin copilot to 1.0.40 since after that mcp allowlist is broken… im looking so forward to opencode supporting mcp elicitation so i can stop using this)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
