### PR TITLE
psd: remove aliased packages

### DIFF
--- a/modules/services/psd.nix
+++ b/modules/services/psd.nix
@@ -93,7 +93,7 @@ in
               gnused
               coreutils
               findutils
-              nettools
+              net-tools
               util-linux
               cfg.package
             ]


### PR DESCRIPTION
### Description

Removes the usage of aliased packages within the profile-sync-daemon service as it causes breakages on systems with home-manager set to use global pkgs and allow aliases turned off.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```
