### PR TITLE
lib: use mkImpureConfigMerger for runtime config merging

### DIFF
--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -960,10 +960,14 @@ in
         for others. Set this to something like `"${json5Bin} --as-json"` when
         the existing file uses a superset of JSON (e.g. JSON5 with comments).
 
+      `verboseMsg` (string or null; optional)
+      : Custom message to log via `verboseEcho` when the merge runs. When
+        `null` (the default), a generic message is used.
+
     # Type
 
     ```
-    mkImpureConfigMerger :: { pkgs :: AttrSet; format :: String; empty :: String; jqOperation :: String; path :: String; staticSettings :: Path; reader ? NullOr String; } -> String
+    mkImpureConfigMerger :: { pkgs :: AttrSet; format :: String; empty :: String; jqOperation :: String; path :: String; staticSettings :: Path; reader ? NullOr String; verboseMsg ? NullOr String; } -> String
     ```
 
     # Examples
@@ -995,6 +999,7 @@ in
       path,
       staticSettings,
       reader ? null,
+      verboseMsg ? null,
     }:
     let
       jaqBin = lib.getExe pkgs.jaq;
@@ -1011,14 +1016,23 @@ in
           "printf '%s\\n' \"$config\" > ${lib.escapeShellArg path}"
         else
           "printf '%s\\n' \"$config\" | ${jaqBin} --to ${format} -c '.' > ${lib.escapeShellArg path}";
+      defaultVerboseMsg = "Merging Nix-generated config into ${path}";
+      verboseMsg' = if verboseMsg != null then verboseMsg else defaultVerboseMsg;
     in
     ''
