### PR TITLE
wlsunset: add option for duration

### DIFF
--- a/modules/services/wlsunset.nix
+++ b/modules/services/wlsunset.nix
@@ -6,10 +6,7 @@
 }:
 
 let
-  inherit (lib)
-    mkOption
-    types
-    ;
+  inherit (lib) mkOption types;
 
   cfg = config.services.wlsunset;
 in
@@ -96,6 +93,16 @@ in
       '';
     };
 
+    duration = mkOption {
+      type = with types; nullOr int;
+      default = null;
+      example = 1800;
+      description = ''
+        The manual animation time in seconds.
+        Only applicable when using manual sunset/sunrise times.
+      '';
+    };
+
     systemdTarget = mkOption {
       type = with types; str;
       default = config.wayland.systemd.target;
@@ -145,6 +152,7 @@ in
               L = cfg.longitude;
               S = cfg.sunrise;
               s = cfg.sunset;
+              d = cfg.duration;
               o = cfg.output;
             };
           in

--- a/tests/modules/services/wlsunset/wlsunset-service-expected.service
+++ b/tests/modules/services/wlsunset/wlsunset-service-expected.service
@@ -2,7 +2,7 @@
 WantedBy=test.target
 
 [Service]
-ExecStart=@wlsunset@/bin/wlsunset -L128.8 -T6000 -g0.6 -l12.3 -t3500
+ExecStart=@wlsunset@/bin/wlsunset -L128.8 -T6000 -d1800 -g0.6 -l12.3 -t3500
 
 [Unit]
 After=test.target

--- a/tests/modules/services/wlsunset/wlsunset-service.nix
+++ b/tests/modules/services/wlsunset/wlsunset-service.nix
@@ -9,6 +9,7 @@
       longitude = "128.8";
       temperature.day = 6000;
       temperature.night = 3500;
+      duration = 1800;
       gamma = "0.6";
       systemdTarget = "test.target";
     };


### PR DESCRIPTION
### Description

Allows users to set a duration over which to apply the blue light filter

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module
  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
