### PR TITLE
concord: add module

### DIFF
--- a/modules/misc/news/2026/07/2026-07-30_04-55-42.nix
+++ b/modules/misc/news/2026/07/2026-07-30_04-55-42.nix
@@ -1,0 +1,8 @@
+{
+  time = "2026-07-30T03:55:42+00:00";
+  message = ''
+    A new module is available: 'programs.concord'.
+
+    concord is a TUI client for Discord.
+  '';
+}

--- a/modules/programs/concord.nix
+++ b/modules/programs/concord.nix
@@ -1,0 +1,62 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.concord;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.maintainers; [ yarn ];
+
+  options.programs.concord = {
+    enable = lib.mkEnableOption "Feature-rich TUI client for Discord";
+
+    package = lib.mkPackageOption pkgs "concord-tui" { nullable = true; };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule { freeformType = tomlFormat.type; };
+      default = { };
+      description = ''
+        Concord configuration.
+        See <https://github.com/chojs23/concord/blob/main/src/config/options.rs> for supported values.
+      '';
+    };
+
+    keymapSettings = lib.mkOption {
+      type = lib.types.submodule { freeformType = tomlFormat.type; };
+      default = { };
+      description = ''
+        Concord keymap configuration.
+        See <https://github.com/chojs23/concord/blob/main/docs/keymap-options.md> for supported values.
+      '';
+    };
+
+    themeSettings = lib.mkOption {
+      type = lib.types.submodule { freeformType = tomlFormat.type; };
+      default = { };
+      description = ''
+        Concord theme configuration.
+        See <https://github.com/chojs23/concord/blob/main/docs/theme-options.md> for supported values.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."concord/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "concord-config.toml" cfg.settings;
+    };
+
+    xdg.configFile."concord/keymap.toml" = lib.mkIf (cfg.keymapSettings != { }) {
+      source = tomlFormat.generate "concord-keymap.toml" { keymap = cfg.keymapSettings; };
+    };
+
+    xdg.configFile."concord/theme.toml" = lib.mkIf (cfg.themeSettings != { }) {
+      source = tomlFormat.generate "concord-theme.toml" cfg.themeSettings;
+    };
+  };
+}

