### PR TITLE
make gpg package field nullable

### DIFF
--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -109,7 +109,7 @@ let
 
   importTrustBashFunctions =
     let
-      gpg = "${cfg.package}/bin/gpg";
+      gpg = if cfg.package != null then "${cfg.package}/bin/gpg" else "gpg";
     in
     ''
       function gpgKeyId() {
@@ -132,7 +132,7 @@ let
 
   keyringFiles =
     let
-      gpg = "${cfg.package}/bin/gpg";
+      gpg = if cfg.package != null then "${cfg.package}/bin/gpg" else "gpg";
 
       importKey =
         { source, trust, ... }:
@@ -163,6 +163,7 @@ in
     enable = lib.mkEnableOption "GnuPG";
 
     package = lib.mkPackageOption pkgs "gnupg" {
+      nullable = true;
       example = "pkgs.gnupg23";
       extraDescription = "Also used by the gpg-agent service.";
     };
@@ -303,7 +304,7 @@ in
       no-symkey-cache = mkDefault true;
     };
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
     home.sessionVariables = {
       GNUPGHOME = cfg.homedir;
     };
@@ -336,7 +337,7 @@ in
 
       importGpgKeys =
         let
-          gpg = "${cfg.package}/bin/gpg";
+          gpg = if cfg.package != null then "${cfg.package}/bin/gpg" else "gpg";
 
           importKey =
             { source, trust, ... }:


### PR DESCRIPTION
### Description

make the package field of gpg nullable so that the system package  can be used on non-nix systems
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