+      if [[ -v VERBOSE ]]; then
+        echo ${lib.escapeShellArg verboseMsg'}
+      fi
+      if [[ -v DRY_RUN ]]; then
+        echo "jaq -n ${lib.escapeShellArg jqOperation} --argjson dynamic ... --argjson static ..."
+        return 0
+      fi
       mkdir -p $(dirname ${lib.escapeShellArg path})
       if [ ! -e ${lib.escapeShellArg path} ]; then
         : > ${lib.escapeShellArg path}
       fi
       dynamic="$(${readerCmd} ${lib.escapeShellArg path} 2>/dev/null || echo ${lib.escapeShellArg empty})"
-      static="$(cat ${lib.escapeShellArg staticSettings})"
+      static="$(${readerCmd} ${lib.escapeShellArg staticSettings})"
       config="$(${jaqBin} -n ${lib.escapeShellArg jqOperation} --argjson dynamic "$dynamic" --argjson static "$static")"
       ${writerCmd}
       unset config

--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -916,6 +916,114 @@ in
       ${concatStringsSep "\n" (mapAttrsToList convertAttributeToKDL attrs)}
     '';
 
+  /**
+    Create a bash script snippet that merges a Nix-generated config file with
+    an existing user config file at activation time. This preserves any changes
+    the user has made interactively while applying the Nix-declared settings on
+    top.
+
+    The merge uses `jaq` internally, which supports JSON, YAML, TOML, and CBOR
+    natively via its `--from`/`--to` flags — no extra tools needed.
+
+    # Inputs
+
+    `options`
+
+    : Function options
+
+      `pkgs` (attribute set)
+      : Package set used to find `jaq`.
+
+      `format` (string)
+      : Config file format. One of `"json"`, `"yaml"`, `"toml"`, `"cbor"`.
+
+      `empty` (string)
+      : JSON value to use when the file does not exist yet. Typically `"{}"`
+        for objects or `"[]"` for arrays.
+
+      `jqOperation` (string)
+      : jq-compatible expression that merges `$dynamic` (existing config) with
+        `$static` (Nix-generated config). For example `"$dynamic * $static"`
+        for a recursive object merge.
+
+      `path` (string)
+      : Absolute path to the config file on disk.
+
+      `staticSettings` (path or derivation)
+      : Path to the Nix-generated static config file, typically produced by
+        `format.generate`.
+
+      `reader` (string or null; optional)
+      : Shell command that reads the existing file from stdin and writes JSON
+        to stdout. When `null` (the default), the reader is auto-detected
+        from `format`: `jaq -c '.'` for JSON, `jaq --from <format> -c '.'`
+        for others. Set this to something like `"${json5Bin} --as-json"` when
+        the existing file uses a superset of JSON (e.g. JSON5 with comments).
+
+    # Type
+
+    ```
+    mkImpureConfigMerger :: { pkgs :: AttrSet; format :: String; empty :: String; jqOperation :: String; path :: String; staticSettings :: Path; reader ? NullOr String; } -> String
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.hm.generators.mkImpureConfigMerger` usage example
+
+    ```nix
+    let
+      jsonFormat = pkgs.formats.json { };
+    in
+    lib.hm.generators.mkImpureConfigMerger {
+      inherit pkgs;
+      format = "json";
+      empty = "{}";
+      jqOperation = "$dynamic * $static";
+      path = "${config.xdg.configHome}/myapp/settings.json";
+      staticSettings = jsonFormat.generate "myapp-settings" cfg.settings;
+    }
+    ```
+
+    :::
+  */
+  mkImpureConfigMerger =
+    {
+      pkgs,
+      format,
+      empty,
+      jqOperation,
+      path,
+      staticSettings,
+      reader ? null,
+    }:
+    let
+      jaqBin = lib.getExe pkgs.jaq;
+      isJson = format == "json";
+      readerCmd =
+        if reader != null then
+          reader
+        else if isJson then
+          "${jaqBin} -c '.'"
+        else
+          "${jaqBin} --from ${format} -c '.'";
+      writerCmd =
+        if isJson then
+          "printf '%s\\n' \"$config\" > ${lib.escapeShellArg path}"
+        else
+          "printf '%s\\n' \"$config\" | ${jaqBin} --to ${format} -c '.' > ${lib.escapeShellArg path}";
+    in
+    ''
+      mkdir -p $(dirname ${lib.escapeShellArg path})
+      if [ ! -e ${lib.escapeShellArg path} ]; then
+        : > ${lib.escapeShellArg path}
+      fi
+      dynamic="$(${readerCmd} ${lib.escapeShellArg path} 2>/dev/null || echo ${lib.escapeShellArg empty})"
+      static="$(cat ${lib.escapeShellArg staticSettings})"
+      config="$(${jaqBin} -n ${lib.escapeShellArg jqOperation} --argjson dynamic "$dynamic" --argjson static "$static")"
+      ${writerCmd}
+      unset config
+    '';
+
   toSCFG =
     _:
     let

--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -954,15 +954,16 @@ in
         `format.generate`.
 
       `reader` (string or null; optional)
-      : Shell command that reads the existing file from stdin and writes JSON
-        to stdout. When `null` (the default), the reader is auto-detected
-        from `format`: `jaq -c '.'` for JSON, `jaq --from <format> -c '.'`
-        for others. Set this to something like `"${json5Bin} --as-json"` when
-        the existing file uses a superset of JSON (e.g. JSON5 with comments).
+      : Shell command that reads the existing file given as its last argument
+        and writes JSON to stdout. When `null` (the default), the reader is
+        auto-detected from `format`: `jaq -c '.'` for JSON, `jaq --from
+        <format> -c '.'` for others. Set this to something like
+        `"${json5Bin} --as-json"` when the existing file uses a superset of
+        JSON (e.g. JSON5 with comments).
 
       `verboseMsg` (string or null; optional)
-      : Custom message to log via `verboseEcho` when the merge runs. When
-        `null` (the default), a generic message is used.
+      : Message to log when `$VERBOSE` is set. When `null` (the default), a
+        generic message is used.
 
     # Type
 
@@ -1011,11 +1012,14 @@ in
           "${jaqBin} -c '.'"
         else
           "${jaqBin} --from ${format} -c '.'";
-      writerCmd =
+      # Write the merge result to a temporary file and move it into place only
+      # after the merge has succeeded, so a failing merge never clobbers the
+      # existing config.
+      writeCmd =
         if isJson then
-          "printf '%s\\n' \"$config\" > ${lib.escapeShellArg path}"
+          "printf '%s\\n' \"$config\" > \"$tmp\""
         else
-          "printf '%s\\n' \"$config\" | ${jaqBin} --to ${format} -c '.' > ${lib.escapeShellArg path}";
+          "printf '%s\\n' \"$config\" | ${jaqBin} --to ${format} -c '.' > \"$tmp\"";
       defaultVerboseMsg = "Merging Nix-generated config into ${path}";
       verboseMsg' = if verboseMsg != null then verboseMsg else defaultVerboseMsg;
     in
@@ -1024,18 +1028,22 @@ in
         echo ${lib.escapeShellArg verboseMsg'}
       fi
       if [[ -v DRY_RUN ]]; then
-        echo "jaq -n ${lib.escapeShellArg jqOperation} --argjson dynamic ... --argjson static ..."
-        return 0
+        echo "Would merge Nix-generated config into ${path}"
+      else
+        mkdir -p "$(dirname ${lib.escapeShellArg path})"
+        if [ ! -e ${lib.escapeShellArg path} ]; then
+          echo ${lib.escapeShellArg empty} > ${lib.escapeShellArg path}
+        fi
+        dynamic="$(${readerCmd} ${lib.escapeShellArg path} 2>/dev/null || echo ${lib.escapeShellArg empty})"
+        [ -n "$dynamic" ] || dynamic=${lib.escapeShellArg empty}
+        static="$(${readerCmd} ${lib.escapeShellArg staticSettings})"
+        config="$(${jaqBin} -n ${lib.escapeShellArg jqOperation} --argjson dynamic "$dynamic" --argjson static "$static")"
+        tmp="$(mktemp)"
+        ${writeCmd}
+        install -m644 "$tmp" ${lib.escapeShellArg path}
+        rm -f "$tmp"
+        unset config
       fi
-      mkdir -p $(dirname ${lib.escapeShellArg path})
-      if [ ! -e ${lib.escapeShellArg path} ]; then
-        : > ${lib.escapeShellArg path}
-      fi
-      dynamic="$(${readerCmd} ${lib.escapeShellArg path} 2>/dev/null || echo ${lib.escapeShellArg empty})"
-      static="$(${readerCmd} ${lib.escapeShellArg staticSettings})"
-      config="$(${jaqBin} -n ${lib.escapeShellArg jqOperation} --argjson dynamic "$dynamic" --argjson static "$static")"
-      ${writerCmd}
-      unset config
     '';
 
   toSCFG =

--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -925,6 +925,13 @@ in
     The merge uses `jaq` internally, which supports JSON, YAML, TOML, and CBOR
     natively via its `--from`/`--to` flags — no extra tools needed.
 
+    :::{.warning}
+    This function is **experimental**: its interface and generated script may
+    change without notice in future releases, as edge cases around the
+    activation contract are still being discovered. If you use it from an
+    external flake, pin the Home Manager input accordingly.
+    :::
+
     # Inputs
 
     `options`
@@ -1034,13 +1041,30 @@ in
         if [ ! -e ${lib.escapeShellArg path} ]; then
           echo ${lib.escapeShellArg empty} > ${lib.escapeShellArg path}
         fi
-        dynamic="$(${readerCmd} ${lib.escapeShellArg path} 2>/dev/null || echo ${lib.escapeShellArg empty})"
-        [ -n "$dynamic" ] || dynamic=${lib.escapeShellArg empty}
+        # A missing or empty file is treated as `empty` (see the
+        # `-empty` tests), but an existing file with content that fails to
+        # parse must fail activation loudly instead of silently overwriting
+        # the user's settings with the generated defaults.
+        dynamic="$(${readerCmd} ${lib.escapeShellArg path} 2>/dev/null || true)"
+        if [ ! -s ${lib.escapeShellArg path} ]; then
+          # Missing or zero-byte file: treat as absent.
+          dynamic=${lib.escapeShellArg empty}
+        elif [ -z "$dynamic" ]; then
+          errorEcho "Could not parse ${lib.escapeShellArg path}; refusing to merge"
+          exit 1
+        fi
         static="$(${readerCmd} ${lib.escapeShellArg staticSettings})"
         config="$(${jaqBin} -n ${lib.escapeShellArg jqOperation} --argjson dynamic "$dynamic" --argjson static "$static")"
         tmp="$(mktemp)"
         ${writeCmd}
-        install -m644 "$tmp" ${lib.escapeShellArg path}
+        # Overwrite in place: an existing file keeps its permissions and
+        # symlink target (`install -m644` would reset the mode), while a new
+        # file is created with sane defaults.
+        if [ -e ${lib.escapeShellArg path} ]; then
+          cat "$tmp" > ${lib.escapeShellArg path}
+        else
+          install -m644 "$tmp" ${lib.escapeShellArg path}
+        fi
         rm -f "$tmp"
         unset config
       fi

--- a/modules/programs/joplin-desktop.nix
+++ b/modules/programs/joplin-desktop.nix
@@ -137,15 +137,16 @@ in
             )
           );
         in
