### PR TITLE
home: document defaults inheritaults inherited from NixOS/nix-darwin

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -583,10 +583,6 @@ in
         assertion = config.home.username != "";
         message = "Username could not be determined";
       }
-      {
-        assertion = config.home.homeDirectory != "";
-        message = "Home directory could not be determined";
-      }
     ];
 
     warnings =

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -190,14 +190,24 @@ in
         undefined, otherwise.
       '';
       example = "jane.doe";
-      description = "The user's username.";
+      description = ''
+        The user's username.
+
+        If Home Manager is installed as a NixOS or nix-darwin submodule, it is
+        set to `osConfig.users.users.<name>.name`.
+      '';
     };
 
     home.uid = mkOption {
       type = types.nullOr types.ints.unsigned;
       default = null;
       example = 1000;
-      description = "The user's uid.";
+      description = ''
+        The user's uid.
+
+        If Home Manager is installed as a NixOS or nix-darwin submodule, it is
+        set to `osConfig.users.users.<name>.uid`.
+      '';
     };
 
     home.homeDirectory = mkOption {
@@ -208,7 +218,12 @@ in
       '';
       apply = toString;
       example = "/home/jane.doe";
-      description = "The user's home directory. Must be an absolute path.";
+      description = ''
+        The user's home directory. Must be an absolute path.
+
+        If Home Manager is installed as a NixOS or nix-darwin submodule, it is
+        set to `osConfig.users.users.<name>.home`.
+      '';
     };
 
     home.profileDirectory = mkOption {

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -185,9 +185,9 @@ in
   options = {
     home.username = mkOption {
       type = types.nonEmptyStr;
-      defaultText = literalExpression ''
-        "$USER"   for state version < 20.09,
-        undefined for state version ≥ 20.09
+      defaultText = lib.literalMD ''
+        `$USER`,   for state version < 20.09,
+        undefined, otherwise.
       '';
       example = "jane.doe";
       description = "The user's username.";
@@ -202,9 +202,9 @@ in
 
     home.homeDirectory = mkOption {
       type = types.path;
-      defaultText = literalExpression ''
-        "$HOME"   for state version < 20.09,
-        undefined for state version ≥ 20.09
+      defaultText = lib.literalMD ''
+        `$HOME`,   for state version < 20.09
+        undefined, otherwise.
       '';
       apply = toString;
       example = "/home/jane.doe";
@@ -220,7 +220,7 @@ in
           "${config.xdg.stateHome}/nix/profile"
         else
           cfg.homeDirectory + "/.nix-profile";
-      defaultText = ''
+      defaultText = lib.literalMD ''
         - `/etc/profiles/per-user/''${home.username}`, if Home Manager is installed as
           a submodule and `home-manager.useUserPackages` is enabled, else
         - `''${xdg.stateHome}/nix/profile`, if `nix.useXdg` is enabled, else

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -184,7 +184,7 @@ in
 
   options = {
     home.username = mkOption {
-      type = types.str;
+      type = types.nonEmptyStr;
       defaultText = literalExpression ''
         "$USER"   for state version < 20.09,
         undefined for state version ≥ 20.09
@@ -578,13 +578,6 @@ in
   };
 
   config = {
-    assertions = [
-      {
-        assertion = config.home.username != "";
-        message = "Username could not be determined";
-      }
-    ];
-
     warnings =
       let
         hmRelease = config.home.version.release;


### PR DESCRIPTION
### Description

This PR documents that `home.homeDirectory`, `home.uid`, and `home.username` are inherited when Home Manager is installed as a submodule of NixOS/nix-darwin.

While at it, I also moved two string non-emptiness assertions into the respective option types.

Closes: #9556

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
