### PR TITLE
launchd: fix user domain agents

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -14,7 +14,7 @@ let
   dstDir = "${config.home.homeDirectory}/Library/LaunchAgents";
 
   launchdConfig =
-    { name, ... }:
+    { name, config, ... }:
     {
       options = {
         enable = lib.mkEnableOption name;
@@ -55,9 +55,14 @@ let
         };
       };
 
-      config = {
-        config.Label = lib.mkDefault "${labelPrefix}${name}";
-      };
+      config = lib.mkMerge [
+        {
+          config.Label = lib.mkDefault "${labelPrefix}${name}";
+        }
+        (lib.mkIf (config.domain == "user") {
+          config.LimitLoadToSessionType = lib.mkDefault "Background";
+        })
+      ];
     };
 
   # mutateConfig calls /bin/sh with /bin/wait4path to wait for /nix/store before
@@ -211,6 +216,13 @@ in
               esac
             }
 
+            agentIsLoaded() {
+              local domain="$1"
+              local agentName="$2"
+
+              run /bin/launchctl print "$domain/$agentName" >/dev/null 2>&1
+            }
+
             # Stop an agent if it's running
             bootoutAgent() {
               local domain="$1"
@@ -218,21 +230,24 @@ in
 
               verboseEcho "Stopping agent '$domain/$agentName'..."
               local bootout_output
-              bootout_output=$(run /bin/launchctl bootout --wait "$domain/$agentName" 2>&1) || {
+              if bootout_output=$(run /bin/launchctl bootout --wait "$domain/$agentName" 2>&1); then
+                return 0
+              else
                 # Only show warning if it's not the common "No such process" error
                 if [[ "$bootout_output" != *"No such process"* ]]; then
                   warnEcho "Failed to stop agent '$domain/$agentName': $bootout_output"
+                  return 1
                 else
                   verboseEcho "Agent '$domain/$agentName' was not running"
+                  return 2
                 fi
-              }
+              fi
             }
 
-            installAndBootstrapAgent() {
+            installAgentFile() {
               local srcPath="$1"
               local dstPath="$2"
-              local domain="$3"
-              local agentName="$4"
+              local agentName="$3"
 
               verboseEcho "Installing agent file to $dstPath"
               if ! run install -Dm444 -T "$srcPath" "$dstPath"; then
@@ -240,11 +255,17 @@ in
                 return 1
               fi
 
+              return 0
+            }
+
+            bootstrapAgent() {
+              local domain="$1"
+              local dstPath="$2"
+              local agentName="$3"
+
               verboseEcho "Starting agent '$domain/$agentName'"
               local bootstrap_output
               bootstrap_output=$(run /bin/launchctl bootstrap "$domain" "$dstPath" 2>&1) || {
-                local error_code=$?
-
                 if [[ "$bootstrap_output" == *"Bootstrap failed: 5: Input/output error"* ]]; then
                   errorEcho "Failed to start agent '$domain/$agentName' with I/O error (code 5)"
                   errorEcho "This typically happens when the agent wasn't unloaded before attempting to bootstrap the new agent."
@@ -259,29 +280,55 @@ in
               return 0
             }
 
+            restoreAgent() {
+              local oldSrcPath="$1"
+              local dstPath="$2"
+              local oldDomain="$3"
+              local agentName="$4"
+
+              if [[ ! -f "$oldSrcPath" ]]; then
+                warnEcho "Cannot restore previous agent '$oldDomain/$agentName', old file '$oldSrcPath' is missing"
+                return 1
+              fi
+
+              warnEcho "Restoring previous agent '$oldDomain/$agentName'"
+              installAgentFile "$oldSrcPath" "$dstPath" "$agentName" \
+                && bootstrapAgent "$oldDomain" "$dstPath" "$agentName"
+            }
+
             processAgent() {
               local srcPath="$1"
               local dstDir="$2"
-              local oldDomainsDir="$3"
-              local newDomainsDir="$4"
+              local oldDir="$3"
+              local oldDomainsDir="$4"
+              local newDomainsDir="$5"
 
               local agentFile="''${srcPath##*/}"
               local agentName="''${agentFile%.plist}"
               local dstPath="$dstDir/$agentFile"
+              local oldSrcPath=""
               local oldDomainName
               local newDomainName
               local oldDomain
               local newDomain
+              local oldAgentBootedOut=0
 
               oldDomainName="$(readAgentDomain "$oldDomainsDir" "$agentName")"
               newDomainName="$(readAgentDomain "$newDomainsDir" "$agentName")"
               oldDomain="$(resolveDomain "$oldDomainName")"
               newDomain="$(resolveDomain "$newDomainName")"
+              if [[ -n "$oldDir" ]]; then
+                oldSrcPath="$oldDir/$agentFile"
+              fi
 
               # Skip if unchanged
               if cmp -s "$srcPath" "$dstPath" && [[ "$oldDomainName" == "$newDomainName" ]]; then
-                verboseEcho "Agent '$newDomain/$agentName' is already up-to-date"
-                return 0
+                if agentIsLoaded "$newDomain" "$agentName"; then
+                  verboseEcho "Agent '$newDomain/$agentName' is already up-to-date"
+                  return 0
+                else
+                  verboseEcho "Agent '$newDomain/$agentName' is up-to-date but not loaded"
+                fi
               fi
 
               verboseEcho "Processing agent '$newDomain/$agentName'"
@@ -289,11 +336,48 @@ in
               # Stop/Unload agent if it's already running
               if [[ -f "$dstPath" ]]; then
                 bootoutAgent "$oldDomain" "$agentName"
+                case "$?" in
+                  0)
+                    oldAgentBootedOut=1
+                    ;;
+                  2)
+                    ;;
+                  *)
+                    return 1
+                    ;;
+                esac
               fi
 
