### PR TITLE
fcitx5: improve flexibility

### DIFF
--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -2,6 +2,7 @@
   config,
   pkgs,
   lib,
+  options,
   ...
 }:
 let
@@ -32,6 +33,17 @@ in
           The fcitx5 package to use.
         '';
       };
+
+      systemd.enable = lib.mkEnableOption "" // {
+        default = true;
+        description = ''
+          Whether to enable the systemd user service.
+
+          This service is not required if the desktop environment supports
+          [XDG Autostart](https://fcitx-im.org/wiki/Setup_Fcitx_5#XDG_Autostart).
+        '';
+      };
+
       addons = lib.mkOption {
         type = with lib.types; listOf package;
         default = [ ];
@@ -47,6 +59,24 @@ in
         description = ''
           Use the Wayland input method frontend.
           See [Using Fcitx 5 on Wayland](https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland).
+        '';
+      };
+
+      sessionVariables = lib.mkOption {
+        inherit (options.home.sessionVariables) type;
+        default = {
+          GLFW_IM_MODULE = "ibus"; # IME support in kitty
+          SDL_IM_MODULE = "fcitx";
+          XMODIFIERS = "@im=fcitx";
+        };
+        description = ''
+          The environment variables used to configure Fcitx5.
+
+          The default values should be suitable for most desktop environments and should
+          not normally need to be changed.
+
+          If you need to override them, see the
+          [Fcitx5 user guide](https://fcitx-im.org/wiki/Fcitx_5#For_Users).
         '';
       };
 
@@ -201,18 +231,16 @@ in
     };
 
     home = {
-      sessionVariables = {
-        GLFW_IM_MODULE = "ibus"; # IME support in kitty
-        SDL_IM_MODULE = "fcitx";
-        XMODIFIERS = "@im=fcitx";
-      }
-      // lib.optionalAttrs (!cfg.waylandFrontend) {
-        GTK_IM_MODULE = "fcitx";
-        QT_IM_MODULE = "fcitx";
-      }
-      // lib.optionalAttrs cfg.ignoreUserConfig {
-        SKIP_FCITX_USER_PATH = "1";
-      };
+      sessionVariables = lib.mkMerge [
+        cfg.sessionVariables
+
+        (lib.optionalAttrs (!cfg.waylandFrontend) {
+          GTK_IM_MODULE = "fcitx";
+          QT_IM_MODULE = "fcitx";
+        })
+
+        (lib.optionalAttrs cfg.ignoreUserConfig { SKIP_FCITX_USER_PATH = "1"; })
+      ];
 
       sessionSearchVariables.QT_PLUGIN_PATH = [ "${fcitx5Package}/${pkgs.qt6.qtbase.qtPluginPrefix}" ];
     };
@@ -267,7 +295,7 @@ in
       ) cfg.themes;
     };
 
-    systemd.user.services.fcitx5-daemon = {
+    systemd.user.services.fcitx5-daemon = lib.mkIf cfg.systemd.enable {
       Unit = {
         Description = "Fcitx5 input method editor";
         PartOf = [ "graphical-session.target" ];

--- a/tests/modules/i18n/input-method/default.nix
+++ b/tests/modules/i18n/input-method/default.nix
@@ -1,5 +1,7 @@
 {
   input-method-fcitx5-configuration = ./fcitx5/configuration.nix;
+  input-method-fcitx5-disabled-systemd = ./fcitx5/disabled-systemd.nix;
+  input-method-fcitx5-user-session-variables = ./fcitx5/user-session-variables.nix;
   input-method-fcitx5-old-enable = ./fcitx5/old-enable.nix;
   input-method-kime-configuration = ./kime-configuration.nix;
 }

--- a/tests/modules/i18n/input-method/fcitx5/disabled-systemd.nix
+++ b/tests/modules/i18n/input-method/fcitx5/disabled-systemd.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  config,
+  realPkgs,
+  ...
+}:
+
+lib.mkIf config.test.enableBig {
+  i18n.inputMethod = {
+    enable = true;
+    type = "fcitx5";
+    fcitx5 = {
+      systemd.enable = false;
+    };
+  };
+
+  _module.args.pkgs = lib.mkForce realPkgs;
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/systemd/user/fcitx5-daemon.service
+  '';
+}

--- a/tests/modules/i18n/input-method/fcitx5/user-session-variables.nix
+++ b/tests/modules/i18n/input-method/fcitx5/user-session-variables.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  config,
+  realPkgs,
+  ...
+}:
+
+lib.mkIf config.test.enableBig {
+  i18n.inputMethod = {
+    enable = true;
+    type = "fcitx5";
+    fcitx5 = {
+      ignoreUserConfig = true;
+      sessionVariables = {
+        NIXOS_OZONE_WL = 1;
+        XMODIFIERS = "@im=fcitx";
+      };
+    };
+  };
+
+  _module.args.pkgs = lib.mkForce realPkgs;
+
+  nmt.script = ''
+    assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh 'GLFW_IM_MODULE'
+    assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh 'SDL_IM_MODULE'
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh 'export SKIP_FCITX_USER_PATH="1"'
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh 'export NIXOS_OZONE_WL="1"'
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh 'export XMODIFIERS="@im=fcitx"'
+  '';
+}


### PR DESCRIPTION
Add options to disable the systemd user service and override `home.sessionVariables`.

The systemd user service is often unnecessary when the desktop environment supports XDG Autostart. Overriding `home.sessionVariables` allows users to define the environment variables appropriate for their desktop environment.

cc @Kranzes @khaneliman

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
