### PR TITLE
lib/systemd: expose systemd unit translation helpers

### DIFF
--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -17,6 +17,7 @@ rec {
   types = import ./types.nix { inherit gvariant lib; };
 
   shell = import ./shell.nix { inherit lib; };
+  systemd = import ./systemd.nix { inherit lib; };
   zsh = import ./zsh.nix { inherit lib; };
   nushell = import ./nushell.nix { inherit lib; };
 }

--- a/modules/lib/systemd.nix
+++ b/modules/lib/systemd.nix
@@ -37,8 +37,16 @@ let
   normalizeTargets = v: if lib.isList v then map normalizeTarget v else v;
 
   /*
+    Capitalize the first letter of a string while preserving the rest of its casing.
+
+    Type: upperFirstChar :: String -> String
+  */
+  upperFirstChar =
+    string: lib.toUpper (builtins.substring 0 1 string) + builtins.substring 1 (-1) string;
+
+  /*
     Filter and convert camelCase NixOS unit option keys into PascalCase INI
-    section keys using `lib.toSentenceCase`.
+    section keys using `upperFirstChar`.
 
     Type: pickSection :: List String -> AttrSet -> AttrSet
   */
@@ -48,7 +56,7 @@ let
       lib.concatMap (
         k:
         lib.optional (src ? ${k} && src.${k} != null && src.${k} != [ ]) {
-          name = lib.toSentenceCase k;
+          name = upperFirstChar k;
           value = normalizeTargets src.${k};
         }
       ) keys

--- a/modules/lib/systemd.nix
+++ b/modules/lib/systemd.nix
@@ -1,0 +1,129 @@
+{ lib }:
+
+let
+  /*
+    Common NixOS-style systemd unit option keys that are mapped to PascalCase
+    [Unit] section keys in Home Manager INI unit files.
+  */
+  unitAttrKeys = [
+    "description"
+    "documentation"
+    "requires"
+    "wants"
+    "upholds"
+    "after"
+    "before"
+    "bindsTo"
+    "partOf"
+    "conflicts"
+    "requisite"
+    "onFailure"
+    "onSuccess"
+  ];
+
+  /*
+    Translate a system-level target (e.g. `multi-user.target`) to its user-session
+    equivalent (`default.target`).
+
+    Type: normalizeTarget :: String -> String
+  */
+  normalizeTarget = t: if t == "multi-user.target" then "default.target" else t;
+
+  /*
+    Normalize target string or list of target strings.
+
+    Type: normalizeTargets :: (String | List String) -> (String | List String)
+  */
+  normalizeTargets = v: if lib.isList v then map normalizeTarget v else v;
+
+  /*
+    Filter and convert camelCase NixOS unit option keys into PascalCase INI
+    section keys using `lib.toSentenceCase`.
+
+    Type: pickSection :: List String -> AttrSet -> AttrSet
+  */
+  pickSection =
+    keys: src:
+    lib.listToAttrs (
+      lib.concatMap (
+        k:
+        lib.optional (src ? ${k} && src.${k} != null && src.${k} != [ ]) {
+          name = lib.toSentenceCase k;
+          value = normalizeTargets src.${k};
+        }
+      ) keys
+    );
+
+  /*
+    Convert an environment attribute set into a list of `KEY=VALUE` strings
+    for systemd INI `Environment=` settings.
+
+    Type: envToList :: AttrSet -> List String
+  */
+  envToList =
+    env: lib.mapAttrsToList (k: v: "${k}=${toString v}") (lib.filterAttrs (_: v: v != null) env);
+
+  /*
+    Construct the `[Install]` INI section mapping `wantedBy` and `requiredBy` to
+    normalized user target names.
+
+    Type: installSection :: AttrSet -> AttrSet
+  */
+  installSection =
+    u:
+    lib.filterAttrs (_: v: v != [ ]) {
+      WantedBy = map normalizeTarget (u.wantedBy or [ ]);
+      RequiredBy = map normalizeTarget (u.requiredBy or [ ]);
+    };
+
+  /*
+    Translate a NixOS-style systemd unit attrset (wantedBy, serviceConfig,
+    unitConfig, environment, ...) into the section-based INI shape that
+    Home Manager's `systemd.user.<unitType>` expects (Unit/Service/Install).
+    Only the common keys are mapped; uncommon options can still be set
+    explicitly via `unitConfig` / `serviceConfig` / `socketConfig`.
+
+    Type: toHmIni :: AttrSet -> AttrSet
+  */
+  toHmIni = unit: {
+    Unit = pickSection unitAttrKeys unit // (unit.unitConfig or { });
+    Service =
+      (unit.serviceConfig or { })
+      // lib.optionalAttrs (unit ? environment && unit.environment != { }) {
+        Environment = envToList unit.environment;
+      };
+    Install = installSection unit;
+  };
+
+  /*
+    Translate a NixOS-style systemd socket unit attrset into the section-based
+    INI shape that Home Manager expects (Unit/Socket/Install). Maps
+    `listenStreams` and `listenDatagrams` to `ListenStream` and `ListenDatagram`.
+
+    Type: toHmIniSocket :: AttrSet -> AttrSet
+  */
+  toHmIniSocket = sock: {
+    Unit = pickSection unitAttrKeys sock // (sock.unitConfig or { });
+    Socket =
+      (sock.socketConfig or { })
+      // lib.optionalAttrs (sock ? listenStreams && sock.listenStreams != [ ]) {
+        ListenStream = sock.listenStreams;
+      }
+      // lib.optionalAttrs (sock ? listenDatagrams && sock.listenDatagrams != [ ]) {
+        ListenDatagram = sock.listenDatagrams;
+      };
+    Install = installSection sock;
+  };
+in
+{
+  inherit
+    unitAttrKeys
+    normalizeTarget
+    normalizeTargets
+    pickSection
+    envToList
+    installSection
+    toHmIni
+    toHmIniSocket
+    ;
+}

