### PR TITLE
syncthing: fix badly escaped ignore patterns test

### DIFF
--- a/tests/modules/services/syncthing/linux/ignore-patterns.nix
+++ b/tests/modules/services/syncthing/linux/ignore-patterns.nix
@@ -1,3 +1,5 @@
+{ lib, ... }:
+
 {
   services.syncthing = {
     enable = true;
@@ -19,9 +21,8 @@
 
   nmt.script =
     let
-      ignoreString = ''
-        {"ignore":["val1","!val2","*al3","val'\'''4","val\"5"]}
-      '';
+      ignoreString = ''{"ignore":["val1","!val2","*al3","val'\'''4","val\"5"]}'';
+      ignoreStringBad = ''{"ignore":["WRONG","!val2","*al3","val'\'''4","val\"5"]}'';
     in
     ''
       serviceFile=home-files/.config/systemd/user/syncthing-init.service
@@ -30,7 +31,10 @@
       assertFileContains "$serviceFile" "ExecStart="
 
       updateScript=$(grep -o '/nix/store/[^ ]*-merge-syncthing-config' "$TESTED/$serviceFile")
-      assertFileContains "$updateScript" '${ignoreString}'
       assertFileContains "$updateScript" "/rest/db/ignores?folder=ew8bc-4uanl"
+      assertFileContains "$updateScript" ${lib.escapeShellArg ignoreString}
+      if grep -qF ${lib.escapeShellArg ignoreStringBad} "$(_abs "$updateScript")"; then
+        fail "syncthing bad ignore string shouldn't be found in updateScript"
+      fi
     '';
 }


### PR DESCRIPTION
### Description

The previous test would pass no matter what the `ignoreString` was. I don't know enough Bash/Grep to explain it, but it was easy to test by just changing the pattern to have `WRONG` instead of `val1`, and that would still pass the `assertFileContains` test.

I've hopefully fixed it now, by using `lib.escapeShellArg` before passing it to `assertFileContains`, and I've also added a negative test case, to ensure that a bad ignore string is _not_ found in the merge script.

For reference, here is my previous PR: #9562

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)