### PR TITLE
kakoune: add linkAutoload option

### DIFF
--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -707,6 +707,16 @@ in
           `programs.kakoune.config.colorScheme = "theme"`.
         '';
       };
+
+      linkAutoload = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to symlink the built-in autoload scripts to
+          {file}`$XDG_CONFIG_HOME/kak/autoload`. Linking is performed recursively
+          so you can add and edit your own local plugins alongside the built-in scripts.
+        '';
+      };
     };
   };
 
@@ -728,6 +738,13 @@ in
       { "kak/kakrc".source = configFile; }
       (mkIf (cfg.colorSchemePackage != null) {
         "kak/colors/${cfg.colorSchemePackage.name}".source = cfg.colorSchemePackage;
+      })
+      (mkIf cfg.linkAutoload {
+        "kak/autoload" = {
+          ignorelinks = true;
+          recursive = true;
+          source = "${config.programs.kakoune.finalPackage}/share/kak/autoload";
+        };
       })
     ];
   };

--- a/tests/modules/programs/kakoune/default.nix
+++ b/tests/modules/programs/kakoune/default.nix
@@ -1,4 +1,5 @@
 {
+  kakoune-link-autoload = ./link-autoload.nix;
   kakoune-no-plugins = ./no-plugins.nix;
   kakoune-use-plugins = ./use-plugins.nix;
   kakoune-whitespace-highlighter = ./whitespace-highlighter.nix;

--- a/tests/modules/programs/kakoune/link-autoload.nix
+++ b/tests/modules/programs/kakoune/link-autoload.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+
+{
+  programs.kakoune = {
+    enable = true;
+    linkAutoload = true;
+  };
+
+  nmt.script = ''
+    assertLinkPointsTo home-files/.config/kak/autoload/rc ${config.programs.kakoune.finalPackage}/share/kak/autoload/rc
+  '';
+}


### PR DESCRIPTION
### Description

Add `linkAutoload` option to support a user-local `autoload` directory while still loading the built-in scripts, as documented in [the man page](https://github.com/mawww/kakoune/blob/018d402301696834f4ff8443b3cd3df70c13a137/doc/kak.1#L253-L260).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.
  - New test passes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
 
- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
