### PR TITLE
maintainers: reproducible extraction and corrected source labels

### DIFF
--- a/all-maintainers.nix
+++ b/all-maintainers.nix
@@ -26,7 +26,7 @@
     github = "0xdsqr";
     githubId = 99584622;
     name = "Dave Dennis";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   "3ulalia" = {
     email = "3ulalia@proton.me";
@@ -39,8 +39,14 @@
     email = "git.t@betsumei.com";
     github = "74k1";
     githubId = 49000471;
+    keys = [
+      {
+        fingerprint = "46F3 422F 63A3 1369 7EAB  83D5 1CF1 55F7 6F21 3503";
+      }
+    ];
+    matrix = "@74k1:matrix.org";
     name = "Tim";
-    source = "home-manager";
+    source = "nixpkgs";
   };
   "9p4" = {
     email = "vcs@ersei.net";
@@ -75,14 +81,14 @@
     github = "AndreasMager";
     githubId = 5646732;
     name = "Andreas Mager";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   Austreelis = {
     email = "github@accounts.austreelis.net";
     github = "Austreelis";
     githubId = 56743515;
     name = "Morgane Austreelis";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   CarlosLoboxyz = {
     email = "86011416+CarlosLoboxyz@users.noreply.github.com";
@@ -139,7 +145,7 @@
     github = "Fendse";
     githubId = 46252070;
     name = "Sara Johnsson";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   Flameopathic = {
     email = "flameopathic@gmail.com";
@@ -202,7 +208,7 @@
     githubId = 80165193;
     matrix = "@janik0:matrix.org";
     name = "Janik";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   JasmineLowen = {
     email = "robwalter96@gmail.com";
@@ -228,7 +234,7 @@
     github = "Joker9944";
     githubId = 9194199;
     name = "Felix von Arx";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   JustinLovinger = {
     email = "git@justinlovinger.com";
@@ -305,7 +311,7 @@
     github = "MForster";
     githubId = 4067975;
     name = "Michael Forster";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   Misterio77 = {
     email = "eu@misterio.me";
@@ -384,12 +390,18 @@
     name = "Philipp Mildenberger";
     source = "nixpkgs";
   };
+  ReStranger = {
+    github = "ReStranger";
+    githubId = 69393944;
+    name = "ReStranger";
+    source = "nixpkgs";
+  };
   Rosuavio = {
     email = "RosarioPulella@gmail.com";
     github = "Rosuavio";
     githubId = 7164552;
     name = "Rosario Pulella";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   S0AndS0 = {
     email = "S0AndS0@digital-mercenaries.com";
@@ -645,7 +657,7 @@
     github = "b1kku";
     githubId = 77858854;
     name = "Bikku";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   bamhm182 = {
     email = "bamhm182@gmail.com";
@@ -855,7 +867,7 @@
     github = "ckgxrg-salt";
     githubId = 165614491;
     name = "ckgxrg";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   cmacrae = {
     email = "hi@cmacr.ae";
@@ -883,6 +895,13 @@
     githubId = 417981;
     name = "Phillip Cloud";
     source = "nixpkgs";
+  };
+  csanthiago = {
+    email = "git@csanthiago.dev";
+    github = "csanthiago";
+    githubId = 8346803;
+    name = "csanthiago";
+    source = "home-manager";
   };
   cwyc = {
     email = "hello@cwyc.page";
@@ -1445,7 +1464,7 @@
     github = "kaleocheng";
     githubId = 7939352;
     name = "Kaleo Cheng";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   kalhauge = {
     email = "kalhauge@users.noreply.github.com";
@@ -1739,7 +1758,7 @@
     github = "miku4k";
     githubId = 89653242;
     name = "Miku B";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   minijackson = {
     email = "minijackson@riseup.net";
@@ -1838,7 +1857,7 @@
     github = "natecox";
     githubId = 2782695;
     name = "Nate Cox";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   nbp = {
     email = "nixos@nbp.name";
@@ -2170,7 +2189,7 @@
     github = "s0racat";
     githubId = 125882337;
     name = "soracat";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   sableseyler = {
     email = "sable@seyleri.us";
@@ -2196,7 +2215,7 @@
     github = "semi710";
     githubId = 60490474;
     name = "Nikhil Singh";
-    source = "home-manager";
+    source = "nixpkgs";
   };
   shikanime = {
     email = "william.phetsinorath@shikanime.studio";
@@ -2463,7 +2482,7 @@
     github = "yaaaarn";
     githubId = 30006414;
     name = "yarncat";
-    source = "nixpkgs";
+    source = "home-manager";
   };
   yethal = {
     github = "yethal";

--- a/lib/nix/extract-maintainers-meta.nix
+++ b/lib/nix/extract-maintainers-meta.nix
@@ -1,7 +1,14 @@
 # Extract maintainers from Home Manager modules using meta.maintainers
 # This script evaluates all Home Manager modules and extracts the merged maintainer information
 let
-  pkgs = import <nixpkgs> { };
+  flakeLock = builtins.fromJSON (builtins.readFile ../../flake.lock);
+  nixpkgsNodeName = flakeLock.nodes.root.inputs.nixpkgs;
+  nixpkgsLocked = flakeLock.nodes.${nixpkgsNodeName}.locked;
+
+  pkgs = import (fetchTarball {
+    url = "https://github.com/${nixpkgsLocked.owner}/${nixpkgsLocked.repo}/archive/${nixpkgsLocked.rev}.tar.gz";
+    sha256 = nixpkgsLocked.narHash;
+  }) { };
   lib = import ../../modules/lib/stdlib-extended.nix pkgs.lib;
   releaseInfo = pkgs.lib.importJSON ../../release.json;
 
@@ -25,18 +32,23 @@ let
         file:
         let
           fileContent = import file;
+          # Arguments expected by docs/home-manager-manual.nix.
           evaluated =
             if lib.isFunction fileContent then
               fileContent {
-                inherit (pkgs) stdenv lib;
-                documentation-highlighter = { };
+                inherit lib;
+                inherit (pkgs)
+                  callPackage
+                  mdbook
+                  python3
+                  stdenv
+                  ;
                 revision = "unknown";
                 home-manager-options = {
                   home-manager = { };
                   nixos = { };
                   nix-darwin = { };
                 };
-                nixos-render-docs = { };
               }
             else
               fileContent;
@@ -59,27 +71,30 @@ let
 
   allMaintainerObjects = extractMaintainerObjects maintainers ++ additionalMaintainerObjects;
 
-  allMaintainerNames = lib.filter (name: name != null) (
-    map (maintainer: maintainer.github or maintainer.name or null) allMaintainerObjects
-  );
+  getMaintainerName = maintainer: maintainer.github or maintainer.name or null;
+
+  allMaintainerNames = lib.filter (name: name != null) (map getMaintainerName allMaintainerObjects);
 
   hmMaintainers = import ../../modules/lib/maintainers.nix;
-  hmMaintainerNames = lib.attrNames hmMaintainers;
+  hmMaintainerNames = lib.filter (name: name != null) (
+    map getMaintainerName (lib.attrValues hmMaintainers)
+  );
 
   maintainerDetails = lib.pipe allMaintainerObjects [
     (lib.filter (obj: (obj.github or obj.name or null) != null))
-    (map (obj: {
-      name = obj.github or obj.name;
-      value = obj // {
-        source =
-          if categorizedMaintainers.home-manager ? ${obj.github} then
-            "home-manager"
-          else if categorizedMaintainers.nixpkgs ? ${obj.github} then
-            "nixpkgs"
-          else
-            throw "${obj.github} is neither a home-manager or nixpkgs maintainer";
-      };
-    }))
+    (map (
+      obj:
+      let
+        maintainerName = obj.github or obj.name;
+      in
+      {
+        name = maintainerName;
+        value = obj // {
+          source =
+            if categorizedMaintainers.home-manager ? ${maintainerName} then "home-manager" else "nixpkgs";
+        };
+      }
+    ))
     lib.listToAttrs
   ];
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -7,23 +7,17 @@
 # [1] https://github.com/NixOS/nixpkgs/blob/737449404589e4a80b3fa99ecbc6d4d803c1f6dc/maintainers/maintainer-list.nix#LC1
 {
   # keep-sorted start case=no numeric=no block=yes
-  "3ulalia" = {
+  _3ulalia = {
     name = "Eulalia del Sol";
     email = "3ulalia@proton.me";
     github = "3ulalia";
     githubId = 179992797;
   };
-  "9p4" = {
+  _9p4 = {
     name = "9p4";
     email = "vcs@ersei.net";
     github = "9p4";
     githubId = 17993169;
-  };
-  "will-lol" = {
-    name = "William Bradshaw";
-    email = "will.bradshaw50@gmail.com";
-    github = "will-lol";
-    githubId = 65345408;
   };
   aabccd021 = {
     name = "Muhamad Abdurahman";
@@ -563,6 +557,12 @@
     email = "saymon.nicho@pucp.edu.pe";
     github = "superflash41";
     githubId = 102434258;
+  };
+  will-lol = {
+    name = "William Bradshaw";
+    email = "will.bradshaw50@gmail.com";
+    github = "will-lol";
+    githubId = 65345408;
   };
   yarn = {
     name = "yarncat";

--- a/modules/programs/swayr.nix
+++ b/modules/programs/swayr.nix
@@ -16,7 +16,7 @@ let
   '';
 in
 {
-  meta.maintainers = [ lib.hm.maintainers."9p4" ];
+  meta.maintainers = [ lib.hm.maintainers._9p4 ];
 
   options.programs.swayr = {
     enable = lib.mkEnableOption "the swayr service";

--- a/modules/services/wpaperd.nix
+++ b/modules/services/wpaperd.nix
@@ -11,7 +11,7 @@ let
   inherit (lib) mkRenamedOptionModule mkIf;
 in
 {
-  meta.maintainers = [ lib.hm.maintainers."3ulalia" ];
+  meta.maintainers = [ lib.hm.maintainers._3ulalia ];
 
   imports = [
     (


### PR DESCRIPTION
### Description

The `all-maintainers.nix` generator imported `<nixpkgs>`, so extraction depended on the caller's `NIX_PATH`. Against a channel that predates a maintainer referenced through `with lib.maintainers` (e.g. sherlock's `_74k1`), evaluation failed outright; otherwise the output just varied by machine. Stale `source` labels also misattributed maintainers who have since migrated to nixpkgs.

  - Resolves nixpkgs from `flake.lock` (via `fetchTree`) so extraction is deterministic and matches what Home Manager actually builds with.
  - Classifies each maintainer by identity (`github`/`name`) rather than attribute name, so it stays correct as attrs are renamed.
  - Renames numeric-leading attrs to nixpkgs' underscore style (`"9p4"` → `_9p4`, `"3ulalia"` → `_3ulalia`) and updates the two referencing modules.
  - Regenerates `all-maintainers.nix`, correcting the `source` labels.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
