### PR TITLE
launchd: treat absent domain as harmless in bootoutAgent

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -250,8 +250,8 @@ in
               # At this point we know exit code is not 0 because otherwise we
               # would have returned by now
 
-              # Only show warning if it's not the common "No such process" error
-              if [[ "$bootout_output" != *"No such process"* ]]; then
+              # Only show warning if it's not a common harmless error
+              if [[ "$bootout_output" != *"No such process"* && "$bootout_output" != *"Domain does not support specified action"* ]]; then
                 warnEcho "Failed to stop agent '$domain/$agentName': $bootout_output"
                 return 1
               else

--- a/tests/modules/launchd/agents.nix
+++ b/tests/modules/launchd/agents.nix
@@ -37,6 +37,7 @@
       assertFileContains activate "printf 'user/%s"
       assertFileContains activate 'restoreAgent "$oldSrcPath" "$dstPath" "$oldDomain" "$agentName"'
       assertFileContains activate 'bootoutAgent "$newDomain" "$agentName"'
+      assertFileContains activate 'Domain does not support specified action'
       assertFileContains activate 'processAgent "$srcPath" "$dstDir" "$oldDir" "$oldDomainsDir" "$newDomainsDir" \'
       assertFileContains activate '|| launchdStatus=1'
       assertFileContains activate 'done < <(find -L "$newDir" -maxdepth 1 -name'


### PR DESCRIPTION
When an agent's `launchd.agents.<name>.domain` is changed from `gui` to `user` (or the agent is newly installed on a headless macOS system where the `gui/<UID>` domain never existed), `bootoutAgent` attempts to unload the agent from the old domain first. On such systems, this fails with: `Boot-out failed: 125: Domain does not support specified action`.

The `bootoutAgent` function only treated "No such process" as a non-fatal condition (return 2). This change adds the domain-not-exist error to the same handling path: the agent wasn't running in a domain that doesn't exist, so we can safely skip the boot-out and proceed with the bootstrap into the new domain.

Existing modules that create `launchd.agents` (e.g. `services.gpg-agent`, `services.sops-nix`) default to the `gui` domain and will still fail to bootstrap into `gui/<UID>` on headless macOS. Those modules should expose the `domain` option so users can opt into `user` domain for headless deployments.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` (treefmt confirmed 0 changes).
- [ ] Code tested through `nix build .#test-all` or a targeted `nix run .#tests -- <pattern>` (macOS-only module, skipped on Linux).
- [x] Test cases updated/added.
