### PR TITLE
dank-material-shell: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -7,6 +7,7 @@
 # [1] https://github.com/NixOS/nixpkgs/blob/737449404589e4a80b3fa99ecbc6d4d803c1f6dc/maintainers/maintainer-list.nix#LC1
 {
   # keep-sorted start case=no numeric=no block=yes
+
   _3ulalia = {
     name = "Eulalia del Sol";
     email = "3ulalia@proton.me";

--- a/modules/misc/news/2026/07/2026-07-19_12-04-45.nix
+++ b/modules/misc/news/2026/07/2026-07-19_12-04-45.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+{
+  time = "2026-07-19T09:04:45+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'programs.dank-material-shell'.
+    DankMaterialShell is a complete desktop shell for niri, Hyprland, MangoWC,
+    Sway, labwc, Scroll, Miracle WM, and other Wayland compositors. It replaces
+    waybar, swaylock, swayidle, mako, fuzzel, polkit, and everything else you'd
+    normally stitch together to make a desktop.
+  '';
+}

--- a/modules/programs/dank-material-shell.nix
+++ b/modules/programs/dank-material-shell.nix
@@ -20,10 +20,10 @@ let
   jsonFormat = pkgs.formats.json { };
 
   hasPluginSettings = lib.any (plugin: plugin.settings != { }) (
-    lib.attrValues (lib.filterAttrs (n: v: v.enable) cfg.plugins)
+    lib.attrValues (lib.filterAttrs (_n: v: v.enable) cfg.plugins)
   );
-  pluginSettings = lib.mapAttrs (name: plugin: { enabled = plugin.enable; } // plugin.settings) (
-    lib.filterAttrs (n: v: v.enable) cfg.plugins
+  pluginSettings = lib.mapAttrs (_name: plugin: { enabled = plugin.enable; } // plugin.settings) (
+    lib.filterAttrs (_n: v: v.enable) cfg.plugins
   );
 
   common = {
@@ -39,9 +39,9 @@ let
     ++ lib.optional cfg.enableAudioWavelength pkgs.cava
     ++ lib.optional cfg.enableCalendarEvents pkgs.khal;
 
-    plugins = lib.mapAttrs (name: plugin: {
+    plugins = lib.mapAttrs (_name: plugin: {
       source = plugin.src;
-    }) (lib.filterAttrs (n: v: v.enable) cfg.plugins);
+    }) (lib.filterAttrs (_n: v: v.enable) cfg.plugins);
   };
 
   path = [
@@ -169,7 +169,7 @@ in
               description = "Source of the plugin package or path";
             };
             settings = lib.mkOption {
-              type = jsonFormat.type;
+              inherit (jsonFormat) type;
               default = { };
               description = "Plugin settings as an attribute set";
             };

--- a/modules/programs/dank-material-shell.nix
+++ b/modules/programs/dank-material-shell.nix
@@ -1,0 +1,281 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    types
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    mkRenamedOptionModule
+    mkRemovedOptionModule
+    ;
+
+  cfg = config.programs.dank-material-shell;
+
+  jsonFormat = pkgs.formats.json { };
+
+  hasPluginSettings = lib.any (plugin: plugin.settings != { }) (
+    lib.attrValues (lib.filterAttrs (n: v: v.enable) cfg.plugins)
+  );
+  pluginSettings = lib.mapAttrs (name: plugin: { enabled = plugin.enable; } // plugin.settings) (
+    lib.filterAttrs (n: v: v.enable) cfg.plugins
+  );
+
+  common = {
+    packages = [
+      cfg.package
+    ]
+    ++ lib.optional cfg.enableSystemMonitoring cfg.dgop.package
+    ++ lib.optionals cfg.enableVPN [
+      pkgs.glib
+      pkgs.networkmanager
+    ]
+    ++ lib.optional cfg.enableDynamicTheming pkgs.matugen
+    ++ lib.optional cfg.enableAudioWavelength pkgs.cava
+    ++ lib.optional cfg.enableCalendarEvents pkgs.khal;
+
+    plugins = lib.mapAttrs (name: plugin: {
+      source = plugin.src;
+    }) (lib.filterAttrs (n: v: v.enable) cfg.plugins);
+  };
+
+  path = [
+    "programs"
+    "dank-material-shell"
+  ];
+
+  builtInRemovedMsg = "This is now built-in in DMS and doesn't need additional dependencies.";
+
+in
+{
+  meta.maintainers = [ lib.maintainers.artur-sannikov ];
+
+  imports = [
+    (mkRenamedOptionModule
+      [
+        "programs"
+        "dankMaterialShell"
+      ]
+      [
+        "programs"
+        "dank-material-shell"
+      ]
+    )
+
+    (mkRemovedOptionModule (path ++ [ "enableBrightnessControl" ]) builtInRemovedMsg)
+    (mkRemovedOptionModule (path ++ [ "enableColorPicker" ]) builtInRemovedMsg)
+    (mkRemovedOptionModule (path ++ [ "enableClipboard" ]) builtInRemovedMsg)
+    (mkRemovedOptionModule (path ++ [ "enableNightMode" ]) "Night mode is now always available")
+    (mkRemovedOptionModule (
+      path ++ [ "enableSystemSound" ]
+    ) "qtmultimedia is now included on dms-shell package.")
+    (mkRemovedOptionModule (
+      path
+      ++ [
+        "default"
+        "settings"
+      ]
+    ) "Default settings have been removed and been replaced with programs.dank-material-shell.settings")
+    (mkRemovedOptionModule (
+      path
+      ++ [
+        "default"
+        "session"
+      ]
+    ) "Default session has been removed and been replaced with programs.dank-material-shell.session")
+    (mkRenamedOptionModule
+      [ "programs" "dank-material-shell" "enableSystemd" ]
+      [ "programs" "dank-material-shell" "systemd" "enable" ]
+    )
+  ];
+
+  options.programs.dank-material-shell = {
+
+    enable = mkEnableOption "DankMaterialShell";
+
+    package = mkPackageOption pkgs "dms-shell" { nullable = true; };
+
+    settings = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      description = ''
+        DankMaterialShell configuration settings as an attribute set, to be written to ~/.config/DankMaterialShell/settings.json.
+        Full up-to-date list of available settings can be found at https://raw.githubusercontent.com/AvengeMedia/DankMaterialShell/refs/heads/master/quickshell/Common/settings/SettingsSpec.js.
+      '';
+    };
+
+    dgop = {
+      package = mkPackageOption pkgs "dgop" { };
+    };
+
+    enableSystemMonitoring = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Add needed dependencies to use system monitoring widgets";
+    };
+
+    enableVPN = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Add needed dependencies to use the VPN widget";
+    };
+
+    enableDynamicTheming = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Add needed dependencies to have dynamic theming support";
+    };
+
+    enableAudioWavelength = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Add needed dependencies to have audio wavelength support";
+    };
+
+    enableCalendarEvents = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Add calendar events support via khal";
+    };
+
+    enableClipboardPaste = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Deprecated: paste is built into dms; no extra dependencies needed. Kept as a no-op for compatibility.";
+    };
+
+    quickshell = {
+      package = mkPackageOption pkgs "quickshell" {
+        extraDescription = "(we recommend at least 0.3.0, currently available in nixos-unstable)";
+      };
+    };
+
+    plugins = lib.mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          options = {
+            enable = lib.mkOption {
+              type = types.bool;
+              default = true;
+              description = "Whether to enable this plugin";
+            };
+            src = lib.mkOption {
+              type = types.either types.package types.path;
+              description = "Source of the plugin package or path";
+            };
+            settings = lib.mkOption {
+              type = jsonFormat.type;
+              default = { };
+              description = "Plugin settings as an attribute set";
+            };
+          };
+        }
+      );
+      default = { };
+      description = "DMS Plugins to install and enable";
+      example = lib.literalExpression ''
+        {
+          DockerManager = {
+            src = pkgs.fetchFromGitHub {
+              owner = "LuckShiba";
+              repo = "DmsDockerManager";
+              rev = "v1.2.0";
+              sha256 = "sha256-VoJCaygWnKpv0s0pqTOmzZnPM922qPDMHk4EPcgVnaU=";
+            };
+          };
+          AnotherPlugin = {
+            enable = true;
+            src = pkgs.another-plugin;
+          };
+        }
+      '';
+    };
+
+    clipboardSettings = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      description = "DankMaterialShell clipboard settings as an attribute set, to be written to ~/.config/DankMaterialShell/clsettings.json.";
+    };
+
+    session = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      description = ''
+        DankMaterialShell session settings as an attribute set, to be written to ~/.local/state/DankMaterialShell/session.json.
+          Full up-to-date list of available settings can be found at https://raw.githubusercontent.com/AvengeMedia/DankMaterialShell/refs/heads/master/quickshell/Common/settings/SessionSpec.js
+
+      '';
+    };
+
+    managePluginSettings = mkOption {
+      type = lib.types.bool;
+      default = hasPluginSettings;
+      defaultText = lib.literalExpression ''
+        true if any enabled plugin has non-empty `settings`, otherwise false
+      '';
+      description = "Whether to manage plugin settings. Automatically enabled if any plugins have settings configured.";
+    };
+
+    systemd = {
+      enable = lib.mkEnableOption "DankMaterialShell systemd startup";
+    };
+
+    systemd.target = mkOption {
+      type = lib.types.str;
+      default = config.wayland.systemd.target;
+      defaultText = lib.literalExpression "config.wayland.systemd.target";
+      description = "Systemd target to bind to.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.quickshell = {
+      enable = true;
+      inherit (cfg.quickshell) package;
+    };
+
+    systemd.user.services.dms = mkIf cfg.systemd.enable {
+      Unit = {
+        Description = "DankMaterialShell";
+        PartOf = [ cfg.systemd.target ];
+        After = [ cfg.systemd.target ];
+      };
+
+      Service = {
+        ExecStart = lib.getExe cfg.package + " run --session";
+        Restart = "on-failure";
+      };
+
+      Install.WantedBy = [ cfg.systemd.target ];
+    };
+
+    xdg.stateFile."DankMaterialShell/session.json" = mkIf (cfg.session != { }) {
+      source = jsonFormat.generate "session.json" cfg.session;
+    };
+
+    xdg.configFile = {
+      "DankMaterialShell/settings.json" = mkIf (cfg.settings != { }) {
+        source = jsonFormat.generate "settings.json" cfg.settings;
+      };
+      "DankMaterialShell/clsettings.json" = mkIf (cfg.clipboardSettings != { }) {
+        source = jsonFormat.generate "clsettings.json" cfg.clipboardSettings;
+      };
+      "DankMaterialShell/plugin_settings.json" = mkIf cfg.managePluginSettings {
+        source = jsonFormat.generate "plugin_settings.json" pluginSettings;
+      };
+    }
+    // (lib.mapAttrs' (name: value: {
+      name = "DankMaterialShell/plugins/${name}";
+      inherit value;
+    }) common.plugins);
+    warnings =
+      lib.optional (!cfg.managePluginSettings && hasPluginSettings)
+        "You have disabled managePluginSettings but provided plugin settings. These settings will be ignored.";
+    home.packages = common.packages;
+  };
+}

