### PR TITLE
kanshi: Reload on config change

### DIFF
--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -16,6 +16,8 @@ let
 
   cfg = config.services.kanshi;
 
+  configPath = "kanshi/config";
+
   directivesTag = types.attrTag {
     profile = mkOption {
       type = profileModule;
@@ -346,7 +348,7 @@ in
       {
         home.packages = [ cfg.package ];
 
-        xdg.configFile."kanshi/config" =
+        xdg.configFile.${configPath} =
           let
             generatedConfigStr =
               if cfg.profiles == { } && cfg.extraConfig == "" then directivesStr else oldDirectivesStr;
@@ -361,11 +363,15 @@ in
             PartOf = cfg.systemdTarget;
             Requires = cfg.systemdTarget;
             After = cfg.systemdTarget;
+            X-Reload-Triggers = lib.mkIf (cfg.settings != { }) [
+              "${config.xdg.configFile.${configPath}.source}"
+            ];
           };
 
           Service = {
             Type = "simple";
             ExecStart = "${cfg.package}/bin/kanshi";
+            ExecReload = "${lib.getExe' cfg.package "kanshictl"} reload";
             Restart = "always";
           };
 


### PR DESCRIPTION
### Description

Reload kanshi daemon via `kanshictl reload` on config change.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
