### PR TITLE
senpai: use correct config directory on darwin systems

### DIFF
--- a/modules/misc/news/2026/07/2026-07-15_23-56-32.nix
+++ b/modules/misc/news/2026/07/2026-07-15_23-56-32.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+{
+  time = "2026-07-15T21:56:32+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin;
+  message = ''
+    The config path for 'senpai' on Darwin now defaults to:
+      ~/Library/Application Support/senpai/senpai.scfg
+  '';
+}

--- a/modules/programs/senpai.nix
+++ b/modules/programs/senpai.nix
@@ -8,6 +8,10 @@ let
   inherit (lib) mkOption types;
 
   cfg = config.programs.senpai;
+
+  configDir =
+    if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else config.xdg.configHome;
+
 in
 {
   meta.maintainers = [ lib.maintainers.malte-v ];
@@ -15,6 +19,7 @@ in
   options.programs.senpai = {
     enable = lib.mkEnableOption "senpai";
     package = lib.mkPackageOption pkgs "senpai" { };
+
     config = mkOption {
       type = types.submodule {
         freeformType = types.attrsOf types.anything;
@@ -102,8 +107,10 @@ in
         message = "senpai: no-tls is deprecated, use tls instead";
       }
     ];
+
     home.packages = [ cfg.package ];
-    xdg.configFile."senpai/senpai.scfg".text =
+
+    home.file."${configDir}/senpai/senpai.scfg".text =
       let
         attrsToDirectiveList = lib.mapAttrsToList (
           name: value:
@@ -111,22 +118,14 @@ in
             inherit name;
           }
           // (
-            if (builtins.typeOf value != "set") then
-              {
-                params = lib.toList value;
-              }
+            if builtins.typeOf value != "set" then
+              { params = lib.toList value; }
             else
               let
                 children = lib.filterAttrs (n: _: n != "_params") value;
               in
-              (
-                lib.optionalAttrs (value ? "_params") {
-                  params = value._params;
-                }
-                // lib.optionalAttrs (children != { }) {
-                  children = attrsToDirectiveList children;
-                }
-              )
+              lib.optionalAttrs (value ? "_params") { params = value._params; }
+              // lib.optionalAttrs (children != { }) { children = attrsToDirectiveList children; }
           )
         );
       in

--- a/tests/modules/programs/senpai/empty-settings.nix
+++ b/tests/modules/programs/senpai/empty-settings.nix
@@ -1,5 +1,11 @@
-{ config, ... }:
-
+{ config, pkgs, ... }:
+let
+  targetPath =
+    if pkgs.stdenv.isDarwin then
+      "home-files/Library/Application Support/senpai/senpai.scfg"
+    else
+      "home-files/.config/senpai/senpai.scfg";
+in
 {
   config = {
     programs.senpai = {
@@ -13,7 +19,7 @@
 
     nmt.script = ''
       assertFileContent \
-        home-files/.config/senpai/senpai.scfg \
+        "${targetPath}" \
         ${./empty-settings-expected.conf}
     '';
   };

--- a/tests/modules/programs/senpai/example-settings.nix
+++ b/tests/modules/programs/senpai/example-settings.nix
@@ -1,5 +1,11 @@
-{ config, ... }:
-
+{ config, pkgs, ... }:
+let
+  targetPath =
+    if pkgs.stdenv.isDarwin then
+      "home-files/Library/Application Support/senpai/senpai.scfg"
+    else
+      "home-files/.config/senpai/senpai.scfg";
+in
 {
   config = {
     programs.senpai = {
@@ -32,7 +38,7 @@
 
     nmt.script = ''
       assertFileContent \
-        home-files/.config/senpai/senpai.scfg \
+        "${targetPath}" \
         ${./example-settings-expected.conf}
     '';
   };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Made Darwin systems use `Library/Application Support/senpai/senpai.scfg` instead of using the XDG config directory.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