-        lib.hm.dag.entryAfter [ "linkGeneration" ] ''
-          # Ensure that settings.json exists.
-          mkdir -p ${dirOf configPath}
-          touch ${configPath}
-          # Config has to be written to temporary variable because jq cannot edit files in place.
-          config="$(jq -s '.[0] + .[1]' ${configPath} ${newConfig})"
-          printf '%s\n' "$config" > ${configPath}
-          unset config
-        '';
+        lib.hm.dag.entryAfter [ "linkGeneration" ] (
+          lib.hm.generators.mkImpureConfigMerger {
+            inherit pkgs;
+            format = "json";
+            empty = "{}";
+            jqOperation = "$dynamic + $static";
+            path = configPath;
+            staticSettings = newConfig;
+          }
+        );
     };
   };
 }

--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -576,19 +576,16 @@ in
               cli = cfg.cli.enable;
             };
           in
-          lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-            OBSIDIAN_CONFIG="${obsidianConfigDir}/obsidian.json"
-            if [ -f "$OBSIDIAN_CONFIG" ]; then
-              verboseEcho "Merging existing Obsidian config with generated template"
-              tmp="$(mktemp)"
-              run ${lib.getExe pkgs.jq} -s '(.[0] // {}) * (.[1] // {})' "$OBSIDIAN_CONFIG" "${template}" > "$tmp"
-              run install -m644 "$tmp" "$OBSIDIAN_CONFIG"
-              rm -f "$tmp"
-            else
-              verboseEcho "Installing fresh Obsidian config"
-              run install -D -m644 "${template}" "$OBSIDIAN_CONFIG"
-            fi
-          '';
+          lib.hm.dag.entryAfter [ "writeBoundary" ] (
+            lib.hm.generators.mkImpureConfigMerger {
+              inherit pkgs;
+              format = "json";
+              empty = "{}";
+              jqOperation = "$dynamic * $static";
+              path = obsidianConfigDir + "/obsidian.json";
+              staticSettings = template;
+            }
+          );
       };
 
       assertions = [

--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -584,6 +584,7 @@ in
               jqOperation = "$dynamic * $static";
               path = obsidianConfigDir + "/obsidian.json";
               staticSettings = template;
+              verboseMsg = "Merging existing Obsidian config with generated template";
             }
           );
       };

