### PR TITLE
fzf, atuin: add widget controls and Ctrl-R conflict handling

### DIFF
--- a/modules/misc/news/2026/07/2026-07-01_18-57-59.nix
+++ b/modules/misc/news/2026/07/2026-07-01_18-57-59.nix
@@ -1,0 +1,17 @@
+{ config, ... }:
+{
+  time = "2026-07-01T23:57:59+00:00";
+  condition =
+    config.programs.atuin.enable
+    && config.programs.atuin.enableNushellIntegration
+    && config.programs.nushell.enable;
+  message = ''
+    Home Manager now loads the Atuin Nushell integration after other shell
+    integrations such as fzf. This restores Atuin's Ctrl-R binding when both
+    programs are enabled.
+
+    If you previously used `programs.nushell.extraConfig = lib.mkAfter ...`
+    to place custom Nushell configuration after Atuin, use a later order such
+    as `lib.mkOrder 2001 ...` instead.
+  '';
+}

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -20,7 +20,11 @@ let
     else
       [ "daemon" ];
 
-  inherit (lib) mkIf mkOption types;
+  inherit (lib)
+    mkIf
+    mkOption
+    types
+    ;
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -224,7 +228,8 @@ in
           '';
 
           programs.nushell = mkIf cfg.enableNushellIntegration {
-            extraConfig = ''
+            # Load after fzf so Atuin keeps Ctrl-R in Nushell.
+            extraConfig = lib.mkOrder 2000 ''
               source ${
                 pkgs.runCommand "atuin-nushell-config.nu"
                   {

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -281,13 +281,98 @@ in
     in
     mkIf cfg.enable {
       warnings =
-        lib.optional (cfg.historyWidget.command != null && lib.versionOlder cfg.package.version "0.66.0")
-          ''
-            `programs.fzf.historyWidget.command` defined in ${lib.showFiles options.programs.fzf.historyWidget.command.files} requires fzf 0.66.0 or greater.
+        let
+          shellIntegrationOptions = {
+            bash = "enableBashIntegration";
+            fish = "enableFishIntegration";
+            nushell = "enableNushellIntegration";
+            zsh = "enableZshIntegration";
+          };
 
-            The configured FZF_CTRL_R_COMMAND value will be ignored by older fzf
-            versions.
-          '';
+          integrationCtrlRActive =
+            shell: programConfig:
+            config.programs.${shell}.enable
+            && programConfig.enable
+            && programConfig.${shellIntegrationOptions.${shell}};
+
+          fzfCtrlRActive =
+            shell:
+            let
+              shellCommand = cfg.historyWidget.${shell}.command;
+              effectiveCommand = if shellCommand != null then shellCommand else cfg.historyWidget.command;
+            in
+            integrationCtrlRActive shell cfg && effectiveCommand != "";
+
+          atuinCtrlRActive =
+            shell:
+            integrationCtrlRActive shell config.programs.atuin
+            && !(builtins.elem "--disable-ctrl-r" config.programs.atuin.flags);
+
+          mcflyCtrlRActive = shell: shell != "nushell" && integrationCtrlRActive shell config.programs.mcfly;
+
+          ctrlRConflictShells = builtins.filter (
+            shell: fzfCtrlRActive shell && (atuinCtrlRActive shell || mcflyCtrlRActive shell)
+          ) shells;
+
+          showOptionFiles = option: lib.showFiles option.files;
+
+          fzfCtrlRDefinition =
+            shell:
+            if cfg.historyWidget.${shell}.command != null then
+              "`programs.fzf.historyWidget.${shell}.command` defined in ${
+                showOptionFiles options.programs.fzf.historyWidget.${shell}.command
+              }"
+            else if cfg.historyWidget.command != null then
+              "`programs.fzf.historyWidget.command` defined in ${showOptionFiles options.programs.fzf.historyWidget.command}"
+            else
+              "`programs.fzf.enable` defined in ${showOptionFiles options.programs.fzf.enable}";
+
+          atuinCtrlRDefinition =
+            if config.programs.atuin.flags != [ ] then
+              "`programs.atuin.flags` defined in ${showOptionFiles options.programs.atuin.flags}"
+            else
+              "`programs.atuin.enable` defined in ${showOptionFiles options.programs.atuin.enable}";
+
+          mcflyCtrlRDefinition = "`programs.mcfly.enable` defined in ${showOptionFiles options.programs.mcfly.enable}";
+
+          ctrlRConflictDefinitions = lib.concatStringsSep "\n" (
+            lib.concatMap (
+              shell:
+              [
+                "  ${shell}:"
+                "    ${fzfCtrlRDefinition shell}"
+              ]
+              ++ lib.optionals (atuinCtrlRActive shell) [ "    ${atuinCtrlRDefinition}" ]
+              ++ lib.optionals (mcflyCtrlRActive shell) [ "    ${mcflyCtrlRDefinition}" ]
+            ) ctrlRConflictShells
+          );
+        in
+
+        lib.optional (cfg.historyWidget.command != null && lib.versionOlder cfg.package.version "0.66.0") ''
+          `programs.fzf.historyWidget.command` defined in ${lib.showFiles options.programs.fzf.historyWidget.command.files} requires fzf 0.66.0 or greater.
+
+          The configured FZF_CTRL_R_COMMAND value will be ignored by older fzf
+          versions.
+        ''
+        ++ lib.optional (ctrlRConflictShells != [ ]) ''
+          programs.fzf and a history manager both configure Ctrl-R for ${lib.concatStringsSep ", " ctrlRConflictShells}.
+
+          Definitions:
+          ${ctrlRConflictDefinitions}
+
+          The history manager integration is sourced after fzf and owns Ctrl-R.
+          Choose which integration should own Ctrl-R.
+          To keep the history manager on Ctrl-R, disable fzf's binding:
+            programs.fzf.historyWidget.command = "";
+          or disable it for one shell:
+            programs.fzf.historyWidget.${builtins.head ctrlRConflictShells}.command = "";
+          To keep fzf on Ctrl-R with Atuin, disable Atuin's Ctrl-R binding:
+            programs.atuin.flags = [ "--disable-ctrl-r" ];
+          McFly has no Ctrl-R-only option in Home Manager. Disable McFly's
+          shell integration for that shell if fzf should own Ctrl-R.
+          To use another key, disable one default Ctrl-R binding and add a
+          shell-specific key binding in your shell configuration.
+        '';
 
       assertions = [
         {

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -39,6 +40,7 @@ let
   fzfEnvVars = lib.filterAttrs (_n: v: v != [ ] && v != null) {
     FZF_ALT_C_COMMAND = cfg.changeDirWidget.command;
     FZF_ALT_C_OPTS = cfg.changeDirWidget.options;
+    FZF_CTRL_R_COMMAND = cfg.historyWidget.command;
     FZF_CTRL_R_OPTS = cfg.historyWidget.options;
     FZF_CTRL_T_COMMAND = cfg.fileWidget.command;
     FZF_CTRL_T_OPTS = cfg.fileWidget.options;
@@ -85,11 +87,10 @@ in
         "historyWidget"
         "options"
       ])
-      (lib.mkRemovedOptionModule [
-        "programs"
-        "fzf"
-        "historyWidgetCommand"
-      ] "This option is no longer supported by fzf.")
+      (mkRenamedFzfOption "historyWidgetCommand" [
+        "historyWidget"
+        "command"
+      ])
     ];
 
   options.programs.fzf =
@@ -170,6 +171,16 @@ in
       };
 
       historyWidget = mkWidgetOption {
+        commandExample = "";
+        commandDescription = ''
+          The command that gets executed as the source for fzf for the
+          CTRL-R keybinding.
+
+          An empty string disables the CTRL-R binding, which is the supported
+          way to yield CTRL-R to a history manager such as Atuin or McFly.
+          Non-empty custom commands require fzf 0.66.0 or later but are not
+          supported by fzf yet and currently print a shell startup warning.
+        '';
         optionsExample = [
           "--sort"
           "--exact"
@@ -224,6 +235,15 @@ in
     };
 
   config = mkIf cfg.enable {
+    warnings =
+      lib.optional (cfg.historyWidget.command != null && lib.versionOlder cfg.package.version "0.66.0")
+        ''
+          `programs.fzf.historyWidget.command` defined in ${lib.showFiles options.programs.fzf.historyWidget.command.files} requires fzf 0.66.0 or greater.
+
+          The configured FZF_CTRL_R_COMMAND value will be ignored by older fzf
+          versions.
+        '';
+
     assertions = [
       {
         assertion =

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -18,38 +18,13 @@ let
 
   cfg = config.programs.fzf;
 
-  renderedColors =
-    colors: lib.concatStringsSep "," (lib.mapAttrsToList (name: value: "${name}:${value}") colors);
+  shells = [
+    "bash"
+    "fish"
+    "nushell"
+    "zsh"
+  ];
 
-  bashIntegration = ''
-    if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
-      eval "$(${getExe cfg.package} --bash)"
-    fi
-  '';
-
-  zshIntegration = ''
-    if [[ $options[zle] = on ]]; then
-      source <(${getExe cfg.package} --zsh)
-    fi
-  '';
-
-  fishIntegration = ''
-    ${getExe cfg.package} --fish | source
-  '';
-
-  fzfEnvVars = lib.filterAttrs (_n: v: v != [ ] && v != null) {
-    FZF_ALT_C_COMMAND = cfg.changeDirWidget.command;
-    FZF_ALT_C_OPTS = cfg.changeDirWidget.options;
-    FZF_CTRL_R_COMMAND = cfg.historyWidget.command;
-    FZF_CTRL_R_OPTS = cfg.historyWidget.options;
-    FZF_CTRL_T_COMMAND = cfg.fileWidget.command;
-    FZF_CTRL_T_OPTS = cfg.fileWidget.options;
-    FZF_DEFAULT_COMMAND = cfg.defaultCommand;
-    FZF_DEFAULT_OPTS =
-      cfg.defaultOptions ++ lib.optionals (cfg.colors != { }) [ "--color ${renderedColors cfg.colors}" ];
-    FZF_TMUX = if cfg.tmux.enableShellIntegration then "1" else null;
-    FZF_TMUX_OPTS = cfg.tmux.shellIntegrationOptions;
-  };
 in
 {
   meta.maintainers = with lib.maintainers; [ khaneliman ];
@@ -95,8 +70,44 @@ in
 
   options.programs.fzf =
     let
-      mkWidgetOption =
+      mkWidgetShellOverrides =
         {
+          commandExample ? null,
+          commandDescription ? null,
+          optionsExample,
+          ...
+        }:
+        lib.genAttrs shells (
+          _shell:
+          lib.optionalAttrs (commandDescription != null) {
+            command = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              example = commandExample;
+              description = ''
+                Shell-specific override for this widget command.
+
+                If this is `null`, the global command is used.
+              '';
+            };
+          }
+          // {
+            options = mkOption {
+              type = types.nullOr (types.listOf types.str);
+              default = null;
+              example = optionsExample;
+              description = ''
+                Shell-specific override for this widget's command line
+                options.
+
+                If this is `null`, the global options are used.
+              '';
+            };
+          }
+        );
+
+      mkWidgetOption =
+        args@{
           commandExample ? null,
           commandDescription ? null,
           optionsExample,
@@ -117,7 +128,8 @@ in
             example = optionsExample;
             description = optionsDescription;
           };
-        };
+        }
+        // mkWidgetShellOverrides args;
     in
     {
       enable = lib.mkEnableOption "fzf - a command-line fuzzy finder";
@@ -234,55 +246,144 @@ in
       enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
     };
 
-  config = mkIf cfg.enable {
-    warnings =
-      lib.optional (cfg.historyWidget.command != null && lib.versionOlder cfg.package.version "0.66.0")
-        ''
-          `programs.fzf.historyWidget.command` defined in ${lib.showFiles options.programs.fzf.historyWidget.command.files} requires fzf 0.66.0 or greater.
+  config =
+    let
+      shellFzfEnvVars =
+        shell:
+        lib.filterAttrs (_n: v: v != null) {
+          FZF_ALT_C_COMMAND = cfg.changeDirWidget.${shell}.command;
+          FZF_ALT_C_OPTS = cfg.changeDirWidget.${shell}.options;
+          FZF_CTRL_R_COMMAND = cfg.historyWidget.${shell}.command;
+          FZF_CTRL_R_OPTS = cfg.historyWidget.${shell}.options;
+          FZF_CTRL_T_COMMAND = cfg.fileWidget.${shell}.command;
+          FZF_CTRL_T_OPTS = cfg.fileWidget.${shell}.options;
+        };
 
-          The configured FZF_CTRL_R_COMMAND value will be ignored by older fzf
-          versions.
-        '';
+      fzfEnvVars = lib.filterAttrs (_n: v: v != [ ] && v != null) {
+        FZF_ALT_C_COMMAND = cfg.changeDirWidget.command;
+        FZF_ALT_C_OPTS = cfg.changeDirWidget.options;
+        FZF_CTRL_R_COMMAND = cfg.historyWidget.command;
+        FZF_CTRL_R_OPTS = cfg.historyWidget.options;
+        FZF_CTRL_T_COMMAND = cfg.fileWidget.command;
+        FZF_CTRL_T_OPTS = cfg.fileWidget.options;
+        FZF_DEFAULT_COMMAND = cfg.defaultCommand;
+        FZF_DEFAULT_OPTS =
+          cfg.defaultOptions
+          ++ lib.optionals (cfg.colors != { }) [
+            "--color ${
+              lib.concatStringsSep "," (lib.mapAttrsToList (name: value: "${name}:${value}") cfg.colors)
+            }"
+          ];
+        FZF_TMUX = if cfg.tmux.enableShellIntegration then "1" else null;
+        FZF_TMUX_OPTS = cfg.tmux.shellIntegrationOptions;
+      };
 
-    assertions = [
-      {
-        assertion =
-          (cfg.enableBashIntegration || cfg.enableFishIntegration || cfg.enableZshIntegration)
-          -> lib.versionAtLeast cfg.package.version "0.48.0";
-        message = "fzf package version must be 0.48.0 or greater for bash, fish, or zsh integration";
-      }
-      {
-        assertion = cfg.enableNushellIntegration -> lib.versionAtLeast cfg.package.version "0.73.0";
-        message = "fzf package version must be 0.73.0 or greater for nushell integration";
-      }
-    ];
-
-    home.packages = [ cfg.package ];
-    home.sessionVariables = lib.mapAttrs (_n: toString) fzfEnvVars;
-
-    # Load early so history managers can reclaim Ctrl-R.
-    programs.bash.initExtra = mkIf cfg.enableBashIntegration (mkOrder 200 bashIntegration);
-
-    # Still needs to be initialized after oh-my-zsh (order 800), otherwise
-    # omz will take precedence.
-    programs.zsh.initContent = mkIf cfg.enableZshIntegration (mkOrder 910 zshIntegration);
-
-    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration (mkOrder 200 fishIntegration);
-
-    # Initialize after other completion integrations, such as carapace.
-    # fzf preserves the previous external completer and falls back to it
-    # when its own completer does not apply.
-    programs.nushell = lib.mkIf cfg.enableNushellIntegration {
-      environmentVariables = lib.mapAttrs (_n: toString) fzfEnvVars;
-
-      extraConfig = mkAfter ''
-        source ${
-          pkgs.runCommand "nushell-fzf-integration.nu" { } ''
-            ${getExe cfg.package} --nushell > $out
+    in
+    mkIf cfg.enable {
+      warnings =
+        lib.optional (cfg.historyWidget.command != null && lib.versionOlder cfg.package.version "0.66.0")
           ''
-        }
-      '';
-    };
+            `programs.fzf.historyWidget.command` defined in ${lib.showFiles options.programs.fzf.historyWidget.command.files} requires fzf 0.66.0 or greater.
 
-  };
+            The configured FZF_CTRL_R_COMMAND value will be ignored by older fzf
+            versions.
+          '';
+
+      assertions = [
+        {
+          assertion =
+            (cfg.enableBashIntegration || cfg.enableFishIntegration || cfg.enableZshIntegration)
+            -> lib.versionAtLeast cfg.package.version "0.48.0";
+          message = "fzf package version must be 0.48.0 or greater for bash, fish, or zsh integration";
+        }
+        {
+          assertion = cfg.enableNushellIntegration -> lib.versionAtLeast cfg.package.version "0.73.0";
+          message = "fzf package version must be 0.73.0 or greater for nushell integration";
+        }
+      ];
+
+      home.packages = [ cfg.package ];
+      home.sessionVariables = lib.mapAttrs (_n: toString) fzfEnvVars;
+
+      # Load early so history managers can reclaim Ctrl-R.
+      programs.bash.initExtra =
+        let
+          vars = shellFzfEnvVars "bash";
+        in
+        mkIf cfg.enableBashIntegration (
+          mkOrder 200 (
+            ''
+              if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
+            ''
+            + lib.optionalString (vars != { }) "${config.lib.shell.exportAll vars}\n"
+            + ''
+                eval "$(${getExe cfg.package} --bash)"
+              fi
+            ''
+          )
+        );
+
+      # Still needs to be initialized after oh-my-zsh (order 800), otherwise
+      # omz will take precedence.
+      programs.zsh.initContent =
+        let
+          vars = shellFzfEnvVars "zsh";
+        in
+        mkIf cfg.enableZshIntegration (
+          mkOrder 910 (
+            ''
+              if [[ $options[zle] = on ]]; then
+            ''
+            + lib.optionalString (vars != { }) "${config.lib.shell.exportAll vars}\n"
+            + ''
+                source <(${getExe cfg.package} --zsh)
+              fi
+            ''
+          )
+        );
+
+      programs.fish.interactiveShellInit =
+        let
+          vars = shellFzfEnvVars "fish";
+          exports = lib.concatStringsSep "\n" (
+            lib.mapAttrsToList (name: value: "set -gx ${name} ${lib.escapeShellArg (toString value)}") vars
+          );
+        in
+        mkIf cfg.enableFishIntegration (
+          mkOrder 200 (
+            lib.optionalString (vars != { }) "${exports}\n"
+            + ''
+              ${getExe cfg.package} --fish | source
+            ''
+          )
+        );
+
+      # Initialize after other completion integrations, such as carapace.
+      # fzf preserves the previous external completer and falls back to it
+      # when its own completer does not apply.
+      programs.nushell = lib.mkIf cfg.enableNushellIntegration {
+        environmentVariables = lib.mapAttrs (_n: toString) fzfEnvVars;
+
+        extraConfig =
+          let
+            vars = shellFzfEnvVars "nushell";
+            assignments = lib.concatStringsSep "\n" (
+              lib.mapAttrsToList (
+                name: value: "$env.${name} = ${lib.hm.nushell.toNushell { } (toString value)}"
+              ) vars
+            );
+          in
+          mkAfter (
+            lib.optionalString (vars != { }) "${assignments}\n"
+            + ''
+              source ${
+                pkgs.runCommand "nushell-fzf-integration.nu" { } ''
+                  ${getExe cfg.package} --nushell > $out
+                ''
+              }
+            ''
+          );
+      };
+
+    };
 }

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -20,47 +20,21 @@ let
   renderedColors =
     colors: lib.concatStringsSep "," (lib.mapAttrsToList (name: value: "${name}:${value}") colors);
 
-  hasShellIntegrationEmbedded = lib.versionAtLeast cfg.package.version "0.48.0";
+  bashIntegration = ''
+    if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
+      eval "$(${getExe cfg.package} --bash)"
+    fi
+  '';
 
-  bashIntegration =
-    if hasShellIntegrationEmbedded then
-      ''
-        if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
-          eval "$(${getExe cfg.package} --bash)"
-        fi
-      ''
-    else
-      ''
-        if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
-          . ${cfg.package}/share/fzf/completion.bash
-          . ${cfg.package}/share/fzf/key-bindings.bash
-        fi
-      '';
+  zshIntegration = ''
+    if [[ $options[zle] = on ]]; then
+      source <(${getExe cfg.package} --zsh)
+    fi
+  '';
 
-  zshIntegration =
-    if hasShellIntegrationEmbedded then
-      ''
-        if [[ $options[zle] = on ]]; then
-          source <(${getExe cfg.package} --zsh)
-        fi
-      ''
-    else
-      ''
-        if [[ $options[zle] = on ]]; then
-          . ${cfg.package}/share/fzf/completion.zsh
-          . ${cfg.package}/share/fzf/key-bindings.zsh
-        fi
-      '';
-
-  fishIntegration =
-    if hasShellIntegrationEmbedded then
-      ''
-        ${getExe cfg.package} --fish | source
-      ''
-    else
-      ''
-        source ${cfg.package}/share/fzf/key-bindings.fish && fzf_key_bindings
-      '';
+  fishIntegration = ''
+    ${getExe cfg.package} --fish | source
+  '';
 in
 {
   meta.maintainers = with lib.maintainers; [ khaneliman ];
@@ -195,6 +169,12 @@ in
 
   config = mkIf cfg.enable {
     assertions = [
+      {
+        assertion =
+          (cfg.enableBashIntegration || cfg.enableFishIntegration || cfg.enableZshIntegration)
+          -> lib.versionAtLeast cfg.package.version "0.48.0";
+        message = "fzf package version must be 0.48.0 or greater for bash, fish, or zsh integration";
+      }
       {
         assertion = cfg.enableNushellIntegration -> lib.versionAtLeast cfg.package.version "0.73.0";
         message = "fzf package version must be 0.73.0 or greater for nushell integration";

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -387,87 +387,91 @@ in
         }
       ];
 
-      home.packages = [ cfg.package ];
-      home.sessionVariables = lib.mapAttrs (_n: toString) fzfEnvVars;
+      home = {
+        packages = [ cfg.package ];
+        sessionVariables = lib.mapAttrs (_n: toString) fzfEnvVars;
+      };
 
-      # Load early so history managers can reclaim Ctrl-R.
-      programs.bash.initExtra =
-        let
-          vars = shellFzfEnvVars "bash";
-        in
-        mkIf cfg.enableBashIntegration (
-          mkOrder 200 (
-            ''
-              if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
-            ''
-            + lib.optionalString (vars != { }) "${config.lib.shell.exportAll vars}\n"
-            + ''
-                eval "$(${getExe cfg.package} --bash)"
-              fi
-            ''
-          )
-        );
-
-      # Still needs to be initialized after oh-my-zsh (order 800), otherwise
-      # omz will take precedence.
-      programs.zsh.initContent =
-        let
-          vars = shellFzfEnvVars "zsh";
-        in
-        mkIf cfg.enableZshIntegration (
-          mkOrder 910 (
-            ''
-              if [[ $options[zle] = on ]]; then
-            ''
-            + lib.optionalString (vars != { }) "${config.lib.shell.exportAll vars}\n"
-            + ''
-                source <(${getExe cfg.package} --zsh)
-              fi
-            ''
-          )
-        );
-
-      programs.fish.interactiveShellInit =
-        let
-          vars = shellFzfEnvVars "fish";
-          exports = lib.concatStringsSep "\n" (
-            lib.mapAttrsToList (name: value: "set -gx ${name} ${lib.escapeShellArg (toString value)}") vars
-          );
-        in
-        mkIf cfg.enableFishIntegration (
-          mkOrder 200 (
-            lib.optionalString (vars != { }) "${exports}\n"
-            + ''
-              ${getExe cfg.package} --fish | source
-            ''
-          )
-        );
-
-      # Initialize after other completion integrations, such as carapace.
-      # fzf preserves the previous external completer and falls back to it
-      # when its own completer does not apply.
-      programs.nushell = lib.mkIf cfg.enableNushellIntegration {
-        environmentVariables = lib.mapAttrs (_n: toString) fzfEnvVars;
-
-        extraConfig =
+      programs = {
+        # Load early so history managers can reclaim Ctrl-R.
+        bash.initExtra =
           let
-            vars = shellFzfEnvVars "nushell";
-            assignments = lib.concatStringsSep "\n" (
-              lib.mapAttrsToList (
-                name: value: "$env.${name} = ${lib.hm.nushell.toNushell { } (toString value)}"
-              ) vars
+            vars = shellFzfEnvVars "bash";
+          in
+          mkIf cfg.enableBashIntegration (
+            mkOrder 200 (
+              ''
+                if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
+              ''
+              + lib.optionalString (vars != { }) "${config.lib.shell.exportAll vars}\n"
+              + ''
+                  eval "$(${getExe cfg.package} --bash)"
+                fi
+              ''
+            )
+          );
+
+        # Still needs to be initialized after oh-my-zsh (order 800), otherwise
+        # omz will take precedence.
+        zsh.initContent =
+          let
+            vars = shellFzfEnvVars "zsh";
+          in
+          mkIf cfg.enableZshIntegration (
+            mkOrder 910 (
+              ''
+                if [[ $options[zle] = on ]]; then
+              ''
+              + lib.optionalString (vars != { }) "${config.lib.shell.exportAll vars}\n"
+              + ''
+                  source <(${getExe cfg.package} --zsh)
+                fi
+              ''
+            )
+          );
+
+        fish.interactiveShellInit =
+          let
+            vars = shellFzfEnvVars "fish";
+            exports = lib.concatStringsSep "\n" (
+              lib.mapAttrsToList (name: value: "set -gx ${name} ${lib.escapeShellArg (toString value)}") vars
             );
           in
-          mkAfter (
-            lib.optionalString (vars != { }) "${assignments}\n"
-            + ''
-              source ${
-                pkgs.runCommand "nushell-fzf-integration.nu" { } ''
-                  ${getExe cfg.package} --nushell > $out
-                ''
-              }
-            ''
+          mkIf cfg.enableFishIntegration (
+            mkOrder 200 (
+              lib.optionalString (vars != { }) "${exports}\n"
+              + ''
+                ${getExe cfg.package} --fish | source
+              ''
+            )
           );
+
+        # Initialize after other completion integrations, such as carapace.
+        # fzf preserves the previous external completer and falls back to it
+        # when its own completer does not apply.
+        nushell = lib.mkIf cfg.enableNushellIntegration {
+          environmentVariables = lib.mapAttrs (_n: toString) fzfEnvVars;
+
+          extraConfig =
+            let
+              vars = shellFzfEnvVars "nushell";
+              assignments = lib.concatStringsSep "\n" (
+                lib.mapAttrsToList (
+                  name: value: "$env.${name} = ${lib.hm.nushell.toNushell { } (toString value)}"
+                ) vars
+              );
+            in
+            mkAfter (
+              lib.optionalString (vars != { }) "${assignments}\n"
+              + ''
+                source ${
+                  pkgs.runCommand "nushell-fzf-integration.nu" { } ''
+                    ${getExe cfg.package} --nushell > $out
+                  ''
+                }
+              ''
+            );
+        };
       };
 
     };

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -273,6 +273,8 @@ in
     # fzf preserves the previous external completer and falls back to it
     # when its own completer does not apply.
     programs.nushell = lib.mkIf cfg.enableNushellIntegration {
+      environmentVariables = lib.mapAttrs (_n: toString) fzfEnvVars;
+
       extraConfig = mkAfter ''
         source ${
           pkgs.runCommand "nushell-fzf-integration.nu" { } ''

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -35,137 +35,193 @@ let
   fishIntegration = ''
     ${getExe cfg.package} --fish | source
   '';
+
+  fzfEnvVars = lib.filterAttrs (_n: v: v != [ ] && v != null) {
+    FZF_ALT_C_COMMAND = cfg.changeDirWidget.command;
+    FZF_ALT_C_OPTS = cfg.changeDirWidget.options;
+    FZF_CTRL_R_OPTS = cfg.historyWidget.options;
+    FZF_CTRL_T_COMMAND = cfg.fileWidget.command;
+    FZF_CTRL_T_OPTS = cfg.fileWidget.options;
+    FZF_DEFAULT_COMMAND = cfg.defaultCommand;
+    FZF_DEFAULT_OPTS =
+      cfg.defaultOptions ++ lib.optionals (cfg.colors != { }) [ "--color ${renderedColors cfg.colors}" ];
+    FZF_TMUX = if cfg.tmux.enableShellIntegration then "1" else null;
+    FZF_TMUX_OPTS = cfg.tmux.shellIntegrationOptions;
+  };
 in
 {
   meta.maintainers = with lib.maintainers; [ khaneliman ];
 
-  imports = [
-    (lib.mkRemovedOptionModule [
-      "programs"
-      "fzf"
-      "historyWidgetCommand"
-    ] "This option is no longer supported by fzf.")
-  ];
-  options.programs.fzf = {
-    enable = lib.mkEnableOption "fzf - a command-line fuzzy finder";
+  imports =
+    let
+      mkRenamedFzfOption =
+        oldName: newPath:
+        lib.mkRenamedOptionModule [ "programs" "fzf" oldName ] (
+          [
+            "programs"
+            "fzf"
+          ]
+          ++ newPath
+        );
+    in
+    [
+      (mkRenamedFzfOption "fileWidgetCommand" [
+        "fileWidget"
+        "command"
+      ])
+      (mkRenamedFzfOption "fileWidgetOptions" [
+        "fileWidget"
+        "options"
+      ])
+      (mkRenamedFzfOption "changeDirWidgetCommand" [
+        "changeDirWidget"
+        "command"
+      ])
+      (mkRenamedFzfOption "changeDirWidgetOptions" [
+        "changeDirWidget"
+        "options"
+      ])
+      (mkRenamedFzfOption "historyWidgetOptions" [
+        "historyWidget"
+        "options"
+      ])
+      (lib.mkRemovedOptionModule [
+        "programs"
+        "fzf"
+        "historyWidgetCommand"
+      ] "This option is no longer supported by fzf.")
+    ];
 
-    package = lib.mkPackageOption pkgs "fzf" { };
-
-    defaultCommand = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "fd --type f";
-      description = ''
-        The command that gets executed as the default source for fzf
-        when running.
-      '';
-    };
-
-    defaultOptions = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      example = [
-        "--height 40%"
-        "--border"
-      ];
-      description = ''
-        Extra command line options given to fzf by default.
-      '';
-    };
-
-    fileWidgetCommand = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "fd --type f";
-      description = ''
-        The command that gets executed as the source for fzf for the
-        CTRL-T keybinding.
-      '';
-    };
-
-    fileWidgetOptions = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      example = [ "--preview 'head {}'" ];
-      description = ''
-        Command line options for the CTRL-T keybinding.
-      '';
-    };
-
-    changeDirWidgetCommand = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "fd --type d";
-      description = ''
-        The command that gets executed as the source for fzf for the
-        ALT-C keybinding.
-      '';
-    };
-
-    changeDirWidgetOptions = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      example = [ "--preview 'tree -C {} | head -200'" ];
-      description = ''
-        Command line options for the ALT-C keybinding.
-      '';
-    };
-
-    historyWidgetOptions = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      example = [
-        "--sort"
-        "--exact"
-      ];
-      description = ''
-        Command line options for the CTRL-R keybinding.
-      '';
-    };
-
-    colors = mkOption {
-      type = types.attrsOf types.str;
-      default = { };
-      example = literalExpression ''
+  options.programs.fzf =
+    let
+      mkWidgetOption =
         {
-          bg = "#1e1e1e";
-          "bg+" = "#1e1e1e";
-          fg = "#d4d4d4";
-          "fg+" = "#d4d4d4";
+          commandExample ? null,
+          commandDescription ? null,
+          optionsExample,
+          optionsDescription,
+        }:
+        lib.optionalAttrs (commandDescription != null) {
+          command = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            example = commandExample;
+            description = commandDescription;
+          };
         }
-      '';
-      description = ''
-        Color scheme options added to `FZF_DEFAULT_OPTS`. See
-        <https://github.com/junegunn/fzf/wiki/Color-schemes>
-        for documentation.
-      '';
-    };
+        // {
+          options = mkOption {
+            type = types.listOf types.str;
+            default = [ ];
+            example = optionsExample;
+            description = optionsDescription;
+          };
+        };
+    in
+    {
+      enable = lib.mkEnableOption "fzf - a command-line fuzzy finder";
 
-    tmux = {
-      enableShellIntegration = lib.mkEnableOption ''
-        setting `FZF_TMUX=1` which causes shell integration to use fzf-tmux
-      '';
+      package = lib.mkPackageOption pkgs "fzf" { };
 
-      shellIntegrationOptions = mkOption {
-        type = types.listOf types.str;
-        default = [ ];
-        example = [ "-d 40%" ];
+      defaultCommand = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "fd --type f";
         description = ''
-          If {option}`programs.fzf.tmux.enableShellIntegration` is set to `true`,
-          shell integration will use these options for fzf-tmux.
-          See {command}`fzf-tmux --help` for available options.
+          The command that gets executed as the default source for fzf
+          when running.
         '';
       };
+
+      defaultOptions = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [
+          "--height 40%"
+          "--border"
+        ];
+        description = ''
+          Extra command line options given to fzf by default.
+        '';
+      };
+
+      fileWidget = mkWidgetOption {
+        commandExample = "fd --type f";
+        commandDescription = ''
+          The command that gets executed as the source for fzf for the
+          CTRL-T keybinding.
+        '';
+        optionsExample = [ "--preview 'head {}'" ];
+        optionsDescription = ''
+          Command line options for the CTRL-T keybinding.
+        '';
+      };
+
+      changeDirWidget = mkWidgetOption {
+        commandExample = "fd --type d";
+        commandDescription = ''
+          The command that gets executed as the source for fzf for the
+          ALT-C keybinding.
+        '';
+        optionsExample = [ "--preview 'tree -C {} | head -200'" ];
+        optionsDescription = ''
+          Command line options for the ALT-C keybinding.
+        '';
+      };
+
+      historyWidget = mkWidgetOption {
+        optionsExample = [
+          "--sort"
+          "--exact"
+        ];
+        optionsDescription = ''
+          Command line options for the CTRL-R keybinding.
+        '';
+      };
+
+      colors = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        example = literalExpression ''
+          {
+            bg = "#1e1e1e";
+            "bg+" = "#1e1e1e";
+            fg = "#d4d4d4";
+            "fg+" = "#d4d4d4";
+          }
+        '';
+        description = ''
+          Color scheme options added to `FZF_DEFAULT_OPTS`. See
+          <https://github.com/junegunn/fzf/wiki/Color-schemes>
+          for documentation.
+        '';
+      };
+
+      tmux = {
+        enableShellIntegration = lib.mkEnableOption ''
+          setting `FZF_TMUX=1` which causes shell integration to use fzf-tmux
+        '';
+
+        shellIntegrationOptions = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          example = [ "-d 40%" ];
+          description = ''
+            If {option}`programs.fzf.tmux.enableShellIntegration` is set to `true`,
+            shell integration will use these options for fzf-tmux.
+            See {command}`fzf-tmux --help` for available options.
+          '';
+        };
+      };
+
+      enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
+
+      enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
+
+      enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+
+      enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
     };
