### PR TITLE
waterfox: add module

### DIFF
--- a/modules/programs/waterfox.nix
+++ b/modules/programs/waterfox.nix
@@ -1,0 +1,39 @@
+{ lib, config, ... }:
+let
+  modulePath = [
+    "programs"
+    "waterfox"
+  ];
+
+  cfg = config.programs.waterfox;
+
+  mkFirefoxModule = import ./firefox/mkFirefoxModule.nix;
+in
+{
+  meta.maintainers = [ lib.maintainers.maximsmol ];
+
+  imports = [
+    (mkFirefoxModule {
+      inherit modulePath;
+      name = "Waterfox";
+      description = "Waterfox, a privacy focused, performance oriented browser based on Firefox.";
+      wrappedPackageName = "waterfox-bin";
+      unwrappedPackageName = "waterfox-bin-unwrapped";
+
+      platforms.linux = {
+        configPath = ".waterfox";
+      };
+      platforms.darwin = {
+        appName = "Waterfox";
+        configPath = "Library/Application Support/Waterfox";
+      };
+    })
+  ];
+
+  config = lib.mkIf cfg.enable {
+    mozilla.firefoxNativeMessagingHosts =
+      cfg.nativeMessagingHosts
+      # package configured native messaging hosts (entire browser actually)
+      ++ (lib.optional (cfg.finalPackage != null) cfg.finalPackage);
+  };
+}

--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -11,3 +11,4 @@
 // (import ./firefox.nix { inherit lib; })
 // (import ./floorp.nix { inherit lib; })
 // (import ./librewolf.nix { inherit lib; })
+// (import ./waterfox.nix { inherit lib; })

--- a/tests/modules/programs/firefox/waterfox.nix
+++ b/tests/modules/programs/firefox/waterfox.nix
@@ -1,0 +1,5 @@
+{ lib, ... }:
+import ./common.nix {
+  inherit lib;
+  name = "waterfox";
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adds a home-manager module for Waterfox, which is a Firefox clone.

Depends on https://github.com/NixOS/nixpkgs/pull/541154

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [X] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
