### PR TITLE
posting: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -517,6 +517,12 @@
       }
     ];
   };
+  reesilva = {
+    name = "Renato da Silva";
+    email = "reesilva@proton.me";
+    github = "ReeSilva";
+    githubId = 3605032;
+  };
   rosuavio = {
     name = "Rosario Pulella";
     email = "RosarioPulella@gmail.com";

--- a/modules/misc/news/2026/07/2026-07-08_22-43-29.nix
+++ b/modules/misc/news/2026/07/2026-07-08_22-43-29.nix
@@ -1,0 +1,12 @@
+{
+  time = "2026-07-08T20:43:23+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.posting'.
+
+    Posting is an open-source terminal-based API client for developing
+    and testing APIs. The module supports configuration via
+    `programs.posting.settings` and custom themes via
+    `programs.posting.themes`.
+  '';
+}

--- a/modules/programs/posting.nix
+++ b/modules/programs/posting.nix
@@ -1,0 +1,97 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.posting;
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.reesilva ];
+
+  options.programs.posting = {
+    enable = lib.mkEnableOption "Posting";
+
+    package = lib.mkPackageOption pkgs "posting" { nullable = true; };
+
+    settings = lib.mkOption {
+      inherit (yamlFormat) type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          theme = "custom";
+          layout = "horizontal";
+          response = {
+            prettify_json = false;
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/posting/config.yaml`.
+
+        See <https://posting.sh/guide/configuration/>
+        for supported values.
+      '';
+    };
+
+    themes = lib.mkOption {
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          yamlFormat.type
+          path
+          lines
+        ]);
+      default = { };
+      example = lib.literalExpression ''
+        {
+          custom = {
+            name = "custom";
+            primary = "#4e78c4";
+            secondary = "#f39c12";
+            accent = "#e74c3c";
+            background = "#0e1726";
+            surface = "#17202a";
+            error = "#e74c3c";
+            success = "#2ecc71";
+            warning = "#f1c40f";
+          };
+        }
+      '';
+      description = ''
+        Each theme is written to
+        {file}`$XDG_DATA_HOME/posting/themes/NAME.yaml`.
+
+        See <https://posting.sh/guide/themes/>
+        for more information.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."posting/config.yaml" = lib.mkIf (cfg.settings != { }) {
+      source = yamlFormat.generate "posting-config.yaml" cfg.settings;
+    };
+
+    xdg.dataFile = lib.mkIf (cfg.themes != { }) (
+      lib.mapAttrs' (
+        name: value:
+        lib.nameValuePair "posting/themes/${name}.yaml" {
+          source =
+            if builtins.isPath value || lib.isStorePath value then
+              value
+            else if lib.isString value then
+              pkgs.writeText "posting-theme-${name}.yaml" value
+            else
+              yamlFormat.generate "posting-theme-${name}.yaml" value;
+        }
+      ) cfg.themes
+    );
+  };
+}

--- a/tests/modules/programs/posting/configuration.nix
+++ b/tests/modules/programs/posting/configuration.nix
@@ -1,0 +1,39 @@
+{
+  programs.posting = {
+    enable = true;
+    settings = {
+      animation = "basic";
+      heading = {
+        show_host = false;
+      };
+      layout = "horizontal";
+      response = {
+        prettify_json = false;
+      };
+      theme = "custom";
+    };
+    themes = {
+      custom = {
+        name = "custom";
+        primary = "#4e78c4";
+        secondary = "#f39c12";
+        accent = "#e74c3c";
+        background = "#0e1726";
+        surface = "#17202a";
+        error = "#e74c3c";
+        success = "#2ecc71";
+        warning = "#f1c40f";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/posting/config.yaml
+    assertFileContent home-files/.config/posting/config.yaml \
+      ${./expected-config.yaml}
+
+    assertFileExists home-files/.local/share/posting/themes/custom.yaml
+    assertFileContent home-files/.local/share/posting/themes/custom.yaml \
+      ${./expected-theme.yaml}
+  '';
+}

--- a/tests/modules/programs/posting/default.nix
+++ b/tests/modules/programs/posting/default.nix
@@ -1,0 +1,4 @@
+{
+  posting-empty-settings = ./empty-settings.nix;
+  posting-configuration = ./configuration.nix;
+}

--- a/tests/modules/programs/posting/empty-settings.nix
+++ b/tests/modules/programs/posting/empty-settings.nix
@@ -1,0 +1,10 @@
+{
+  programs.posting = {
+    enable = true;
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/posting/config.yaml
+    assertPathNotExists home-files/.local/share/posting
+  '';
+}

--- a/tests/modules/programs/posting/expected-config.yaml
+++ b/tests/modules/programs/posting/expected-config.yaml
@@ -1,0 +1,7 @@
+animation: basic
+heading:
+  show_host: false
+layout: horizontal
+response:
+  prettify_json: false
+theme: custom

--- a/tests/modules/programs/posting/expected-theme.yaml
+++ b/tests/modules/programs/posting/expected-theme.yaml
@@ -1,0 +1,9 @@
+accent: '#e74c3c'
+background: '#0e1726'
+error: '#e74c3c'
+name: custom
+primary: '#4e78c4'
+secondary: '#f39c12'
+success: '#2ecc71'
+surface: '#17202a'
+warning: '#f1c40f'


### PR DESCRIPTION
Add a module for Posting, a terminal-based API client.

Upstream: https://github.com/darrenburns/posting
Docs: https://posting.sh/

The module uses `pkgs.formats.yaml` for settings (RFC 42) and writes
themes to `$XDG_DATA_HOME/posting/themes/`.

Closes #9623

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt`.
- [x] Code tested through `nix run .#tests -- posting`.
- [x] Test cases updated/added.
- [x] Commit messages follow the `{component}: {description}` format.
- [x] Added myself as module maintainer.
- [x] News entry generated.

---

*AI assisted via [OpenCode's ACP](https://opencode.ai/docs) through [codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) with DeepSeek v4 Pro. Supervised and reviewed throughout - I understand and can maintain all generated code.*