### PR TITLE
pass-secret-service: Add service Mount Requirement

### DIFF
--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -59,6 +59,7 @@ in
           Description = "Pass libsecret service";
           Documentation = "https://github.com/mdellweg/pass_secret_service";
           PartOf = [ "default.target" ];
+          RequiresMountsFor = [ cfg.storePath ];
         };
 
         Service = {


### PR DESCRIPTION
### Description

Add a "RequiresMountsFor" stipulation on the provided storePath, to ensure the service doesn't start until any prerequisite mounts are performed.

Can't really add a test for this using nmt AFAIK, since it's more a check on systemd behavior.

The encryption key directory (i.e. GNUPGHOME) should probably also be required, but that should also probably not be contingent on other modules... maybe even its own option.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
