### PR TITLE
television: add extraPackages option with default dependencies

### DIFF
--- a/modules/programs/television.nix
+++ b/modules/programs/television.nix
@@ -18,6 +18,20 @@ in
     enable = lib.mkEnableOption "television";
     package = lib.mkPackageOption pkgs "television" { nullable = true; };
 
+    extraPackages = lib.mkOption {
+      type = with lib.types; listOf package;
+      default = with pkgs; [
+        fd
+        bat
+        ripgrep
+      ];
+      defaultText = lib.literalExpression "with pkgs; [ fd bat ripgrep ]";
+      example = lib.literalExpression "with pkgs; [ eza ]";
+      description = ''
+        Extra packages available to television.
+      '';
+    };
+
     settings = lib.mkOption {
       inherit (tomlFormat) type;
       default = { };
@@ -132,7 +146,23 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) (
+      if cfg.extraPackages != [ ] then
+        [
+          (pkgs.symlinkJoin {
+            name = "${lib.getName cfg.package}-wrapped-${lib.getVersion cfg.package}";
+            paths = [ cfg.package ];
+            preferLocalBuild = true;
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+            postBuild = ''
+              wrapProgram $out/bin/tv \
+                --suffix PATH : ${lib.makeBinPath cfg.extraPackages}
+            '';
+          })
+        ]
+      else
+        [ cfg.package ]
+    );
 
     xdg.configFile = lib.mkMerge [
       {

--- a/tests/modules/programs/nix-search-tv/television.nix
+++ b/tests/modules/programs/nix-search-tv/television.nix
@@ -1,6 +1,9 @@
 { lib, pkgs, ... }:
 {
-  programs.television.enable = true;
+  programs.television = {
+    enable = true;
+    extraPackages = [ ];
+  };
 
   programs.nix-search-tv.enable = true;
 

--- a/tests/modules/programs/television/basic-config.nix
+++ b/tests/modules/programs/television/basic-config.nix
@@ -2,6 +2,7 @@
 {
   programs.television = {
     enable = true;
+    extraPackages = [ ];
     settings = {
       tick_rate = 50;
       ui = {

--- a/tests/modules/programs/television/default.nix
+++ b/tests/modules/programs/television/default.nix
@@ -1,4 +1,5 @@
 {
   television-basic-config = ./basic-config.nix;
+  television-extra-packages = ./extra-packages.nix;
   television-themes-config = ./themes-config.nix;
 }

--- a/tests/modules/programs/television/extra-packages.nix
+++ b/tests/modules/programs/television/extra-packages.nix
@@ -1,0 +1,45 @@
+{ pkgs, config, ... }:
+let
+  televisionPackage = config.lib.test.mkStubPackage {
+    name = "television";
+    buildScript = ''
+      mkdir -p "$out/bin"
+      touch "$out/bin/tv"
+      chmod +x "$out/bin/tv"
+    '';
+  };
+in
+{
+  programs.television = {
+    enable = true;
+    package = televisionPackage;
+    extraPackages = with pkgs; [
+      fd
+      bat
+      ripgrep
+    ];
+  };
+
+  test.stubs = {
+    fd = {
+      name = "fd";
+    };
+    bat = {
+      name = "bat";
+    };
+    ripgrep = {
+      name = "ripgrep";
+    };
+  };
+
+  nmt = {
+    description = "Check if the television binary is correctly wrapped with extraPackages in PATH";
+    script = ''
+      tvWrapper="$TESTED/home-path/bin/tv"
+      assertFileExists "$tvWrapper"
+      assertFileRegex "$tvWrapper" "fd"
+      assertFileRegex "$tvWrapper" "bat"
+      assertFileRegex "$tvWrapper" "ripgrep"
+    '';
+  };
+}

--- a/tests/modules/programs/television/themes-config.nix
+++ b/tests/modules/programs/television/themes-config.nix
@@ -3,6 +3,7 @@
   programs.television = {
     enable = true;
     package = config.lib.test.mkStubPackage { name = "television"; };
+    extraPackages = [ ];
 
     settings = {
       ui.theme = "default";


### PR DESCRIPTION
## Summary

Television allows to add custom cables depending on different tools, the ability of adding local packages to television only allows to keep a clean configuration. This PR adds the `extraPackages` option to the module.

I configured the defaults to `fd`, `bat`, and `ripgrep` — the three dependencies television's default channels require, per the [upstream installation docs](https://alexpasmantier.github.io/television/getting-started/installation#dependencies). This was just a guess on nice to have, we can remove it if make more sense.

## Changes

- **`modules/programs/television.nix`**: Add `extraPackages` option (`listOf package`, default `[ fd bat ripgrep ]`). When non-empty, the `tv` binary is wrapped with `--suffix PATH` to include the extra
  packages. When empty, the unwrapped package is installed as before.
- **`tests/modules/programs/television/extra-packages.nix`** (new): Test verifying the `tv` binary is correctly wrapped with the default extra packages in PATH.
- **`tests/modules/programs/television/default.nix`**: Register the new test.
- **Existing tests** (`basic-config.nix`, `themes-config.nix`, `nix-search-tv/television.nix`): Set `extraPackages = [ ]` since they test config/channels/themes generation, not binary wrapping.

## Testing

All television tests pass:

- `television-basic-config`
- `television-extra-packages` (new)
- `television-themes-config`
- `nix-search-tv-television`

## AI Disclosure

The code in this PR was written by an AI assistant (Crush) and reviewed
and tested by a human.

---

💘 Generated with Crush

Assisted-by: Crush:glm-5.2