### PR TITLE
fzf: source nushell integration after carapace

### DIFF
--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     getExe
     literalExpression
+    mkAfter
     mkIf
     mkOption
     mkOrder
@@ -230,8 +231,11 @@ in
 
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration (mkOrder 200 fishIntegration);
 
+    # Initialize after other completion integrations, such as carapace.
+    # fzf preserves the previous external completer and falls back to it
+    # when its own completer does not apply.
     programs.nushell = lib.mkIf cfg.enableNushellIntegration {
-      extraConfig = ''
+      extraConfig = mkAfter ''
         source ${
           pkgs.runCommand "nushell-fzf-integration.nu" { } ''
             ${lib.getExe cfg.package} --nushell > $out

--- a/tests/modules/programs/fzf/nushell-integration.nix
+++ b/tests/modules/programs/fzf/nushell-integration.nix
@@ -1,6 +1,22 @@
 { config, pkgs, ... }:
 
 {
+  programs.carapace = {
+    enable = true;
+
+    package = config.lib.test.mkStubPackage {
+      name = "carapace";
+      buildScript = ''
+        mkdir -p $out/bin
+        cat > $out/bin/carapace << 'EOF'
+        #!/bin/sh
+        echo "Stub carapace"
+        EOF
+        chmod +x $out/bin/carapace
+      '';
+    };
+  };
+
   programs.fzf = {
     enable = true;
     enableNushellIntegration = true;
@@ -31,7 +47,11 @@
     in
     ''
       assertFileExists "${nushellConfigFile}"
-      assertFileRegex "${nushellConfigFile}" \
-        'source.*nushell-fzf-integration'
+      assertFileContent "$(normalizeStorePaths "${nushellConfigFile}")" ${builtins.toFile "nushell-fzf-integration-expected.nu" ''
+        source /nix/store/00000000000000000000000000000000-carapace-nushell-config.nu
+
+        source /nix/store/00000000000000000000000000000000-nushell-fzf-integration.nu
+
+      ''}
     '';
 }


### PR DESCRIPTION
### Description

When both `programs.carapace` and `programs.fzf` enable Nushell integration, the generated Nushell config can source fzf before carapace. This breaks carapace completions because carapace's Nushell setup does not install `$env.config.completions.external` when that field is already present.

fzf's Nushell integration is able to compose with an existing external completer: it stores the previous completer and calls it when fzf completion should not handle the current input. Loading fzf later lets carapace install its external completer first, then lets fzf wrap it as the fallback.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