-              installAndBootstrapAgent "$srcPath" "$dstPath" "$newDomain" "$agentName"
-              # Note: We continue processing even if this agent fails
-              return 0
+              if [[ "$oldDomainName" != "$newDomainName" ]]; then
+                bootoutAgent "$newDomain" "$agentName"
+                case "$?" in
+                  0|2)
+                    ;;
+                  *)
+                    if [[ "$oldAgentBootedOut" -eq 1 ]]; then
+                      restoreAgent "$oldSrcPath" "$dstPath" "$oldDomain" "$agentName"
+                    fi
+                    return 1
+                    ;;
+                esac
+              fi
+
+              if ! installAgentFile "$srcPath" "$dstPath" "$agentName"; then
+                if [[ "$oldAgentBootedOut" -eq 1 ]]; then
+                  restoreAgent "$oldSrcPath" "$dstPath" "$oldDomain" "$agentName"
+                fi
+                return 1
+              fi
+
+              if bootstrapAgent "$newDomain" "$dstPath" "$agentName"; then
+                return 0
+              fi
+
+              if [[ "$oldAgentBootedOut" -eq 1 ]]; then
+                restoreAgent "$oldSrcPath" "$dstPath" "$oldDomain" "$agentName"
+              fi
+
+              return 1
             }
 
             removeAgent() {
@@ -328,23 +412,32 @@ in
 
               # Stop and remove the agent
               bootoutAgent "$domain" "$agentName"
+              case "$?" in
+                0|2)
+                  ;;
+                *)
+                  return 1
+                  ;;
+              esac
 
               verboseEcho "Removing agent file '$dstPath'"
               if run rm -f $VERBOSE_ARG "$dstPath"; then
                 verboseEcho "Successfully removed agent file for '$agentName'"
               else
                 warnEcho "Failed to remove agent file '$dstPath'"
