### PR TITLE
modules: small performance-motivated cleanups

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -86,7 +86,6 @@ let
           (
             dir:
             lib.pipe (builtins.readDir dir) [
-              (lib.filterAttrs (path: _kind: !lib.hasPrefix "_" path))
               (lib.filterAttrs (
                 _path: kind: kind == "directory" || (kind == "regular" && lib.hasSuffix ".nix" _path)
               ))

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -16,6 +16,7 @@
 }:
 
 let
+  hasNixSuffix = lib.hasSuffix ".nix";
 
   modules = builtins.concatLists [
     [
@@ -86,9 +87,7 @@ let
           (
             dir:
             lib.pipe (builtins.readDir dir) [
-              (lib.filterAttrs (
-                _path: kind: kind == "directory" || (kind == "regular" && lib.hasSuffix ".nix" _path)
-              ))
+              (lib.filterAttrs (path: kind: kind == "directory" || (kind == "regular" && hasNixSuffix path)))
               (lib.mapAttrsToList (path: _kind: lib.path.append dir path))
             ]
           )


### PR DESCRIPTION
`hasPrefix` in nixpkgs has some intelligent partial application logic:
```nix
  hasPrefix =
    pref:
    let
      lenPrefix = stringLength pref;
    in
    if isPath pref then
      # Before 23.05, paths would be copied to the store before converting them
      # to strings and comparing. This was surprising and confusing.
      throw ''
        lib.strings.hasPrefix: The first argument (${toString pref}) is a path value, but only strings are supported.
            You might want to use `lib.path.hasPrefix` instead, which correctly supports paths.''
    else
      str: substring 0 lenPrefix str == pref;
```
But if you don't partially apply it, it'll run this logic on every single module (573, per my latest test). We can only do this once with an intelligent `let` binding.

Also removed the _ check, since it doesn't seem to be used at all.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
