### PR TITLE
clipse: use rfc 042 style settings

### DIFF
--- a/modules/services/clipse.nix
+++ b/modules/services/clipse.nix
@@ -11,6 +11,25 @@ in
 {
   meta.maintainers = [ lib.hm.maintainers.dsoverlord ];
 
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "clipse" "allowDuplicates" ]
+      [ "services" "clipse" "settings" "allowDuplicates" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "clipse" "imageDisplay" ]
+      [ "services" "clipse" "settings" "imageDisplay" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "clipse" "keyBindings" ]
+      [ "services" "clipse" "settings" "keyBindings" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "clipse" "historySize" ]
+      [ "services" "clipse" "settings" "maxHistory" ]
+    )
+  ];
+
   options.services.clipse = {
     enable = lib.mkEnableOption "Enable clipse clipboard manager";
 
@@ -29,82 +48,26 @@ in
       '';
     };
 
-    allowDuplicates = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Allow duplicates";
-    };
-
-    historySize = lib.mkOption {
-      type = lib.types.int;
-      default = 100;
-      description = "Number of history lines to keep.";
-    };
-
-    imageDisplay = {
-      type = lib.mkOption {
-        type = lib.types.enum [
-          "basic"
-          "kitty"
-          "sixel"
-        ];
-        default = "basic";
-        description = "Preview image method";
-      };
-
-      scaleX = lib.mkOption {
-        type = lib.types.int;
-        default = 9;
-        description = "Image scaling factor X";
-      };
-
-      scaleY = lib.mkOption {
-        type = lib.types.int;
-        default = 9;
-        description = "Image scaling factor Y";
-      };
-
-      heightCut = lib.mkOption {
-        type = lib.types.int;
-        default = 2;
-        description = "Height cut";
-      };
-    };
-
-    keyBindings = lib.mkOption {
+    settings = lib.mkOption {
       inherit (jsonFormat) type;
-
       default = { };
-
       example = lib.literalExpression ''
-         {
-           "choose" = "enter";
-           "clearSelected" = "S";
-           "down" = "down";
-           "end" = "end";
-           "filter" = "/";
-           "home" = "home";
-           "more" = "?";
-           "nextPage" = "right";
-           "prevPage" = "left";
-           "preview" = "t";
-           "quit" = "q";
-           "remove" = "x";
-           "selectDown" = "ctrl+down";
-           "selectSingle" = "s";
-           "selectUp" = "ctrl+up";
-           "togglePin" = "p";
-           "togglePinned" = "tab";
-           "up" = "up";
-           "yankFilter" = "ctrl+s";
-        };
+        {
+          allowDuplicates = true;
+          maxHistory = 1001;
+        }
       '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/clipse/config.json`
 
-      description = "Custom key bindings";
+        Please refer to <https://github.com/savedra1/clipse#configuration> for
+        more information.
+      '';
     };
 
     theme = lib.mkOption {
-      inherit (jsonFormat) type;
+      type = lib.types.either jsonFormat.type lib.types.path;
 
       default = {
         useCustomTheme = false;
@@ -143,16 +106,11 @@ in
 
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-    xdg.configFile."clipse/config.json".source = jsonFormat.generate "settings" {
-      inherit (cfg) allowDuplicates imageDisplay keyBindings;
-      historyFile = "clipboard_history.json";
-      maxHistory = cfg.historySize;
-      logFile = "clipse.log";
-      themeFile = "custom_theme.json";
-      tempDir = "tmp_files";
+    xdg.configFile = {
+      "clipse/config.json".source = jsonFormat.generate "settings" cfg.settings;
+      "clipse/custom_theme.json".source =
+        if lib.isPath cfg.theme then cfg.theme else jsonFormat.generate "theme" cfg.theme;
     };
-
-    xdg.configFile."clipse/custom_theme.json".source = jsonFormat.generate "theme" cfg.theme;
 
     systemd.user.services.clipse = lib.mkIf (cfg.package != null) {
       Unit = {

--- a/tests/modules/services/clipse/clipse-settings-expected.json
+++ b/tests/modules/services/clipse/clipse-settings-expected.json
@@ -1,0 +1,9 @@
+{
+  "allowDuplicates": true,
+  "imageDisplay": {
+    "scaleX": 9,
+    "scaleY": 9,
+    "type": "kitty"
+  },
+  "maxHistory": 1001
+}

--- a/tests/modules/services/clipse/clipse-settings.nix
+++ b/tests/modules/services/clipse/clipse-settings.nix
@@ -1,0 +1,31 @@
+{
+  services.clipse = {
+    enable = true;
+
+    settings = {
+      allowDuplicates = true;
+      imageDisplay = {
+        type = "kitty";
+        scaleX = 9;
+        scaleY = 9;
+      };
+    };
+
+    # Legacy option renamed to `services.clipse.settings.maxHistory`.
+    historySize = 1001;
+  };
+
+  test = {
+    stubs.clipse = { };
+
+    asserts.warnings.expected = [
+      "The option `services.clipse.historySize' defined in `${toString ./clipse-settings.nix}' has been renamed to `services.clipse.settings.maxHistory'."
+    ];
+  };
+
+  nmt.script = ''
+    configFile=home-files/.config/clipse/config.json
+    assertFileExists "$configFile"
+    assertFileContent "$configFile" ${./clipse-settings-expected.json}
+  '';
+}

--- a/tests/modules/services/clipse/default.nix
+++ b/tests/modules/services/clipse/default.nix
@@ -1,5 +1,6 @@
 { lib, pkgs, ... }:
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  clipse-settings = ./clipse-settings.nix;
   clipse-sway-session-target = ./clipse-sway-session-target.nix;
 }


### PR DESCRIPTION
### Description

Refactors clipse, to accept the themefile as a path, and changes all other configuration options into RFC 042 style settings. This also allows for options that were not changeable before e.g. `services.clipse.settings.logFile` to be changed. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