+                return 1
               fi
 
               return 0
             }
 
             setupLaunchAgents() {
-              local oldDir newDir oldDomainsDir newDomainsDir dstDir
+              local oldDir newDir oldDomainsDir newDomainsDir dstDir launchdStatus
 
               newDir="$(readlink -m "$newGenPath/LaunchAgents")"
               newDomainsDir="$(readlink -m "$newGenPath/LaunchAgentDomains")"
               dstDir=${lib.escapeShellArg dstDir}
+              launchdStatus=0
 
               if [[ -n "''${oldGenPath:-}" ]]; then
                 oldDir="$(readlink -m "$oldGenPath/LaunchAgents")"
@@ -363,29 +456,49 @@ in
               fi
 
               verboseEcho "Setting up LaunchAgents in $dstDir"
-              [[ -d "$dstDir" ]] || run mkdir -p "$dstDir"
+              if [[ ! -d "$dstDir" ]] && ! run mkdir -p "$dstDir"; then
+                errorEcho "Failed to create LaunchAgents directory '$dstDir'"
+                return 1
+              fi
 
               verboseEcho "Processing new/updated LaunchAgents..."
-              find -L "$newDir" -maxdepth 1 -name '*.plist' -type f | while read -r srcPath; do
-                processAgent "$srcPath" "$dstDir" "$oldDomainsDir" "$newDomainsDir"
-              done
+              while IFS= read -r srcPath; do
+                processAgent "$srcPath" "$dstDir" "$oldDir" "$oldDomainsDir" "$newDomainsDir" \
+                  || launchdStatus=1
+              done < <(find -L "$newDir" -maxdepth 1 -name '*.plist' -type f)
 
               # Skip cleanup if there's no previous generation
               if [[ -z "$oldDir" || ! -d "$oldDir" ]]; then
+                if [[ "$launchdStatus" -ne 0 ]]; then
+                  errorEcho "Failed to activate one or more LaunchAgents"
+                fi
+
                 verboseEcho "LaunchAgents setup complete"
-                return
+                return "$launchdStatus"
               fi
 
               verboseEcho "Cleaning up removed LaunchAgents..."
-              find -L "$oldDir" -maxdepth 1 -name '*.plist' -type f | while read -r srcPath; do
-                removeAgent "$srcPath" "$dstDir" "$newDir" "$oldDomainsDir"
-              done
+              while IFS= read -r srcPath; do
+                removeAgent "$srcPath" "$dstDir" "$newDir" "$oldDomainsDir" \
+                  || launchdStatus=1
+              done < <(find -L "$oldDir" -maxdepth 1 -name '*.plist' -type f)
+
+              if [[ "$launchdStatus" -ne 0 ]]; then
+                errorEcho "Failed to activate one or more LaunchAgents"
+              fi
+
+              return "$launchdStatus"
             }
 
-            setupLaunchAgents
+            launchdStatus=0
+            setupLaunchAgents || launchdStatus=$?
 
             # Restore errexit
             set -e
+
+            if [[ "$launchdStatus" -ne 0 ]]; then
+              exit "$launchdStatus"
+            fi
           '';
     })
   ];

--- a/tests/modules/launchd/agent-domain.nix
+++ b/tests/modules/launchd/agent-domain.nix
@@ -11,6 +11,8 @@
     nmt.script = ''
       serviceFile=LaunchAgents/org.nix-community.home.user-service.plist
       assertFileExists $serviceFile
+      assertFileContains $serviceFile '<key>LimitLoadToSessionType</key>'
+      assertFileContains $serviceFile '<string>Background</string>'
 
       domainFile=LaunchAgentDomains/org.nix-community.home.user-service.domain
       assertFileExists $domainFile

--- a/tests/modules/launchd/agents.nix
+++ b/tests/modules/launchd/agents.nix
@@ -30,8 +30,19 @@
       assertFileExists activate
       assertFileContains activate 'readAgentDomain'
       assertFileContains activate 'resolveDomain'
+      assertFileContains activate 'agentIsLoaded'
+      assertFileContains activate 'if agentIsLoaded "$newDomain" "$agentName"; then'
+      assertFileContains activate 'is up-to-date but not loaded'
       assertFileContains activate "printf 'gui/%s"
       assertFileContains activate "printf 'user/%s"
