### PR TITLE
claude-code: link plugins so agents and commands load

### DIFF
--- a/modules/programs/claude-code/default.nix
+++ b/modules/programs/claude-code/default.nix
@@ -82,6 +82,7 @@ in
     let
       helpers = claudeCodeLib.mkHelpers { inherit (cfg) configDir; };
       inherit (helpers)
+        derivePluginName
         mkHookEntries
         mkInstalledMarketplaceEntry
         mkMarkdownEntries
@@ -118,14 +119,26 @@ in
         )
       );
 
+      # The list form predates named plugins and is kept working, with a
+      # warning, so existing configurations keep evaluating.
+      pluginsAreList = builtins.isList cfg.plugins;
+
+      pluginSources = if pluginsAreList then cfg.plugins else lib.attrValues cfg.plugins;
+
+      managedPluginEntries =
+        if pluginsAreList then
+          map (plugin: mkPluginEntry (derivePluginName plugin) plugin) cfg.plugins
+        else
+          lib.mapAttrsToList mkPluginEntry cfg.plugins;
+
       pluginEntries =
         lib.optional (generatedPluginFiles != [ ]) {
           name = "claude-code-home-manager";
           source = generatedPlugin;
         }
-        ++ map mkPluginEntry cfg.plugins;
+        ++ managedPluginEntries;
 
-      legacyPluginPaths = lib.optional (generatedPluginFiles != [ ]) generatedPlugin ++ cfg.plugins;
+      legacyPluginPaths = lib.optional (generatedPluginFiles != [ ]) generatedPlugin ++ pluginSources;
 
       hasManagedPlugins = legacyPluginPaths != [ ];
       useLegacyPluginWrapper = hasManagedPlugins && !supportsPersonalPlugins;
@@ -161,13 +174,18 @@ in
           lib.optionalAttrs skillsAreDirectory (builtins.readDir cfg.skills)
       );
 
