### PR TITLE
firefox: allow setting persistent StoreID

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -457,13 +457,13 @@ in
               };
 
               storeId = mkOption {
-                type = types.nullOr types.str;
+                type = types.nullOr (types.strMatching "[0-9a-f]{8}");
                 default = null;
                 description = ''
                   Store ID. Either null, or the first segment of a UUID string.
 
-                  If this value is set ; then profile.ini is created
-                  with predictable StoreID's.
+                  If this value is set, then profile.ini is created
+                  with predictable StoreIDs.
 
                   This is useful to keep the StoreID static,
                   which helps to bridge the firefox profiles and the new
@@ -927,12 +927,6 @@ in
                     '${lib.showOption profilePath}.extensions.force' or the corresponding
                     '${lib.showOption profilePath}.extensions.settings.<extensionId>.force'
                     to acknowledge this.
-                  '';
-                }
-                {
-                  assertion = (config.storeId == null) || ((builtins.match "[0-9a-f]{8}" config.storeId) != null);
-                  message = ''
-                    ${moduleName}.profiles.${name}.storeId must be null or 8 lowercase hex characters.
                   '';
                 }
                 {

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -55,12 +55,17 @@ let
   profiles =
     lib.flip lib.mapAttrs' cfg.profiles (
       _: profile:
-      lib.nameValuePair "Profile${toString profile.id}" {
-        Name = profile.name;
-        Path = if isDarwin then "Profiles/${profile.path}" else profile.path;
-        IsRelative = 1;
-        Default = if profile.isDefault then 1 else 0;
-      }
+      lib.nameValuePair "Profile${toString profile.id}" (
+        {
+          Name = profile.name;
+          Path = if isDarwin then "Profiles/${profile.path}" else profile.path;
+          IsRelative = 1;
+          Default = if profile.isDefault then 1 else 0;
+        }
+        // (lib.optionalAttrs (profile.storeId != null) {
+          StoreID = profile.storeId;
+        })
+      )
     )
     // {
       General = {
@@ -448,6 +453,23 @@ in
                 default = 0;
                 description = ''
                   Profile ID. This should be set to a unique number per profile.
+                '';
+              };
+
+              storeId = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                description = ''
+                  Store ID. Either null, or the first segment of a UUID string.
+
+                  If this value is set ; then profile.ini is created
+                  with predictable StoreID's.
+
+                  This is useful to keep the StoreID static,
+                  which helps to bridge the firefox profiles and the new
+                  firefox switchable profile implementations.
+
+                  This should be set to a string of 8 lowercase hex characters.
                 '';
               };
 
@@ -885,9 +907,15 @@ in
             };
 
             config = {
-              settings = mkIf (config.userChrome != "") {
-                "toolkit.legacyUserProfileCustomizations.stylesheets" = mkDefault true;
-              };
+              settings = mkMerge [
+                (mkIf (config.userChrome != "") {
+                  "toolkit.legacyUserProfileCustomizations.stylesheets" = mkDefault true;
+                })
+
+                (mkIf (config.storeId != null) {
+                  "toolkit.profiles.storeID" = mkDefault config.storeId;
+                })
+              ];
 
               assertions = [
                 (mkNoDuplicateAssertion config.containers "container")
@@ -899,6 +927,21 @@ in
                     '${lib.showOption profilePath}.extensions.force' or the corresponding
                     '${lib.showOption profilePath}.extensions.settings.<extensionId>.force'
                     to acknowledge this.
+                  '';
+                }
+                {
+                  assertion = (config.storeId == null) || ((builtins.match "[0-9a-f]{8}" config.storeId) != null);
+                  message = ''
+                    ${moduleName}.profiles.${name}.storeId must be null or 8 lowercase hex characters.
+                  '';
+                }
+                {
+                  assertion =
+                    (config.storeId == null)
+                    || ((config.settings."toolkit.profiles.storeID" or config.storeId) == config.storeId);
+                  message = ''
+                    ${moduleName}.profiles.${name}.storeId must match
+                    ${moduleName}.profiles.${name}.settings."toolkit.profiles.storeID"
                   '';
                 }
               ]
@@ -1090,6 +1133,30 @@ in
         }
 
         (mkNoDuplicateAssertion cfg.profiles "profile")
+
+        (
+          let
+            profilesWithStoreId = lib.filterAttrs (_: profile: profile.storeId != null) cfg.profiles;
+
+            duplicateStoreIds = lib.filterAttrs (_storeId: profileNames: length profileNames != 1) (
+              lib.zipAttrs (
+                mapAttrsToList (profileName: profile: {
+                  "${profile.storeId}" = profileName;
+                }) profilesWithStoreId
+              )
+            );
+
+            mkMsg =
+              storeId: profileNames: "  - StoreID ${storeId} is used by " + (concatStringsSep ", " profileNames);
+          in
+          {
+            assertion = cfg.profiles == { } || duplicateStoreIds == { };
+            message = ''
+              Must not have duplicate ${appName} profile StoreIDs:
+              ${concatStringsSep "\n" (mapAttrsToList mkMsg duplicateStoreIds)}
+            '';
+          }
+        )
       ]
       ++ (lib.concatMap (profile: profile.assertions) (attrValues cfg.profiles));
 

--- a/tests/modules/programs/firefox/profiles/settings/default.nix
+++ b/tests/modules/programs/firefox/profiles/settings/default.nix
@@ -23,6 +23,7 @@ in
         basic.isDefault = true;
         test = {
           id = 1;
+          storeId = "1a2b3c4d";
           settings = {
             "browser.bookmarks.file" = ./bookmarks.html;
             "general.smoothScroll" = false;
@@ -59,6 +60,10 @@ in
           assertFileContent \
             "$settingsUserJs" \
             ${expectedUserJs}
+
+          assertFileRegex \
+            "home-files/${cfg.configPath}/profiles.ini" \
+            "StoreID=1a2b3c4d"
         '';
     }
   );

--- a/tests/modules/programs/firefox/profiles/settings/expected-user.js
+++ b/tests/modules/programs/firefox/profiles/settings/expected-user.js
@@ -5,5 +5,6 @@
 user_pref("browser.bookmarks.file", "/nix/store/00000000000000000000000000000000-bookmarks.html");
 user_pref("browser.newtabpage.pinned", "[{\"title\":\"NixOS\",\"url\":\"https://nixos.org\"}]");
 user_pref("general.smoothScroll", false);
+user_pref("toolkit.profiles.storeID", "1a2b3c4d");
 
 


### PR DESCRIPTION
### Description

Added a new config option `programs.firefox.profiles.<name>.storeId`.
Setting this option to non-null, and to a valid string (8 lowercase hex characters) writes the StoreID to;

- `profiles.ini`
- `programes.firefox.profiles.<name>.settings."toolkit.profiles.storeID"`

This does *not* immediately fix #6934.
However, storeId is the bridge between the two profile implementations.
When the migration bug is fixed, linking both implementations will require `StoreID` to not be overwritten.
This commit allows for this.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or `nix-shell -A dev --run treefmt`.
- [x] Code tested through `nix run .#tests -- <firefox>`.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```