### PR TITLE
direnv: fix nushell integration failing to unset variables

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -147,9 +147,19 @@ in
               $env.config.hooks.pre_prompt?
               | default []
               | append {||
-                  ${getExe cfg.package} export json
-                  | from json --strict
-                  | default {}
+                  let direnv = (
+                      ${getExe cfg.package} export json
+                      | from json --strict
+                      | default {}
+                  )
+
+                  for key in ($direnv | columns) {
+                      if ($direnv | get $key) == null {
+                          hide-env --ignore-errors $key
+                      }
+                  }
+
+                  $direnv
                   | items {|key, value|
                       let value = do (
                           {
@@ -164,6 +174,7 @@ in
                       ) $value
                       return [ $key $value ]
                   }
+                  | where {|pair| $pair.1 != null }
                   | into record
                   | load-env
               }

--- a/tests/modules/programs/direnv/basic-config.nix
+++ b/tests/modules/programs/direnv/basic-config.nix
@@ -99,6 +99,10 @@ in
         'direnv export json'
       assertFileRegex "${nushellConfigFile}" \
         'load-env'
+      # Variables direnv marks for removal (null values) must be unset via
+      # hide-env; load-env alone cannot remove them and leaves empty ghosts.
+      assertFileRegex "${nushellConfigFile}" \
+        'hide-env'
 
       # Test mise integration creates library file
       assertFileExists home-files/.config/direnv/lib/hm-mise.sh


### PR DESCRIPTION
### Description

The nushell pre_prompt hook applied direnv's export diff with `load-env`, which cannot remove a variable. Variables direnv marks for removal (null values) were left behind as empty ghosts. Hide those keys explicitly and drop them before `load-env`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.
    _Yes, in the sense of module interface, but no, for the behavior._

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

