### PR TITLE
hyprpaper: add system target option

### DIFF
--- a/modules/services/hyprpaper.nix
+++ b/modules/services/hyprpaper.nix
@@ -71,6 +71,14 @@ in
         List of prefix of attributes to source at the top of the config.
       '';
     };
+
+    systemdTarget = lib.mkOption {
+      type = lib.types.str;
+      default = config.wayland.systemd.target;
+      defaultText = lib.literalExpression "config.wayland.systemd.target";
+      example = "hyprland-session.target";
+      description = "Systemd target to bind to.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -83,14 +91,14 @@ in
 
     systemd.user.services.hyprpaper = lib.mkIf (cfg.package != null) {
       Install = {
-        WantedBy = [ config.wayland.systemd.target ];
+        WantedBy = [ cfg.systemdTarget ];
       };
 
       Unit = {
         ConditionEnvironment = "WAYLAND_DISPLAY";
         Description = "hyprpaper";
-        After = [ config.wayland.systemd.target ];
-        PartOf = [ config.wayland.systemd.target ];
+        After = [ cfg.systemdTarget ];
+        PartOf = [ cfg.systemdTarget ];
         X-Restart-Triggers = lib.mkIf (cfg.settings != { }) [
           "${config.xdg.configFile."hypr/hyprpaper.conf".source}"
         ];


### PR DESCRIPTION
### Description

Other hyprland/wayland services, such as wlsunset and hypridle have an option `systemdTarget`. It seems on my system default one needs to be changed to `hyprland-session.target`, which makes them start nicely.

No such option is available for hyprpaper so I had to do:
```nix
  systemd.user.services.hyprpaper.Unit.After = lib.mkForce "hyprland-session.target";
```

This is exactly what `systemdTarget` option does in those other modules.

My first home-manager pr, open to feedback!

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