--- a/tests/modules/services/dank-material-shell/clsettings.json
+++ b/tests/modules/services/dank-material-shell/clsettings.json
@@ -1,0 +1,9 @@
+{
+  "autoClearDays": 1,
+  "clearAtStartup": true,
+  "disableHistory": false,
+  "disablePersist": true,
+  "disabled": false,
+  "maxEntrySize": 5242880,
+  "maxHistory": 25
+}

--- a/tests/modules/services/dank-material-shell/default.nix
+++ b/tests/modules/services/dank-material-shell/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  dank-material-shell-example = ./example-config.nix;
+}

--- a/tests/modules/services/dank-material-shell/example-config.nix
+++ b/tests/modules/services/dank-material-shell/example-config.nix
@@ -1,0 +1,38 @@
+{
+  programs.dank-material-shell = {
+    enable = true;
+
+    settings = {
+      theme = "dark";
+      dynamicTheming = true;
+    };
+
+    session = {
+      isLightMode = false;
+    };
+
+    clipboardSettings = {
+      maxHistory = 25;
+      maxEntrySize = 5242880;
+      autoClearDays = 1;
+      clearAtStartup = true;
+      disabled = false;
+      disableHistory = false;
+      disablePersist = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/DankMaterialShell/settings.json
+    assertFileContent home-files/.config/DankMaterialShell/settings.json \
+    ${./settings.json}
+
+    assertFileExists home-files/.local/state/DankMaterialShell/session.json
+    assertFileContent home-files/.local/state/DankMaterialShell/session.json \
+    ${./session.json}
+
+    assertFileExists home-files/.config/DankMaterialShell/clsettings.json
+    assertFileContent home-files/.config/DankMaterialShell/clsettings.json \
+    ${./clsettings.json}
+  '';
+}

--- a/tests/modules/services/dank-material-shell/session.json
+++ b/tests/modules/services/dank-material-shell/session.json
@@ -1,0 +1,3 @@
+{
+  "isLightMode": false
+}

--- a/tests/modules/services/dank-material-shell/settings.json
+++ b/tests/modules/services/dank-material-shell/settings.json
@@ -1,0 +1,4 @@
+{
+  "dynamicTheming": true,
+  "theme": "dark"
+}


### PR DESCRIPTION
### Description

Adds a module for [DankMaterialShell](https://github.com/AvengeMedia/DankMaterialShell), a bar for Wayland window managers.

They already provide a module for Home Manager in their repo, so I stitched together what they already had there and tested that it works with Home Manager.

One thing I did not manage to do is the automatic reloading of the systemd unit when the config changes. NixOS provides this functionality with [systemd.user.services.<name>.reloadIfChanged](https://search.nixos.org/options?channel=26.05&query=reloadIfChanged&type=options), but it does not seem to work with Home Manager. Actually, their module also does not reload the unit.

Also, it's a "program", not a service, even though some other shells like `hyprshell` are services. I just followed what they already had in the repo, and wanted to maintain compatibility with [stylix](https://github.com/nix-community/stylix), which assumes `programs.dank-material-shell`.

Test the module by setting the flake input of home-manager to `github:artur-sannikov/home-manager/add-module-dms`, remove `inputs.nixpkgs.follows =  "nixpkgs`", and then use the example-config.nix from the tests of this PR.

I'm on NixOS, using home-manager as a module, so I would appreciate tests from those who do not use flakes/use standalone home-manager.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