-
-    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
-
-    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
-
-    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
-
-    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
-  };
 
   config = mkIf cfg.enable {
     assertions = [
@@ -182,29 +238,11 @@ in
     ];
 
     home.packages = [ cfg.package ];
-    home.sessionVariables = lib.mapAttrs (_n: toString) (
-      lib.filterAttrs (_n: v: v != [ ] && v != null) {
-        FZF_ALT_C_COMMAND = cfg.changeDirWidgetCommand;
-        FZF_ALT_C_OPTS = cfg.changeDirWidgetOptions;
-        FZF_CTRL_R_OPTS = cfg.historyWidgetOptions;
-        FZF_CTRL_T_COMMAND = cfg.fileWidgetCommand;
-        FZF_CTRL_T_OPTS = cfg.fileWidgetOptions;
-        FZF_DEFAULT_COMMAND = cfg.defaultCommand;
-        FZF_DEFAULT_OPTS =
-          cfg.defaultOptions ++ lib.optionals (cfg.colors != { }) [ "--color ${renderedColors cfg.colors}" ];
-        FZF_TMUX = if cfg.tmux.enableShellIntegration then "1" else null;
-        FZF_TMUX_OPTS = cfg.tmux.shellIntegrationOptions;
-      }
-    );
+    home.sessionVariables = lib.mapAttrs (_n: toString) fzfEnvVars;
 
-    # Note, since fzf unconditionally binds C-r we use `mkOrder` to make the
-    # initialization show up a bit earlier. This is to make initialization of
-    # other history managers, like mcfly or atuin, take precedence.
+    # Load early so history managers can reclaim Ctrl-R.
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (mkOrder 200 bashIntegration);
 
-    # Note, since fzf unconditionally binds C-r we use `mkOrder` to make the
-    # initialization show up a bit earlier. This is to make initialization of
-    # other history managers, like mcfly or atuin, take precedence.
     # Still needs to be initialized after oh-my-zsh (order 800), otherwise
     # omz will take precedence.
     programs.zsh.initContent = mkIf cfg.enableZshIntegration (mkOrder 910 zshIntegration);
@@ -218,7 +256,7 @@ in
       extraConfig = mkAfter ''
         source ${
           pkgs.runCommand "nushell-fzf-integration.nu" { } ''
-            ${lib.getExe cfg.package} --nushell > $out
+            ${getExe cfg.package} --nushell > $out
           ''
         }
       '';

--- a/tests/modules/programs/atuin/default.nix
+++ b/tests/modules/programs/atuin/default.nix
@@ -8,4 +8,5 @@
   atuin-set-flags = ./set-flags.nix;
   atuin-theme = ./theme.nix;
   atuin-nushell = ./nushell.nix;
+  atuin-nushell-fzf-order = ./nushell-fzf-order.nix;
 }

