### PR TITLE
kanshi: fix check for empty settings

### DIFF
--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -363,7 +363,7 @@ in
             PartOf = cfg.systemdTarget;
             Requires = cfg.systemdTarget;
             After = cfg.systemdTarget;
-            X-Reload-Triggers = lib.mkIf (cfg.settings != { }) [
+            X-Reload-Triggers = lib.mkIf (cfg.settings != [ ]) [
               "${config.xdg.configFile.${configPath}.source}"
             ];
           };

--- a/tests/modules/services/kanshi/default.nix
+++ b/tests/modules/services/kanshi/default.nix
@@ -4,4 +4,5 @@ lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   kanshi-basic-configuration = ./basic-configuration.nix;
   kanshi-new-configuration = ./new-configuration.nix;
   kanshi-alias-assertion = ./alias-assertion.nix;
+  kanshi-empty-settings = ./empty-settings.nix;
 }

--- a/tests/modules/services/kanshi/empty-settings.nix
+++ b/tests/modules/services/kanshi/empty-settings.nix
@@ -1,0 +1,18 @@
+{ config, ... }:
+{
+  config = {
+    services.kanshi = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { };
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/kanshi.service
+
+      assertFileExists $serviceFile
+      assertFileContent \
+        $(normalizeStorePaths $serviceFile) \
+        ${./empty-settings.service}
+    '';
+  };
+}

--- a/tests/modules/services/kanshi/empty-settings.service
+++ b/tests/modules/services/kanshi/empty-settings.service
@@ -1,0 +1,16 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecReload=/nix/store/00000000000000000000000000000000-dummy/bin/kanshictl reload
+ExecStart=/nix/store/00000000000000000000000000000000-dummy/bin/kanshi
+Restart=always
+Type=simple
+
+[Unit]
+After=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+Description=Dynamic output configuration
+Documentation=man:kanshi(1)
+PartOf=graphical-session.target
+Requires=graphical-session.target


### PR DESCRIPTION
Closes https://github.com/nix-community/home-manager/issues/9593.

### Description

Fixes regression introduced by me in 74b3817.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
