### PR TITLE
rbw: add systemd service for rbw-agent and add sshAgent option to make rbw the ssh agent

### DIFF
--- a/modules/programs/rbw.nix
+++ b/modules/programs/rbw.nix
@@ -93,6 +93,19 @@ in
         managed by Home Manager.
       '';
     };
+
+    systemd = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        description = "run the rbw agent in systemd";
+        default = true;
+      };
+      targets = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        description = "targets for the rbw systemd service";
+        default = [ "default.target" ];
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -100,6 +113,21 @@ in
 
     home.file."${configDir}/rbw/config.json" = lib.mkIf (cfg.settings != null) {
       source = jsonFormat.generate "rbw-config.json" (lib.filterAttrs (_: v: v != null) cfg.settings);
+    };
+
+    systemd.user.services.rbw-agent = lib.mkIf cfg.systemd.enable {
+      Service = {
+        ExecStart = "${cfg.package}/bin/rbw-agent --no-daemonize";
+        PIDFile = "rbw/pidfile";
+      };
+      Install = {
+        WantedBy = cfg.systemd.targets;
+      };
+      Unit = {
+        After = [ "network.target" ];
+        Description = "rbw Agent";
+        Documentation = "man:rbw-agent(1)";
+      };
     };
   };
 }

--- a/modules/programs/rbw.nix
+++ b/modules/programs/rbw.nix
@@ -64,6 +64,7 @@ let
 
   configDir =
     if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else config.xdg.configHome;
+  socketPath = "$XDG_RUNTIME_DIR/rbw/ssh-agent-socket";
 in
 {
   meta.maintainers = with lib.maintainers; [ ambroisie ];
@@ -93,6 +94,11 @@ in
         managed by Home Manager.
       '';
     };
+    sshAgent = lib.mkOption {
+      type = lib.types.bool;
+      description = "rbw as an SSH Agent";
+      default = false;
+    };
 
     systemd = {
       enable = lib.mkOption {
@@ -109,6 +115,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.rbw.sshAgent" pkgs lib.platforms.linux)
+    ];
+
     home.packages = [ cfg.package ];
 
     home.file."${configDir}/rbw/config.json" = lib.mkIf (cfg.settings != null) {
@@ -127,6 +137,19 @@ in
         After = [ "network.target" ];
         Description = "rbw Agent";
         Documentation = "man:rbw-agent(1)";
+      };
+    };
+
+    sshAuthSock = lib.mkIf cfg.sshAgent {
+      enable = true;
+      systemd = {
+        socketProviderUnit = lib.mkIf cfg.systemd.enable "rbw-agent.service";
+      };
+      initialization = {
+        bash = "export SSH_AUTH_SOCK=${socketPath}";
+        fish = "set -x SSH_AUTH_SOCK ${socketPath}";
+        zsh = "export SSH_AUTH_SOCK=${socketPath}";
+        nushell = "$env.SSH_AUTH_SOCK = ${socketPath}";
       };
     };
   };


### PR DESCRIPTION
### Description
add systemd service for rbw-agent and add sshAgent option to make rbw the ssh agent
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
