### PR TITLE
navi: update url for config file docs

### DIFF
--- a/modules/programs/navi.nix
+++ b/modules/programs/navi.nix
@@ -41,7 +41,7 @@ in
         {file}`$XDG_CONFIG_HOME/navi/config.yaml` on Linux or
         {file}`$HOME/Library/Application Support/navi/config.yaml`
         on Darwin. See
-        <https://github.com/denisidoro/navi/blob/master/docs/config_file.md>
+        <https://github.com/denisidoro/navi/blob/master/docs/configuration/README.md>
         for more information.
       '';
     };


### PR DESCRIPTION
### Description

Updates the broken/outdated URL in the current `programs.navi.settings` description.

Current URL:
_[https://github.com/denisidoro/navi/blob/master/docs/config_file.md](https://github.com/denisidoro/navi/blob/master/docs/config_file.md)_

Updated URL:
_[https://github.com/denisidoro/navi/blob/master/docs/configuration/README.md](https://github.com/denisidoro/navi/blob/master/docs/configuration/README.md)_

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
