### PR TITLE
b4: add module

### DIFF
--- a/modules/misc/news/2026/07/2026-07-14_00-00-00.nix
+++ b/modules/misc/news/2026/07/2026-07-14_00-00-00.nix
@@ -1,0 +1,14 @@
+{
+  time = "2026-07-14T00:00:00+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.b4'.
+
+    b4 is a tool for working with kernel-style patch and email review
+    workflows on lore.kernel.org. The module installs b4 and writes its
+    configuration to git-config's [b4] section via `programs.b4.settings`. It
+    can also wire b4's review-editor syntax highlighting into Vim/Neovim/Emacs
+    and exposes b4's shipped agent-reviewer instructions for driving an AI
+    reviewer.
+  '';
+}

--- a/modules/programs/b4.nix
+++ b/modules/programs/b4.nix
@@ -1,0 +1,166 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.b4;
+in
+{
+  meta.maintainers = [ lib.maintainers.fzakaria ];
+
+  options.programs.b4 = {
+    enable = lib.mkEnableOption "b4, a tool for kernel-style patch/email review workflows";
+
+    package = lib.mkPackageOption pkgs "b4" { };
+
+    settings = lib.mkOption {
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          bool
+          int
+          str
+          (listOf str)
+        ]);
+      default = { };
+      example = lib.literalExpression ''
+        {
+          attestation-policy = "hardfail";
+          midmask = "https://lore.kernel.org/all/%s";
+        }
+      '';
+      description = ''
+        Settings written to git-config's `[b4]` section, b4's only configuration
+        source. Written via {option}`programs.git.settings`, so a non-empty value
+        requires {option}`programs.git.enable`.
+
+        See <https://b4.docs.kernel.org/en/latest/config.html> for the keys.
+      '';
+    };
+
+    agentReview = {
+      enable = lib.mkEnableOption ''
+        the AI reviewer behind the `a` key in the `b4 review` TUI, by writing the
+        `review-agent-command` and `review-agent-prompt-path` `[b4]` settings
+      '';
+
+      command = lib.mkOption {
+        type = lib.types.str;
+        default =
+          "${lib.getExe pkgs.claude-code}"
+          + " --add-dir .git"
+          + " --add-dir ${lib.escapeShellArg (dirOf cfg.agentReview.instructions)}"
+          + " --allowedTools 'Bash(git:*) Read Glob Grep Write(.git/b4-review/**) Edit(.git/b4-review/**)'"
+          + " --";
+        defaultText = lib.literalMD "A Claude Code invocation (`pkgs.claude-code`)";
+        example = lib.literalExpression ''"''${lib.getExe pkgs.aider-chat} --message"'';
+        description = ''
+          The command b4 runs for the agent action. It is POSIX-shlex-split, gets
+          a final argument pointing at
+          {option}`programs.b4.agentReview.instructions`, and runs with the
+          repository top as its working directory, so relative `.git` paths
+          resolve per-repo.
+        '';
+      };
+
+      instructions = lib.mkOption {
+        type = with lib.types; either str path;
+        # misc/ is absent from the PyPI sdist the package builds from, so the b4
+        # package exposes the matching git checkout as `passthru.src-misc`.
+        default = "${cfg.package.src-misc}/misc/agent-reviewer.md";
+        defaultText = lib.literalMD "b4's shipped `misc/agent-reviewer.md`";
+        example = lib.literalExpression "./my-agent-reviewer.md";
+        description = ''
+          Instructions telling the agent how to write review files under
+          {file}`.git/b4-review/`. Written to `review-agent-prompt-path` as an
+          absolute path, so it applies to every repository.
+        '';
+      };
+    };
+
+    vimSyntax = lib.mkOption {
+      type = lib.types.bool;
+      default = config.programs.vim.enable || config.programs.neovim.enable;
+      defaultText = lib.literalExpression "config.programs.vim.enable || config.programs.neovim.enable";
+      description = ''
+        Whether to add b4's review-editor syntax highlighting, which activates for
+        {file}`*.b4-review.eml` buffers, to
+        {option}`programs.vim`/{option}`programs.neovim`. Editors managed outside
+        home-manager can instead put {option}`programs.b4.vimPlugin` on their
+        runtimepath.
+      '';
+    };
+
+    emacsSyntax = lib.mkOption {
+      type = lib.types.bool;
+      default = config.programs.emacs.enable;
+      defaultText = lib.literalExpression "config.programs.emacs.enable";
+      description = ''
+        Whether to add b4's `b4-review-mode`, which autoloads for
+        {file}`*.b4-review.eml` files, to {option}`programs.emacs`. Editors managed
+        outside home-manager can instead consume
+        {option}`programs.b4.emacsPackage`.
+      '';
+    };
+
+    vimPlugin = lib.mkPackageOption pkgs [ "vimPlugins" "b4-review-vim" ] {
+      extraDescription = ''
+        b4's Vim review-editor files as a runtimepath plugin, for adding to
+        e.g. {option}`programs.neovim.plugins`.
+      '';
+    };
+
+    emacsPackage = lib.mkOption {
+      type = lib.types.functionTo lib.types.package;
+      default = epkgs: epkgs.b4-review-mode;
+      defaultText = lib.literalExpression "epkgs: epkgs.b4-review-mode";
+      description = ''
+        Selector picking b4's `b4-review-mode.el` out of an Emacs package set, for
+        adding to e.g. {option}`programs.emacs.extraPackages`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        home.packages = [ cfg.package ];
+
+        assertions = [
+          {
+            assertion = cfg.settings == { } || config.programs.git.enable;
+            message = ''
+              programs.b4.settings has [b4] git-config to write, so
+              programs.git.enable must be true.
+            '';
+          }
+        ];
+      }
+
+      (lib.mkIf (cfg.settings != { }) {
+        programs.git.settings.b4 = cfg.settings;
+      })
+
+      # mkDefault leaves both keys overridable from `settings`.
+      (lib.mkIf cfg.agentReview.enable {
+        programs.b4.settings = {
+          review-agent-command = lib.mkDefault cfg.agentReview.command;
+          review-agent-prompt-path = lib.mkDefault "${cfg.agentReview.instructions}";
+        };
+      })
+
+      # A plugins/packages list on a disabled editor is inert, so both branches
+      # are safe even when only one editor is enabled.
+      (lib.mkIf cfg.vimSyntax {
+        programs.neovim.plugins = [ cfg.vimPlugin ];
+        programs.vim.plugins = [ cfg.vimPlugin ];
+      })
+
+      (lib.mkIf cfg.emacsSyntax {
+        programs.emacs.extraPackages = epkgs: [ (cfg.emacsPackage epkgs) ];
+      })
+    ]
+  );
+}

