### PR TITLE
launchd: restore gui domain defaults

### DIFF
--- a/docs/release-notes/rl-2611.md
+++ b/docs/release-notes/rl-2611.md
@@ -16,9 +16,9 @@ This release has the following notable changes:
 
 - On Darwin, Home Manager launchd agents now support
   [](#opt-launchd.agents._name_.domain) to choose either the user's GUI or
-  background launchd domain. Background services provided by Home Manager now
-  use the user domain, which allows activations from contexts such as SSH
-  sessions without requiring an active graphical login session.
+  background launchd domain. Agents use the GUI domain by default. Set the
+  domain to `user` for agents that should run without an active graphical login
+  session.
 
 ## State Version Changes {#sec-release-26.11-state-version-changes}
 

--- a/modules/misc/news/2026/06/2026-06-18_02-02-00.nix
+++ b/modules/misc/news/2026/06/2026-06-18_02-02-00.nix
@@ -6,10 +6,8 @@
   message = ''
 
     Home Manager launchd agents now support the
-    `launchd.agents.<name>.domain` option. Background services provided by Home
-    Manager use the user launchd domain by default, so they can be managed from
-    SSH and other non-graphical sessions. Set
-    `launchd.agents.<name>.domain = "gui"` for agents that need the graphical
-    session.
+    `launchd.agents.<name>.domain` option. Agents use the GUI launchd domain by
+    default. Set `launchd.agents.<name>.domain = "user"` for agents that should
+    run without an active graphical login session.
   '';
 }

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -303,7 +303,6 @@ in
 
           launchd.agents.atuin-daemon = {
             enable = true;
-            domain = lib.mkDefault "user";
             config = {
               ProgramArguments = [ (lib.getExe cfg.package) ] ++ daemonArgs;
               EnvironmentVariables = lib.optionalAttrs (daemonCfg.logLevel != null) {

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -609,7 +609,6 @@ in
           {
             "git-maintenance-hourly" = {
               enable = true;
-              domain = lib.mkDefault "user";
               config = {
                 ProgramArguments = baseArguments ++ [ "--schedule=hourly" ];
                 StartCalendarInterval = map (hour: {
@@ -620,7 +619,6 @@ in
             };
             "git-maintenance-daily" = {
               enable = true;
-              domain = lib.mkDefault "user";
               config = {
                 ProgramArguments = baseArguments ++ [ "--schedule=daily" ];
                 StartCalendarInterval = map (weekday: {
@@ -632,7 +630,6 @@ in
             };
             "git-maintenance-weekly" = {
               enable = true;
-              domain = lib.mkDefault "user";
               config = {
                 ProgramArguments = baseArguments ++ [ "--schedule=weekly" ];
                 StartCalendarInterval = [

--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -151,7 +151,6 @@ in
 
     launchd.agents.nh-clean = lib.mkIf cfg.clean.enable {
       enable = true;
-      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           "${lib.getExe cfg.package}"

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -631,7 +631,6 @@ in
     launchd.agents = mkIf webCfg.enable {
       opencode-web = {
         enable = true;
-        domain = lib.mkDefault "user";
         config = {
           ProgramArguments =
             let

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -160,7 +160,6 @@ let
     in
     {
       enable = true;
-      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           (lib.getExe rcloneSidecarWrapper)
@@ -620,7 +619,6 @@ in
       mkLaunchdConfigService = lib.mkIf (cfg.remotes != { }) {
         rclone-config = {
           enable = true;
-          domain = lib.mkDefault "user";
           config = {
             ProgramArguments = [ (lib.getExe rcloneConfigScript) ];
             RunAtLoad = true;

--- a/modules/services/borgmatic.nix
+++ b/modules/services/borgmatic.nix
@@ -87,7 +87,6 @@ in
 
     launchd.agents.borgmatic = {
       enable = true;
-      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           (lib.getExe programConfig.package)

--- a/modules/services/colima.nix
+++ b/modules/services/colima.nix
@@ -265,7 +265,6 @@ in
         name: profile:
         lib.nameValuePair "colima-${name}" {
           enable = true;
-          domain = lib.mkDefault "user";
           config = {
             ProgramArguments = [
               "${lib.getExe cfg.package}"

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -218,7 +218,6 @@ in
 
     launchd.agents.emacs = {
       enable = true;
-      domain = lib.mkDefault (if cfg.startWithUserSession == "graphical" then "gui" else "user");
       config = {
         ProgramArguments = [
           "${cfg.package}/bin/emacs"

--- a/modules/services/exo.nix
+++ b/modules/services/exo.nix
@@ -60,7 +60,6 @@ in
 
     launchd.agents.exo = {
       enable = true;
-      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [ (lib.getExe cfg.package) ] ++ cfg.extraArgs;
         EnvironmentVariables = cfg.environmentVariables;

--- a/modules/services/git-sync.nix
+++ b/modules/services/git-sync.nix
@@ -108,7 +108,6 @@ in
     launchd.agents = services (
       _name: repo: {
         enable = true;
-        domain = lib.mkDefault "user";
         config = {
           StartInterval = repo.interval;
           ProcessType = "Background";

--- a/modules/services/glance.nix
+++ b/modules/services/glance.nix
@@ -87,7 +87,6 @@ in
 
     launchd.agents.glance = mkIf (cfg.package != null) {
       enable = true;
-      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           (getExe cfg.package)

--- a/modules/services/home-manager-auto-expire.nix
+++ b/modules/services/home-manager-auto-expire.nix
@@ -105,7 +105,6 @@ in
 
     launchd.agents.home-manager-auto-expire = {
       enable = true;
-      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [ (toString script) ];
         ProcessType = "Background";

--- a/modules/services/imapnotify/default.nix
+++ b/modules/services/imapnotify/default.nix
@@ -65,7 +65,6 @@ let
       name = "imapnotify-${name}";
       value = {
         enable = true;
-        domain = lib.mkDefault "user";
         config = {
           # Use the nix store path for config to ensure service restarts when it changes
           ProgramArguments = [

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -254,7 +254,6 @@ in
 
       launchd.agents.mpd = {
         enable = true;
-        domain = lib.mkDefault "user";
         config = {
           ProgramArguments = [
             (lib.getExe cfg.package)

--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -121,7 +121,6 @@ in
 
     launchd.agents.nix-gc = {
       enable = true;
-      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           "${nixPackage}/bin/nix-collect-garbage"

--- a/modules/services/ollama.nix
+++ b/modules/services/ollama.nix
@@ -107,7 +107,6 @@ in
 
     launchd.agents.ollama = {
       enable = true;
-      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           "${lib.getExe ollamaPackage}"

--- a/modules/services/podman/darwin.nix
+++ b/modules/services/podman/darwin.nix
@@ -311,7 +311,6 @@ in
           name: machine:
           nameValuePair "podman-machine-${name}" {
             enable = true;
-            domain = lib.mkDefault "user";
             config = {
               ProgramArguments = [ "${mkWatchdogScript name machine}" ];
               KeepAlive = {

--- a/modules/services/pueue.nix
+++ b/modules/services/pueue.nix
@@ -57,7 +57,6 @@ in
 
     launchd.agents.pueued = lib.mkIf (cfg.package != null) {
       enable = true;
-      domain = lib.mkDefault "user";
 
       config = {
         ProgramArguments = [

--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -105,7 +105,6 @@ in
 
     launchd.agents.ssh-agent = {
       enable = true;
-      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           (lib.getExe pkgs.bash)

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -943,7 +943,6 @@ in
       launchd.agents = {
         syncthing = {
           enable = true;
-          domain = lib.mkDefault "user";
           config = {
             ProgramArguments = [
               "${pkgs.writers.writeBash "syncthing-wrapper" ''

--- a/modules/services/tldr-update.nix
+++ b/modules/services/tldr-update.nix
@@ -62,7 +62,6 @@ in
 
     launchd.agents.tldr-update = {
       enable = true;
-      domain = lib.mkDefault "user";
       config = {
         ProgramArguments = [
           (lib.getExe cfg.package)

--- a/tests/modules/programs/git/expected-agent-daily.plist
+++ b/tests/modules/programs/git/expected-agent-daily.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.git-maintenance-daily</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/programs/git/expected-agent-hourly.plist
+++ b/tests/modules/programs/git/expected-agent-hourly.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.git-maintenance-hourly</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/programs/git/expected-agent-weekly.plist
+++ b/tests/modules/programs/git/expected-agent-weekly.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.git-maintenance-weekly</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/programs/nh/darwin/launchd.plist
+++ b/tests/modules/programs/nh/darwin/launchd.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.nh-clean</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/programs/opencode/web-service-environment-file.plist
+++ b/tests/modules/programs/opencode/web-service-environment-file.plist
@@ -11,8 +11,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.opencode-web</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/programs/opencode/web-service.plist
+++ b/tests/modules/programs/opencode/web-service.plist
@@ -11,8 +11,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.opencode-web</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/borgmatic/darwin/expected-agent.plist
+++ b/tests/modules/services/borgmatic/darwin/expected-agent.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.borgmatic</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/colima/darwin/colima-docker-cli-expected.plist
+++ b/tests/modules/services/colima/darwin/colima-docker-cli-expected.plist
@@ -22,8 +22,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.colima-default</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/services/colima/darwin/expected-agent.plist
+++ b/tests/modules/services/colima/darwin/expected-agent.plist
@@ -18,8 +18,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.colima-default</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/services/emacs/darwin/expected-agent.plist
+++ b/tests/modules/services/emacs/darwin/expected-agent.plist
@@ -11,8 +11,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.emacs</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/services/git-sync/darwin/expected-agent.plist
+++ b/tests/modules/services/git-sync/darwin/expected-agent.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.git-sync-test</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/glance/default-settings.nix
+++ b/tests/modules/services/glance/default-settings.nix
@@ -18,12 +18,10 @@
       serviceFile=$(normalizeStorePaths $serviceFile)
       assertFileExists "$serviceFile"
       assertFileContent "$serviceFile" ${./glance.plist}
-      assertFileContains "$serviceFile" '<key>LimitLoadToSessionType</key>'
-      assertFileContains "$serviceFile" '<string>Background</string>'
 
       domainFile=LaunchAgentDomains/org.nix-community.home.glance.domain
-      assertFileContent "$domainFile" ${builtins.toFile "expected-domain" "user\n"}
-      assertFileContains activate 'domain="user/$(id -u)"'
+      assertFileContent "$domainFile" ${builtins.toFile "expected-domain" "gui\n"}
+      assertFileContains activate 'domain="gui/$(id -u)"'
       assertFileContains activate 'launchctl kickstart -k "$domain/org.nix-community.home.glance"'
     '')
   ];

--- a/tests/modules/services/glance/domain-override.nix
+++ b/tests/modules/services/glance/domain-override.nix
@@ -2,13 +2,13 @@
 
 {
   services.glance.enable = true;
-  launchd.agents.glance.domain = "gui";
+  launchd.agents.glance.domain = "user";
 
   nmt.script = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin ''
     domainFile=LaunchAgentDomains/org.nix-community.home.glance.domain
     assertFileExists "$domainFile"
-    assertFileContent "$domainFile" ${builtins.toFile "expected-domain" "gui\n"}
-    assertFileContains activate 'domain="gui/$(id -u)"'
+    assertFileContent "$domainFile" ${builtins.toFile "expected-domain" "user\n"}
+    assertFileContains activate 'domain="user/$(id -u)"'
     assertFileContains activate 'launchctl kickstart -k "$domain/org.nix-community.home.glance"'
   '';
 }

--- a/tests/modules/services/glance/glance.plist
+++ b/tests/modules/services/glance/glance.plist
@@ -6,8 +6,6 @@
 	<true/>
 	<key>Label</key>
 	<string>org.nix-community.home.glance</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/services/home-manager-auto-expire/darwin/expected-agent.plist
+++ b/tests/modules/services/home-manager-auto-expire/darwin/expected-agent.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.home-manager-auto-expire</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/imapnotify/darwin/launchd.plist
+++ b/tests/modules/services/imapnotify/darwin/launchd.plist
@@ -13,8 +13,6 @@
 	<true/>
 	<key>Label</key>
 	<string>org.nix-community.home.imapnotify-hm-example.com</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/nix-gc/darwin/expected-agent.plist
+++ b/tests/modules/services/nix-gc/darwin/expected-agent.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>Label</key>
 	<string>org.nix-community.home.nix-gc</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/sh</string>

--- a/tests/modules/services/ollama/darwin/expected-agent.plist
+++ b/tests/modules/services/ollama/darwin/expected-agent.plist
@@ -20,8 +20,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.ollama</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/podman/darwin/basic-expected-agent.plist
+++ b/tests/modules/services/podman/darwin/basic-expected-agent.plist
@@ -11,8 +11,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.podman-machine-podman-machine-default</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/podman/darwin/custom-machines-dev-expected-agent.plist
+++ b/tests/modules/services/podman/darwin/custom-machines-dev-expected-agent.plist
@@ -11,8 +11,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.podman-machine-dev-machine</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/ssh-agent/darwin/basic-service-expected.plist
+++ b/tests/modules/services/ssh-agent/darwin/basic-service-expected.plist
@@ -11,8 +11,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.ssh-agent</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/ssh-agent/darwin/pkcs11-service-expected.plist
+++ b/tests/modules/services/ssh-agent/darwin/pkcs11-service-expected.plist
@@ -11,8 +11,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.ssh-agent</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/ssh-agent/darwin/timeout-service-expected.plist
+++ b/tests/modules/services/ssh-agent/darwin/timeout-service-expected.plist
@@ -11,8 +11,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.ssh-agent</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>

--- a/tests/modules/services/syncthing/expected-agent.plist
+++ b/tests/modules/services/syncthing/expected-agent.plist
@@ -11,8 +11,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.syncthing</string>
-	<key>LimitLoadToSessionType</key>
-	<string>Background</string>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>ProgramArguments</key>


### PR DESCRIPTION
User-domain agents are not rediscovered from the user LaunchAgents directory after reboot. Let built-in agents inherit the GUI default while keeping explicit user-domain configuration available.

Related https://github.com/nix-community/home-manager/issues/9656

I haven't had the time to dedicate to a proper investigation / solution / testing atm so just reverting these services back to using gui. 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
