### PR TITLE
syncthing: use localhost authority for unix-socket REST calls

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -54,11 +54,12 @@ let
     path:
     if
       isUnixGui
-    # if cfg.guiAddress is a unix socket, tell curl explicitly about it
-    # note that the dot in front of `${path}` is the hostname, which is
-    # required.
+    # if cfg.guiAddress is a unix socket, tell curl explicitly about it.
+    # `localhost` is a placeholder authority routed to the socket by
+    # --unix-socket; a bare-dot host (`http://.`) is rejected as an invalid
+    # hostname by curl >= 8.21.
     then
-      "--unix-socket ${cfg.guiAddress} http://.${path}"
+      "--unix-socket ${cfg.guiAddress} http://localhost${path}"
     # no adjustments are needed if cfg.guiAddress is a network address
     else
       "${cfg.guiAddress}${path}";

--- a/tests/modules/services/syncthing/linux/default.nix
+++ b/tests/modules/services/syncthing/linux/default.nix
@@ -1,5 +1,6 @@
 {
   syncthing-gui-address-init = ./gui-address-init.nix;
+  syncthing-gui-address-unix-socket-init = ./gui-address-unix-socket-init.nix;
   syncthing-ignore-patterns = ./ignore-patterns.nix;
   syncthing-tray = ./tray.nix;
 }

--- a/tests/modules/services/syncthing/linux/gui-address-unix-socket-init.nix
+++ b/tests/modules/services/syncthing/linux/gui-address-unix-socket-init.nix
@@ -1,0 +1,17 @@
+{
+  services.syncthing = {
+    enable = true;
+    guiAddress = "/tmp/syncthing.sock";
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/syncthing-init.service
+    assertFileExists "$serviceFile"
+    assertFileContains "$serviceFile" "ExecStart="
+
+    updateScript=$(grep -o '/nix/store/[^ ]*-merge-syncthing-config' "$TESTED/$serviceFile")
+    # A unix-socket guiAddress must use a `localhost` placeholder authority. A
+    # bare-dot host (`http://.`) is rejected by curl >= 8.21 as "Bad hostname".
+    assertFileContains "$updateScript" "/tmp/syncthing.sock http://localhost/rest/config/gui"
+  '';
+}


### PR DESCRIPTION
### Description

When `services.syncthing.guiAddress` is a unix socket, `curlAddressArgs` builds
curl invocations of the form:

```
curl --unix-socket <sock> http://.<path>
```

The bare-dot host (`http://.`) relied on curl accepting a single dot as a valid
authority. Recent curl (observed with 8.21.0) tightened URL parsing and rejects it:

```
curl: (3) URL rejected: Bad hostname
```

Every REST call in the merge script then fails. Because the calls run with
`--retry 1000 --retry-delay 1 --retry-all-errors`, `syncthing-init.service`
retries roughly once per second until systemd terminates it at the start timeout,
and Home Manager activation fails.

With `--unix-socket`, the URL authority is never resolved or dialed — curl connects
to the socket directly and the authority only supplies the HTTP `Host:` header and
URL validity. `localhost` is the conventional placeholder (e.g. Docker's socket API
examples), is accepted by every curl version, and reaches syncthing unchanged.

Reproduction with syncthing listening on a unix socket:

```
curl --unix-socket "$sock" http://./rest/system/ping         # curl: (3) Bad hostname
curl --unix-socket "$sock" http://localhost/rest/system/ping # reaches syncthing
```

### Checklist

- [x] Change is backwards compatible.
      (TCP `guiAddress` is unaffected; `localhost` is accepted by every curl version.)
- [x] Code formatted with `nix fmt` or `nix-shell -A dev --run treefmt`.
- [x] Code tested through `nix build .#test-all` or a targeted
      `nix run .#tests -- <pattern>`.
      (`nix run .#tests -- syncthing` — all 5 pass.)
- [x] Test cases updated/added.
      (`tests/modules/services/syncthing/linux/gui-address-unix-socket-init.nix`
      asserts the unix-socket path emits `http://localhost`.)
- [x] Commit messages are formatted like `{component}: {description}`.
