### PR TITLE
clipse: support store paths for theme option

### DIFF
--- a/modules/services/clipse.nix
+++ b/modules/services/clipse.nix
@@ -109,7 +109,7 @@ in
     xdg.configFile = {
       "clipse/config.json".source = jsonFormat.generate "settings" cfg.settings;
       "clipse/custom_theme.json".source =
-        if lib.isPath cfg.theme then cfg.theme else jsonFormat.generate "theme" cfg.theme;
+        if lib.hm.strings.isPathLike cfg.theme then cfg.theme else jsonFormat.generate "theme" cfg.theme;
     };
 
     systemd.user.services.clipse = lib.mkIf (cfg.package != null) {


### PR DESCRIPTION
### Description
Changes check from `lib.isPath` to `lib.hm.strings.isPathLike`, so that string Nix store path references passed to the `theme` option won't be incorrectly treated as JSON.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
