### PR TITLE
programs.claude-code: avoid watching the Nix store

### DIFF
--- a/modules/programs/claude-code/default.nix
+++ b/modules/programs/claude-code/default.nix
@@ -233,20 +233,28 @@ in
 
         file = lib.mkMerge [
           (lib.mkIf (cfg.settings != { } || cfg.marketplaces != { } || disabledMcpServerNames != [ ]) {
-            "${cfg.configDir}/settings.json".source = jsonFormat.generate "claude-code-settings.json" (
-              cfg.settings
-              // {
-                "$schema" = "https://json.schemastore.org/claude-code-settings.json";
-              }
-              // lib.optionalAttrs (cfg.marketplaces != { }) {
-                extraKnownMarketplaces = lib.mapAttrs mkMarketplaceEntry cfg.marketplaces;
-              }
-              // lib.optionalAttrs (disabledMcpServerNames != [ ]) {
-                disabledMcpjsonServers = lib.unique (
-                  (cfg.settings.disabledMcpjsonServers or [ ]) ++ disabledMcpServerNames
+            "${cfg.configDir}/settings.json".source =
+              let
+                settingsFile = jsonFormat.generate "claude-code-settings.json" (
+                  cfg.settings
+                  // {
+                    "$schema" = "https://json.schemastore.org/claude-code-settings.json";
+                  }
+                  // lib.optionalAttrs (cfg.marketplaces != { }) {
+                    extraKnownMarketplaces = lib.mapAttrs mkMarketplaceEntry cfg.marketplaces;
+                  }
+                  // lib.optionalAttrs (disabledMcpServerNames != [ ]) {
+                    disabledMcpjsonServers = lib.unique (
+                      (cfg.settings.disabledMcpjsonServers or [ ]) ++ disabledMcpServerNames
+                    );
+                  }
                 );
-              }
-            );
+
+                settingsDirectory = pkgs.runCommand "claude-code-settings-directory" { } ''
+                  install -Dm444 ${settingsFile} "$out/settings.json"
+                '';
+              in
+              "${settingsDirectory}/settings.json";
           })
           (
             if lib.isPath cfg.context then

--- a/tests/modules/programs/claude-code/full-config.nix
+++ b/tests/modules/programs/claude-code/full-config.nix
@@ -1,3 +1,4 @@
+{ config, ... }:
 {
   programs.claude-code = {
     enable = true;
@@ -116,6 +117,19 @@
       '';
     };
   };
+
+  assertions = [
+    {
+      assertion =
+        let
+          settingsSource =
+            toString
+              config.home.file."${config.programs.claude-code.configDir}/settings.json".source;
+        in
+        dirOf settingsSource != builtins.storeDir && baseNameOf settingsSource == "settings.json";
+      message = "Claude Code settings source must be inside a dedicated store directory";
+    }
+  ];
 
   nmt.script = ''
     assertFileExists home-files/.claude/settings.json


### PR DESCRIPTION
Closes #9655

Claude Code follows the settings.json symlink and watches the directory containing its resolved target.

Previously, jsonFormat.generate produced a bare file directly under /nix/store, causing Claude Code to watch the entire store.

Copy the generated settings file into a dedicated store directory so the resolved parent is isolated.

The regression test verifies that the settings source is nested in a store directory and still has the expected filename.

Tests:
- claude-code-full-config
- claude-code-config-dir
- claude-code-marketplacess
- claude-code-mcp-integration