### PR TITLE
programs.carapace: wrap nushell completer to fallback on empty

### DIFF
--- a/modules/programs/carapace.nix
+++ b/modules/programs/carapace.nix
@@ -75,6 +75,15 @@ in
               ${bin} _carapace nushell | sed 's|"/homeless-shelter|$"($env.HOME)|g' >> "$out"
             ''
           }
+          let original_completer = $env.config.completions.external.completer
+          let external_completer = {|spans|
+            if ($spans | length) == 1 {
+              null
+            } else {
+              do $original_completer $spans
+            }
+          }
+          $env.config = ($env.config | upsert completions.external.completer {|| $external_completer})
         '';
       };
     };


### PR DESCRIPTION
### Description

This PR wraps the output of the carapace completer inside Nushell with an `is-empty` check. If the completions are empty, it returns `null` instead of `[]`.

This signals to Nushell that it should fall back to native completion (like file paths) rather than displaying "NO RECORDS FOUND" and blocking completions.

Fixes the issue described in https://github.com/carapace-sh/carapace-bin/issues/3612 , waiting for https://github.com/carapace-sh/carapace-bin/pull/3613

Once closed, I will revert it

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.
- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
