### PR TITLE
launchd: replace bootout --wait with a poll loop

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -230,7 +230,18 @@ in
 
               verboseEcho "Stopping agent '$domain/$agentName'..."
               local bootout_output
-              if bootout_output=$(run /bin/launchctl bootout --wait "$domain/$agentName" 2>&1); then
+              if bootout_output=$(run /bin/launchctl bootout "$domain/$agentName" 2>&1); then
+                # `bootout` can return before launchd has finished unloading
+                # the service, and its `--wait` flag is not supported on all
+                # macOS versions. Poll until the service is gone so that a
+                # following `bootstrap` does not race the unload.
+                if [[ ! -v DRY_RUN ]]; then
+                  local i
+                  for ((i = 0; i < 60; i++)); do
+                    agentIsLoaded "$domain" "$agentName" || break
+                    sleep 0.5
+                  done
+                fi
                 return 0
               else
                 # Only show warning if it's not the common "No such process" error

--- a/tests/modules/launchd/agents.nix
+++ b/tests/modules/launchd/agents.nix
@@ -37,6 +37,7 @@
       assertFileContains activate "printf 'user/%s"
       assertFileContains activate 'restoreAgent "$oldSrcPath" "$dstPath" "$oldDomain" "$agentName"'
       assertFileContains activate 'bootoutAgent "$newDomain" "$agentName"'
+      assertFileContains activate 'agentIsLoaded "$domain" "$agentName" || break'
       assertFileContains activate 'processAgent "$srcPath" "$dstDir" "$oldDir" "$oldDomainsDir" "$newDomainsDir" \'
       assertFileContains activate '|| launchdStatus=1'
       assertFileContains activate 'done < <(find -L "$newDir" -maxdepth 1 -name'


### PR DESCRIPTION
### Description

Fixes #9585.

#9222 switched agent stopping to `launchctl bootout --wait`, but `--wait` is not supported on all macOS versions — macOS 14/15 reject the whole command with `Unrecognized target specifier`, so every agent stop fails during activation:

```text
Activating setupLaunchAgents
Failed to stop agent 'user/501/org.nix-community.home.syncthing': Unrecognized target specifier.
...
Failed to activate one or more LaunchAgents
```

This drops the flag and instead polls `launchctl print` (via the existing `agentIsLoaded` helper) until the service is unloaded, up to 30s. That keeps the synchronous behavior #9222 introduced for slow-stopping services like colima (#8829), portably.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
  `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
  `nix-shell --pure tests -A run.all`. (ran `nix run .#tests -- launchd` — all 3 launchd tests pass)

- [x] Test cases updated/added.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```
