### PR TITLE
launchd: only use --wait on macOS 26 and later

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -179,6 +179,9 @@ in
       home.activation.setupLaunchAgents =
         lib.hm.dag.entryAfter [ "writeBoundary" ] # Bash
           ''
+            # Get the OS version to see if we can use --wait
+            version="$(/usr/bin/sw_vers --productVersion | cut -d. -f 1)"
+
             # Disable errexit to ensure we process all agents even if some fail
             set +e
 
@@ -230,17 +233,30 @@ in
 
               verboseEcho "Stopping agent '$domain/$agentName'..."
               local bootout_output
-              if bootout_output=$(run /bin/launchctl bootout --wait "$domain/$agentName" 2>&1); then
-                return 0
-              else
-                # Only show warning if it's not the common "No such process" error
-                if [[ "$bootout_output" != *"No such process"* ]]; then
-                  warnEcho "Failed to stop agent '$domain/$agentName': $bootout_output"
-                  return 1
-                else
-                  verboseEcho "Agent '$domain/$agentName' was not running"
-                  return 2
+
+              if [[ "$version" -ge "26" ]]; then
+                if bootout_output=$(run /bin/launchctl bootout --wait "$domain/$agentName" 2>&1); then
+                  # --wait already makes sure it was unloaded (BUT we can only use it in >=26)
+                  return 0
                 fi
+              else
+                if bootout_output=$(run /bin/launchctl bootout "$domain/$agentName" 2>&1); then
+                  # Otherwise on <26 give the system a moment to fully unload the agent
+                  run sleep 1
+                  return 0
+                fi
+              fi
+
+              # At this point we know exit code is not 0 because otherwise we
+              # would have returned by now
+
+              # Only show warning if it's not the common "No such process" error
+              if [[ "$bootout_output" != *"No such process"* ]]; then
+                warnEcho "Failed to stop agent '$domain/$agentName': $bootout_output"
+                return 1
+              else
+                verboseEcho "Agent '$domain/$agentName' was not running"
+                return 2
               fi
             }
 


### PR DESCRIPTION
### Description

Fixes this on macOS 15 after #9222 (caused by `--wait` only existing on macOS 26 and later):

```
Activating setupLaunchAgents
Failed to stop agent 'user/501/org.nix-community.home.emacs': Unrecognized target specifier.
Usage: launchctl bootout <domain-target> [service-path1, service-path2, ...] | <service-target>
<service-target> takes a form of <domain-target>/<service-id>.
Please refer to `man launchctl` for explanation of the <domain-target> specifiers.
Failed to activate one or more LaunchAgents
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `nix-shell -A dev --run treefmt`.

- [x] Code tested through ~~`nix build .#test-all` or a targeted `nix run .#tests -- <pattern>`.~~ manual testing

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