+      assertFileContains activate 'restoreAgent "$oldSrcPath" "$dstPath" "$oldDomain" "$agentName"'
+      assertFileContains activate 'bootoutAgent "$newDomain" "$agentName"'
+      assertFileContains activate 'processAgent "$srcPath" "$dstDir" "$oldDir" "$oldDomainsDir" "$newDomainsDir" \'
+      assertFileContains activate '|| launchdStatus=1'
+      assertFileContains activate 'done < <(find -L "$newDir" -maxdepth 1 -name'
+      assertFileContains activate 'done < <(find -L "$oldDir" -maxdepth 1 -name'
+      assertFileContains activate 'if [[ "$launchdStatus" -ne 0 ]]; then'
+      assertFileContains activate 'exit "$launchdStatus"'
     '';
   };
 }

--- a/tests/modules/programs/git/expected-agent-daily.plist
+++ b/tests/modules/programs/git/expected-agent-daily.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.git-maintenance-daily</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/programs/git/expected-agent-hourly.plist
+++ b/tests/modules/programs/git/expected-agent-hourly.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.git-maintenance-hourly</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/programs/git/expected-agent-weekly.plist
+++ b/tests/modules/programs/git/expected-agent-weekly.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.git-maintenance-weekly</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/programs/nh/darwin/launchd.plist
+++ b/tests/modules/programs/nh/darwin/launchd.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.nh-clean</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/programs/opencode/web-service-environment-file.plist
+++ b/tests/modules/programs/opencode/web-service-environment-file.plist
@@ -11,6 +11,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.opencode-web</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/programs/opencode/web-service.plist
+++ b/tests/modules/programs/opencode/web-service.plist
@@ -11,6 +11,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.opencode-web</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/borgmatic/darwin/expected-agent.plist
+++ b/tests/modules/services/borgmatic/darwin/expected-agent.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.borgmatic</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/colima/darwin/colima-docker-cli-expected.plist
+++ b/tests/modules/services/colima/darwin/colima-docker-cli-expected.plist
@@ -22,6 +22,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.colima-default</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/services/colima/darwin/expected-agent.plist
+++ b/tests/modules/services/colima/darwin/expected-agent.plist
@@ -18,6 +18,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.colima-default</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/services/emacs/darwin/expected-agent.plist
+++ b/tests/modules/services/emacs/darwin/expected-agent.plist
@@ -11,6 +11,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.emacs</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/services/git-sync/darwin/expected-agent.plist
+++ b/tests/modules/services/git-sync/darwin/expected-agent.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.git-sync-test</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/glance/default-settings.nix
+++ b/tests/modules/services/glance/default-settings.nix
@@ -18,6 +18,8 @@
       serviceFile=$(normalizeStorePaths $serviceFile)
       assertFileExists "$serviceFile"
       assertFileContent "$serviceFile" ${./glance.plist}
+      assertFileContains "$serviceFile" '<key>LimitLoadToSessionType</key>'
+      assertFileContains "$serviceFile" '<string>Background</string>'
 
       domainFile=LaunchAgentDomains/org.nix-community.home.glance.domain
       assertFileContent "$domainFile" ${builtins.toFile "expected-domain" "user\n"}

--- a/tests/modules/services/glance/glance.plist
+++ b/tests/modules/services/glance/glance.plist
@@ -6,6 +6,8 @@
 	<true/>
 	<key>Label</key>
 	<string>org.nix-community.home.glance</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/services/gpg-agent/expected-agent.plist
