### PR TITLE
sshAuthSock: for Zsh, initialize in `.zprofile` and `.zshenv`

### DIFF
--- a/modules/misc/ssh-auth-sock.nix
+++ b/modules/misc/ssh-auth-sock.nix
@@ -67,18 +67,25 @@ in
 
   config =
     let
+      indentNonEmptyLines = lib.flip lib.pipe [
+        (lib.splitString "\n")
+        (map (line: if line == "" then "" else "  ${line}"))
+        lib.concatLines
+        (lib.removeSuffix "\n")
+      ];
+
       # Preserve $SSH_AUTH_SOCK if it stems from a forwarded agent which is the
       # case if both $SSH_AUTH_SOCK and $SSH_CONNECTION are set.
       mkShIntegration = code: ''
         if [ -z "$SSH_AUTH_SOCK" -o -z "$SSH_CONNECTION" ]; then
-          ${code}
+        ${indentNonEmptyLines code}
         fi
       '';
       bashIntegration = mkShIntegration cfg.initialization.bash;
       zshIntegration = mkShIntegration cfg.initialization.zsh;
       fishIntegration = ''
         if test -z "$SSH_AUTH_SOCK"; or test -z "$SSH_CONNECTION"
-          ${cfg.initialization.fish}
+        ${indentNonEmptyLines cfg.initialization.fish}
         end
       '';
       nushellIntegration =
@@ -87,7 +94,7 @@ in
         in
         ''
           if ${unsetOrEmpty "SSH_AUTH_SOCK"} or ${unsetOrEmpty "SSH_CONNECTION"} {
-            ${cfg.initialization.nushell}
+          ${indentNonEmptyLines cfg.initialization.nushell}
           }
         '';
     in

--- a/modules/misc/ssh-auth-sock.nix
+++ b/modules/misc/ssh-auth-sock.nix
@@ -103,7 +103,17 @@ in
       programs.bash.profileExtra = lib.mkOrder 900 bashIntegration;
       programs.fish.shellInit = lib.mkOrder 900 fishIntegration;
       programs.nushell.extraConfig = lib.mkOrder 900 nushellIntegration;
-      programs.zsh.envExtra = lib.mkOrder 900 zshIntegration;
+      programs.zsh = {
+        # Mimic how `home.sessionVariablesPackage` is sourced in the Zsh module
+        # to ensure that session variables which SSH_AUTH_SOCK might rely on are
+        # set.
+        envExtra = lib.mkOrder 900 ''
+          if [[ ! -o login ]]; then
+          ${indentNonEmptyLines zshIntegration}
+          fi
+        '';
+        profileExtra = lib.mkOrder 900 zshIntegration;
+      };
 
       # Replace this service by an environment generator as soon as they are
       # available per-user. See https://github.com/systemd/systemd/issues/32423

--- a/tests/modules/misc/ssh-auth-sock/disabled.nix
+++ b/tests/modules/misc/ssh-auth-sock/disabled.nix
@@ -19,6 +19,9 @@
     assertFileNotRegex \
       home-files/.zshenv \
       'SSH_AUTH_SOCK'
+    assertFileNotRegex \
+      home-files/.zprofile \
+      'SSH_AUTH_SOCK'
 
     assertPathNotExists home-files/.config/systemd/user/set-SSH_AUTH_SOCK.service
   '';

--- a/tests/modules/misc/ssh-auth-sock/enabled.nix
+++ b/tests/modules/misc/ssh-auth-sock/enabled.nix
@@ -29,6 +29,9 @@
     assertFileContains \
       home-files/.zshenv \
       'if [ -z "$SSH_AUTH_SOCK" -o -z "$SSH_CONNECTION" ]; then'
+    assertFileContains \
+      home-files/.zprofile \
+      'if [ -z "$SSH_AUTH_SOCK" -o -z "$SSH_CONNECTION" ]; then'
   ''
   + lib.optionalString config.systemd.user.enable ''
     assertFileExists home-files/.config/systemd/user/set-SSH_AUTH_SOCK.service

--- a/tests/modules/services/proton-pass-agent/ssh-auth-sock.nix
+++ b/tests/modules/services/proton-pass-agent/ssh-auth-sock.nix
@@ -38,5 +38,8 @@
       assertFileContains \
         home-files/.zshenv \
         'export SSH_AUTH_SOCK="${bashDir}/proton-pass-agent"'
+      assertFileContains \
+        home-files/.zprofile \
+        'export SSH_AUTH_SOCK="${bashDir}/proton-pass-agent"'
     '';
 }

--- a/tests/modules/services/ssh-agent/darwin/ssh-auth-sock.nix
+++ b/tests/modules/services/ssh-agent/darwin/ssh-auth-sock.nix
@@ -18,5 +18,8 @@
     assertFileContains \
       home-files/.zshenv \
       'export SSH_AUTH_SOCK="$(@system_cmds@/bin/getconf DARWIN_USER_TEMP_DIR)/ssh-agent"'
+    assertFileContains \
+      home-files/.zprofile \
+      'export SSH_AUTH_SOCK="$(@system_cmds@/bin/getconf DARWIN_USER_TEMP_DIR)/ssh-agent"'
   '';
 }

--- a/tests/modules/services/ssh-agent/linux/ssh-auth-sock.nix
+++ b/tests/modules/services/ssh-agent/linux/ssh-auth-sock.nix
@@ -18,5 +18,8 @@
     assertFileContains \
       home-files/.zshenv \
       'export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent"'
+    assertFileContains \
+      home-files/.zprofile \
+      'export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent"'
   '';
 }

--- a/tests/modules/services/ssh-tpm-agent/ssh-auth-sock.nix
+++ b/tests/modules/services/ssh-tpm-agent/ssh-auth-sock.nix
@@ -18,5 +18,8 @@
     assertFileContains \
       home-files/.zshenv \
       'export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'
+    assertFileContains \
+      home-files/.zprofile \
+      'export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'
   '';
 }

--- a/tests/modules/services/yubikey-agent/darwin/ssh-auth-sock.nix
+++ b/tests/modules/services/yubikey-agent/darwin/ssh-auth-sock.nix
@@ -18,5 +18,8 @@
     assertFileContains \
       home-files/.zshenv \
       'export SSH_AUTH_SOCK="/tmp/yubikey-agent.sock"'
+    assertFileContains \
+      home-files/.zprofile \
+      'export SSH_AUTH_SOCK="/tmp/yubikey-agent.sock"'
   '';
 }

--- a/tests/modules/services/yubikey-agent/linux/ssh-auth-sock.nix
+++ b/tests/modules/services/yubikey-agent/linux/ssh-auth-sock.nix
@@ -18,5 +18,8 @@
     assertFileContains \
       home-files/.zshenv \
       'export SSH_AUTH_SOCK="''${XDG_RUNTIME_DIR:-/run/user/$UID}/yubikey-agent/yubikey-agent.sock"'
+    assertFileContains \
+      home-files/.zprofile \
+      'export SSH_AUTH_SOCK="''${XDG_RUNTIME_DIR:-/run/user/$UID}/yubikey-agent/yubikey-agent.sock"'
   '';
 }


### PR DESCRIPTION
### Description

Fixes #9565.

See the linked issue and the comments in the code for more information.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
