### PR TITLE
proton-pass-agent: switch to gui domain to prevent error accessing keyring

### DIFF
--- a/modules/services/proton-pass-agent.nix
+++ b/modules/services/proton-pass-agent.nix
@@ -104,7 +104,6 @@ in
 
       launchd.agents.proton-pass-agent = {
         enable = true;
-        domain = lib.mkDefault "user";
         config = {
           ProgramArguments = [
             (lib.getExe pkgs.bash)

--- a/tests/modules/services/proton-pass-agent/basic-service-expected.plist
+++ b/tests/modules/services/proton-pass-agent/basic-service-expected.plist
@@ -6,8 +6,6 @@
 	<true/>
 	<key>Label</key>
 	<string>org.nix-community.home.proton-pass-agent</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/proton-pass-agent/full-service-expected.plist
+++ b/tests/modules/services/proton-pass-agent/full-service-expected.plist
@@ -6,8 +6,6 @@
 	<true/>
 	<key>Label</key>
 	<string>org.nix-community.home.proton-pass-agent</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>


### PR DESCRIPTION
Fixes the following accessing issue:

```
Error accessing credential on keyring: PlatformFailure(Error { code: -25308, message: "User interaction is not allowed." })
```


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
