### PR TITLE
Patch/pass secret service keys

### DIFF
--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -34,6 +34,16 @@ in
         will be checked, if found it will be inherited as the default.
       '';
     };
+
+    keyPath = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.home.homeDirectory}/.gnupg";
+      defaultText = "$GNUPGHOME";
+      example = "/home/user/.config/gnupg";
+      description = ''
+        Absolute path to the directory holding the GnuPG keybox or keyring used to unlock the password store.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -59,13 +69,14 @@ in
           Description = "Pass libsecret service";
           Documentation = "https://github.com/mdellweg/pass_secret_service";
           PartOf = [ "default.target" ];
+          RequiresMountsFor = [ cfg.keyPath ];
         };
 
         Service = {
           Type = "dbus";
           ExecStart = binPath + lib.optionalString (cfg.storePath != null) " --path ${cfg.storePath}";
           BusName = busName;
-          Environment = [ "GNUPGHOME=${config.programs.gpg.homedir}" ];
+          Environment = [ "GNUPGHOME=${cfg.keyPath}" ];
         };
 
         Install.WantedBy = [ "default.target" ];

--- a/tests/modules/services/pass-secret-service/custom-keypath.nix
+++ b/tests/modules/services/pass-secret-service/custom-keypath.nix
@@ -1,0 +1,19 @@
+{ config, ... }:
+let
+  somePath = "/some/random/path/I/store/keys";
+in
+{
+  home.stateVersion = "26.05";
+  services.pass-secret-service = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    keyPath = somePath;
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/pass-secret-service.service
+
+    assertFileRegex $serviceFile '^Environment=GNUPGHOME=${somePath}$'
+    assertFileRegex $serviceFile '^RequiresMountsFor=.*${somePath}.*$'
+  '';
+}

--- a/tests/modules/services/pass-secret-service/default.nix
+++ b/tests/modules/services/pass-secret-service/default.nix
@@ -2,6 +2,7 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   pass-secret-service-default-configuration = ./default-configuration.nix;
+  pass-secret-service-custom-keypath = ./custom-keypath.nix;
   pass-secret-service-old-default-path = ./old-default-path.nix;
   pass-secret-service-old-default-empty-settings = ./old-default-empty-settings.nix;
   pass-secret-service-old-default-explicit-legacy-path = ./old-default-explicit-legacy-path.nix;


### PR DESCRIPTION
### Description

Pull out the option to set the GnuPG key path, setting the default to GnuPG's default GNUPGHOME, but changing the current behavior of pass-secret-service as set in 30e04f3.

Presumably, expected behaviour would then be to set `keyPath = config.programs.gpg.homedir` to replicate the old inter-module behavior (maybe I should double-check this program also uses a gpg lib and not the binary so it should be added to the service path...).

Idk, is this a breaking (non-backwards-compatible) change?


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
