### PR TITLE
gpg-agent, yubikey-agent: switch to gui domain for graphical prompt

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -454,7 +454,6 @@ in
 
     launchd.agents.gpg-agent = {
       enable = true;
-      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           "${gpgPkg}/bin/gpg-agent"

--- a/modules/services/yubikey-agent.nix
+++ b/modules/services/yubikey-agent.nix
@@ -82,7 +82,6 @@ in
 
     launchd.agents.yubikey-agent = {
       enable = true;
-      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           "${cfg.package}/bin/yubikey-agent"

--- a/tests/modules/services/gpg-agent/expected-agent.plist
+++ b/tests/modules/services/gpg-agent/expected-agent.plist
@@ -16,8 +16,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.gpg-agent</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/yubikey-agent/darwin/service.nix
+++ b/tests/modules/services/yubikey-agent/darwin/service.nix
@@ -23,8 +23,6 @@
       	</dict>
       	<key>Label</key>
       	<string>org.nix-community.home.yubikey-agent</string>
-      ${"\t"}<key>LimitLoadToSessionType</key>
-      ${"\t"}<string>Background</string>
       	<key>ProcessType</key>
       	<string>Background</string>
       	<key>ProgramArguments</key>


### PR DESCRIPTION
### Description
Both `gpg-agent` and `yubikey-agent` require access to the macOS Aqua session
 to function correctly:

 - **gpg-agent** uses graphical pinentry programs (`pinentry-mac`,
   `pinentry-gnome3`) to prompt for passphrases. These cannot render in the
   `user` domain.
 - **yubikey-agent** triggers OS-level CCID/PIV PIN dialogs for SSH
   authentication. These system security prompts need window server access.

 Running in the `user` domain sets `LimitLoadToSessionType=Background`, which
 restricts the agent to headless/non-graphical sessions. This causes PIN and
 passphrase prompts to fail silently or hang — the same class of issue fixed for
 `proton-pass-agent` in 53ebbdc40 (`errSecInteractionNotAllowed`, error
 `-25308`).                                                                                                                                                                                                                                
                                                                                                                                                                                                                                           
 Revert both to the default `gui` domain so they run in the graphical login session.

Follow up after investigation seeing https://github.com/nix-community/home-manager/pull/9614

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
