### PR TITLE
herdr: init module

### DIFF
--- a/modules/misc/news/2026/06/2026-06-27_14-17-31.nix
+++ b/modules/misc/news/2026/06/2026-06-27_14-17-31.nix
@@ -1,0 +1,10 @@
+{
+  time = "2026-06-27T12:17:31+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.herdr'.
+
+    Herdr is a terminal workspace and agent manager. The new module lets
+    you install it and declaratively configure its TOML config file.
+  '';
+}

--- a/modules/programs/herdr.nix
+++ b/modules/programs/herdr.nix
@@ -1,0 +1,69 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) mkIf mkOption;
+
+  cfg = config.programs.herdr;
+
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = [ lib.maintainers.amadejkastelic ];
+
+  options.programs.herdr = {
+    enable = lib.mkEnableOption "Herdr";
+
+    package = lib.mkPackageOption pkgs "herdr" { nullable = true; };
+
+    settings = mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = {
+        onboarding = false;
+        terminal = {
+          default_shell = "nu";
+          shell_mode = "auto";
+          new_cwd = "follow";
+        };
+        theme = {
+          name = "catppuccin";
+          auto_switch = true;
+          light_name = "catppuccin-latte";
+          dark_name = "catppuccin";
+        };
+        ui = {
+          sidebar_width = 32;
+          agent_panel_sort = "priority";
+          toast.delivery = "herdr";
+          sound.enabled = true;
+        };
+        keys.prefix = "ctrl+b";
+        keys.command = [
+          {
+            key = "prefix+l";
+            type = "plugin_action";
+            command = "example.layout.apply";
+            description = "apply layout";
+          }
+        ];
+      };
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/herdr/config.toml`.
+        See <https://herdr.dev/docs/configuration/> for the full list of options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."herdr/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "herdr-config.toml" cfg.settings;
+    };
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -82,6 +82,7 @@ let
     "halloy"
     "helix"
     "hello"
+    "herdr"
     "himalaya"
     "hjson-go"
     "htop"

--- a/tests/modules/programs/herdr/default.nix
+++ b/tests/modules/programs/herdr/default.nix
@@ -1,0 +1,4 @@
+{
+  herdr-enable = ./herdr-enable.nix;
+  herdr-settings = ./herdr-settings.nix;
+}

--- a/tests/modules/programs/herdr/herdr-enable.nix
+++ b/tests/modules/programs/herdr/herdr-enable.nix
@@ -1,0 +1,11 @@
+{
+  xdg.enable = true;
+
+  programs.herdr.enable = true;
+
+  test.asserts.warnings.expected = [ ];
+
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/herdr/config.toml"
+  '';
+}

--- a/tests/modules/programs/herdr/herdr-settings.nix
+++ b/tests/modules/programs/herdr/herdr-settings.nix
@@ -1,0 +1,114 @@
+{
+  xdg.enable = true;
+
+  programs.herdr = {
+    enable = true;
+
+    settings = {
+      onboarding = false;
+
+      update = {
+        channel = "stable";
+        version_check = true;
+        manifest_check = true;
+      };
+
+      terminal = {
+        default_shell = "nu";
+        shell_mode = "auto";
+        new_cwd = "follow";
+      };
+
+      worktrees.directory = "~/.herdr/worktrees";
+
+      remote.manage_ssh_config = true;
+
+      theme = {
+        name = "catppuccin";
+        auto_switch = true;
+        light_name = "catppuccin-latte";
+        dark_name = "catppuccin";
+        custom = {
+          accent = "#a6e3a1";
+          green = "#a6e3a1";
+        };
+      };
+
+      ui = {
+        sidebar_width = 32;
+        sidebar_min_width = 18;
+        sidebar_max_width = 36;
+        mobile_width_threshold = 64;
+        mouse_capture = true;
+        confirm_close = true;
+        agent_panel_sort = "priority";
+        accent = "cyan";
+        toast = {
+          delivery = "herdr";
+          delay_seconds = 1;
+          herdr.position = "bottom-right";
+          clipboard = {
+            enabled = true;
+            position = "bottom-center";
+          };
+        };
+        sound = {
+          enabled = true;
+          path = "sounds/notification.mp3";
+          agents = {
+            droid = "off";
+            claude = "on";
+          };
+        };
+      };
+
+      keys = {
+        prefix = "ctrl+b";
+        goto = "prefix+g";
+        new_tab = "prefix+c";
+        next_tab = [
+          "prefix+n"
+          "ctrl+alt+]"
+        ];
+        focus_pane_left = "prefix+h";
+        split_horizontal = "prefix+minus";
+        command = [
+          {
+            key = "prefix+alt+g";
+            type = "pane";
+            command = "lazygit";
+            description = "run lazygit";
+          }
+          {
+            key = "prefix+l";
+            type = "plugin_action";
+            command = "example.layout.apply";
+            description = "apply layout";
+          }
+        ];
+      };
+
+      advanced.scrollback_limit_bytes = 10485760;
+
+      experimental = {
+        pane_history = true;
+        allow_nested = false;
+        kitty_graphics = false;
+        reveal_hidden_cursor_for_cjk_ime = false;
+        cjk_ime_agents = [ ];
+        cjk_ime_cursor_shape = "steady_block";
+      };
+
+      session.resume_agents_on_restore = true;
+    };
+  };
+
+  test.asserts.warnings.expected = [ ];
+
+  nmt.script = ''
+    assertFileExists "home-files/.config/herdr/config.toml"
+    assertFileContent \
+      "home-files/.config/herdr/config.toml" \
+      ${./settings-expected.toml}
+  '';
+}

--- a/tests/modules/programs/herdr/settings-expected.toml
+++ b/tests/modules/programs/herdr/settings-expected.toml
@@ -1,0 +1,90 @@
+onboarding = false
+
+[advanced]
+scrollback_limit_bytes = 10485760
+
+[experimental]
+allow_nested = false
+cjk_ime_agents = []
+cjk_ime_cursor_shape = "steady_block"
+kitty_graphics = false
+pane_history = true
+reveal_hidden_cursor_for_cjk_ime = false
+
+[keys]
+focus_pane_left = "prefix+h"
+goto = "prefix+g"
+new_tab = "prefix+c"
+next_tab = ["prefix+n", "ctrl+alt+]"]
+prefix = "ctrl+b"
+split_horizontal = "prefix+minus"
+
+[[keys.command]]
+command = "lazygit"
+description = "run lazygit"
+key = "prefix+alt+g"
+type = "pane"
+
+[[keys.command]]
+command = "example.layout.apply"
+description = "apply layout"
+key = "prefix+l"
+type = "plugin_action"
+
+[remote]
+manage_ssh_config = true
+
+[session]
+resume_agents_on_restore = true
+
+[terminal]
+default_shell = "nu"
+new_cwd = "follow"
+shell_mode = "auto"
+
+[theme]
+auto_switch = true
+dark_name = "catppuccin"
+light_name = "catppuccin-latte"
+name = "catppuccin"
+
+[theme.custom]
+accent = "#a6e3a1"
+green = "#a6e3a1"
+
+[ui]
+accent = "cyan"
+agent_panel_sort = "priority"
+confirm_close = true
+mobile_width_threshold = 64
+mouse_capture = true
+sidebar_max_width = 36
+sidebar_min_width = 18
+sidebar_width = 32
+
+[ui.sound]
+enabled = true
+path = "sounds/notification.mp3"
+
+[ui.sound.agents]
+claude = "on"
+droid = "off"
+
+[ui.toast]
+delay_seconds = 1
+delivery = "herdr"
+
+[ui.toast.clipboard]
+enabled = true
+position = "bottom-center"
+
+[ui.toast.herdr]
+position = "bottom-right"
+
+[update]
+channel = "stable"
+manifest_check = true
+version_check = true
+
+[worktrees]
+directory = "~/.herdr/worktrees"


### PR DESCRIPTION
### Description

Adds a module for [herdr](https://herdr.dev/).

Closes #9566

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.
- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