--- a/modules/programs/b4.nix
+++ b/modules/programs/b4.nix
@@ -1,0 +1,167 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.b4;
+in
+{
+  meta.maintainers = [ lib.maintainers.fzakaria ];
+
+  options.programs.b4 = {
+    enable = lib.mkEnableOption "b4, a tool for kernel-style patch/email review workflows";
+
+    package = lib.mkPackageOption pkgs "b4" { };
+
+    settings = lib.mkOption {
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          bool
+          int
+          str
+          (listOf str)
+        ]);
+      default = { };
+      example = lib.literalExpression ''
+        {
+          attestation-policy = "hardfail";
+          midmask = "https://lore.kernel.org/all/%s";
+        }
+      '';
+      description = ''
+        Settings making up git-config's `[b4]` section, b4's only configuration
+        source. The generated section is merged into
+        {file}`$XDG_CONFIG_HOME/git/config`, so a non-empty value requires
+        {option}`programs.git.enable`.
+
+        See <https://b4.docs.kernel.org/en/latest/config.html> for the keys.
+      '';
+    };
+
+    agentReview = {
+      enable = lib.mkEnableOption ''
+        the AI reviewer behind the `a` key in the `b4 review` TUI, by writing the
+        `review-agent-command` and `review-agent-prompt-path` `[b4]` settings
+      '';
+
+      command = lib.mkOption {
+        type = lib.types.str;
+        default =
+          "${lib.getExe pkgs.claude-code}"
+          + " --add-dir .git"
+          + " --add-dir ${lib.escapeShellArg (dirOf cfg.agentReview.instructions)}"
+          + " --allowedTools 'Bash(git:*) Read Glob Grep Write(.git/b4-review/**) Edit(.git/b4-review/**)'"
+          + " --";
+        defaultText = lib.literalMD "A Claude Code invocation (`pkgs.claude-code`)";
+        example = lib.literalExpression ''"''${lib.getExe pkgs.aider-chat} --message"'';
+        description = ''
+          The command b4 runs for the agent action. It is POSIX-shlex-split, gets
+          a final argument pointing at
+          {option}`programs.b4.agentReview.instructions`, and runs with the
+          repository top as its working directory, so relative `.git` paths
+          resolve per-repo.
+        '';
+      };
+
+      instructions = lib.mkOption {
+        type = with lib.types; either str path;
+        # misc/ is absent from the PyPI sdist the package builds from, so the b4
+        # package exposes the matching git checkout as `passthru.src-misc`.
+        default = "${cfg.package.src-misc}/misc/agent-reviewer.md";
+        defaultText = lib.literalMD "b4's shipped `misc/agent-reviewer.md`";
+        example = lib.literalExpression "./my-agent-reviewer.md";
+        description = ''
+          Instructions telling the agent how to write review files under
+          {file}`.git/b4-review/`. Written to `review-agent-prompt-path` as an
+          absolute path, so it applies to every repository.
+        '';
+      };
+    };
+
+    vimSyntax = lib.mkOption {
+      type = lib.types.bool;
+      default = config.programs.vim.enable || config.programs.neovim.enable;
+      defaultText = lib.literalExpression "config.programs.vim.enable || config.programs.neovim.enable";
+      description = ''
+        Whether to add b4's review-editor syntax highlighting, which activates for
+        {file}`*.b4-review.eml` buffers, to
+        {option}`programs.vim`/{option}`programs.neovim`. Editors managed outside
+        home-manager can instead put {option}`programs.b4.vimPlugin` on their
+        runtimepath.
+      '';
+    };
+
+    emacsSyntax = lib.mkOption {
+      type = lib.types.bool;
+      default = config.programs.emacs.enable;
+      defaultText = lib.literalExpression "config.programs.emacs.enable";
+      description = ''
+        Whether to add b4's `b4-review-mode`, which autoloads for
+        {file}`*.b4-review.eml` files, to {option}`programs.emacs`. Editors managed
+        outside home-manager can instead consume
+        {option}`programs.b4.emacsPackage`.
+      '';
+    };
+
+    vimPlugin = lib.mkPackageOption pkgs [ "vimPlugins" "b4-review-vim" ] {
+      extraDescription = ''
+        b4's Vim review-editor files as a runtimepath plugin, for adding to
+        e.g. {option}`programs.neovim.plugins`.
+      '';
+    };
+
+    emacsPackage = lib.mkOption {
+      type = lib.types.functionTo lib.types.package;
+      default = epkgs: epkgs.b4-review-mode;
+      defaultText = lib.literalExpression "epkgs: epkgs.b4-review-mode";
+      description = ''
+        Selector picking b4's `b4-review-mode.el` out of an Emacs package set, for
+        adding to e.g. {option}`programs.emacs.extraPackages`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        home.packages = [ cfg.package ];
+
+        assertions = [
+          {
+            assertion = cfg.settings == { } || config.programs.git.enable;
+            message = ''
+              programs.b4.settings has [b4] git-config to write, so
+              programs.git.enable must be true.
+            '';
+          }
+        ];
+      }
+
+      # iniContent, not settings: the public settings option also accepts an
+      # ordered list of fragments, which a `settings.b4` definition would
+      # conflict with. iniContent is the attrset Git integrations merge into.
+      (lib.mkIf (cfg.settings != { }) {
+        programs.git.iniContent.b4 = cfg.settings;
+      })
+
+      (lib.mkIf cfg.agentReview.enable {
+        programs.b4.settings = {
+          review-agent-command = lib.mkDefault cfg.agentReview.command;
+          review-agent-prompt-path = lib.mkDefault "${cfg.agentReview.instructions}";
+        };
+      })
+
+      (lib.mkIf cfg.vimSyntax {
+        programs.neovim.plugins = [ cfg.vimPlugin ];
+        programs.vim.plugins = [ cfg.vimPlugin ];
+      })
+
+      (lib.mkIf cfg.emacsSyntax {
+        programs.emacs.extraPackages = epkgs: [ (cfg.emacsPackage epkgs) ];
+      })
+    ]
+  );
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -19,6 +19,7 @@ let
     "autojump"
     "autorandr"
     "awscli2"
