### PR TITLE
bash: do not source ~/.bashrc from ~/.bash_profile

### DIFF
--- a/docs/manual/installation/standalone.md
+++ b/docs/manual/installation/standalone.md
@@ -64,7 +64,7 @@
     . "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
     ```
 
-    to your `~/.profile` file.
+    to your `~/.bash_profile`, `~/.bash_login`, or `~/.profile` file.
 
 If instead of using channels you want to run Home Manager from a Git
 checkout of the repository then you can use the

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -246,12 +246,12 @@ in
     mkIf cfg.enable {
       home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-      home.file.".bash_profile".source = writeBashScript "bash_profile" ''
-        # include .profile if it exists
-        [[ -f ~/.profile ]] && . ~/.profile
+      home.file.".bash_profile".source = writeBashScript "profile" ''
+        . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
 
-        # include .bashrc if it exists
-        [[ -f ~/.bashrc ]] && . ~/.bashrc
+        ${sessionVarsStr}
+
+        ${cfg.profileExtra}
       '';
 
       # If completion is enabled then make sure it is sourced very early. This
@@ -264,14 +264,6 @@ in
           fi
         ''
       );
-
-      home.file.".profile".source = writeBashScript "profile" ''
-        . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
-
-        ${sessionVarsStr}
-
-        ${cfg.profileExtra}
-      '';
 
       home.file.".bashrc".source = writeBashScript "bashrc" ''
         ${cfg.bashrcExtra}

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -209,8 +209,8 @@ in
     home.file.${cfg.profilePath}.text = ''
       . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
-      if [ -e "$HOME/.profile" ]; then
-        . "$HOME/.profile"
+      if [ -e "$HOME/.bash_profile" ]; then
+        . "$HOME/.bash_profile"
       fi
 
       # If there are any running services from a previous session.

--- a/tests/modules/misc/ssh-auth-sock/disabled.nix
+++ b/tests/modules/misc/ssh-auth-sock/disabled.nix
@@ -8,7 +8,7 @@
 
   nmt.script = ''
     assertFileNotRegex \
-      home-files/.profile \
+      home-files/.bash_profile \
       'SSH_AUTH_SOCK'
     assertFileNotRegex \
       home-files/.config/fish/config.fish \

--- a/tests/modules/misc/ssh-auth-sock/enabled.nix
+++ b/tests/modules/misc/ssh-auth-sock/enabled.nix
@@ -18,7 +18,7 @@
 
   nmt.script = ''
     assertFileContains \
-      home-files/.profile \
+      home-files/.bash_profile \
       'if [ -z "$SSH_AUTH_SOCK" -o -z "$SSH_CONNECTION" ]; then'
     assertFileContains \
       home-files/.config/fish/config.fish \

--- a/tests/modules/misc/xsession/basic-xprofile-expected.txt
+++ b/tests/modules/misc/xsession/basic-xprofile-expected.txt
@@ -1,7 +1,7 @@
 . "/home/hm-user/.nix-profile/etc/profile.d/hm-session-vars.sh"
 
-if [ -e "$HOME/.profile" ]; then
-  . "$HOME/.profile"
+if [ -e "$HOME/.bash_profile" ]; then
+  . "$HOME/.bash_profile"
 fi
 
 # If there are any running services from a previous session.

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -16,9 +16,9 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.profile
+    assertFileExists home-files/.bash_profile
     assertFileContent \
-      "$(normalizeStorePaths home-files/.profile)" \
+      "$(normalizeStorePaths home-files/.bash_profile)" \
       ${builtins.toFile "session-variables-expected" ''
         . "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
 

--- a/tests/modules/services/gpg-agent/ssh-support.nix
+++ b/tests/modules/services/gpg-agent/ssh-support.nix
@@ -11,7 +11,7 @@
 
   nmt.script = ''
     assertFileContains \
-      home-files/.profile \
+      home-files/.bash_profile \
       'export SSH_AUTH_SOCK="$(@gnupg@/bin/gpgconf --list-dirs agent-ssh-socket)"'
     assertFileContains \
       home-files/.config/fish/config.fish \

--- a/tests/modules/services/proton-pass-agent/ssh-auth-sock.nix
+++ b/tests/modules/services/proton-pass-agent/ssh-auth-sock.nix
@@ -27,7 +27,7 @@
     in
     ''
       assertFileContains \
-        home-files/.profile \
+        home-files/.bash_profile \
         'export SSH_AUTH_SOCK="${bashDir}/proton-pass-agent"'
       assertFileContains \
         home-files/.config/fish/config.fish \

--- a/tests/modules/services/ssh-agent/darwin/ssh-auth-sock.nix
+++ b/tests/modules/services/ssh-agent/darwin/ssh-auth-sock.nix
@@ -7,7 +7,7 @@
 
   nmt.script = ''
     assertFileContains \
-      home-files/.profile \
+      home-files/.bash_profile \
       'export SSH_AUTH_SOCK="$(@system_cmds@/bin/getconf DARWIN_USER_TEMP_DIR)/ssh-agent"'
     assertFileContains \
       home-files/.config/fish/config.fish \

--- a/tests/modules/services/ssh-agent/linux/ssh-auth-sock.nix
+++ b/tests/modules/services/ssh-agent/linux/ssh-auth-sock.nix
@@ -7,7 +7,7 @@
 
   nmt.script = ''
     assertFileContains \
-      home-files/.profile \
+      home-files/.bash_profile \
       'export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent"'
     assertFileContains \
       home-files/.config/fish/config.fish \

--- a/tests/modules/services/ssh-tpm-agent/ssh-auth-sock.nix
+++ b/tests/modules/services/ssh-tpm-agent/ssh-auth-sock.nix
@@ -7,7 +7,7 @@
 
   nmt.script = ''
     assertFileContains \
-      home-files/.profile \
+      home-files/.bash_profile \
       'export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'
     assertFileContains \
       home-files/.config/fish/config.fish \

--- a/tests/modules/services/yubikey-agent/darwin/ssh-auth-sock.nix
+++ b/tests/modules/services/yubikey-agent/darwin/ssh-auth-sock.nix
@@ -7,7 +7,7 @@
 
   nmt.script = ''
     assertFileContains \
-      home-files/.profile \
+      home-files/.bash_profile \
       'export SSH_AUTH_SOCK="/tmp/yubikey-agent.sock"'
     assertFileContains \
       home-files/.config/fish/config.fish \

--- a/tests/modules/services/yubikey-agent/linux/ssh-auth-sock.nix
+++ b/tests/modules/services/yubikey-agent/linux/ssh-auth-sock.nix
@@ -7,7 +7,7 @@
 
   nmt.script = ''
     assertFileContains \
-      home-files/.profile \
+      home-files/.bash_profile \
       'export SSH_AUTH_SOCK="''${XDG_RUNTIME_DIR:-/run/user/$UID}/yubikey-agent/yubikey-agent.sock"'
     assertFileContains \
       home-files/.config/fish/config.fish \


### PR DESCRIPTION
### Description

Currently, `~\.bashrc` is sourced from `~\.bash_profile`. This constitutes implicit, undocumented behaviour since it deviates from Bash's startup behaviour as reported in its manual.

This behaviour dates back to [the very first commits](https://github.com/nix-community/home-manager/commit/d7d02c3ce) and does not seem to have a particular reason.

Technically, the change is not backwards-compatible since `~/.bashrc` is no longer sourced in noninteractive login shells. However, Home Manager's API never promised this, implying that setups which would get broken rely on internal behaviour.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
