### PR TITLE
vdirsyncer: keep active service during activation

### DIFF
--- a/modules/services/vdirsyncer.nix
+++ b/modules/services/vdirsyncer.nix
@@ -64,6 +64,7 @@ in
     systemd.user.services.vdirsyncer = {
       Unit = {
         Description = "vdirsyncer calendar&contacts synchronization";
+        X-SwitchMethod = "keep-old";
       };
 
       Service = {

--- a/tests/modules/services/vdirsyncer/basic-configuration.nix
+++ b/tests/modules/services/vdirsyncer/basic-configuration.nix
@@ -1,0 +1,8 @@
+{
+  services.vdirsyncer.enable = true;
+
+  nmt.script = ''
+    assertFileContent home-files/.config/systemd/user/vdirsyncer.service \
+                      ${./vdirsyncer-expected.service}
+  '';
+}

--- a/tests/modules/services/vdirsyncer/default.nix
+++ b/tests/modules/services/vdirsyncer/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  vdirsyncer-basic-configuration = ./basic-configuration.nix;
+}

--- a/tests/modules/services/vdirsyncer/vdirsyncer-expected.service
+++ b/tests/modules/services/vdirsyncer/vdirsyncer-expected.service
@@ -1,0 +1,8 @@
+[Service]
+ExecStart=@vdirsyncer@/bin/vdirsyncer  metasync
+ExecStart=@vdirsyncer@/bin/vdirsyncer  sync
+Type=oneshot
+
+[Unit]
+Description=vdirsyncer calendar&contacts synchronization
+X-SwitchMethod=keep-old


### PR DESCRIPTION
Without this, sd-switch may stop or wait on an in-progress timer-triggered sync during activation. Keeping the old unit lets that sync finish under its current generation; later timer runs use the new unit.### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
