### PR TITLE
kanshi: Fix scale example values from int to float

### DIFF
--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -115,7 +115,7 @@ let
       scale = mkOption {
         type = types.nullOr types.float;
         default = null;
-        example = 2;
+        example = 2.0;
         description = ''
           Scales the output by the specified scale factor.
         '';
@@ -278,7 +278,7 @@ in
         [
           { include = "path/to/included/files"; }
           { output.criteria = "eDP-1";
-            output.scale = 2;
+            output.scale = 2.0;
           }
           { profile.name = "undocked";
             profile.outputs = [


### PR DESCRIPTION
### Description

Fix a documentation typo with a value type mismatch

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```