### PR TITLE
texlive: replace deprecated texlive.combine with texlive.withPackages

### DIFF
--- a/modules/programs/texlive.nix
+++ b/modules/programs/texlive.nix
@@ -9,9 +9,6 @@ let
 
   cfg = config.programs.texlive;
 
-  texlive = cfg.packageSet;
-  texlivePkgs = cfg.extraPackages texlive;
-
 in
 {
   meta.maintainers = [ lib.maintainers.rycee ];
@@ -46,13 +43,15 @@ in
   config = lib.mkIf cfg.enable {
     assertions = [
       {
-        assertion = texlivePkgs != { };
+        assertion = cfg.extraPackages cfg.packageSet != { };
         message = "Must provide at least one extra package in" + " 'programs.texlive.extraPackages'.";
       }
     ];
 
     home.packages = [ cfg.package ];
 
-    programs.texlive.package = texlive.combine texlivePkgs;
+    programs.texlive.package = cfg.packageSet.withPackages (
+      tpkgs: lib.attrValues (cfg.extraPackages tpkgs)
+    );
   };
 }

--- a/tests/modules/programs/texlive/texlive-minimal.nix
+++ b/tests/modules/programs/texlive/texlive-minimal.nix
@@ -1,19 +1,35 @@
-{ lib, pkgs, ... }:
+{
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (config.lib.test) mkStubPackage;
+
+  fakeTexliveSet = {
+    collection-basic = pkgs.writeTextDir "collection-basic" "";
+  };
+in
 {
   config = {
-    programs.texlive.enable = true;
+    programs.texlive = {
+      enable = true;
+      extraPackages = tpkgs: { inherit (tpkgs) collection-basic; };
+    };
 
     # Set up a minimal mocked texlive package set.
     nixpkgs.overlays = [
       (_self: _super: {
-        texlive = {
-          collection-basic = pkgs.writeTextDir "collection-basic" "";
-          combine =
-            tpkgs:
-            pkgs.symlinkJoin {
-              name = "dummy-texlive-combine";
-              paths = lib.attrValues tpkgs;
-            };
+        texlive = mkStubPackage {
+          name = "texlive";
+          extraAttrs = {
+            withPackages =
+              f:
+              pkgs.symlinkJoin {
+                name = "dummy-texlive-combine";
+                paths = f fakeTexliveSet;
+              };
+          };
         };
       })
     ];


### PR DESCRIPTION
### Description

Nixpkgs has deprecated `texlive.combine` (combined schemes), which will
be removed in 27.05. This adapts the Home Manager texlive module
accordingly.
https://github.com/NixOS/nixpkgs/blob/7828bcabbb70303fda1067e6c3b362532302b75f/pkgs/tools/typesetting/tex/texlive/default.nix#L629

Also, some option names have been changed to align with the notation used in other modules, improving overall configuration readability.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- x ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