--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -16,18 +16,6 @@ let
   cfg = config.programs.zed-editor;
   jsonFormat = pkgs.formats.json { };
   json5 = pkgs.python3Packages.toPythonApplication pkgs.python3Packages.json5;
-  impureConfigMerger = empty: jqOperation: path: staticSettings: ''
-    mkdir -p $(dirname ${lib.escapeShellArg path})
-    if [ ! -e ${lib.escapeShellArg path} ]; then
-      # No file? Create it
-      echo ${lib.escapeShellArg empty} > ${lib.escapeShellArg path}
-    fi
-    dynamic="$(${lib.getExe json5} --as-json ${lib.escapeShellArg path} 2>/dev/null || echo ${lib.escapeShellArg empty})"
-    static="$(cat ${lib.escapeShellArg staticSettings})"
-    config="$(${lib.getExe pkgs.jq} -n ${lib.escapeShellArg jqOperation} --argjson dynamic "$dynamic" --argjson static "$static")"
-    printf '%s\n' "$config" > ${lib.escapeShellArg path}
-    unset config
-  '';
 
   transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
     lib.mapAttrs (
@@ -312,33 +300,54 @@ in
     home.activation = mkMerge [
       (mkIf (cfg.mutableUserSettings && mergedSettings != { }) {
         zedSettingsActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-          impureConfigMerger "{}" "$dynamic * $static" "${config.xdg.configHome}/zed/settings.json" (
-            jsonFormat.generate "zed-user-settings" mergedSettings
-          )
+          lib.hm.generators.mkImpureConfigMerger {
+            inherit pkgs;
+            format = "json";
+            empty = "{}";
+            jqOperation = "$dynamic * $static";
+            path = "${config.xdg.configHome}/zed/settings.json";
+            staticSettings = jsonFormat.generate "zed-user-settings" mergedSettings;
+            reader = "${lib.getExe json5} --as-json";
+          }
         );
       })
       (mkIf (cfg.mutableUserKeymaps && cfg.userKeymaps != [ ]) {
         zedKeymapActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-          impureConfigMerger "[]"
-            "$dynamic + $static | group_by(.context) | map(reduce .[] as $item ({}; . * $item))"
-            "${config.xdg.configHome}/zed/keymap.json"
-            (jsonFormat.generate "zed-user-keymaps" cfg.userKeymaps)
+          lib.hm.generators.mkImpureConfigMerger {
+            inherit pkgs;
+            format = "json";
+            empty = "[]";
+            jqOperation = "$dynamic + $static | group_by(.context) | map(reduce .[] as \$item ({}; . * \$item))";
+            path = "${config.xdg.configHome}/zed/keymap.json";
+            staticSettings = jsonFormat.generate "zed-user-keymaps" cfg.userKeymaps;
+            reader = "${lib.getExe json5} --as-json";
+          }
         );
       })
       (mkIf (cfg.mutableUserTasks && cfg.userTasks != [ ]) {
         zedTasksActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-          impureConfigMerger "[]"
-            "$dynamic + $static | group_by(.label) | map(reduce .[] as $item ({}; . * $item))"
-            "${config.xdg.configHome}/zed/tasks.json"
-            (jsonFormat.generate "zed-user-tasks" cfg.userTasks)
+          lib.hm.generators.mkImpureConfigMerger {
+            inherit pkgs;
+            format = "json";
+            empty = "[]";
+            jqOperation = "$dynamic + $static | group_by(.label) | map(reduce .[] as \$item ({}; . * \$item))";
+            path = "${config.xdg.configHome}/zed/tasks.json";
+            staticSettings = jsonFormat.generate "zed-user-tasks" cfg.userTasks;
+            reader = "${lib.getExe json5} --as-json";
+          }
         );
       })
       (mkIf (cfg.mutableUserDebug && cfg.userDebug != [ ]) {
         zedDebugActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-          impureConfigMerger "[]"
-            "$dynamic + $static | group_by(.label) | map(reduce .[] as $item ({}; . * $item))"
-            "${config.xdg.configHome}/zed/debug.json"
-            (jsonFormat.generate "zed-user-debug" cfg.userDebug)
+          lib.hm.generators.mkImpureConfigMerger {
+            inherit pkgs;
+            format = "json";
+            empty = "[]";
+            jqOperation = "$dynamic + $static | group_by(.label) | map(reduce .[] as \$item ({}; . * \$item))";
+            path = "${config.xdg.configHome}/zed/debug.json";
+            staticSettings = jsonFormat.generate "zed-user-debug" cfg.userDebug;
+            reader = "${lib.getExe json5} --as-json";
+          }
         );
       })
     ];

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -51,6 +51,7 @@ let
         inherit (pkgs)
           coreutils
           crudini
