### PR TITLE
codex: stop duplicating hook script deployment

### DIFF
--- a/modules/programs/codex/default.nix
+++ b/modules/programs/codex/default.nix
@@ -42,7 +42,6 @@ in
       configDir = if useXdgDirectories then "${xdgConfigHome}/codex" else ".codex";
       configFileName = if isTomlConfig then "config.toml" else "config.yaml";
       skillsDir = "${configDir}/skills";
-      hookScriptDirs = [ "${configDir}/hooks" ] ++ lib.optional useXdgDirectories ".codex/hooks";
       pluginsMarketplaceName = "home-manager";
       pluginsDir = "${configDir}/plugins";
       pluginsCacheDir = "${pluginsDir}/cache";
@@ -218,7 +217,7 @@ in
           };
         }
         // lib.optionalAttrs hooksAreDir (
-          lib.genAttrs hookScriptDirs (_: {
+          lib.genAttrs [ "${configDir}/hooks" ] (_: {
             source = cfg.hooks;
             recursive = true;
           })

--- a/modules/programs/codex/options.nix
+++ b/modules/programs/codex/options.nix
@@ -140,10 +140,11 @@ in
 
         Directory values install {file}`hooks.json` to
         {file}`CODEX_HOME/hooks.json` and install the full directory to
-        {file}`CODEX_HOME/hooks` so commands can reference bundled scripts.
-        When {option}`home.preferXdgDirectories` is enabled, the hook
-        directory is also installed to {file}`~/.codex/hooks` for upstream
-        compatibility.
+        the active Codex home hooks directory. In the default layout, commands
+        can reference bundled scripts with paths such as
+        {file}`$HOME/.codex/hooks/my-hook`. When
+        {option}`home.preferXdgDirectories` is enabled, use
+        {file}`$CODEX_HOME/hooks/my-hook`.
 
         Hooks can also be configured inline through
         {option}`programs.codex.settings.hooks`; prefer using only one hook

--- a/tests/modules/programs/codex/hooks-dir-xdg.nix
+++ b/tests/modules/programs/codex/hooks-dir-xdg.nix
@@ -3,20 +3,18 @@
 
   programs.codex = {
     enable = true;
-    hooks = ./hooks-dir;
+    hooks = ./hooks-dir-xdg;
   };
 
   nmt.script = ''
     assertFileExists home-files/.config/codex/hooks.json
     assertFileContent home-files/.config/codex/hooks.json \
-      ${./hooks-dir/hooks.json}
+      ${./hooks-dir-xdg/hooks.json}
 
     assertFileExists home-files/.config/codex/hooks/session-start.sh
     assertFileContent home-files/.config/codex/hooks/session-start.sh \
-      ${./hooks-dir/session-start.sh}
+      ${./hooks-dir-xdg/session-start.sh}
 
-    assertFileExists home-files/.codex/hooks/session-start.sh
-    assertFileContent home-files/.codex/hooks/session-start.sh \
-      ${./hooks-dir/session-start.sh}
+    assertPathNotExists home-files/.codex/hooks
   '';
 }

--- a/tests/modules/programs/codex/hooks-dir-xdg/hooks.json
+++ b/tests/modules/programs/codex/hooks-dir-xdg/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CODEX_HOME/hooks/session-start.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/modules/programs/codex/hooks-dir-xdg/session-start.sh
+++ b/tests/modules/programs/codex/hooks-dir-xdg/session-start.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+printf '%s\n' '{"hookSpecificOutput":{"additionalContext":"Loaded from Home Manager hook bundle"}}'


### PR DESCRIPTION
Write path-backed hook bundles only under CODEX_HOME so XDG mode follows the active Codex config layer.

Follow up https://github.com/nix-community/home-manager/pull/9605

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
