### PR TITLE
rclone: add nfsmount mount type

### DIFF
--- a/modules/misc/news/2026/07/2026-07-19_13-55-33.nix
+++ b/modules/misc/news/2026/07/2026-07-19_13-55-33.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+{
+  time = "2026-07-19T13:55:33+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin;
+  message = ''
+    'programs.rclone' mounts now support a 'mountType' option that can be
+    set to "nfsmount" to mount remotes via rclone's built-in NFS server
+    and the system NFS client instead of FUSE. On macOS this removes the
+    need for macFUSE and its kernel extension (and the Reduced Security
+    boot policy the extension requires). When "nfsmount" is selected,
+    'nfs-cache-type = "disk"' is added to the mount's options by default
+    so NFS file handles survive rclone restarts.
+  '';
+}

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -82,7 +82,12 @@ let
     {
       Unit = {
         Description = "Rclone ${
-          if isMount then "FUSE daemon" else "protocol serving"
+          if !isMount then
+            "protocol serving"
+          else if cmdName == "nfsmount" then
+            "NFS mount daemon"
+          else
+            "FUSE daemon"
         } for ${remoteName}:${sidecarPath}";
         Requires = [ "rclone-config.service" ];
         After = [ "rclone-config.service" ];
@@ -196,9 +201,16 @@ let
           _sidecar:
           let
             sidecarPath = _sidecar.name;
-            sidecar = _sidecar.value;
             isMount = sidecarType == "mounts";
-            cmdName = if isMount then "mount" else "serve";
+            cmdName = if isMount then _sidecar.value.mountType else "serve";
+            # nfsmount keeps its NFS file-handle cache in memory by default,
+            # so a service restart would leave the kernel client with stale
+            # handles; persist it to disk unless the user says otherwise.
+            sidecar =
+              if cmdName == "nfsmount" then
+                _sidecar.value // { options = lib.mergeAttrs { nfs-cache-type = "disk"; } _sidecar.value.options; }
+              else
+                _sidecar.value;
           in
           lib.optional sidecar.enable (
             lib.nameValuePair "rclone-${cmdName}:${replaceIllegalChars sidecarPath}@${remoteName}" (mkValue {
@@ -360,6 +372,35 @@ in
                           '';
                           example = "/home/alice/my-remote";
                         };
+
+                        mountType = lib.mkOption {
+                          type = lib.types.enum [
+                            "mount"
+                            "nfsmount"
+                          ];
+                          default = "mount";
+                          example = "nfsmount";
+                          description = ''
+                            Which rclone command performs the mount.
+
+                            `mount` uses FUSE, which on macOS requires macFUSE and its
+                            kernel extension. `nfsmount` instead runs an in-process NFS
+                            server and mounts it via the system NFS client — no FUSE
+                            driver, kernel extension, or Recovery-mode security downgrade
+                            needed, making it the recommended type on macOS. See
+                            <https://rclone.org/commands/rclone_nfsmount/> for details
+                            and caveats.
+
+                            For `nfsmount`, `nfs-cache-type = "disk"` is added to
+                            {option}`options` by default (overridable) so that NFS file
+                            handles survive rclone restarts; the in-memory default would
+                            leave the kernel client with stale handles whenever the
+                            service is restarted.
+
+                            On Linux, mounting NFS normally requires root, so `nfsmount`
+                            is primarily useful on Darwin.
+                          '';
+                        };
                       }
                       // mountServeOptions;
                     }
@@ -378,7 +419,9 @@ in
                   On macOS, FUSE mounts additionally require macFUSE
                   (<https://osxfuse.github.io/>) to be installed and its system extension
                   approved. Home Manager does not install macFUSE; rclone will surface
-                  a runtime error if it is missing.
+                  a runtime error if it is missing. Alternatively, set
+                  {option}`mountType` to `"nfsmount"` to mount via the system NFS
+                  client instead, which requires no additional software.
                 '';
                 example = lib.literalExpression ''
                   {

--- a/tests/modules/programs/rclone/default.nix
+++ b/tests/modules/programs/rclone/default.nix
@@ -8,5 +8,6 @@
 }
 // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
   rclone-mount-service-generation-darwin = ./mount-service-generation-darwin.nix;
+  rclone-nfsmount-service-generation-darwin = ./nfsmount-service-generation-darwin.nix;
   rclone-serve-service-generation-darwin = ./serve-service-generation-darwin.nix;
 }

--- a/tests/modules/programs/rclone/nfsmount-service-generation-darwin.nix
+++ b/tests/modules/programs/rclone/nfsmount-service-generation-darwin.nix
@@ -1,0 +1,59 @@
+_: {
+  programs.rclone = {
+    enable = true;
+    remotes.sftp-remote = {
+      config = {
+        type = "sftp";
+        host = "backup-server.example.com";
+        user = "alice";
+        key_file = "/Users/alice/.ssh/id_ed25519";
+      };
+      mounts = {
+        "documents/work" = {
+          enable = true;
+          mountType = "nfsmount";
+          mountPoint = "/Users/alice/mounts/work-docs";
+          options = {
+            dir-cache-time = "5000h";
+          };
+        };
+        "documents/override" = {
+          enable = true;
+          mountType = "nfsmount";
+          mountPoint = "/Users/alice/mounts/override";
+          options = {
+            nfs-cache-type = "memory";
+          };
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    plist="LaunchAgents/org.nix-community.home.rclone-nfsmount:documents.work@sftp-remote.plist"
+    assertFileExists "$plist"
+
+    # The agent must invoke `rclone nfsmount`, not the FUSE `mount` command.
+    # (The rclone command line is wrapped by the launchd module in
+    # `/bin/sh -c "/bin/wait4path /nix/store && exec <args>"`, so check
+    # for the meaningful substring rather than a standalone plist string.)
+    assertFileContains "$plist" "/bin/rclone nfsmount"
+
+    # nfsmount defaults nfs-cache-type to disk so NFS file handles survive
+    # rclone restarts; the shared mount/serve defaults still apply.
+    assertFileContains "$plist" "&apos;--nfs-cache-type=disk&apos;"
+    assertFileContains "$plist" "&apos;--vfs-cache-mode=full&apos;"
+    assertFileContains "$plist" "&apos;--dir-cache-time=5000h&apos;"
+    assertFileContains "$plist" "sftp-remote:documents/work"
+    assertFileContains "$plist" "/Users/alice/mounts/work-docs"
+
+    # Mount sidecars pre-create the mount point via the wrapper's --mkdir flag.
+    assertFileContains "$plist" "rclone-sidecar-wrapper --mkdir"
+
+    # A user-supplied nfs-cache-type overrides the disk default.
+    override="LaunchAgents/org.nix-community.home.rclone-nfsmount:documents.override@sftp-remote.plist"
+    assertFileExists "$override"
+    assertFileContains "$override" "&apos;--nfs-cache-type=memory&apos;"
+    assertFileNotRegex "$override" "nfs-cache-type=disk"
+  '';
+}


### PR DESCRIPTION
### Description

Adds a per-mount `mountType` option (`"mount"` | `"nfsmount"`, default `"mount"`) to `programs.rclone` mounts, selecting which rclone command performs the mount.

**Motivation:** the module currently hardcodes FUSE `rclone mount`, and its own docs note the wart this creates on macOS: *"Home Manager does not install macFUSE; rclone will surface a runtime error if it is missing."* Installing macFUSE means a kernel extension, which on Apple Silicon requires enabling the Reduced Security boot policy via Recovery plus reboots — and the kext breaks on every new macOS release until macFUSE ships an update (most recently the macOS 27 betas, which is how I ended up here). rclone's `nfsmount` runs an in-process NFS server and mounts it with the system NFS client: same VFS/caching stack, no FUSE driver, no kext, no security downgrade. It has been in rclone since v1.65 and works well on current rclone (≥1.74 recommended; earlier versions had an NFS read-performance issue).

Details:

- `cmdName` (and hence the unit/agent name and label) becomes `rclone-nfsmount:...@...` for nfsmount mounts.
- When `nfsmount` is selected, `nfs-cache-type = "disk"` is merged into the mount's `options` (user-overridable, mirroring the existing `vfs-cache-mode = "full"` defaulting). Rationale: rclone's default NFS handle cache is in-memory, so any service restart leaves the kernel client with stale file handles; the disk cache makes restarts transparent.
- The systemd unit description says "NFS mount daemon" instead of "FUSE daemon" for nfsmount mounts.
- The `mounts` docs now mention the alternative; the option docs note that on Linux NFS mounts generally require root, so this is primarily useful on Darwin (the option is not restricted, though — happy to add an assertion if preferred).
- New test `rclone-nfsmount-service-generation-darwin` covers the generated agent, the `nfs-cache-type` default, and that a user-supplied `nfs-cache-type` overrides it.

### Checklist

- [x] Change is backwards compatible. (Default `mountType = "mount"` generates byte-identical units/agents to before; existing tests pass unchanged.)

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>` — ran `rclone-basic-configuration`, `rclone-mount-service-generation-darwin`, `rclone-nfsmount-service-generation-darwin`, and `rclone-serve-service-generation-darwin` on aarch64-darwin. Also running the equivalent configuration in my own nix-darwin setup (real SFTP remote over `nfsmount`).

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- [x] (News entry added: darwin-conditioned, since that is where the change matters most.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