+          jaq
           jq
           desktop-file-utils
           diffutils

--- a/tests/modules/programs/joplin-desktop/basic-configuration.nix
+++ b/tests/modules/programs/joplin-desktop/basic-configuration.nix
@@ -15,6 +15,15 @@
     assertFileContains activate \
       '/home/hm-user/.config/joplin-desktop/settings.json'
 
+    assertFileContains activate \
+      "if [[ -v VERBOSE ]]; then"
+
+    assertFileContains activate \
+      "Merging Nix-generated config into"
+
+    assertFileContains activate \
+      "if [[ -v DRY_RUN ]]; then"
+
     generated="$(grep -o '/nix/store/.*-joplin-settings.json' $TESTED/activate)"
     diff -u "$generated" ${./basic-configuration.json}
   '';

--- a/tests/modules/programs/joplin-desktop/basic-configuration.nix
+++ b/tests/modules/programs/joplin-desktop/basic-configuration.nix
@@ -24,7 +24,7 @@
     assertFileContains activate \
       "if [[ -v DRY_RUN ]]; then"
 
-    generated="$(grep -o '/nix/store/.*-joplin-settings.json' $TESTED/activate)"
+    generated="$(grep -o '/nix/store/[^ ]*-joplin-settings.json' $TESTED/activate)"
     diff -u "$generated" ${./basic-configuration.json}
   '';
 }

