### PR TITLE
wlsunset: add duration option

### DIFF
--- a/modules/services/wlsunset.nix
+++ b/modules/services/wlsunset.nix
@@ -6,10 +6,7 @@
 }:
 
 let
-  inherit (lib)
-    mkOption
-    types
-    ;
+  inherit (lib) mkOption types;
 
   cfg = config.services.wlsunset;
 in
@@ -96,6 +93,16 @@ in
       '';
     };
 
+    duration = mkOption {
+      type = with types; nullOr ints.positive;
+      default = null;
+      example = 1800;
+      description = ''
+        The duration for the easing (in seconds).
+        Cannot be used when latitude and longitude are set.
+      '';
+    };
+
     systemdTarget = mkOption {
       type = with types; str;
       default = config.wayland.systemd.target;
@@ -122,6 +129,10 @@ in
         assertion = (cfg.latitude != null) == (cfg.longitude != null);
         message = "Both `latitude and `longitude` together must be set for wlsunset";
       }
+      {
+        assertion = ((cfg.latitude != null) || (cfg.longitude != null)) == (cfg.duration == null);
+        message = "Cannot set duration if `latitude` or `longitude` are set";
+      }
     ];
 
     home.packages = [ cfg.package ];
@@ -145,6 +156,7 @@ in
               L = cfg.longitude;
               S = cfg.sunrise;
               s = cfg.sunset;
+              d = cfg.duration;
               o = cfg.output;
             };
           in

--- a/tests/modules/services/wlsunset/default.nix
+++ b/tests/modules/services/wlsunset/default.nix
@@ -2,4 +2,5 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   wlsunset-service = ./wlsunset-service.nix;
+  wlsunset-sunrise-sunset = ./sunrise-sunset.nix;
 }

--- a/tests/modules/services/wlsunset/sunrise-sunset.nix
+++ b/tests/modules/services/wlsunset/sunrise-sunset.nix
@@ -1,0 +1,27 @@
+{
+  services.wlsunset = {
+    enable = true;
+    sunrise = "06:30";
+    sunset = "19:00";
+    duration = 1800;
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/wlsunset.service
+
+    assertFileExists $serviceFile
+    assertFileContent $serviceFile ${builtins.toFile "wlsunset.service" ''
+      [Install]
+      WantedBy=graphical-session.target
+
+      [Service]
+      ExecStart=@wlsunset@/bin/wlsunset -S06:30 -T6500 -d1800 -g1.000000 -s19:00 -t4000
+
+      [Unit]
+      After=graphical-session.target
+      ConditionEnvironment=WAYLAND_DISPLAY
+      Description=Day/night gamma adjustments for Wayland compositors.
+      PartOf=graphical-session.target
+    ''}
+  '';
+}


### PR DESCRIPTION
add an option to set the easing duration
if the times have been set manually

### Description

Add the option to set the duration flag for wlsunset

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