+++ b/tests/modules/services/gpg-agent/expected-agent.plist
@@ -16,6 +16,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.gpg-agent</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/home-manager-auto-expire/darwin/expected-agent.plist
+++ b/tests/modules/services/home-manager-auto-expire/darwin/expected-agent.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.home-manager-auto-expire</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/imapnotify/darwin/launchd.plist
+++ b/tests/modules/services/imapnotify/darwin/launchd.plist
@@ -13,6 +13,8 @@
 	<true/>
 	<key>Label</key>
 	<string>org.nix-community.home.imapnotify-hm-example.com</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/nix-gc/darwin/expected-agent.plist
+++ b/tests/modules/services/nix-gc/darwin/expected-agent.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.nix-gc</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/services/ollama/darwin/expected-agent.plist
+++ b/tests/modules/services/ollama/darwin/expected-agent.plist
@@ -20,6 +20,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.ollama</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/podman/darwin/basic-expected-agent.plist
+++ b/tests/modules/services/podman/darwin/basic-expected-agent.plist
@@ -11,6 +11,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.podman-machine-podman-machine-default</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/podman/darwin/custom-machines-dev-expected-agent.plist
+++ b/tests/modules/services/podman/darwin/custom-machines-dev-expected-agent.plist
@@ -11,6 +11,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.podman-machine-dev-machine</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/proton-pass-agent/basic-service-expected.plist
+++ b/tests/modules/services/proton-pass-agent/basic-service-expected.plist
@@ -6,6 +6,8 @@
 	<true/>
 	<key>Label</key>
 	<string>org.nix-community.home.proton-pass-agent</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/proton-pass-agent/full-service-expected.plist
+++ b/tests/modules/services/proton-pass-agent/full-service-expected.plist
@@ -6,6 +6,8 @@
 	<true/>
 	<key>Label</key>
 	<string>org.nix-community.home.proton-pass-agent</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/ssh-agent/darwin/basic-service-expected.plist
+++ b/tests/modules/services/ssh-agent/darwin/basic-service-expected.plist
@@ -11,6 +11,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.ssh-agent</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/ssh-agent/darwin/pkcs11-service-expected.plist
+++ b/tests/modules/services/ssh-agent/darwin/pkcs11-service-expected.plist
@@ -11,6 +11,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.ssh-agent</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/ssh-agent/darwin/timeout-service-expected.plist
+++ b/tests/modules/services/ssh-agent/darwin/timeout-service-expected.plist
@@ -11,6 +11,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.ssh-agent</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/syncthing/expected-agent.plist
+++ b/tests/modules/services/syncthing/expected-agent.plist
@@ -11,6 +11,8 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.syncthing</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/yubikey-agent/darwin/service.nix
+++ b/tests/modules/services/yubikey-agent/darwin/service.nix
@@ -23,6 +23,8 @@
       	</dict>
       	<key>Label</key>
       	<string>org.nix-community.home.yubikey-agent</string>
+      ${"\t"}<key>LimitLoadToSessionType</key>
+      ${"\t"}<string>Background</string>
       	<key>ProcessType</key>
       	<string>Background</string>
       	<key>ProgramArguments</key>


### PR DESCRIPTION
User-domain agents need the Background session type to bootstrap into user/501, and activation should fail rather than silently unloading services when launchctl bootstrap fails.

Closes https://github.com/nix-community/home-manager/issues/9568

### Note on stricter activation error handling

This PR changes activation from fire-and-forget to fail-on-error for launchd agents. Previously, processAgent always returned 0 and the find | while pipeline ran in a subshell that discarded launchdStatus mutations — so activation always reported success even when agents failed to bootstrap.

Now activation exits non-zero if any agent fails. This is the right default (silent failures left users with dead agents and no indication), but it does mean transient launchd errors will surface as activation failures. Possible scenarios:

    Bootstrap timing races after bootout (agent hasn't fully exited)
    Wake-from-sleep or login-time launchd inconsistencies
    Agents with external dependencies not yet available

Re-running home-manager switch should resolve transient cases. If this becomes a recurring problem in practice, we could consider downgrading to a loud warning instead of a hard failure, or adding a per-agent option to control whether failure is fatal. Leaving this note here so we have the context if issues come in.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