--- a/modules/services-modular/default.nix
+++ b/modules/services-modular/default.nix
@@ -22,68 +22,7 @@ let
     else
       "${before}-${after}";
 
-  # Translate a NixOS-style systemd unit attrset (wantedBy, serviceConfig,
-  # unitConfig, environment, ...) into the section-based INI shape that
-  # Home Manager's `systemd.user.<unitType>` expects (Unit/Service/Install).
-  # Only the common keys are mapped; uncommon options can still be set
-  # explicitly via `unitConfig` / `serviceConfig` / `socketConfig`.
-  unitAttrKeys = [
-    "description"
-    "documentation"
-    "requires"
-    "wants"
-    "upholds"
-    "after"
-    "before"
-    "bindsTo"
-    "partOf"
-    "conflicts"
-    "requisite"
-    "onFailure"
-    "onSuccess"
-  ];
-  pickSection =
-    keys: src:
-    lib.listToAttrs (
-      lib.concatMap (
-        k:
-        lib.optional (src ? ${k} && src.${k} != null && src.${k} != [ ]) {
-          name = lib.toSentenceCase k;
-          value = normalizeTargets src.${k};
-        }
-      ) keys
-    );
-  envToList =
-    env: lib.mapAttrsToList (k: v: "${k}=${toString v}") (lib.filterAttrs (_: v: v != null) env);
-  normalizeTarget = t: if t == "multi-user.target" then "default.target" else t;
-  normalizeTargets = v: if lib.isList v then map normalizeTarget v else v;
-  installSection =
-    u:
-    lib.filterAttrs (_: v: v != [ ]) {
-      WantedBy = map normalizeTarget (u.wantedBy or [ ]);
-      RequiredBy = map normalizeTarget (u.requiredBy or [ ]);
-    };
-  toHmIni = unit: {
-    Unit = pickSection unitAttrKeys unit // (unit.unitConfig or { });
-    Service =
-      (unit.serviceConfig or { })
-      // lib.optionalAttrs (unit ? environment && unit.environment != { }) {
-        Environment = envToList unit.environment;
-      };
-    Install = installSection unit;
-  };
-  toHmIniSocket = sock: {
-    Unit = pickSection unitAttrKeys sock // (sock.unitConfig or { });
-    Socket =
-      (sock.socketConfig or { })
-      // lib.optionalAttrs (sock ? listenStreams && sock.listenStreams != [ ]) {
-        ListenStream = sock.listenStreams;
-      }
-      // lib.optionalAttrs (sock ? listenDatagrams && sock.listenDatagrams != [ ]) {
-        ListenDatagram = sock.listenDatagrams;
-      };
-    Install = installSection sock;
-  };
+  inherit (lib.hm.systemd) toHmIni toHmIniSocket;
 
   # Evaluate a deferredModule into attrs, then translate.
   evalDeferred =