--- a/tests/modules/programs/concord/concord-config.nix
+++ b/tests/modules/programs/concord/concord-config.nix
@@ -1,0 +1,48 @@
+{
+  programs.concord = {
+    enable = true;
+    settings = {
+      display = {
+        image_protocol = "auto";
+        disable_image_preview = false;
+        show_avatars = true;
+        show_images = true;
+        media_playback = false;
+        image_preview_quality = "balanced";
+        attachment_viewer_quality = "original";
+        show_custom_emoji = true;
+        circular_avatars = false;
+      };
+
+      composer.emojis_as_links = false;
+      presence.share_rich_presence = true;
+      credentials.store = "auto";
+
+      notifications = {
+        desktop_notifications = true;
+        notification_icon = "/path/to/icon.svg";
+        notification_sound = "/path/to/message.wav";
+        voice_join_sound = "/path/to/join.wav";
+        voice_leave_sound = "/path/to/leave.wav";
+      };
+
+      voice = {
+        self_mute = false;
+        self_deaf = false;
+        allow_microphone_transmit = false;
+        push_to_talk = false;
+        push_to_talk_shortcut = "F8";
+        noise_suppression = true;
+        microphone_sensitivity = -30;
+        microphone_volume = 100;
+        voice_output_volume = 100;
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/concord/config.toml
+    assertFileContent home-files/.config/concord/config.toml \
+      ${./concord-config.toml}
+  '';
+}

--- a/tests/modules/programs/concord/concord-config.toml
+++ b/tests/modules/programs/concord/concord-config.toml
@@ -1,0 +1,37 @@
+[composer]
+emojis_as_links = false
+
+[credentials]
+store = "auto"
+
+[display]
+attachment_viewer_quality = "original"
+circular_avatars = false
+disable_image_preview = false
+image_preview_quality = "balanced"
+image_protocol = "auto"
+media_playback = false
+show_avatars = true
+show_custom_emoji = true
+show_images = true
+
+[notifications]
+desktop_notifications = true
+notification_icon = "/path/to/icon.svg"
+notification_sound = "/path/to/message.wav"
+voice_join_sound = "/path/to/join.wav"
+voice_leave_sound = "/path/to/leave.wav"
+
+[presence]
+share_rich_presence = true
+
+[voice]
+allow_microphone_transmit = false
+microphone_sensitivity = -30
+microphone_volume = 100
+noise_suppression = true
+push_to_talk = false
+push_to_talk_shortcut = "F8"
+self_deaf = false
+self_mute = false
+voice_output_volume = 100

--- a/tests/modules/programs/concord/concord-empty.nix
+++ b/tests/modules/programs/concord/concord-empty.nix
@@ -1,0 +1,11 @@
+{
+  programs.concord = {
+    enable = true;
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/concord/config.toml
+    assertPathNotExists home-files/.config/concord/keymap.toml
+    assertPathNotExists home-files/.config/concord/theme.toml
+  '';
+}

--- a/tests/modules/programs/concord/concord-keymap.nix
+++ b/tests/modules/programs/concord/concord-keymap.nix
@@ -1,0 +1,71 @@
+{
+  programs.concord = {
+    enable = true;
+    keymapSettings = {
+      StartComposer = {
+        keys = [ "c" ];
+      };
+      ClosePopup = "q";
+      OpenDebugLog = "`";
+      ReplyMessage = "<leader>mr";
+      VoiceDeafen = "<leader>vd";
+      VoiceMute = "<leader>vm";
+      ToggleStream = "<leader>vs";
+      VoiceLeave = "<leader>vl";
+
+      groups = {
+        "<leader>v" = "Voice";
+      };
+
+      guild_actions = {
+        LeaveServer = {
+          keys = [ "l" ];
+          description = "leave server";
+        };
+      };
+
+      channel_actions = {
+        ToggleMute = {
+          keys = [ "x" ];
+          description = "mute channel";
+        };
+        ToggleStream = {
+          keys = [ "s" ];
+          description = "toggle screen share";
+        };
+        WatchStream = {
+          keys = [ "w" ];
+          description = "watch stream";
+        };
+        VoiceParticipantAudio = {
+          keys = [ "v" ];
+          description = "participant audio";
+        };
+      };
+
+      message_actions = {
+        OpenThread = {
+          keys = [ "t" ];
+          description = "open thread";
+        };
+        GoToReferencedMessage = "g";
+      };
+
+      notification_inbox_actions = {
+        MarkRead = "r";
+        MarkAllRead = "a";
+      };
+
+      composer = {
+        OpenEditor = "<C-o>";
+        DeletePreviousWord = "<A-backspace>";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/concord/keymap.toml
+    assertFileContent home-files/.config/concord/keymap.toml \
+      ${./concord-keymap.toml}
+  '';
+}

--- a/tests/modules/programs/concord/concord-keymap.toml
+++ b/tests/modules/programs/concord/concord-keymap.toml
@@ -1,0 +1,49 @@
+[keymap]
+ClosePopup = "q"
+OpenDebugLog = "`"
+ReplyMessage = "<leader>mr"
+ToggleStream = "<leader>vs"
+VoiceDeafen = "<leader>vd"
+VoiceLeave = "<leader>vl"
+VoiceMute = "<leader>vm"
+
+[keymap.StartComposer]
+keys = ["c"]
+
+[keymap.channel_actions.ToggleMute]
+description = "mute channel"
+keys = ["x"]
+
+[keymap.channel_actions.ToggleStream]
+description = "toggle screen share"
+keys = ["s"]
+
+[keymap.channel_actions.VoiceParticipantAudio]
+description = "participant audio"
+keys = ["v"]
+
+[keymap.channel_actions.WatchStream]
+description = "watch stream"
+keys = ["w"]
+
+[keymap.composer]
+DeletePreviousWord = "<A-backspace>"
+OpenEditor = "<C-o>"
+
+[keymap.groups]
+"<leader>v" = "Voice"
+
+[keymap.guild_actions.LeaveServer]
+description = "leave server"
+keys = ["l"]
+
+[keymap.message_actions]
+GoToReferencedMessage = "g"
+
+[keymap.message_actions.OpenThread]
+description = "open thread"
+keys = ["t"]
+
+[keymap.notification_inbox_actions]
+MarkAllRead = "a"
+MarkRead = "r"

--- a/tests/modules/programs/concord/concord-theme.nix
+++ b/tests/modules/programs/concord/concord-theme.nix
@@ -1,0 +1,28 @@
+{
+  programs.concord = {
+    enable = true;
+    themeSettings = {
+      highlight = {
+        Normal = {
+          foreground = "terminal_default";
+          background = "terminal_default";
+        };
+
+        FocusBorder.foreground = "light_magenta";
+        ComposerPickerBorder.link = "FocusBorder";
+        Selection.background = "none";
+      };
+
+      ui.border = {
+        default = "plain";
+        composer = "rounded";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/concord/theme.toml
+    assertFileContent home-files/.config/concord/theme.toml \
+      ${./concord-theme.toml}
+  '';
+}

--- a/tests/modules/programs/concord/concord-theme.toml
+++ b/tests/modules/programs/concord/concord-theme.toml
@@ -1,0 +1,16 @@
+[highlight.ComposerPickerBorder]
+link = "FocusBorder"
+
+[highlight.FocusBorder]
+foreground = "light_magenta"
+
+[highlight.Normal]
+background = "terminal_default"
+foreground = "terminal_default"
+
+[highlight.Selection]
+background = "none"
+
+[ui.border]
+composer = "rounded"
+default = "plain"

--- a/tests/modules/programs/concord/default.nix
+++ b/tests/modules/programs/concord/default.nix
@@ -1,0 +1,6 @@
+{
+  concord-config = ./concord-config.nix;
+  concord-keymap = ./concord-keymap.nix;
+  concord-theme = ./concord-theme.nix;
+  concord-empty = ./concord-empty.nix;
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Added concord, a TUI client for Discord.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
