### PR TITLE
vscode: refactor profile paths to use unified profileDir helper

### DIFF
--- a/modules/programs/vscode/mkVscodeModule.nix
+++ b/modules/programs/vscode/mkVscodeModule.nix
@@ -38,15 +38,15 @@ let
       "${config.xdg.configHome}/${nameShort}/User";
 
   argvPath = "${dataFolderName}/argv.json";
-  configFilePath =
-    name: "${userDir}/${optionalString (name != "default") "profiles/${name}/"}settings.json";
-  tasksFilePath =
-    name: "${userDir}/${optionalString (name != "default") "profiles/${name}/"}tasks.json";
-  mcpFilePath = name: "${userDir}/${optionalString (name != "default") "profiles/${name}/"}mcp.json";
-  keybindingsFilePath =
-    name: "${userDir}/${optionalString (name != "default") "profiles/${name}/"}keybindings.json";
 
-  snippetDir = name: "${userDir}/${optionalString (name != "default") "profiles/${name}/"}snippets";
+  profileDir = name: "${userDir}${optionalString (name != "default") "/profiles/${name}"}";
+
+  configFilePath = name: "${profileDir name}/settings.json";
+  tasksFilePath = name: "${profileDir name}/tasks.json";
+  mcpFilePath = name: "${profileDir name}/mcp.json";
+  keybindingsFilePath = name: "${profileDir name}/keybindings.json";
+
+  snippetDir = name: "${profileDir name}/snippets";
 
   extensionPath = "${dataFolderName}/extensions";
 
@@ -450,7 +450,7 @@ in
       (mkIf (allProfilesExceptDefault != { }) (
         lib.mapAttrs' (
           n: v:
-          lib.nameValuePair "${userDir}/profiles/${n}/extensions.json" {
+          lib.nameValuePair "${profileDir n}/extensions.json" {
             source = "${extensionJsonFile n (extensionJson v.extensions)}/share/vscode/extensions/extensions.json";
           }
         ) allProfilesExceptDefault


### PR DESCRIPTION
### Description

Refactor code to remove duplicated code. The location of the profile directory dependent on the profile name was duplicated over several locations. This PR unifies this into one single helper function profileDir.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`. (ran `nix run .#tests -- vscode`)

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
