### PR TITLE
modules: fix modular services with strict nixpkgs modules

### DIFF
--- a/modules/services-modular/service.nix
+++ b/modules/services-modular/service.nix
@@ -8,10 +8,18 @@
 # drop in unchanged. Then overrides the primary unit's `wantedBy` default
 # to `default.target`, since user units typically attach to that instead
 # of `multi-user.target`.
-{ lib, nixpkgsPath, ... }:
+args@{
+  lib,
+  nixpkgsPath,
+  ...
+}:
+let
+  systemdServiceModule = import (nixpkgsPath + "/nixos/modules/system/service/systemd/service.nix");
+  systemdServiceModuleArgs = builtins.intersectAttrs (builtins.functionArgs systemdServiceModule) args;
+in
 {
   imports = [
-    (nixpkgsPath + "/nixos/modules/system/service/systemd/service.nix")
+    (systemdServiceModule systemdServiceModuleArgs)
   ];
 
   # The empty key `""` is the modular service's *primary* unit (see


### PR DESCRIPTION
### Description

Fixes evaluation of modular services when the imported nixpkgs systemd service module does not accept every argument passed by the Home Manager module system.

Minimal reproducer:

```nix
{
  inputs = {
    # Nixpkgs master as of 2026-07-25 06:57:37 UTC.
    nixpkgs.url = "github:NixOS/nixpkgs/9e3461d3ed9792395b1ebb8e99a9bb7f866cda7b";
    # Home Manager master as of 2026-07-24 17:12:39 UTC.
    home-manager.url = "github:nix-community/home-manager/079a3b5d1aa6a719920a51316253b7d6dd22738d";
    home-manager.inputs.nixpkgs.follows = "nixpkgs";
  };

  outputs =
    {
      nixpkgs,
      home-manager,
      ...
    }:
    let
      pkgs = nixpkgs.legacyPackages.x86_64-linux;
    in
    {
      homeConfigurations.repro = home-manager.lib.homeManagerConfiguration {
        inherit pkgs;
        modules = [
          {
            home.username = "me";
            home.homeDirectory = "/home/me";
            home.stateVersion = "25.11";
            programs.home-manager.enable = true;
          }
        ];
      };
    };
}
```

Build command:

```sh
nix build .#homeConfigurations.repro.activationPackage --show-trace
```

This currently fails while generating the Home Manager manpage/options:

```text
error: function 'anonymous lambda' called with unexpected argument 'lib'
at .../nixos/modules/system/service/systemd/service.nix:4:1:
     3| # This makes service modules self-contained, allowing mixing of Nixpkgs versions.
     4| { pkgs }:
       | ^
```

This happens because `modules/services-modular/service.nix` imports the nixpkgs systemd service module as a module path. The module system then calls it with the full Home Manager argument set. Some nixpkgs revisions expose that file as a stricter function and reject extra arguments such as `lib` or `specialArgs`.

The fix imports the nixpkgs module function explicitly and calls it with only the arguments declared by that function. This preserves compatibility with different nixpkgs signatures while avoiding accidental argument injection by the module system.

### Checklist

- [x] Change is backwards compatible.
- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.
- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.
- [ ] Test cases updated/added.