+      # Each plugin is linked as a single directory symlink rather than
+      # recursively. Claude Code discovers a plugin's `agents/` and `commands/`
+      # entries with a `readdir` that only accepts regular files, so recursive
+      # linking - which materializes a real directory holding one symlink per
+      # file - silently drops every agent and command the plugin provides.
+      # Symlinked directories are followed, so a whole-plugin link keeps them.
       pluginFileEntries = lib.optionalAttrs supportsPersonalPlugins (
         lib.listToAttrs (
           map (
             plugin:
             lib.nameValuePair "${cfg.configDir}/skills/${plugin.name}" {
               inherit (plugin) source;
-              recursive = true;
             }
           ) pluginEntries
         )
@@ -175,15 +193,24 @@ in
 
     in
     lib.mkIf cfg.enable {
-      warnings = lib.optional (useLegacyPluginWrapper && supportsPluginDir) ''
-        `programs.claude-code.package` ${
-          if hasPackageVersion then "version ${packageVersion}" else "has no detectable version and"
-        }
-        uses the legacy `--plugin-dir` wrapper. Strict-parser subcommands such
-        as `claude rc` may reject managed MCP, LSP, or plugin arguments. Upgrade
-        Claude Code to version 2.1.157 or later to use persistent personal
-        plugins instead.
-      '';
+      warnings =
+        lib.optional (pluginsAreList && cfg.plugins != [ ]) ''
+          `programs.claude-code.plugins` is set to a list. Names are then derived
+          from each entry's base name, which for store paths yields unstable
+          directory names such as `bxa1s0m3h4sh-source`. Use an attribute set
+          instead so plugin directory names stay stable and readable:
+
+            plugins.my-plugin = ./my-plugin;
+        ''
+        ++ lib.optional (useLegacyPluginWrapper && supportsPluginDir) ''
+          `programs.claude-code.package` ${
+            if hasPackageVersion then "version ${packageVersion}" else "has no detectable version and"
+          }
+          uses the legacy `--plugin-dir` wrapper. Strict-parser subcommands such
+          as `claude rc` may reject managed MCP, LSP, or plugin arguments. Upgrade
+          Claude Code to version 2.1.157 or later to use persistent personal
+          plugins instead.
+        '';
 
       assertions =
         let

--- a/modules/programs/claude-code/lib.nix
+++ b/modules/programs/claude-code/lib.nix
@@ -42,29 +42,47 @@ in
           name: content: lib.nameValuePair "${configDir}/${subdir}/${name}.md" (mkSourceEntry content)
         ) attrs;
 
-      mkPluginEntry =
+      # Legacy list entries have no user-supplied name, so derive one from the
+      # source's base name. Store paths yield unstable names like
+      # `bxa1s0m3h4sh-source`, which is why the attribute set form is preferred.
+      derivePluginName =
         plugin:
-        let
-          name = builtins.unsafeDiscardStringContext (
-            lib.strings.sanitizeDerivationName (baseNameOf (toString plugin))
-          );
-        in
-        {
-          inherit name;
-          source = pkgs.symlinkJoin {
-            name = "claude-code-${name}";
-            paths = [ plugin ];
-            postBuild = ''
-              if [[ ! -e $out/.claude-plugin/plugin.json ]]; then
-                install -Dm644 ${
-                  jsonFormat.generate "claude-code-${name}.json" {
-                    inherit name;
-                  }
-                } $out/.claude-plugin/plugin.json
-              fi
-            '';
-          };
-        };
+        builtins.unsafeDiscardStringContext (
+          lib.strings.sanitizeDerivationName (baseNameOf (toString plugin))
+        );
+
+      # Wraps a plugin so a manifest can be synthesized for sources that lack
+      # one. Only top-level entries are linked, leaving each component
+      # directory a single symlink to the original. `pkgs.symlinkJoin` cannot
+      # be used here: it mirrors directories and symlinks the leaf files, and
+      # Claude Code's `agents/` and `commands/` scanners accept only regular
+      # files, so every agent and command would be dropped.
+      mkPluginEntry = name: plugin: {
+        inherit name;
+        source = pkgs.runCommand "claude-code-${name}" { } ''
+          mkdir -p "$out"
+
+          shopt -s dotglob nullglob
+          for entry in "${plugin}"/*; do
+            ln -s "$entry" "$out/$(basename "$entry")"
+          done
+
+          if [[ ! -e $out/.claude-plugin/plugin.json ]]; then
+            # Replace the linked manifest directory with a real one so the
+            # generated manifest can sit beside any existing contents.
+            rm -f "$out/.claude-plugin"
+            mkdir -p "$out/.claude-plugin"
+            for entry in "${plugin}"/.claude-plugin/*; do
+              ln -s "$entry" "$out/.claude-plugin/$(basename "$entry")"
+            done
+            install -m644 ${
+              jsonFormat.generate "claude-code-${name}.json" {
+                inherit name;
+              }
+            } "$out/.claude-plugin/plugin.json"
+          fi
+        '';
+      };
 
       mkRecursiveDirAttrs =
         subdir: dir:

--- a/modules/programs/claude-code/options.nix
+++ b/modules/programs/claude-code/options.nix
@@ -148,30 +148,45 @@ in
     };
 
     plugins = lib.mkOption {
-      type = with lib.types; listOf (either package path);
-      default = [ ];
+      type = with lib.types; either (attrsOf (either package path)) (listOf (either package path));
+      default = { };
       description = ''
-        List of plugins to use when running Claude Code.
-        Each entry is either:
+        Plugins to use when running Claude Code.
+        The attribute name becomes the plugin directory name, and the value is
+        either:
         - A path to the plugin directory
         - The plugin package, whether a nix package or the output of a fetcher
-        With Claude Code 2.1.157 or later, plugins are linked into
-        {option}`programs.claude-code.configDir` and loaded as personal plugins.
+        With Claude Code 2.1.157 or later, each plugin is symlinked into the
+        {file}`skills/` subdirectory of
+        {option}`programs.claude-code.configDir` and loaded as a personal
+        plugin, exposing its skills, agents, commands, hooks, and MCP servers.
         Versions 2.1.76 through 2.1.156 fall back to a legacy `--plugin-dir`
         wrapper, as do packages without detectable version metadata.
         Strict-parser subcommands such as {command}`claude rc` may reject
         arguments from that compatibility path.
+
+        A plugin that lives in a subdirectory of a larger repository can be
+        referenced through a store path, in which case only that subdirectory
+        is linked and the surrounding repository is left out.
+
+        A plain list of plugins is still accepted but deprecated, since the
+        directory name is then derived from each entry's base name and store
+        paths produce unstable names such as `bxa1s0m3h4sh-source`.
       '';
       example = literalExpression ''
-        [
-          ./my-local-plugin
-          fetchFromGitHub {
+        {
+          my-local-plugin = ./my-local-plugin;
+          claude-plugin = fetchFromGitHub {
             owner = "some-github-org";
             repo = "claude-plugin";
             rev = "779a68ebc2a75e4a184d2c87e5a43a758e6458a1";
             sha256 = "228fdd7e5908ea1d2f65218ecd9c71e1eefa0834d200d55fbb8bf8b5563acec0";
-          }
-        ]
+          };
+
+          # A plugin can also be a subdirectory within a package source
+          # (store path).
+          nested-plugin = "''${pkgs.some-package.src}/claude-plugin";
+        }
       '';
     };
 

--- a/tests/modules/programs/claude-code/collision-assertions-legacy-list.nix
+++ b/tests/modules/programs/claude-code/collision-assertions-legacy-list.nix
@@ -1,0 +1,38 @@
+{ config, ... }:
+let
+  plugin = ./test-plugin;
+in
+{
+  programs.claude-code = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "claude-code";
+      version = "2.1.157";
+      buildScript = ''
+        mkdir -p $out/bin
+        touch $out/bin/claude
+        chmod 755 $out/bin/claude
+      '';
+    };
+    # Two list entries can derive the same directory name.
+    plugins = [
+      plugin
+      plugin
+    ];
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      `programs.claude-code.plugins` is set to a list. Names are then derived
+      from each entry's base name, which for store paths yields unstable
+      directory names such as `bxa1s0m3h4sh-source`. Use an attribute set
+      instead so plugin directory names stay stable and readable:
+
+        plugins.my-plugin = ./my-plugin;
+    ''
+  ];
+
+  test.asserts.assertions.expected = [
+    "`programs.claude-code.plugins` entries must resolve to unique personal-plugin directory names"
+  ];
+}

--- a/tests/modules/programs/claude-code/collision-assertions.nix
+++ b/tests/modules/programs/claude-code/collision-assertions.nix
@@ -1,8 +1,4 @@
 { config, ... }:
-let
-  plugin = ./test-plugin;
-  pluginDirName = baseNameOf (toString plugin);
-in
 {
   programs.claude-code = {
     enable = true;
@@ -15,15 +11,18 @@ in
         chmod 755 $out/bin/claude
       '';
     };
-    plugins = [
-      plugin
-      plugin
-    ];
-    skills.${pluginDirName} = "test skill";
+
+    # An attribute set cannot hold duplicate names, so uniqueness can only be
+    # violated by colliding with the generated Home Manager plugin, which is
+    # present because `mcpServers` is set.
+    mcpServers.github = {
+      type = "http";
+      url = "https://api.githubcopilot.com/mcp/";
+    };
+    plugins.claude-code-home-manager = ./test-plugin;
   };
 
   test.asserts.assertions.expected = [
     "`programs.claude-code.plugins` entries must resolve to unique personal-plugin directory names"
-    "`programs.claude-code.skills` and managed plugins must have unique directory names"
   ];
 }

--- a/tests/modules/programs/claude-code/default.nix
+++ b/tests/modules/programs/claude-code/default.nix
@@ -8,6 +8,7 @@
   claude-code-mcp-integration = ./mcp-integration.nix;
   claude-code-assertion = ./assertion.nix;
   claude-code-collision-assertions = ./collision-assertions.nix;
+  claude-code-collision-assertions-legacy-list = ./collision-assertions-legacy-list.nix;
   claude-code-context-inline = ./memory-management.nix;
   claude-code-context-path = ./memory-from-source.nix;
   claude-code-rules-dir = ./rules-dir.nix;
@@ -27,6 +28,8 @@
   claude-code-output-styles = ./output-styles.nix;
   claude-code-output-styles-not-set = ./output-styles-not-set.nix;
   claude-code-plugins = ./plugins.nix;
+  claude-code-plugins-legacy-list = ./plugins-legacy-list.nix;
+  claude-code-plugins-subdir = ./plugins-subdir.nix;
   claude-code-versionless-package = ./versionless-package.nix;
   claude-code-marketplacess = ./marketplaces.nix;
 }

--- a/tests/modules/programs/claude-code/mcp-lsp.nix
+++ b/tests/modules/programs/claude-code/mcp-lsp.nix
@@ -66,7 +66,7 @@
       };
     };
 
-    plugins = [ ./test-plugin ];
+    plugins.test-plugin = ./test-plugin;
   };
 
   test.asserts.warnings.expected = [

--- a/tests/modules/programs/claude-code/plugins-legacy-list.nix
+++ b/tests/modules/programs/claude-code/plugins-legacy-list.nix
@@ -1,0 +1,48 @@
+{ config, pkgs, ... }:
+let
+  pluginDirName = plugin: baseNameOf (toString plugin);
+in
+
+{
+  programs.claude-code = {
+    package = config.lib.test.mkStubPackage {
+      name = "claude-code";
+      version = "2.1.197";
+      buildScript = ''
+        mkdir -p $out/bin
+        cat > $out/bin/claude <<'EOF'
+        #!${pkgs.runtimeShell}
+        test "$#" -eq 1
+        test "$1" = rc
+        EOF
+        chmod +x $out/bin/claude
+      '';
+    };
+    enable = true;
+
+    plugins = [ ./test-plugin ];
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      `programs.claude-code.plugins` is set to a list. Names are then derived
+      from each entry's base name, which for store paths yields unstable
+      directory names such as `bxa1s0m3h4sh-source`. Use an attribute set
+      instead so plugin directory names stay stable and readable:
+
+        plugins.my-plugin = ./my-plugin;
+    ''
+  ];
+
+  nmt.script = ''
+    "$TESTED/home-path/bin/claude" rc
+
+    # The list form still derives the directory name from the entry's base name.
+    pluginDir="$TESTED/home-files/.claude/skills/${pluginDirName ./test-plugin}"
+    assertLinkExists "home-files/.claude/skills/${pluginDirName ./test-plugin}"
+    assertFileContent "$pluginDir/.claude-plugin/plugin.json" ${./test-plugin/.claude-plugin/plugin.json}
+    assertFileContent \
+      "$pluginDir/agents/test-plugin-agent.md" \
+      ${./test-plugin/agents/test-plugin-agent.md}
+  '';
+}

--- a/tests/modules/programs/claude-code/plugins-subdir.nix
+++ b/tests/modules/programs/claude-code/plugins-subdir.nix
@@ -1,0 +1,84 @@
+{ pkgs, ... }:
+
+let
+  # Mimics a fetched repository that holds plugins in subdirectories
+  # alongside unrelated repository content. One subdirectory contains
+  # whitespace, which must survive the wrapper's glob expansion.
+  # Claude Code rejects plugin names containing spaces, so the manifest name
+  # stays kebab-case while the directory holding it does not.
+  repo = pkgs.runCommand "claude-plugin-repo" { } ''
+    mkPlugin() {
+      local dir="$1" name="$2"
+      mkdir -p "$out/plugins/$dir/.claude-plugin" "$out/plugins/$dir/agents"
+      echo "{\"name\":\"$name\",\"version\":\"1.0.0\"}" \
+        > "$out/plugins/$dir/.claude-plugin/plugin.json"
+      cat > "$out/plugins/$dir/agents/$name-agent.md" <<EOF
+    ---
+    name: $name-agent
+    description: Agent provided by a plugin nested in a repository
+    ---
+
+    Agent body.
+    EOF
+    }
+
+    mkPlugin "nested-plugin" "nested-plugin"
+    mkPlugin "spaced plugin" "spaced-plugin"
+    echo '# Repository readme' > "$out/README.md"
+  '';
+in
+{
+  programs.claude-code = {
+    enable = true;
+    plugins = {
+      nested-plugin = "${repo}/plugins/nested-plugin";
+      spaced-plugin = "${repo}/plugins/spaced plugin";
+    };
+  };
+
+  nmt.script = ''
+    assertLinkExists "home-files/.claude/skills/nested-plugin"
+    assertLinkExists "home-files/.claude/skills/spaced-plugin"
+
+    nestedDir="$TESTED/home-files/.claude/skills/nested-plugin"
+    assertFileContent \
+      "$nestedDir/.claude-plugin/plugin.json" \
+      "${repo}/plugins/nested-plugin/.claude-plugin/plugin.json"
+    assertFileContent \
+      "$nestedDir/agents/nested-plugin-agent.md" \
+      "${repo}/plugins/nested-plugin/agents/nested-plugin-agent.md"
+
+    # A source path containing whitespace must not be split during glob
+    # expansion, which would leave dangling links and drop plugin contents.
+    spacedDir="$TESTED/home-files/.claude/skills/spaced-plugin"
+    assertFileContent \
+      "$spacedDir/.claude-plugin/plugin.json" \
+      "${repo}/plugins/spaced plugin/.claude-plugin/plugin.json"
+    assertFileContent \
+      "$spacedDir/agents/spaced-plugin-agent.md" \
+      "${repo}/plugins/spaced plugin/agents/spaced-plugin-agent.md"
+
+    for pluginDir in "$nestedDir" "$spacedDir"; do
+      # Only the plugin subdirectory is linked, not the enclosing repository.
+      assertPathNotExists "$pluginDir/README.md"
+      assertPathNotExists "$pluginDir/plugins"
+
+      # Every linked entry must resolve; a split path yields dangling links.
+      for entry in "$pluginDir"/* "$pluginDir"/.[!.]*; do
+        if [[ -e "$entry" ]]; then
+          continue
+        fi
+        echo "Linked plugin entry does not resolve: $entry"
+        exit 1
+      done
+
+      # Agents must stay regular files or Claude Code's scanner skips them.
+      for agentFile in "$pluginDir"/agents/*.md; do
+        if [[ -L "$agentFile" ]]; then
+          echo "Plugin component must be a regular file, not a symlink: $agentFile"
+          exit 1
+        fi
+      done
+    done
+  '';
+}

--- a/tests/modules/programs/claude-code/plugins.nix
+++ b/tests/modules/programs/claude-code/plugins.nix
@@ -14,9 +14,6 @@ let
   manifestlessPlugin = pkgs.runCommand "manifestless-plugin" { } ''
     install -Dm644 ${./test-command.md} $out/commands/test.md
   '';
-  packagePluginOne = mkPackagePlugin "package-plugin-one";
-  packagePluginTwo = mkPackagePlugin "package-plugin-two";
-  pluginDirName = plugin: baseNameOf (toString plugin);
 in
 
 {
@@ -36,31 +33,57 @@ in
     };
     enable = true;
 
-    plugins = [
-      ./test-plugin
-      packagePluginOne
-      packagePluginTwo
-      manifestlessPlugin
-    ];
+    plugins = {
+      test-plugin = ./test-plugin;
+      package-plugin-one = mkPackagePlugin "package-plugin-one";
+      package-plugin-two = mkPackagePlugin "package-plugin-two";
+      manifestless = manifestlessPlugin;
+    };
   };
 
   nmt.script = ''
     "$TESTED/home-path/bin/claude" rc
     assertPathNotExists "$TESTED/home-path/bin/.claude-wrapped"
 
-    pluginDir="$TESTED/home-files/.claude/skills/${pluginDirName ./test-plugin}"
+    # Each plugin must be linked as a single directory symlink. Linking
+    # recursively materializes a real directory holding one symlink per file,
+    # which makes Claude Code skip every agent and command the plugin ships.
+    assertLinkExists "home-files/.claude/skills/test-plugin"
+    assertLinkExists "home-files/.claude/skills/package-plugin-one"
+    assertLinkExists "home-files/.claude/skills/manifestless"
+
+    pluginDir="$TESTED/home-files/.claude/skills/test-plugin"
     assertFileContent "$pluginDir/.claude-plugin/plugin.json" ${./test-plugin/.claude-plugin/plugin.json}
+    assertFileContent \
+      "$pluginDir/agents/test-plugin-agent.md" \
+      ${./test-plugin/agents/test-plugin-agent.md}
+    assertFileContent \
+      "$pluginDir/commands/test-plugin-command.md" \
+      ${./test-plugin/commands/test-plugin-command.md}
+
+    # Claude Code lists a plugin's agents and commands with a `readdir` that
+    # accepts only regular files, so these must not be per-file symlinks.
+    # `assertFileContent` follows symlinks and cannot catch this on its own.
+    for componentFile in \
+      "$pluginDir/agents/test-plugin-agent.md" \
+      "$pluginDir/commands/test-plugin-command.md"; do
+      if [[ -L "$componentFile" ]]; then
+        echo "Plugin component must be a regular file, not a symlink: $componentFile"
+        exit 1
+      fi
+    done
+
     assertFileContains \
-      "$TESTED/home-files/.claude/skills/${pluginDirName packagePluginOne}/.claude-plugin/plugin.json" \
+      "$TESTED/home-files/.claude/skills/package-plugin-one/.claude-plugin/plugin.json" \
       '"name":"package-plugin-one"'
     assertFileContains \
-      "$TESTED/home-files/.claude/skills/${pluginDirName packagePluginTwo}/.claude-plugin/plugin.json" \
+      "$TESTED/home-files/.claude/skills/package-plugin-two/.claude-plugin/plugin.json" \
       '"name":"package-plugin-two"'
     assertFileContains \
-      "$TESTED/home-files/.claude/skills/${pluginDirName manifestlessPlugin}/.claude-plugin/plugin.json" \
-      '"name": "${pluginDirName manifestlessPlugin}"'
+      "$TESTED/home-files/.claude/skills/manifestless/.claude-plugin/plugin.json" \
+      '"name": "manifestless"'
     assertFileContent \
-      "$TESTED/home-files/.claude/skills/${pluginDirName manifestlessPlugin}/commands/test.md" \
+      "$TESTED/home-files/.claude/skills/manifestless/commands/test.md" \
       ${./test-command.md}
   '';
 }

--- a/tests/modules/programs/claude-code/skills-dir.nix
+++ b/tests/modules/programs/claude-code/skills-dir.nix
@@ -2,7 +2,7 @@
   programs.claude-code = {
     enable = true;
     skills = ./skills;
-    plugins = [ ./test-plugin ];
+    plugins.test-plugin = ./test-plugin;
   };
 
   nmt.script = ''
@@ -12,7 +12,7 @@
       home-files/.claude/skills/test-skill/SKILL.md \
       ${./skills/test-skill/SKILL.md}
     assertFileContent \
-      home-files/.claude/skills/${baseNameOf (toString ./test-plugin)}/.claude-plugin/plugin.json \
+      home-files/.claude/skills/test-plugin/.claude-plugin/plugin.json \
       ${./test-plugin/.claude-plugin/plugin.json}
   '';
 }

--- a/tests/modules/programs/claude-code/test-plugin/agents/test-plugin-agent.md
+++ b/tests/modules/programs/claude-code/test-plugin/agents/test-plugin-agent.md
@@ -1,0 +1,6 @@
+---
+name: test-plugin-agent
+description: Agent provided by a managed plugin
+---
+
+Agent body provided by the plugin.

--- a/tests/modules/programs/claude-code/test-plugin/commands/test-plugin-command.md
+++ b/tests/modules/programs/claude-code/test-plugin/commands/test-plugin-command.md
@@ -1,0 +1,5 @@
+---
+description: Command provided by a managed plugin
+---
+
+Command body provided by the plugin.

--- a/tests/modules/programs/claude-code/versionless-package.nix
+++ b/tests/modules/programs/claude-code/versionless-package.nix
@@ -11,7 +11,7 @@
         chmod 755 $out/bin/claude
       '';
     };
-    plugins = [ ./test-plugin ];
+    plugins.test-plugin = ./test-plugin;
   };
 
   test.asserts.warnings.expected = [


### PR DESCRIPTION
### Description

Managed Claude Code plugins currently load, but every agent and command they ship is silently discarded.

Claude Code enumerates a plugin's `agents/` and `commands/` entries with `readdir(…, { withFileTypes: true })` and accepts only `isFile()` dirents. A symlink reports `isSymbolicLink()`, so per-file symlinks are skipped. Two layers of the module produced exactly that layout:

1. `pluginFileEntries` linked each plugin with `recursive = true`, which materializes a real directory holding one symlink per file.
2. `mkPluginEntry` wrapped plugins with `pkgs.symlinkJoin`, which uses `lndir` — mirroring directories while symlinking the leaf files.

Skills were unaffected because they sit one directory deeper, so the scanned dirent is a real directory. That made the breakage look like "only skills load from `~/.claude/skills/`".

Observed with an unmodified plugin that ships one agent and no skills:

```
$ claude plugin details code-simplifier
code-simplifier 1.0.0
  Source: code-simplifier@skills-dir
Component inventory
  Skills (0)   Agents (0)   Hooks (0)   MCP servers (0)   LSP servers (0)
Projected token cost
  Always-on:   ~0 tok   added to every session
```

It reports `✔ loaded` and contributes nothing.

#### Changes

- Link each plugin as a single directory symlink instead of recursively. Symlinked *directories* are followed by the scanners; only symlinked files are skipped.
- Replace `pkgs.symlinkJoin` in `mkPluginEntry` with a `runCommand` that links only top-level entries, so each component directory stays a symlink to the original. The wrapper still exists solely to synthesize `.claude-plugin/plugin.json` for manifestless sources.
- Accept an attribute set for `plugins`, so the personal-plugin directory name is user-controlled and stable. Previously it was derived from the source's base name, which for fetched plugins yields `979rb6hs2dxg117zddvsvkfzxjiz1rvr-source` and changes on every update. The list form still works and emits a deprecation warning.

Result on disk:

```
skills/mattpocock-skills -> /nix/store/…-claude-code-mattpocock-skills
skills/code-simplifier   -> /nix/store/…-claude-code-code-simplifier
```

Verified against `claude plugin details` using the config built by the `claude-code-plugins` test: `Agents (0)` → `Agents (1) test-plugin-agent`, and the plugin's command now appears too.

#### Plugins nested in a larger repository

A plugin that ships inside a subdirectory of a bigger repository can be referenced through a store path, which the wrapper handles by linking only that subdirectory:

```nix
plugins.nested-plugin = "${pkgs.some-package.src}/claude-plugin";
```

```
skills/nested-plugin -> /nix/store/…-claude-code-nested-plugin
  ├── agents         -> /nix/store/…-repo/plugins/nested-plugin/agents
  └── .claude-plugin -> /nix/store/…-repo/plugins/nested-plugin/.claude-plugin
```

The enclosing repository's files are not exposed. This mirrors what `skills` already supports (`beads = "${pkgs.beads.src}/claude-plugin/skills/beads"`), and is covered by the new `claude-code-plugins-subdir` test, which asserts both that the nested agent loads and that the repository root is absent. It is also a case the attribute set form improves: `baseNameOf` on a nested path tends to produce a generic name like `claude-plugin`, so two plugins vendored from different repositories would previously collide.

#### Notes for reviewers

- `assertFileContent` follows symlinks and cannot detect this class of bug, so `plugins.nix` additionally asserts that plugin component files are not symlinks. I confirmed the guard fails when `symlinkJoin` is reintroduced.
- A plugin/skill name collision previously merged both into one directory; it now conflicts loudly, since nothing can be written inside a store symlink. The existing assertions catch this first in real use — `modules/default.nix` throws on failed assertions before `activationPackage` is evaluated.
- Because of that, the `skills`-vs-plugins collision assertion no longer has an nmt test: the harness turns assertions into data and still builds `home.file`, so it hits the file conflict before the assertion is observable. The assertion itself is unchanged; `collision-assertions.nix` now covers the uniqueness assertion, and `collision-assertions-legacy-list.nix` covers the list form.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.
      <sub>All 33 `claude-code-*` tests were built and pass; the full `test-all` suite was not run.</sub>

- [x] Test cases updated/added.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```
