### PR TITLE
launchd: add waitForNixStore agent option

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -34,6 +34,24 @@ let
             services that do not require a graphical login session.
           '';
         };
+        waitForNixStore = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          example = false;
+          description = ''
+            Whether to start the agent through a `/bin/sh` wrapper that waits
+            for the Nix store to be mounted before running the agent's
+            command. This guards against launchd starting the agent before
+            the Nix store volume is available, for example early during login
+            when the store volume is encrypted.
+
+            When disabled, the agent's command is run through a launcher
+            script named after the agent instead. This makes the agent appear
+            under its own name, rather than as "sh", in System Settings >
+            Login Items & Extensions, but the agent will fail to start if
+            launchd runs it before the Nix store is mounted.
+          '';
+        };
         config = lib.mkOption {
           type = lib.types.submodule (import ./launchd.nix);
           default = { };
@@ -65,35 +83,51 @@ let
       ];
     };
 
-  # mutateConfig calls /bin/sh with /bin/wait4path to wait for /nix/store before
-  # running the original Program and ProgramArguments. This is intentional to
-  # fix the issue where launchd starts the agent before /nix/store is ready
-  # (before the Nix store is mounted.)
+  # mutateConfig replaces the original Program and ProgramArguments. By
+  # default it calls /bin/sh with /bin/wait4path to wait for /nix/store
+  # before running the original command. This is intentional to fix the
+  # issue where launchd starts the agent before /nix/store is ready (before
+  # the Nix store is mounted.) When waitForNixStore is disabled, the command
+  # is run through a launcher script named after the agent instead, so that
+  # the agent is displayed under its own name (rather than "sh") in System
+  # Settings > Login Items & Extensions.
   mutateConfig =
-    cnf:
+    name: waitForNixStore: cnf:
     let
       args =
         lib.optional (cnf.Program != null) cnf.Program
         ++ lib.optionals (cnf.ProgramArguments != null) cnf.ProgramArguments;
+      launcherName = lib.strings.sanitizeDerivationName name;
+      launcher = pkgs.writeScriptBin launcherName ''
+        #!/bin/sh
+        exec ${lib.escapeShellArgs args}
+      '';
     in
     (removeAttrs cnf [
       "Program"
       "ProgramArguments"
     ])
     // {
-      ProgramArguments = [
-        "/bin/sh"
-        "-c"
-        "/bin/wait4path /nix/store && exec ${lib.escapeShellArgs args}"
-      ];
+      ProgramArguments =
+        if waitForNixStore then
+          [
+            "/bin/sh"
+            "-c"
+            "/bin/wait4path /nix/store && exec ${lib.escapeShellArgs args}"
+          ]
+        else
+          [ "${launcher}/bin/${launcherName}" ];
     };
 
   toAgent =
-    config: pkgs.writeText "${config.Label}.plist" (toPlist { escape = true; } (mutateConfig config));
+    name: v:
+    pkgs.writeText "${v.config.Label}.plist" (
+      toPlist { escape = true; } (mutateConfig name v.waitForNixStore v.config)
+    );
 
-  agentPlists = lib.mapAttrs' (
-    _n: v: lib.nameValuePair "${v.config.Label}.plist" (toAgent v.config)
-  ) (lib.filterAttrs (_n: v: v.enable) cfg.agents);
+  agentPlists = lib.mapAttrs' (n: v: lib.nameValuePair "${v.config.Label}.plist" (toAgent n v)) (
+    lib.filterAttrs (_n: v: v.enable) cfg.agents
+  );
 
   agentDomains = lib.mapAttrs' (
     _n: v:

--- a/modules/misc/news/2026/07/2026-07-15_01-26-11.nix
+++ b/modules/misc/news/2026/07/2026-07-15_01-26-11.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+{
+  time = "2026-07-15T00:26:11+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin;
+  message = ''
+    A new option is available: 'launchd.agents.<name>.waitForNixStore'.
+
+    By default, launchd agents are started through a '/bin/sh' wrapper
+    that waits for the Nix store to be mounted, which makes every agent
+    show up as "sh" in System Settings > Login Items & Extensions. When
+    this option is disabled, the agent is instead started through a
+    launcher script named after the agent, so it is displayed under its
+    own name. Note that disabling it means the agent will fail to start
+    if launchd runs it before the Nix store volume is mounted (e.g.
+    early during login when the store volume is encrypted).
+  '';
+}

--- a/tests/modules/launchd/agent-launcher.nix
+++ b/tests/modules/launchd/agent-launcher.nix
@@ -1,0 +1,31 @@
+{
+  config = {
+    launchd.agents."launcher-service" = {
+      enable = true;
+      waitForNixStore = false;
+      config = {
+        ProgramArguments = [
+          "/some/command"
+          "--with-arguments"
+          "foo"
+        ];
+      };
+    };
+
+    nmt.script = ''
+      serviceFile=LaunchAgents/org.nix-community.home.launcher-service.plist
+      assertFileExists $serviceFile
+
+      # The agent should exec a launcher script named after it, so that it
+      # is displayed under its own name in Login Items & Extensions
+      assertFileRegex $serviceFile '<string>/nix/store/[^<]*/bin/launcher-service</string>'
+
+      # Ensure the agent wasn't started through a shell wrapper.
+      assertFileNotRegex $serviceFile '<string>/bin/sh</string>'
+
+      launcher=$(sed -n 's|.*<string>\(/nix/store/[^<]*/bin/launcher-service\)</string>.*|\1|p' \
+        "$(_abs $serviceFile)")
+      assertFileContains "$launcher" 'exec /some/command --with-arguments foo'
+    '';
+  };
+}

--- a/tests/modules/launchd/default.nix
+++ b/tests/modules/launchd/default.nix
@@ -1,4 +1,5 @@
 {
   launchd-agent-domain = ./agent-domain.nix;
+  launchd-agent-launcher = ./agent-launcher.nix;
   launchd-agents = ./agents.nix;
 }


### PR DESCRIPTION
### Description

By default agents are started via /bin/sh with /bin/wait4path, which makes every Home Manager agent show up as "sh" in System Settings > Login Items & Extensions. Ideally by default it would show something more descriptive, but it's that way to ensure the nix store is mounted before they're started. This change allows opting out per agent, in which case the command is exec'd through a launcher script named after the agent so it is displayed under its own name.

Here you can see the new names of my agents via sfltool:
```
❯ sudo sfltool dumpbtm | awk -v RS='' '/org\.nix-community\.home/' | grep -E '(^ *Name|Identifier|Executable Path):'
                 Name: activate-agenix
           Identifier: 8.org.nix-community.home.activate-agenix
      Executable Path: /nix/store/rz4mql3impk7p3lx1dk6nsng6n1inmff-activate-agenix/bin/activate-agenix
                 Name: colima-default
           Identifier: 8.org.nix-community.home.colima-default
      Executable Path: /nix/store/gk1jsp9qam42kyl21cqb1wydr6zd7sr1-colima-default/bin/colima-default
```

It's worth noting that if the nix store was somehow not mounted before launching, the agent would fail on the first attempt. This is mentioned in the docs of the option and is the reason I made it opt-in (or opt-out of the default), hopefully that's sufficient.

Also this is my first time contributing to home-manager so I'm not sure if this is a sufficiently exciting new feature for a news entry, it is to me so I added one but I'll admit I'm biased so if it is in fact not sufficiently exciting then I can remove that :)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