--- a/tests/modules/programs/zed-editor/default.nix
+++ b/tests/modules/programs/zed-editor/default.nix
@@ -10,6 +10,7 @@
   zed-settings = ./settings.nix;
   zed-settings-immutable = ./settings-immutable.nix;
   zed-settings-empty = ./settings-empty.nix;
+  zed-settings-dry-run = ./settings-dry-run.nix;
   zed-tasks = ./tasks.nix;
   zed-tasks-immutable = ./tasks-immutable.nix;
   zed-tasks-empty = ./tasks-empty.nix;

--- a/tests/modules/programs/zed-editor/settings-dry-run.nix
+++ b/tests/modules/programs/zed-editor/settings-dry-run.nix
@@ -1,0 +1,74 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    userSettings = {
+      theme = "XY-Zed";
+      vim_mode = false;
+    };
+  };
+
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+  nmt.script =
+    let
+      preexistingSettings = builtins.toFile "preexisting.json" ''
+        {
+          "theme": "Default"
+        }
+      '';
+
+      expectedContent = builtins.toFile "expected.json" ''
+        {
+          "theme": "XY-Zed",
+          "vim_mode": false
+        }
+      '';
+
+      settingsPath = ".config/zed/settings.json";
+      activationScript = pkgs.writeScript "activation" config.home.activation.zedSettingsActivation.data;
+      mkActivation = name: ''
+        substitute ${activationScript} $TMPDIR/${name} --subst-var TMPDIR
+        chmod +x $TMPDIR/${name}
+      '';
+    in
+    ''
+      export HOME=$TMPDIR/hm-user
+
+      # Simulate preexisting settings
+      mkdir -p $HOME/.config/zed
+      cat ${preexistingSettings} > $HOME/${settingsPath}
+
+      ${mkActivation "activate"}
+
+      # Dry-run must leave the existing settings untouched and must not fail
+      # with an unbound variable error.
+      export DRY_RUN=1
+      $TMPDIR/activate > $TMPDIR/dry-output
+      unset DRY_RUN
+      assertFileContent "$HOME/${settingsPath}" "${preexistingSettings}"
+      grep 'Would merge Nix-generated config into' $TMPDIR/dry-output
+
+      # A live run applies the Nix-generated settings on top.
+      $TMPDIR/activate
+      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
+
+      # Verbose mode logs the merge message.
+      ${mkActivation "activate-verbose"}
+      export VERBOSE=1
+      $TMPDIR/activate-verbose > $TMPDIR/verbose-output
+      unset VERBOSE
+      grep 'Merging Nix-generated config into' $TMPDIR/verbose-output
+
+      # Without verbose, no merge message is logged.
+      $TMPDIR/activate > $TMPDIR/quiet-output
+      test ! -s $TMPDIR/quiet-output
+    '';
+}

