### PR TITLE
syncthing: add option for ignore patterns

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -180,6 +180,7 @@ let
               override = cfg.overrideFolders;
               conf = folders;
               baseAddress = curlAddressArgs "/rest/config/folders";
+              ignoreAddress = curlAddressArgs "/rest/db/ignores";
             };
           }
           [
@@ -205,7 +206,8 @@ let
                   let
                     jsonPreSecretsFile = pkgs.writeTextFile {
                       name = "${conf_type}-${new_cfg.id}-conf-pre-secrets.json";
-                      text = builtins.toJSON new_cfg;
+                      # Remove the ignorePatterns attribute, it is handled separately
+                      text = builtins.toJSON (removeAttrs new_cfg [ "ignorePatterns" ]);
                     };
                     injectSecretsJqCmd =
                       {
@@ -271,6 +273,15 @@ let
                   in
                   ''
                     ${injectSecretsJqCmd} ${jsonPreSecretsFile} | curl --json @- -X POST ${s.baseAddress}
+                  ''
+                  /*
+                    Check if we are configuring a folder which has ignore patterns.
+                    If it does, write the ignore patterns to the rest API.
+                  */
+                  + lib.optionalString ((conf_type == "dirs") && (new_cfg.ignorePatterns != null)) ''
+                    curl -d ${
+                      lib.escapeShellArg (builtins.toJSON { ignore = new_cfg.ignorePatterns; })
+                    } -X POST ${s.ignoreAddress}?folder=${lib.strings.escapeURL new_cfg.id}
                   ''
                 ))
                 (lib.concatStringsSep "\n")
@@ -749,6 +760,26 @@ in
                           granting it additional capabilities (e.g. CAP_CHOWN on
                           Linux).
                         '';
+                      };
+
+                      ignorePatterns = mkOption {
+                        type = types.nullOr (types.listOf types.str);
+                        default = null;
+                        description = ''
+                          Syncthing can be configured to ignore certain files in a folder using ignore patterns.
+                          Enter them as a list of strings, one string per line.
+                          See the Syncthing documentation for syntax: <https://docs.syncthing.net/users/ignoring.html>
+                          Patterns set using the WebUI will be overridden if you define this option.
+                          If you want to override the ignore patterns to be empty, use `ignorePatterns = []`.
+                          Deleting the `ignorePatterns` option will not remove the patterns from Syncthing automatically
+                          because patterns are only handled by the module if this option is defined. Either use
+                          `ignorePatterns = []` before deleting the option or remove the patterns afterwards using the WebUI.
+                        '';
+                        example = [
+                          "// This is a comment"
+                          "*.part // Firefox downloads and other things"
+                          "*.crdownload // Chrom(ium|e) downloads"
+                        ];
                       };
                     };
                   }

--- a/tests/modules/services/syncthing/linux/default.nix
+++ b/tests/modules/services/syncthing/linux/default.nix
@@ -1,4 +1,5 @@
 {
   syncthing-gui-address-init = ./gui-address-init.nix;
+  syncthing-ignore-patterns = ./ignore-patterns.nix;
   syncthing-tray = ./tray.nix;
 }

--- a/tests/modules/services/syncthing/linux/ignore-patterns.nix
+++ b/tests/modules/services/syncthing/linux/ignore-patterns.nix
@@ -1,0 +1,36 @@
+{
+  services.syncthing = {
+    enable = true;
+    settings.folders = {
+      "Folder1" = {
+        id = "ew8bc-4uanl";
+        path = "/home/username/folder1";
+
+        ignorePatterns = [
+          "val1"
+          "!val2"
+          "*al3"
+          "val'4"
+          "val\"5"
+        ];
+      };
+    };
+  };
+
+  nmt.script =
+    let
+      ignoreString = ''
+        {"ignore":["val1","!val2","*al3","val'\'''4","val\"5"]}
+      '';
+    in
+    ''
+      serviceFile=home-files/.config/systemd/user/syncthing-init.service
+      assertFileExists "$serviceFile"
+      assertFileExists home-files/.config/systemd/user/default.target.wants/syncthing-init.service
+      assertFileContains "$serviceFile" "ExecStart="
+
+      updateScript=$(grep -o '/nix/store/[^ ]*-merge-syncthing-config' "$TESTED/$serviceFile")
+      assertFileContains "$updateScript" '${ignoreString}'
+      assertFileContains "$updateScript" "/rest/db/ignores?folder=ew8bc-4uanl"
+    '';
+}


### PR DESCRIPTION
### Description

Taken from this nixpkgs commit by @zorrobert: https://github.com/NixOS/nixpkgs/commit/7a223b26858aaebb44009c8966a1756918e936e3

Syncthing shared folders can be configured to ignore paths. These changes add support for this functionality.

The nixpkgs' commit also adds test cases, but they seem quite different to the syncthing test cases in home-manager, and I wasn't able to figure out how to replicate the nixpkgs ones here.

It is my first time contributing to anything Nix related so I might need some hand-holding. Let me know if I made any mistakes or I should improve something, and I'll do my utmost.

Closes #7545

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
