### PR TITLE
home-cursor: remove legacy enable

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -1,6 +1,5 @@
 {
   config,
-  options,
   lib,
   pkgs,
   ...
@@ -13,18 +12,13 @@ let
     mkIf
     mkMerge
     mkDefault
-    mkAliasOptionModule
     types
     literalExpression
     escapeShellArg
     hm
-    getAttrFromPath
-    any
-    optional
     ;
 
   cfg = config.home.pointerCursor;
-  opts = options.home.pointerCursor;
 
   pointerCursorModule = types.submodule {
     options = {
@@ -140,46 +134,10 @@ in
 {
   meta.maintainers = [ lib.maintainers.league ];
 
-  imports = [
-    (mkAliasOptionModule
-      [ "xsession" "pointerCursor" "package" ]
-      [
-        "home"
-        "pointerCursor"
-        "package"
-      ]
-    )
-    (mkAliasOptionModule
-      [ "xsession" "pointerCursor" "name" ]
-      [
-        "home"
-        "pointerCursor"
-        "name"
-      ]
-    )
-    (mkAliasOptionModule
-      [ "xsession" "pointerCursor" "size" ]
-      [
-        "home"
-        "pointerCursor"
-        "size"
-      ]
-    )
-    (mkAliasOptionModule
-      [ "xsession" "pointerCursor" "defaultCursor" ]
-      [
-        "home"
-        "pointerCursor"
-        "x11"
-        "defaultCursor"
-      ]
-    )
-  ];
-
   options = {
     home.pointerCursor = mkOption {
-      type = types.nullOr pointerCursorModule;
-      default = null;
+      type = pointerCursorModule;
+      default = { };
       description = ''
         Cursor configuration.
 
@@ -200,124 +158,78 @@ in
     };
   };
 
-  config =
-    let
-      # Check if enable option was explicitly defined by the user
-      enableDefined = any (x: x ? enable) opts.definitions;
+  config = mkIf cfg.enable (mkMerge [
+    {
+      assertions = [
+        (hm.assertions.assertPlatform "home.pointerCursor" pkgs lib.platforms.linux)
+      ];
 
-      # Determine if cursor configuration should be enabled
-      enable = if enableDefined then cfg.enable else cfg != null;
-    in
-    mkMerge [
-      (mkIf enable (mkMerge [
-        {
-          assertions = [
-            (hm.assertions.assertPlatform "home.pointerCursor" pkgs lib.platforms.linux)
-          ];
+      home.packages = [
+        cfg.package
+        defaultIndexThemePackage
+      ];
 
-          home.packages = [
-            cfg.package
-            defaultIndexThemePackage
-          ];
+      home.sessionVariables = {
+        XCURSOR_SIZE = mkDefault cfg.x11.size;
+        XCURSOR_THEME = mkDefault cfg.name;
+      };
 
-          home.sessionVariables = {
-            XCURSOR_SIZE = mkDefault cfg.x11.size;
-            XCURSOR_THEME = mkDefault cfg.name;
-          };
+      # Set directory to look for cursors in, needed for some applications
+      # that are unable to find cursors otherwise. See:
+      # https://github.com/nix-community/home-manager/issues/2812
+      # https://wiki.archlinux.org/title/Cursor_themes#Environment_variable
+      home.sessionSearchVariables.XCURSOR_PATH = [ "${config.home.profileDirectory}/share/icons" ];
 
-          # Set directory to look for cursors in, needed for some applications
-          # that are unable to find cursors otherwise. See:
-          # https://github.com/nix-community/home-manager/issues/2812
-          # https://wiki.archlinux.org/title/Cursor_themes#Environment_variable
-          home.sessionSearchVariables.XCURSOR_PATH = [ "${config.home.profileDirectory}/share/icons" ];
+      # Add cursor icon link to $XDG_DATA_HOME/icons as well for redundancy.
+      xdg.dataFile."icons/default/index.theme".source =
+        "${defaultIndexThemePackage}/share/icons/default/index.theme";
+      xdg.dataFile."icons/${cfg.name}".source = "${cfg.package}/share/icons/${cfg.name}";
+    }
 
-          # Add cursor icon link to $XDG_DATA_HOME/icons as well for redundancy.
-          xdg.dataFile."icons/default/index.theme".source =
-            "${defaultIndexThemePackage}/share/icons/default/index.theme";
-          xdg.dataFile."icons/${cfg.name}".source = "${cfg.package}/share/icons/${cfg.name}";
-        }
+    (mkIf cfg.dotIcons.enable {
+      # Add symlink of cursor icon directory to $HOME/.icons, needed for
+      # backwards compatibility with some applications. See:
+      # https://specifications.freedesktop.org/icon-theme-spec/latest/ar01s03.html
+      home.file.".icons/default/index.theme".source =
+        "${defaultIndexThemePackage}/share/icons/default/index.theme";
+      home.file.".icons/${cfg.name}".source = "${cfg.package}/share/icons/${cfg.name}";
+    })
 
-        (mkIf cfg.dotIcons.enable {
-          # Add symlink of cursor icon directory to $HOME/.icons, needed for
-          # backwards compatibility with some applications. See:
-          # https://specifications.freedesktop.org/icon-theme-spec/latest/ar01s03.html
-          home.file.".icons/default/index.theme".source =
-            "${defaultIndexThemePackage}/share/icons/default/index.theme";
-          home.file.".icons/${cfg.name}".source = "${cfg.package}/share/icons/${cfg.name}";
-        })
+    (mkIf cfg.x11.enable {
+      xsession.profileExtra = ''
+        ${lib.getExe pkgs.xsetroot} -xcf ${cursorPath} ${toString cfg.x11.size}
+      '';
 
-        (mkIf cfg.x11.enable {
-          xsession.profileExtra = ''
-            ${lib.getExe pkgs.xsetroot} -xcf ${cursorPath} ${toString cfg.x11.size}
-          '';
+      xresources.properties = {
+        "Xcursor.theme" = cfg.name;
+        "Xcursor.size" = cfg.x11.size;
+      };
+    })
 
-          xresources.properties = {
-            "Xcursor.theme" = cfg.name;
-            "Xcursor.size" = cfg.x11.size;
-          };
-        })
+    (mkIf cfg.gtk.enable {
+      gtk.cursorTheme = mkDefault {
+        inherit (cfg) package name;
+        inherit (cfg.gtk) size;
+      };
+    })
 
-        (mkIf cfg.gtk.enable {
-          gtk.cursorTheme = mkDefault {
-            inherit (cfg) package name;
-            inherit (cfg.gtk) size;
-          };
-        })
+    (mkIf cfg.hyprcursor.enable {
+      home.sessionVariables = {
+        HYPRCURSOR_THEME = cfg.name;
+        HYPRCURSOR_SIZE = cfg.hyprcursor.size;
+      };
+    })
 
-        (mkIf cfg.hyprcursor.enable {
-          home.sessionVariables = {
-            HYPRCURSOR_THEME = cfg.name;
-            HYPRCURSOR_SIZE = cfg.hyprcursor.size;
-          };
-        })
-
-        (mkIf cfg.sway.enable {
-          wayland.windowManager.sway = {
-            config = {
-              seat = {
-                "*" = {
-                  xcursor_theme = "${cfg.name} ${toString cfg.sway.size}";
-                };
-              };
+    (mkIf cfg.sway.enable {
+      wayland.windowManager.sway = {
+        config = {
+          seat = {
+            "*" = {
+              xcursor_theme = "${cfg.name} ${toString cfg.sway.size}";
             };
           };
-        })
-      ]))
-
-      {
-        warnings =
-          (optional
-            (any
-              (
-                x:
-                getAttrFromPath (
-                  [
-                    "xsession"
-                    "pointerCursor"
-                  ]
-                  ++ [ x ]
-                  ++ [ "isDefined" ]
-                ) options
-              )
-              [
-                "package"
-                "name"
-                "size"
-                "defaultCursor"
-              ]
-            )
-            ''
-              The option `xsession.pointerCursor` has been merged into `home.pointerCursor` and will be removed
-              in the future. Please change to set `home.pointerCursor` directly and enable `home.pointerCursor.x11.enable`
-              to generate x11 specific cursor configurations. You can refer to the documentation for more details.
-            ''
-          )
-          ++ (optional (opts.highestPrio != (lib.mkOptionDefault { }).priority && cfg == null) ''
-            Setting home.pointerCursor to null is deprecated.
-            Please update your configuration to explicitly set:
-
-              home.pointerCursor.enable = false;
-          '');
-      }
-    ];
+        };
+      };
+    })
+  ]);
 }

--- a/tests/modules/config/home-cursor/default.nix
+++ b/tests/modules/config/home-cursor/default.nix
@@ -7,63 +7,6 @@ let
   };
 in
 {
-  # Ensure backwards compatibility with existing configs
-  home-cursor-legacy =
-    { config, ... }:
-    {
-      config = {
-        home.pointerCursor = {
-          name = "catppuccin-macchiato-blue-standard";
-          package = config.lib.test.mkStubPackage package;
-          size = 64;
-          gtk.enable = true;
-          hyprcursor.enable = true;
-          x11.enable = true;
-        };
-
-        home.stateVersion = "24.11";
-
-        nmt.script = ''
-          assertFileExists home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme
-
-          hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
-          assertFileExists $hmEnvFile
-          assertFileRegex $hmEnvFile 'XCURSOR_THEME="catppuccin-macchiato-blue-standard"'
-          assertFileRegex $hmEnvFile 'XCURSOR_SIZE="64"'
-          assertFileRegex $hmEnvFile 'HYPRCURSOR_THEME="catppuccin-macchiato-blue-standard"'
-          assertFileRegex $hmEnvFile 'HYPRCURSOR_SIZE="64"'
-        '';
-      };
-    };
-
-  home-cursor-legacy-disabled = {
-    config = {
-      home.pointerCursor = null;
-
-      home.stateVersion = "24.11";
-
-      test.asserts.warnings.expected = [
-        ''
-          Setting home.pointerCursor to null is deprecated.
-          Please update your configuration to explicitly set:
-
-            home.pointerCursor.enable = false;
-        ''
-      ];
-
-      nmt.script = ''
-        assertPathNotExists home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme
-
-        hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
-        assertFileExists $hmEnvFile
-        assertFileNotRegex $hmEnvFile 'XCURSOR_THEME="catppuccin-macchiato-blue-standard"'
-        assertFileNotRegex $hmEnvFile 'XCURSOR_SIZE="32"'
-        assertFileNotRegex $hmEnvFile 'HYPRCURSOR_THEME="catppuccin-macchiato-blue-standard"'
-        assertFileNotRegex $hmEnvFile 'HYPRCURSOR_SIZE="32"'
-      '';
-    };
-  };
-
   home-cursor-legacy-disabled-with-enable =
     { config, ... }:
     {


### PR DESCRIPTION
### Description

its been 482 days since this was merged. users should have had enough time to migrate. see https://github.com/nix-community/home-manager/pull/6492

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
