### PR TITLE
ghostty: source shell integration only when present

### DIFF
--- a/modules/programs/ghostty.nix
+++ b/modules/programs/ghostty.nix
@@ -247,7 +247,7 @@ in
         # Make order 101 to be placed exactly after bash completions, as Ghostty
         # documentation suggests sourcing the script as soon as possible
         programs.bash.initExtra = lib.mkOrder 101 ''
-          if [[ -n "''${GHOSTTY_RESOURCES_DIR}" ]]; then
+          if [[ -r "''${GHOSTTY_RESOURCES_DIR}/shell-integration/bash/ghostty.bash" ]]; then
             builtin source "''${GHOSTTY_RESOURCES_DIR}/shell-integration/bash/ghostty.bash"
           fi
         '';
@@ -255,7 +255,7 @@ in
 
       (lib.mkIf cfg.enableFishIntegration {
         programs.fish.interactiveShellInit = ''
-          if set -q GHOSTTY_RESOURCES_DIR
+          if test -r "$GHOSTTY_RESOURCES_DIR/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish"
             source "$GHOSTTY_RESOURCES_DIR/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish"
           end
         '';
@@ -263,7 +263,7 @@ in
 
       (lib.mkIf cfg.enableZshIntegration {
         programs.zsh.initContent = ''
-          if [[ -n $GHOSTTY_RESOURCES_DIR ]]; then
+          if [[ -r "$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration ]]; then
             source "$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration
           fi
         '';

--- a/tests/modules/programs/ghostty/example-settings.nix
+++ b/tests/modules/programs/ghostty/example-settings.nix
@@ -1,5 +1,9 @@
 { config, ... }:
 {
+  programs.bash.enable = true;
+  programs.fish.enable = true;
+  programs.zsh.enable = true;
+
   programs.ghostty = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = null; };
@@ -17,5 +21,12 @@
     assertFileContent \
       home-files/.config/ghostty/config \
       ${./example-config-expected}
+
+    assertFileContains home-files/.bashrc \
+      '"''${GHOSTTY_RESOURCES_DIR}/shell-integration/bash/ghostty.bash" ]]; then'
+    assertFileContains home-files/.config/fish/config.fish \
+      'test -r "$GHOSTTY_RESOURCES_DIR/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish"'
+    assertFileContains home-files/.zshrc \
+      '"$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration ]]; then'
   '';
 }


### PR DESCRIPTION
### Description

The Ghostty shell integration snippets keyed off `GHOSTTY_RESOURCES_DIR` merely
being set, then sourced the integration script unconditionally.

Applications that embed GhosttyKit rather than shipping the full Ghostty
resource tree — cmux is one — export
`GHOSTTY_RESOURCES_DIR` pointing at a bundle directory that contains `terminfo`
and `themes` but no `shell-integration` directory. Every interactive shell
started inside such an application then failed at startup:

```
/Users/me/.config/zsh/.zshrc:source:370: no such file or directory: /Applications/cmux.app/Contents/Resources/ghostty/shell-integration/zsh/ghostty-integration
```

This tests for the integration file itself instead of the variable, for bash,
fish, and zsh. Behavior under Ghostty proper is unchanged: the file exists
there, so it is still sourced.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

  `nix run .#tests -- ghostty` — 3/3 passing on `aarch64-darwin`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

  Extended `ghostty-example-settings` to enable bash, fish, and zsh and assert
  the guarded source line in `.bashrc`, `config.fish`, and `.zshrc`.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
