### PR TITLE
nushell: add completions support

### DIFF
--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -211,6 +211,18 @@ in
         Inline values can be set with `lib.hm.nushell.mkNushellInline`.
       '';
     };
+
+    completions = lib.mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [
+        "git"
+        "gh"
+      ];
+      description = ''
+        List of nushell completions to preload. For full list of available completions consult https://github.com/nushell/nu_scripts/tree/main/custom-completions
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -220,7 +232,9 @@ in
       The listed plugins will not be installed.
     '';
 
-    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) (
+      [ cfg.package ] ++ lib.optionals (cfg.completions != [ ]) [ pkgs.nu_scripts ]
+    );
 
     home.extraDependencies = cfg.plugins; # make sure the plugins are not garbage-collected
 
@@ -232,7 +246,8 @@ in
             || cfg.extraConfig != ""
             || aliasesStr != ""
             || cfg.settings != { }
-            || cfg.environmentVariables != { };
+            || cfg.environmentVariables != { }
+            || cfg.completions != [ ];
 
           aliasesStr = lib.concatLines (
             lib.mapAttrsToList (k: v: "alias ${toNushell { } k} = ${v}") cfg.shellAliases
@@ -248,6 +263,15 @@ in
                 '';
               in
               lib.mkIf hasEnvVars envVarsStr
+            )
+            (
+              let
+                hasCompletions = cfg.completions != [ ];
+                completionsStr = lib.concatMapStringsSep "\n" (
+                  x: "use ${pkgs.nu_scripts}/share/nu_scripts/custom-completions/${x}/${x}-completions.nu *"
+                ) cfg.completions;
+              in
+              lib.mkIf hasCompletions completionsStr
             )
             (
               let

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -143,6 +143,7 @@ let
     "nix-your-shell"
     "notmuch"
     "npth"
+    "nu_scripts"
     "nushell"
     "nyxt"
     "oh-my-posh"

--- a/tests/modules/programs/nushell/config-expected.nu
+++ b/tests/modules/programs/nushell/config-expected.nu
@@ -13,6 +13,7 @@ load-env {
     "PROMPT_COMMAND": ({|| "> "})
 }
 
+use @nu_scripts@/share/nu_scripts/custom-completions/nix/nix-completions.nu *
 $env.config.abbreviations.gs = "git status"
 $env.config.abbreviations.ll = "ls -l"
 $env.config.display_errors.exit_code = false

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -60,6 +60,8 @@
         to_string = lib.hm.nushell.mkNushellInline "{|v| $v | str join (char esep) }";
       };
     };
+
+    completions = [ "nix" ];
   };
 
   nmt.script =


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Allow automatically adding completions scripts from the nu_scripts package to nushell config via new `completions` config option

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
