### PR TITLE
tirith: zsh initExtra -> initContent

### DIFF
--- a/modules/programs/tirith.nix
+++ b/modules/programs/tirith.nix
@@ -75,7 +75,7 @@ in
       ${lib.getExe cfg.package} init --shell fish | source
     '';
 
-    programs.zsh.initExtra = lib.mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = lib.mkIf cfg.enableZshIntegration ''
       eval "$(${lib.getExe cfg.package} init --shell zsh)"
     '';
   };


### PR DESCRIPTION
### Description

Migrate usage of zsh initExtra to initContent because initExtra is deprecated.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [~] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