--- a/modules/services/comodoro.nix
+++ b/modules/services/comodoro.nix
@@ -64,7 +64,7 @@ in
         ExecSearchPath = "/bin";
         Restart = "always";
         RestartSec = 10;
-        Environment = lib.mapAttrsToList (key: val: "${key}=${val}") cfg.environment;
+        Environment = lib.hm.systemd.envToList cfg.environment;
       };
     };
   };

--- a/modules/services/exo.nix
+++ b/modules/services/exo.nix
@@ -51,7 +51,7 @@ in
 
       Service = {
         ExecStart = lib.escapeShellArgs ([ (lib.getExe cfg.package) ] ++ cfg.extraArgs);
-        Environment = lib.mapAttrsToList (name: value: "${name}=${value}") cfg.environmentVariables;
+        Environment = lib.hm.systemd.envToList cfg.environmentVariables;
         Restart = "on-failure";
       };
 

--- a/modules/services/local-ai.nix
+++ b/modules/services/local-ai.nix
@@ -37,7 +37,7 @@ in
 
       Service = {
         ExecStart = lib.getExe cfg.package;
-        Environment = lib.mapAttrsToList (key: val: "${key}=${val}") cfg.environment;
+        Environment = lib.hm.systemd.envToList cfg.environment;
       };
 
       Install = {

--- a/modules/services/ollama.nix
+++ b/modules/services/ollama.nix
@@ -95,7 +95,7 @@ in
 
       Service = {
         ExecStart = "${lib.getExe ollamaPackage} serve";
-        Environment = (lib.mapAttrsToList (n: v: "${n}=${v}") cfg.environmentVariables) ++ [
+        Environment = (lib.hm.systemd.envToList cfg.environmentVariables) ++ [
           "OLLAMA_HOST=${cfg.host}:${toString cfg.port}"
         ];
       };

--- a/modules/services/radicle.nix
+++ b/modules/services/radicle.nix
@@ -6,11 +6,9 @@
 }:
 let
   inherit (lib)
-    generators
     getBin
     getExe'
     last
-    mapAttrsToList
     mkDefault
     mkEnableOption
     mkIf
@@ -34,7 +32,7 @@ let
   radicleHome = config.home.homeDirectory + "/.radicle";
 
   gitPath = [ "PATH=${getBin pkgs.gitMinimal}/bin" ];
-  env = attrs: (mapAttrsToList (generators.mkKeyValueDefault { } "=") attrs) ++ gitPath;
+  env = attrs: (lib.hm.systemd.envToList attrs) ++ gitPath;
 in
 {
   meta.maintainers = with lib.maintainers; [

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -180,6 +180,7 @@ import nmtSrc {
           ./lib/deprecations
           ./lib/generators
           ./lib/mcp
+          ./lib/systemd
           ./lib/types
           ./modules/files
           ./modules/home-environment

--- a/tests/lib/systemd/default.nix
+++ b/tests/lib/systemd/default.nix
@@ -1,0 +1,3 @@
+{
+  lib-systemd-translators = ./translators.nix;
+}

--- a/tests/lib/systemd/translators.nix
+++ b/tests/lib/systemd/translators.nix
@@ -1,0 +1,63 @@
+{ lib, pkgs, ... }:
+
+let
+  unitResult = lib.hm.systemd.toHmIni {
+    description = "Test service";
+    bindsTo = [ "other.service" ];
+    partOf = [ "target.service" ];
+    onFailure = [ "failed.service" ];
+    onSuccess = [ "success.service" ];
+    wantedBy = [ "multi-user.target" ];
+    environment = {
+      FOO = "bar";
+    };
+  };
+
+  socketResult = lib.hm.systemd.toHmIniSocket {
+    description = "Test socket";
+    listenStreams = [ "/run/test.sock" ];
+    wantedBy = [ "sockets.target" ];
+  };
+
+  expectedUnit = pkgs.writeText "systemd-unit.expected" (
+    builtins.toJSON {
+      Unit = {
+        Description = "Test service";
+        BindsTo = [ "other.service" ];
+        PartOf = [ "target.service" ];
+        OnFailure = [ "failed.service" ];
+        OnSuccess = [ "success.service" ];
+      };
+      Service = {
+        Environment = [ "FOO=bar" ];
+      };
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+    }
+  );
+
+  actualUnit = pkgs.writeText "systemd-unit.actual" (builtins.toJSON unitResult);
+
+  expectedSocket = pkgs.writeText "systemd-socket.expected" (
+    builtins.toJSON {
+      Unit = {
+        Description = "Test socket";
+      };
+      Socket = {
+        ListenStream = [ "/run/test.sock" ];
+      };
+      Install = {
+        WantedBy = [ "sockets.target" ];
+      };
+    }
+  );
+
+  actualSocket = pkgs.writeText "systemd-socket.actual" (builtins.toJSON socketResult);
+in
+{
+  nmt.script = ''
+    assertFileContent ${actualUnit} ${expectedUnit}
+    assertFileContent ${actualSocket} ${expectedSocket}
+  '';
+}

--- a/tests/modules/services/radicle/default.nix
+++ b/tests/modules/services/radicle/default.nix
@@ -1,0 +1,3 @@
+{
+  services-radicle-environment = ./environment.nix;
+}

--- a/tests/modules/services/radicle/environment.nix
+++ b/tests/modules/services/radicle/environment.nix
@@ -1,0 +1,43 @@
+{ config, pkgs, ... }:
+
+let
+  dummyPkg = pkgs.hello;
+in
+{
+  services.radicle.node = {
+    enable = true;
+    environment = {
+      OMITTED_NULL = null;
+      STR_VAL = "hello";
+      PATH_VAL = /tmp/some-path;
+      PACKAGE_VAL = dummyPkg;
+    };
+  };
+
+  test.stubs.radicle-node = {
+    buildScript = ''
+      mkdir -p "$out/bin"
+      cat > "$out/bin/rad" << 'EOF'
+      #!/bin/sh
+      exit 0
+      EOF
+      chmod +x "$out/bin/rad"
+    '';
+  };
+
+  nmt.script =
+    let
+      expectedEnv = [
+        "PACKAGE_VAL=${dummyPkg}"
+        "PATH_VAL=/tmp/some-path"
+        "STR_VAL=hello"
+        "PATH=${pkgs.gitMinimal}/bin"
+      ];
+      actualEnv = config.systemd.user.services.radicle-node.Service.Environment;
+    in
+    ''
+      assertFileContent \
+        ${pkgs.writeText "actual-env" (builtins.toJSON actualEnv)} \
+        ${pkgs.writeText "expected-env" (builtins.toJSON expectedEnv)}
+    '';
+}


### PR DESCRIPTION
### Description

This PR extracts Home Manager's internal systemd unit translation logic (`toHmIni`, `toHmIniSocket`, `normalizeTarget`, `envToList`, `pickSection`, `installSection`) into a public library module `lib.hm.systemd` (`modules/lib/systemd.nix`).

It enables flake authors maintaining both `nixosModules` and `homeModules` to easily convert and reuse NixOS-style unit definitions in Home Manager without duplicating unit metadata and scripts.

Additionally, 5 service modules (`comodoro`, `exo`, `local-ai`, `ollama`, `radicle`) have been refactored to use `lib.hm.systemd.envToList` instead of ad-hoc `mapAttrsToList` string formatting.

An alternative is to make Home Manager options to have the same schema as NixOS' ones (or the other way around)
I find it preferable, but don't know if this is possible nor desirable

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or `nix-shell -A dev --run treefmt`.
- [ ] Code tested through `nix build .#test-all` or a targeted `nix run .#tests -- <pattern>`.
- [ ] Test cases updated/added.
- [x] Commit messages are formatted like `{component}: {description}`.