+    "b4"
     "bacon"
     "bash"
     "bash-completion"

--- a/tests/modules/programs/b4/agent-review.nix
+++ b/tests/modules/programs/b4/agent-review.nix
@@ -1,0 +1,24 @@
+{ config, ... }:
+{
+  # agentReview writes both agent keys, with the instructions directory
+  # shell-quoted inside the shlex-split command.
+  programs.git.enable = true;
+
+  programs.b4 = {
+    enable = true;
+    agentReview = {
+      enable = true;
+      instructions = "/some dir/agent-reviewer.md";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContains home-files/.config/git/config '[b4]'
+    assertFileContains home-files/.config/git/config \
+      "review-agent-command = \"${config.programs.b4.agentReview.command}\""
+    assertFileContains home-files/.config/git/config \
+      "review-agent-prompt-path = \"/some dir/agent-reviewer.md\""
+    assertFileContains home-files/.config/git/config "add-dir '/some dir'"
+  '';
+}

--- a/tests/modules/programs/b4/default-settings.nix
+++ b/tests/modules/programs/b4/default-settings.nix
@@ -1,0 +1,8 @@
+{
+  # By default the module writes no [b4] git-config at all.
+  programs.b4.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/git/config
+  '';
+}

--- a/tests/modules/programs/b4/default.nix
+++ b/tests/modules/programs/b4/default.nix
@@ -1,0 +1,5 @@
+{
+  b4-default-settings = ./default-settings.nix;
+  b4-settings = ./settings.nix;
+  b4-agent-review = ./agent-review.nix;
+}

--- a/tests/modules/programs/b4/settings.nix
+++ b/tests/modules/programs/b4/settings.nix
@@ -1,0 +1,18 @@
+{
+  programs.git.enable = true;
+
+  programs.b4 = {
+    enable = true;
+    settings = {
+      attestation-policy = "hardfail";
+      midmask = "https://lore.kernel.org/all/%s";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContains home-files/.config/git/config '[b4]'
+    assertFileContains home-files/.config/git/config 'attestation-policy = "hardfail"'
+    assertFileContains home-files/.config/git/config 'midmask = "https://lore.kernel.org/all/%s"'
+  '';
+}

--- a/tests/modules/programs/b4/settings.nix
+++ b/tests/modules/programs/b4/settings.nix
@@ -1,0 +1,29 @@
+{
+  # settings lands in the [b4] section and coexists with the ordered-list form
+  # of programs.git.settings, which a `programs.git.settings.b4` definition
+  # would conflict with.
+  programs.git = {
+    enable = true;
+    settings = [
+      { core.whitespace = "trailing-space,space-before-tab"; }
+    ];
+  };
+
+  programs.b4 = {
+    enable = true;
+    settings = {
+      attestation-policy = "hardfail";
+      midmask = "https://lore.kernel.org/all/%s";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContains home-files/.config/git/config '[b4]'
+    assertFileContains home-files/.config/git/config 'attestation-policy = "hardfail"'
+    assertFileContains home-files/.config/git/config 'midmask = "https://lore.kernel.org/all/%s"'
+    assertFileContains home-files/.config/git/config '[core]'
+    assertFileContains home-files/.config/git/config \
+      'whitespace = "trailing-space,space-before-tab"'
+  '';
+}


### PR DESCRIPTION
### Description

b4 (https://b4.docs.kernel.org) is a tool for kernel-style patch and email review workflows on lore.kernel.org. The module installs b4 and writes its configuration to git-config's [b4] section via programs.b4.settings, defaulting to a recommended Claude Code review-agent wiring. It also inlines b4's review-editor syntax highlighting into programs.vim/neovim/emacs and exposes b4's shipped agent-reviewer instructions for driving an AI reviewer.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
