### PR TITLE
rclone: set `programs.fuse.enable` to fix integration tests

### DIFF
--- a/tests/integration/standalone/rclone/mount.nix
+++ b/tests/integration/standalone/rclone/mount.nix
@@ -87,6 +87,10 @@ in
     ];
   };
 
+  nodes.machine = {
+    programs.fuse.enable = true;
+  };
+
   script = ''
     remote.wait_for_unit("network.target")
     remote.wait_for_unit("multi-user.target")


### PR DESCRIPTION
### Description
#9596 (specifically https://github.com/NixOS/nixpkgs/pull/528369) broke the fuse mount integration test (and any nixos install where `programs.fuse.enable` isn't set). I might add docs telling people to enable that option after #9678 is merged.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