--- a/tests/modules/programs/atuin/nushell-fzf-order.nix
+++ b/tests/modules/programs/atuin/nushell-fzf-order.nix
@@ -1,0 +1,60 @@
+{ config, pkgs, ... }:
+
+{
+  programs = {
+    atuin = {
+      enable = true;
+      enableNushellIntegration = true;
+
+      package = config.lib.test.mkStubPackage {
+        name = "atuin";
+        buildScript = ''
+          mkdir -p $out/bin
+          cat > $out/bin/atuin <<'EOF'
+          #!/bin/sh
+          echo "Stub atuin"
+          EOF
+          chmod +x $out/bin/atuin
+        '';
+      };
+    };
+
+    fzf = {
+      enable = true;
+      enableNushellIntegration = true;
+
+      package = config.lib.test.mkStubPackage {
+        name = "fzf";
+        version = "0.73.0";
+        buildScript = ''
+          mkdir -p $out/bin
+          cat > $out/bin/fzf <<'EOF'
+          #!/bin/sh
+          echo "Stub fzf"
+          EOF
+          chmod +x $out/bin/fzf
+        '';
+      };
+    };
+
+    nushell.enable = true;
+  };
+
+  nmt.script =
+    let
+      nushellConfigFile =
+        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+          "home-files/Library/Application Support/nushell/config.nu"
+        else
+          "home-files/.config/nushell/config.nu";
+    in
+    ''
+      assertFileExists "${nushellConfigFile}"
+      assertFileContent "$(normalizeStorePaths "${nushellConfigFile}")" ${builtins.toFile "nushell-fzf-atuin-order-expected.nu" ''
+        source /nix/store/00000000000000000000000000000000-nushell-fzf-integration.nu
+
+        source /nix/store/00000000000000000000000000000000-atuin-nushell-config.nu
+
+      ''}
+    '';
+}

