### PR TITLE
nix: add nix.package to home.packages

### DIFF
--- a/modules/misc/nix/default.nix
+++ b/modules/misc/nix/default.nix
@@ -386,6 +386,11 @@ in
       ];
     }
     (mkIf cfg.enable (mkMerge [
+      # ensure the nix the user's PATH is nix.package
+      (mkIf (cfg.package != null) {
+        home.packages = [ cfg.package ];
+      })
+
       (mkIf (cfg.nixPath != [ ] && !cfg.keepOldNixPath) {
         home.sessionVariables.NIX_PATH = "${nixPath}";
       })


### PR DESCRIPTION
### Description

when `nix.package` is set, we add it the user's `$PATH`, to ensure that
  1. the user's nix is managed as declaratively as they expect, because otherwise they'll set `nix.package` expecting it to have an impact, and then end up with the ambient nix from the system, which wouldn't be pure
  2. the settings we generate are aligned with the actual nix version the user will use, instead of the system's one

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
