### PR TITLE
difftastic: fix jujutsu integration

### DIFF
--- a/modules/programs/difftastic.nix
+++ b/modules/programs/difftastic.nix
@@ -188,10 +188,14 @@ in
         programs.jujutsu.settings.ui.diff-formatter = [
           (lib.getExe cfg.package)
         ]
-        ++ (lib.cli.toCommandLineGNU { } cfg.options)
+        ++ (lib.cli.toCommandLineGNU { } (
+          cfg.options
+          // {
+            color = "always";
+            sort-paths = true;
+          }
+        ))
         ++ [
-          "--color=always"
-          "--sort-paths"
           "$left"
           "$right"
         ];


### PR DESCRIPTION
Don’t append `--color=always` and `--sort-paths` unconditionally, since `difftastic` doesn’t like repeated arguments, and the user might have already set them (via `config.programs.difftastic.options`).

To clarify, if `difft` gets called with any parameter repeated, it will croak:

    difft --color=always --color=always
    error: the argument '--color <WHEN>' cannot be used multiple times

    Usage: difft [OPTIONS] OLD-PATH NEW-PATH

    For more information, try '--help'.

By patching `cfg.options` we ensure that the parameters are defined, and have the required value, since the user might have selected differently for their general setup (again, via `config.programs.difftastic.options`).

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.
      **n.b**.: this code path is not checked by tests, so I’ve tested the code by plugging my fork to my flake and verifying that the jujutsu config file gets the correct version of the configuration (`~/.config/jj/config.toml`, `ui.diff-formatter` entry). See note¹ below.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

¹: I reckon that a good way to test this would be with a test/assertion that verifies that no arguments are repeated when setting `programs.jujutsu.settings.ui.diff-formatter`.  I would greatly appreciate any comments and/or guidance with this.

---
Pinging @ners, since this change updates theirs.