--- a/tests/modules/programs/atuin/nushell-fzf-order.nix
+++ b/tests/modules/programs/atuin/nushell-fzf-order.nix
@@ -22,6 +22,7 @@
     fzf = {
       enable = true;
       enableNushellIntegration = true;
+      historyWidget.nushell.command = "";
 
       package = config.lib.test.mkStubPackage {
         name = "fzf";
@@ -51,6 +52,7 @@
     ''
       assertFileExists "${nushellConfigFile}"
       assertFileContent "$(normalizeStorePaths "${nushellConfigFile}")" ${builtins.toFile "nushell-fzf-atuin-order-expected.nu" ''
+        $env.FZF_CTRL_R_COMMAND = ""
         source /nix/store/00000000000000000000000000000000-nushell-fzf-integration.nu
 
         source /nix/store/00000000000000000000000000000000-atuin-nushell-config.nu

--- a/tests/modules/programs/fzf/all-options.nix
+++ b/tests/modules/programs/fzf/all-options.nix
@@ -14,10 +14,13 @@
       command = "fd --type d";
       options = [ "--preview 'tree -C {} | head -200'" ];
     };
-    historyWidget.options = [
-      "--sort"
-      "--exact"
-    ];
+    historyWidget = {
+      command = "";
+      options = [
+        "--sort"
+        "--exact"
+      ];
+    };
     colors = {
       bg = "#1e1e1e";
     };
@@ -47,6 +50,8 @@
       'FZF_ALT_C_OPTS="--preview'
 
     # Test history widget
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_CTRL_R_COMMAND=""'
     assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
       'FZF_CTRL_R_OPTS="--sort --exact"'
 

--- a/tests/modules/programs/fzf/all-options.nix
+++ b/tests/modules/programs/fzf/all-options.nix
@@ -6,11 +6,15 @@
       "--height 40%"
       "--border"
     ];
-    fileWidgetCommand = "fd --type f";
-    fileWidgetOptions = [ "--preview 'head {}'" ];
-    changeDirWidgetCommand = "fd --type d";
-    changeDirWidgetOptions = [ "--preview 'tree -C {} | head -200'" ];
-    historyWidgetOptions = [
+    fileWidget = {
+      command = "fd --type f";
+      options = [ "--preview 'head {}'" ];
+    };
+    changeDirWidget = {
+      command = "fd --type d";
+      options = [ "--preview 'tree -C {} | head -200'" ];
+    };
+    historyWidget.options = [
       "--sort"
       "--exact"
     ];

--- a/tests/modules/programs/fzf/bash-widget-overrides.nix
+++ b/tests/modules/programs/fzf/bash-widget-overrides.nix
@@ -1,32 +1,34 @@
 { config, ... }:
 
 {
-  programs.fzf = {
-    enable = true;
-    enableBashIntegration = true;
+  programs = {
+    fzf = {
+      enable = true;
+      enableBashIntegration = true;
 
-    historyWidget = {
-      command = "global-history";
-      bash.command = "";
+      historyWidget = {
+        command = "global-history";
+        bash.command = "";
+      };
+
+      fileWidget.bash.command = "$HOME/bin/files";
+
+      package = config.lib.test.mkStubPackage {
+        name = "fzf";
+        version = "0.73.0";
+        buildScript = ''
+          mkdir -p $out/bin
+          cat > $out/bin/fzf <<'EOF'
+          #!/bin/sh
+          echo "Stub fzf"
+          EOF
+          chmod +x $out/bin/fzf
+        '';
+      };
     };
 
-    fileWidget.bash.command = "$HOME/bin/files";
-
-    package = config.lib.test.mkStubPackage {
-      name = "fzf";
-      version = "0.73.0";
-      buildScript = ''
-        mkdir -p $out/bin
-        cat > $out/bin/fzf <<'EOF'
-        #!/bin/sh
-        echo "Stub fzf"
-        EOF
-        chmod +x $out/bin/fzf
-      '';
-    };
+    bash.enable = true;
   };
-
-  programs.bash.enable = true;
 
   nmt.script = ''
     assertFileRegex home-files/.bashrc \

--- a/tests/modules/programs/fzf/bash-widget-overrides.nix
+++ b/tests/modules/programs/fzf/bash-widget-overrides.nix
@@ -1,0 +1,45 @@
+{ config, ... }:
+
+{
+  programs.fzf = {
+    enable = true;
+    enableBashIntegration = true;
+
+    historyWidget = {
+      command = "global-history";
+      bash.command = "";
+    };
+
+    fileWidget.bash.command = "$HOME/bin/files";
+
+    package = config.lib.test.mkStubPackage {
+      name = "fzf";
+      version = "0.73.0";
+      buildScript = ''
+        mkdir -p $out/bin
+        cat > $out/bin/fzf <<'EOF'
+        #!/bin/sh
+        echo "Stub fzf"
+        EOF
+        chmod +x $out/bin/fzf
+      '';
+    };
+  };
+
+  programs.bash.enable = true;
+
+  nmt.script = ''
+    assertFileRegex home-files/.bashrc \
+      'export FZF_CTRL_R_COMMAND='
+
+    assertFileContains home-files/.bashrc \
+      'export FZF_CTRL_T_COMMAND="$HOME/bin/files"'
+
+    overrideLine=$(grep -n 'export FZF_CTRL_R_COMMAND=' "$TESTED/home-files/.bashrc" | head -n1 | cut -d: -f1)
+    sourceLine=$(grep -n 'fzf.*--bash' "$TESTED/home-files/.bashrc" | head -n1 | cut -d: -f1)
+
+    if [[ -z "$overrideLine" || -z "$sourceLine" || "$overrideLine" -ge "$sourceLine" ]]; then
+      fail "bash fzf widget override must appear before fzf initialization"
+    fi
+  '';
+}

--- a/tests/modules/programs/fzf/ctrl-r-conflict-atuin-disabled.nix
+++ b/tests/modules/programs/fzf/ctrl-r-conflict-atuin-disabled.nix
@@ -1,0 +1,27 @@
+{ config, ... }:
+
+{
+  programs = {
+    atuin = {
+      enable = true;
+      enableZshIntegration = true;
+      flags = [ "--disable-ctrl-r" ];
+      package = config.lib.test.mkStubPackage { name = "atuin"; };
+    };
+
+    fzf = {
+      enable = true;
+      enableZshIntegration = true;
+      package = config.lib.test.mkStubPackage {
+        name = "fzf";
+        version = "0.73.0";
+      };
+    };
+
+    zsh.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+  '';
+}

--- a/tests/modules/programs/fzf/ctrl-r-conflict-fzf-disabled.nix
+++ b/tests/modules/programs/fzf/ctrl-r-conflict-fzf-disabled.nix
@@ -1,0 +1,27 @@
+{ config, ... }:
+
+{
+  programs = {
+    atuin = {
+      enable = true;
+      enableZshIntegration = true;
+      package = config.lib.test.mkStubPackage { name = "atuin"; };
+    };
+
+    fzf = {
+      enable = true;
+      enableZshIntegration = true;
+      historyWidget.command = "";
+      package = config.lib.test.mkStubPackage {
+        name = "fzf";
+        version = "0.73.0";
+      };
+    };
+
+    zsh.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+  '';
+}

--- a/tests/modules/programs/fzf/ctrl-r-conflict-per-shell-disabled.nix
+++ b/tests/modules/programs/fzf/ctrl-r-conflict-per-shell-disabled.nix
@@ -1,0 +1,27 @@
+{ config, ... }:
+
+{
+  programs = {
+    atuin = {
+      enable = true;
+      enableZshIntegration = true;
+      package = config.lib.test.mkStubPackage { name = "atuin"; };
+    };
+
+    fzf = {
+      enable = true;
+      enableZshIntegration = true;
+      historyWidget.zsh.command = "";
+      package = config.lib.test.mkStubPackage {
+        name = "fzf";
+        version = "0.73.0";
+      };
+    };
+
+    zsh.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+  '';
+}

--- a/tests/modules/programs/fzf/ctrl-r-conflict-warning.nix
+++ b/tests/modules/programs/fzf/ctrl-r-conflict-warning.nix
@@ -1,0 +1,55 @@
+{
+  config,
+  lib,
+  options,
+  ...
+}:
+
+{
+  programs = {
+    atuin = {
+      enable = true;
+      enableZshIntegration = true;
+      package = config.lib.test.mkStubPackage { name = "atuin"; };
+    };
+
+    fzf = {
+      enable = true;
+      enableZshIntegration = true;
+      package = config.lib.test.mkStubPackage {
+        name = "fzf";
+        version = "0.73.0";
+      };
+    };
+
+    zsh.enable = true;
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      programs.fzf and a history manager both configure Ctrl-R for zsh.
+
+      Definitions:
+        zsh:
+          `programs.fzf.enable` defined in ${lib.showFiles options.programs.fzf.enable.files}
+          `programs.atuin.enable` defined in ${lib.showFiles options.programs.atuin.enable.files}
+
+      The history manager integration is sourced after fzf and owns Ctrl-R.
+      Choose which integration should own Ctrl-R.
+      To keep the history manager on Ctrl-R, disable fzf's binding:
+        programs.fzf.historyWidget.command = "";
+      or disable it for one shell:
+        programs.fzf.historyWidget.zsh.command = "";
+      To keep fzf on Ctrl-R with Atuin, disable Atuin's Ctrl-R binding:
+        programs.atuin.flags = [ "--disable-ctrl-r" ];
+      McFly has no Ctrl-R-only option in Home Manager. Disable McFly's
+      shell integration for that shell if fzf should own Ctrl-R.
+      To use another key, disable one default Ctrl-R binding and add a
+      shell-specific key binding in your shell configuration.
+    ''
+  ];
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+  '';
+}

--- a/tests/modules/programs/fzf/default.nix
+++ b/tests/modules/programs/fzf/default.nix
@@ -5,4 +5,5 @@
   fzf-zsh-integration = ./zsh-integration.nix;
   fzf-fish-integration = ./fish-integration.nix;
   fzf-nushell-integration = ./nushell-integration.nix;
+  fzf-renamed-options = ./renamed-options.nix;
 }

--- a/tests/modules/programs/fzf/default.nix
+++ b/tests/modules/programs/fzf/default.nix
@@ -4,6 +4,7 @@
   fzf-bash-integration = ./bash-integration.nix;
   fzf-zsh-integration = ./zsh-integration.nix;
   fzf-fish-integration = ./fish-integration.nix;
+  fzf-history-command-version-warning = ./history-command-version-warning.nix;
   fzf-nushell-integration = ./nushell-integration.nix;
   fzf-renamed-options = ./renamed-options.nix;
 }

--- a/tests/modules/programs/fzf/default.nix
+++ b/tests/modules/programs/fzf/default.nix
@@ -6,5 +6,6 @@
   fzf-fish-integration = ./fish-integration.nix;
   fzf-history-command-version-warning = ./history-command-version-warning.nix;
   fzf-nushell-integration = ./nushell-integration.nix;
+  fzf-nushell-history-command = ./nushell-history-command.nix;
   fzf-renamed-options = ./renamed-options.nix;
 }

--- a/tests/modules/programs/fzf/default.nix
+++ b/tests/modules/programs/fzf/default.nix
@@ -1,5 +1,9 @@
 {
   fzf-bash-widget-overrides = ./bash-widget-overrides.nix;
+  fzf-ctrl-r-conflict-atuin-disabled = ./ctrl-r-conflict-atuin-disabled.nix;
+  fzf-ctrl-r-conflict-fzf-disabled = ./ctrl-r-conflict-fzf-disabled.nix;
+  fzf-ctrl-r-conflict-per-shell-disabled = ./ctrl-r-conflict-per-shell-disabled.nix;
+  fzf-ctrl-r-conflict-warning = ./ctrl-r-conflict-warning.nix;
   fzf-disabled = ./disabled.nix;
   fzf-options = ./all-options.nix;
   fzf-bash-integration = ./bash-integration.nix;

--- a/tests/modules/programs/fzf/default.nix
+++ b/tests/modules/programs/fzf/default.nix
@@ -1,11 +1,15 @@
 {
+  fzf-bash-widget-overrides = ./bash-widget-overrides.nix;
   fzf-disabled = ./disabled.nix;
   fzf-options = ./all-options.nix;
   fzf-bash-integration = ./bash-integration.nix;
+  fzf-zsh-widget-overrides = ./zsh-widget-overrides.nix;
   fzf-zsh-integration = ./zsh-integration.nix;
+  fzf-fish-widget-overrides = ./fish-widget-overrides.nix;
   fzf-fish-integration = ./fish-integration.nix;
   fzf-history-command-version-warning = ./history-command-version-warning.nix;
   fzf-nushell-integration = ./nushell-integration.nix;
   fzf-nushell-history-command = ./nushell-history-command.nix;
+  fzf-nushell-widget-overrides = ./nushell-widget-overrides.nix;
   fzf-renamed-options = ./renamed-options.nix;
 }

--- a/tests/modules/programs/fzf/fish-widget-overrides.nix
+++ b/tests/modules/programs/fzf/fish-widget-overrides.nix
@@ -1,30 +1,32 @@
 { config, ... }:
 
 {
-  programs.fzf = {
-    enable = true;
-    enableFishIntegration = true;
+  programs = {
+    fzf = {
+      enable = true;
+      enableFishIntegration = true;
 
-    historyWidget = {
-      command = "global-history";
-      fish.command = "";
+      historyWidget = {
+        command = "global-history";
+        fish.command = "";
+      };
+
+      package = config.lib.test.mkStubPackage {
+        name = "fzf";
+        version = "0.73.0";
+        buildScript = ''
+          mkdir -p $out/bin
+          cat > $out/bin/fzf <<'EOF'
+          #!/bin/sh
+          echo "Stub fzf"
+          EOF
+          chmod +x $out/bin/fzf
+        '';
+      };
     };
 
-    package = config.lib.test.mkStubPackage {
-      name = "fzf";
-      version = "0.73.0";
-      buildScript = ''
-        mkdir -p $out/bin
-        cat > $out/bin/fzf <<'EOF'
-        #!/bin/sh
-        echo "Stub fzf"
-        EOF
-        chmod +x $out/bin/fzf
-      '';
-    };
+    fish.enable = true;
   };
-
-  programs.fish.enable = true;
 
   nmt.script = ''
     assertFileRegex home-files/.config/fish/config.fish \

--- a/tests/modules/programs/fzf/fish-widget-overrides.nix
+++ b/tests/modules/programs/fzf/fish-widget-overrides.nix
@@ -1,0 +1,40 @@
+{ config, ... }:
+
+{
+  programs.fzf = {
+    enable = true;
+    enableFishIntegration = true;
+
+    historyWidget = {
+      command = "global-history";
+      fish.command = "";
+    };
+
+    package = config.lib.test.mkStubPackage {
+      name = "fzf";
+      version = "0.73.0";
+      buildScript = ''
+        mkdir -p $out/bin
+        cat > $out/bin/fzf <<'EOF'
+        #!/bin/sh
+        echo "Stub fzf"
+        EOF
+        chmod +x $out/bin/fzf
+      '';
+    };
+  };
+
+  programs.fish.enable = true;
+
+  nmt.script = ''
+    assertFileRegex home-files/.config/fish/config.fish \
+      'set -gx FZF_CTRL_R_COMMAND'
+
+    overrideLine=$(grep -n 'set -gx FZF_CTRL_R_COMMAND' "$TESTED/home-files/.config/fish/config.fish" | head -n1 | cut -d: -f1)
+    sourceLine=$(grep -n 'fzf.*--fish.*source' "$TESTED/home-files/.config/fish/config.fish" | head -n1 | cut -d: -f1)
+
+    if [[ -z "$overrideLine" || -z "$sourceLine" || "$overrideLine" -ge "$sourceLine" ]]; then
+      fail "fish fzf widget override must appear before fzf initialization"
+    fi
+  '';
+}

--- a/tests/modules/programs/fzf/history-command-version-warning.nix
+++ b/tests/modules/programs/fzf/history-command-version-warning.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  options,
+  ...
+}:
+
+{
+  programs.fzf = {
+    enable = true;
+    enableNushellIntegration = false;
+
+    historyWidget.command = "history";
+
+    package = config.lib.test.mkStubPackage {
+      name = "fzf";
+      version = "0.65.0";
+    };
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      `programs.fzf.historyWidget.command` defined in ${lib.showFiles options.programs.fzf.historyWidget.command.files} requires fzf 0.66.0 or greater.
+
+      The configured FZF_CTRL_R_COMMAND value will be ignored by older fzf
+      versions.
+    ''
+  ];
+
+  nmt.script = ''
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+  '';
+}

--- a/tests/modules/programs/fzf/nushell-history-command.nix
+++ b/tests/modules/programs/fzf/nushell-history-command.nix
@@ -1,27 +1,29 @@
 { config, pkgs, ... }:
 
 {
-  programs.fzf = {
-    enable = true;
-    enableNushellIntegration = true;
+  programs = {
+    fzf = {
+      enable = true;
+      enableNushellIntegration = true;
 
-    historyWidget.command = "";
+      historyWidget.command = "";
 
-    package = config.lib.test.mkStubPackage {
-      name = "fzf";
-      version = "0.73.0";
-      buildScript = ''
-        mkdir -p $out/bin
-        cat > $out/bin/fzf <<'EOF'
-        #!/bin/sh
-        echo "Stub fzf"
-        EOF
-        chmod +x $out/bin/fzf
-      '';
+      package = config.lib.test.mkStubPackage {
+        name = "fzf";
+        version = "0.73.0";
+        buildScript = ''
+          mkdir -p $out/bin
+          cat > $out/bin/fzf <<'EOF'
+          #!/bin/sh
+          echo "Stub fzf"
+          EOF
+          chmod +x $out/bin/fzf
+        '';
+      };
     };
-  };
 
-  programs.nushell.enable = true;
+    nushell.enable = true;
+  };
 
   nmt.script =
     let

--- a/tests/modules/programs/fzf/nushell-history-command.nix
+++ b/tests/modules/programs/fzf/nushell-history-command.nix
@@ -1,0 +1,45 @@
+{ config, pkgs, ... }:
+
+{
+  programs.fzf = {
+    enable = true;
+    enableNushellIntegration = true;
+
+    historyWidget.command = "";
+
+    package = config.lib.test.mkStubPackage {
+      name = "fzf";
+      version = "0.73.0";
+      buildScript = ''
+        mkdir -p $out/bin
+        cat > $out/bin/fzf <<'EOF'
+        #!/bin/sh
+        echo "Stub fzf"
+        EOF
+        chmod +x $out/bin/fzf
+      '';
+    };
+  };
+
+  programs.nushell.enable = true;
+
+  nmt.script =
+    let
+      nushellConfigFile =
+        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+          "home-files/Library/Application Support/nushell/config.nu"
+        else
+          "home-files/.config/nushell/config.nu";
+    in
+    ''
+      assertFileExists "${nushellConfigFile}"
+      assertFileContent "$(normalizeStorePaths "${nushellConfigFile}")" ${builtins.toFile "nushell-fzf-history-command-expected.nu" ''
+        load-env {
+            "FZF_CTRL_R_COMMAND": ""
+        }
+
+        source /nix/store/00000000000000000000000000000000-nushell-fzf-integration.nu
+
+      ''}
+    '';
+}

--- a/tests/modules/programs/fzf/nushell-widget-overrides.nix
+++ b/tests/modules/programs/fzf/nushell-widget-overrides.nix
@@ -1,30 +1,32 @@
 { config, pkgs, ... }:
 
 {
-  programs.fzf = {
-    enable = true;
-    enableNushellIntegration = true;
+  programs = {
+    fzf = {
+      enable = true;
+      enableNushellIntegration = true;
 
-    historyWidget = {
-      command = "global-history";
-      nushell.command = "";
+      historyWidget = {
+        command = "global-history";
+        nushell.command = "";
+      };
+
+      package = config.lib.test.mkStubPackage {
+        name = "fzf";
+        version = "0.73.0";
+        buildScript = ''
+          mkdir -p $out/bin
+          cat > $out/bin/fzf <<'EOF'
+          #!/bin/sh
+          echo "Stub fzf"
+          EOF
+          chmod +x $out/bin/fzf
+        '';
+      };
     };
 
-    package = config.lib.test.mkStubPackage {
-      name = "fzf";
-      version = "0.73.0";
-      buildScript = ''
-        mkdir -p $out/bin
-        cat > $out/bin/fzf <<'EOF'
-        #!/bin/sh
-        echo "Stub fzf"
-        EOF
-        chmod +x $out/bin/fzf
-      '';
-    };
+    nushell.enable = true;
   };
-
-  programs.nushell.enable = true;
 
   nmt.script =
     let

--- a/tests/modules/programs/fzf/nushell-widget-overrides.nix
+++ b/tests/modules/programs/fzf/nushell-widget-overrides.nix
@@ -1,0 +1,49 @@
+{ config, pkgs, ... }:
+
+{
+  programs.fzf = {
+    enable = true;
+    enableNushellIntegration = true;
+
+    historyWidget = {
+      command = "global-history";
+      nushell.command = "";
+    };
+
+    package = config.lib.test.mkStubPackage {
+      name = "fzf";
+      version = "0.73.0";
+      buildScript = ''
+        mkdir -p $out/bin
+        cat > $out/bin/fzf <<'EOF'
+        #!/bin/sh
+        echo "Stub fzf"
+        EOF
+        chmod +x $out/bin/fzf
+      '';
+    };
+  };
+
+  programs.nushell.enable = true;
+
+  nmt.script =
+    let
+      nushellConfigFile =
+        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+          "home-files/Library/Application Support/nushell/config.nu"
+        else
+          "home-files/.config/nushell/config.nu";
+    in
+    ''
+      assertFileExists "${nushellConfigFile}"
+      assertFileContent "$(normalizeStorePaths "${nushellConfigFile}")" ${builtins.toFile "nushell-fzf-widget-overrides-expected.nu" ''
+        load-env {
+            "FZF_CTRL_R_COMMAND": "global-history"
+        }
+
+        $env.FZF_CTRL_R_COMMAND = ""
+        source /nix/store/00000000000000000000000000000000-nushell-fzf-integration.nu
+
+      ''}
+    '';
+}

--- a/tests/modules/programs/fzf/renamed-options.nix
+++ b/tests/modules/programs/fzf/renamed-options.nix
@@ -7,6 +7,7 @@
     fileWidgetOptions = [ "--preview 'head {}'" ];
     changeDirWidgetCommand = "fd --type d";
     changeDirWidgetOptions = [ "--preview 'tree -C {} | head -200'" ];
+    historyWidgetCommand = "";
     historyWidgetOptions = [
       "--sort"
       "--exact"
@@ -14,6 +15,7 @@
   };
 
   test.asserts.warnings.expected = [
+    "The option `programs.fzf.historyWidgetCommand' defined in ${lib.showFiles options.programs.fzf.historyWidgetCommand.files} has been renamed to `programs.fzf.historyWidget.command'."
     "The option `programs.fzf.historyWidgetOptions' defined in ${lib.showFiles options.programs.fzf.historyWidgetOptions.files} has been renamed to `programs.fzf.historyWidget.options'."
     "The option `programs.fzf.changeDirWidgetOptions' defined in ${lib.showFiles options.programs.fzf.changeDirWidgetOptions.files} has been renamed to `programs.fzf.changeDirWidget.options'."
     "The option `programs.fzf.changeDirWidgetCommand' defined in ${lib.showFiles options.programs.fzf.changeDirWidgetCommand.files} has been renamed to `programs.fzf.changeDirWidget.command'."

--- a/tests/modules/programs/fzf/renamed-options.nix
+++ b/tests/modules/programs/fzf/renamed-options.nix
@@ -1,0 +1,32 @@
+{ lib, options, ... }:
+
+{
+  programs.fzf = {
+    enable = true;
+    fileWidgetCommand = "fd --type f";
+    fileWidgetOptions = [ "--preview 'head {}'" ];
+    changeDirWidgetCommand = "fd --type d";
+    changeDirWidgetOptions = [ "--preview 'tree -C {} | head -200'" ];
+    historyWidgetOptions = [
+      "--sort"
+      "--exact"
+    ];
+  };
+
+  test.asserts.warnings.expected = [
+    "The option `programs.fzf.historyWidgetOptions' defined in ${lib.showFiles options.programs.fzf.historyWidgetOptions.files} has been renamed to `programs.fzf.historyWidget.options'."
+    "The option `programs.fzf.changeDirWidgetOptions' defined in ${lib.showFiles options.programs.fzf.changeDirWidgetOptions.files} has been renamed to `programs.fzf.changeDirWidget.options'."
+    "The option `programs.fzf.changeDirWidgetCommand' defined in ${lib.showFiles options.programs.fzf.changeDirWidgetCommand.files} has been renamed to `programs.fzf.changeDirWidget.command'."
+    "The option `programs.fzf.fileWidgetOptions' defined in ${lib.showFiles options.programs.fzf.fileWidgetOptions.files} has been renamed to `programs.fzf.fileWidget.options'."
+    "The option `programs.fzf.fileWidgetCommand' defined in ${lib.showFiles options.programs.fzf.fileWidgetCommand.files} has been renamed to `programs.fzf.fileWidget.command'."
+  ];
+
+  nmt.script = ''
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_CTRL_T_COMMAND="fd --type f"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_ALT_C_COMMAND="fd --type d"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'FZF_CTRL_R_OPTS="--sort --exact"'
+  '';
+}

--- a/tests/modules/programs/fzf/zsh-widget-overrides.nix
+++ b/tests/modules/programs/fzf/zsh-widget-overrides.nix
@@ -1,32 +1,34 @@
 { config, ... }:
 
 {
-  programs.fzf = {
-    enable = true;
-    enableZshIntegration = true;
+  programs = {
+    fzf = {
+      enable = true;
+      enableZshIntegration = true;
 
-    historyWidget = {
-      command = "global-history";
-      zsh.command = "";
+      historyWidget = {
+        command = "global-history";
+        zsh.command = "";
+      };
+
+      fileWidget.zsh.command = "$HOME/bin/files";
+
+      package = config.lib.test.mkStubPackage {
+        name = "fzf";
+        version = "0.73.0";
+        buildScript = ''
+          mkdir -p $out/bin
+          cat > $out/bin/fzf <<'EOF'
+          #!/bin/sh
+          echo "Stub fzf"
+          EOF
+          chmod +x $out/bin/fzf
+        '';
+      };
     };
 
-    fileWidget.zsh.command = "$HOME/bin/files";
-
-    package = config.lib.test.mkStubPackage {
-      name = "fzf";
-      version = "0.73.0";
-      buildScript = ''
-        mkdir -p $out/bin
-        cat > $out/bin/fzf <<'EOF'
-        #!/bin/sh
-        echo "Stub fzf"
-        EOF
-        chmod +x $out/bin/fzf
-      '';
-    };
+    zsh.enable = true;
   };
-
-  programs.zsh.enable = true;
 
   nmt.script = ''
     assertFileRegex home-files/.zshrc \

--- a/tests/modules/programs/fzf/zsh-widget-overrides.nix
+++ b/tests/modules/programs/fzf/zsh-widget-overrides.nix
@@ -1,0 +1,45 @@
+{ config, ... }:
+
+{
+  programs.fzf = {
+    enable = true;
+    enableZshIntegration = true;
+
+    historyWidget = {
+      command = "global-history";
+      zsh.command = "";
+    };
+
+    fileWidget.zsh.command = "$HOME/bin/files";
+
+    package = config.lib.test.mkStubPackage {
+      name = "fzf";
+      version = "0.73.0";
+      buildScript = ''
+        mkdir -p $out/bin
+        cat > $out/bin/fzf <<'EOF'
+        #!/bin/sh
+        echo "Stub fzf"
+        EOF
+        chmod +x $out/bin/fzf
+      '';
+    };
+  };
+
+  programs.zsh.enable = true;
+
+  nmt.script = ''
+    assertFileRegex home-files/.zshrc \
+      'export FZF_CTRL_R_COMMAND='
+
+    assertFileContains home-files/.zshrc \
+      'export FZF_CTRL_T_COMMAND="$HOME/bin/files"'
+
+    overrideLine=$(grep -n 'export FZF_CTRL_R_COMMAND=' "$TESTED/home-files/.zshrc" | head -n1 | cut -d: -f1)
+    sourceLine=$(grep -n 'fzf.*--zsh' "$TESTED/home-files/.zshrc" | head -n1 | cut -d: -f1)
+
+    if [[ -z "$overrideLine" || -z "$sourceLine" || "$overrideLine" -ge "$sourceLine" ]]; then
+      fail "zsh fzf widget override must appear before fzf initialization"
+    fi
+  '';
+}


### PR DESCRIPTION
### Description

Fixes #9584.

This expands fzf shell integration configuration and makes Ctrl-R ownership explicit when fzf is used with history managers.

Changes included:

- Group fzf widget options under `fileWidget`, `changeDirWidget`, and `historyWidget`.
- Keep renamed-option aliases for existing widget options.
- Add `historyWidget.command` for `FZF_CTRL_R_COMMAND`, allowing fzf Ctrl-R to be disabled.
- Add per-shell widget command/options overrides for bash, fish, zsh, and Nushell.
- Render per-shell fzf environment overrides before sourcing fzf integration.
- Export fzf environment variables through Nushell config so pure Nushell sessions see them.
- Source Atuin's Nushell integration after fzf so Atuin reclaims Ctrl-R while fzf still chains completion integrations like carapace.
- Warn when fzf and Atuin or McFly both configure Ctrl-R, with config paths to silence the warning.
- Add tests for option migration, per-shell overrides, Nushell ordering, and conflict warnings.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