--- a/tests/modules/programs/zed-editor/settings-dry-run.nix
+++ b/tests/modules/programs/zed-editor/settings-dry-run.nix
@@ -33,6 +33,9 @@
       '';
 
       settingsPath = ".config/zed/settings.json";
+      corruptedSettings = builtins.toFile "corrupted.json" ''
+        { not valid json
+      '';
       activationScript = pkgs.writeScript "activation" config.home.activation.zedSettingsActivation.data;
       mkActivation = name: ''
         substitute ${activationScript} $TMPDIR/${name} --subst-var TMPDIR
@@ -70,5 +73,23 @@
       # Without verbose, no merge message is logged.
       $TMPDIR/activate > $TMPDIR/quiet-output
       test ! -s $TMPDIR/quiet-output
+
+      # A live run must preserve the permissions of an existing file.
+      chmod 600 $HOME/${settingsPath}
+      $TMPDIR/activate
+      currentMode="$(stat -c '%a' $HOME/${settingsPath})"
+      test "$currentMode" = 600 || {
+        echo "Expected mode 600, got $currentMode"
+        exit 1
+      }
+
+      # A corrupted existing file must fail activation loudly instead of
+      # silently overwriting it with the generated defaults.
+      echo '{ not valid json' > $HOME/${settingsPath}
+      if $TMPDIR/activate > /dev/null 2>&1; then
+        echo "Activation unexpectedly succeeded on a corrupted config file"
+        exit 1
+      fi
+      assertFileContent "$HOME/${settingsPath}" "${corruptedSettings}"
     '';
 }


### PR DESCRIPTION


### Description
Add a reusable `mkImpureConfigMerger` function to `lib.hm.generators`
that generates a bash script snippet for merging Nix-generated config
files with existing user config files at activation time. This preserves
any interactive changes the user has made while applying Nix-declared
settings on top.

The function uses `jaq` for both the merge operation and format
conversion, supporting JSON, YAML, TOML, and CBOR natively via its
`--from`/`--to` flags. An optional `reader` parameter allows custom
preprocessing (e.g., JSON5 with comments).

Refactor three existing modules to use the new library function:

- `programs.zed-editor`: Replaces local `impureConfigMerger` with
  `mkImpureConfigMerger`, preserving JSON5 reader support.
- `programs.obsidian`: Replaces inline jq merge script with
  `mkImpureConfigMerger`.
- `programs.joplin-desktop`: Replaces inline jq merge script with
  `mkImpureConfigMerger`.

Also add `jaq` to the test whitelist in `tests/default.nix` so the
activation scripts can resolve it at test time.

Assisted-by: OpenCode + DeepSeek v4 Flash

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
