### PR TITLE
wlsunset: make duration optional with manual sunrise/sunset

### DIFF
--- a/modules/services/wlsunset.nix
+++ b/modules/services/wlsunset.nix
@@ -130,8 +130,8 @@ in
         message = "Both `latitude and `longitude` together must be set for wlsunset";
       }
       {
-        assertion = ((cfg.latitude != null) || (cfg.longitude != null)) == (cfg.duration == null);
-        message = "Cannot set duration if `latitude` or `longitude` are set";
+        assertion = cfg.duration == null || (cfg.latitude == null && cfg.longitude == null);
+        message = "Cannot set `duration` if `latitude` or `longitude` are set";
       }
     ];
 

--- a/tests/modules/services/wlsunset/default.nix
+++ b/tests/modules/services/wlsunset/default.nix
@@ -3,4 +3,5 @@
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   wlsunset-service = ./wlsunset-service.nix;
   wlsunset-sunrise-sunset = ./sunrise-sunset.nix;
+  wlsunset-sunrise-sunset-no-duration = ./sunrise-sunset-no-duration.nix;
 }

--- a/tests/modules/services/wlsunset/sunrise-sunset-no-duration.nix
+++ b/tests/modules/services/wlsunset/sunrise-sunset-no-duration.nix
@@ -1,0 +1,26 @@
+{
+  services.wlsunset = {
+    enable = true;
+    sunrise = "06:30";
+    sunset = "19:00";
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/wlsunset.service
+
+    assertFileExists $serviceFile
+    assertFileContent $serviceFile ${builtins.toFile "wlsunset.service" ''
+      [Install]
+      WantedBy=graphical-session.target
+
+      [Service]
+      ExecStart=@wlsunset@/bin/wlsunset -S06:30 -T6500 -g1.000000 -s19:00 -t4000
+
+      [Unit]
+      After=graphical-session.target
+      ConditionEnvironment=WAYLAND_DISPLAY
+      Description=Day/night gamma adjustments for Wayland compositors.
+      PartOf=graphical-session.target
+    ''}
+  '';
+}


### PR DESCRIPTION
### Description

#9667 added the `duration` option with an assertion requiring `duration` to be set whenever `latitude`/`longitude` were unset. Configurations using manual `sunrise`/`sunset` times without a `duration` therefore failed with the misleading message "Cannot set duration if `latitude` or `longitude` are set".

This relaxes the assertion to only forbid combining `duration` with `latitude`/`longitude`, matching the option's documented behavior, and adds a regression test covering manual times without a duration.

Fixes #9694

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)