### PR TITLE
maintainers: remove diniamo

### DIFF
--- a/all-maintainers.nix
+++ b/all-maintainers.nix
@@ -990,13 +990,6 @@
     name = "Robin Stumm";
     source = "nixpkgs";
   };
-  diniamo = {
-    email = "diniamo53@gmail.com";
-    github = "diniamo";
-    githubId = 55629891;
-    name = "diniamo";
-    source = "nixpkgs";
-  };
   donovanglover = {
     github = "donovanglover";
     githubId = 2374245;

--- a/modules/programs/spotify-player.nix
+++ b/modules/programs/spotify-player.nix
@@ -19,7 +19,7 @@ let
   tomlType = tomlFormat.type;
 in
 {
-  meta.maintainers = with lib.maintainers; [ diniamo ];
+  meta.maintainers = [ ];
 
   options.programs.spotify-player = {
     enable = mkEnableOption "spotify-player";


### PR DESCRIPTION
### Checklist

- [x] Change is backwards compatible.
- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.
- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.