### PR TITLE
services-modular: accept both shapes of the nixpkgs service module

### DIFF
--- a/modules/services-modular/default.nix
+++ b/modules/services-modular/default.nix
@@ -170,12 +170,11 @@ let
   modularServiceConfiguration = portable-lib.configure {
     serviceManagerPkgs = pkgs;
     extraRootModules = [
-      ./service.nix
+      (lib.modules.importApply ./service.nix { inherit pkgs; })
       ./config-data-path.nix
     ];
     extraRootSpecialArgs = {
       systemdPackage = pkgs.systemd;
-      nixpkgsPath = pkgs.path;
       xdgConfigHome = config.xdg.configHome;
     };
   };

--- a/modules/services-modular/service.nix
+++ b/modules/services-modular/service.nix
@@ -8,11 +8,37 @@
 # drop in unchanged. Then overrides the primary unit's `wantedBy` default
 # to `default.target`, since user units typically attach to that instead
 # of `multi-user.target`.
-{ lib, nixpkgsPath, ... }:
+#
+# Non-module arguments, matching nixpkgs' `lib/services` convention: keeping
+# `pkgs` out of the module arguments is what lets service modules stay
+# portable.
+{ pkgs }:
+
+{ lib, ... }:
+let
+  servicePath = pkgs.path + "/nixos/modules/system/service/systemd/service.nix";
+
+  # nixpkgs has shipped this file both as a plain module and wrapped in a
+  # `{ pkgs }:` non-module-arguments closure (see nixpkgs `541a6f371`,
+  # reverted in `ec69cf3f7`). The module system cannot apply such a closure
+  # itself, so pick the shape at import time instead of assuming one. The
+  # plain module always declares `config`; the closure declares `pkgs` and no
+  # module arguments.
+  nonModuleArgs = lib.functionArgs (import servicePath);
+  isWrapped = nonModuleArgs ? pkgs && !(nonModuleArgs ? config);
+
+  serviceModule =
+    if isWrapped then
+      # `importApply` preserves `_file`, so module-system errors keep pointing
+      # at the nixpkgs file. `intersectAttrs` passes only the arguments the
+      # closure actually declares, so a closed `{ pkgs }` pattern is satisfied
+      # exactly while a hypothetical `{ pkgs, lib }` also works.
+      lib.modules.importApply servicePath (lib.intersectAttrs nonModuleArgs { inherit lib pkgs; })
+    else
+      servicePath;
+in
 {
-  imports = [
-    (nixpkgsPath + "/nixos/modules/system/service/systemd/service.nix")
-  ];
+  imports = [ serviceModule ];
 
   # The empty key `""` is the modular service's *primary* unit (see
   # `dashed` in `default.nix`).


### PR DESCRIPTION
Fixes #9708.

Make the import of nixpkgs' modular services (see #9215) robust to its temporary closure wrapper (added in NixOS/nixpkgs#518860, reverted in NixOS/nixpkgs#545519), making Home Manager robust to this mismatch (still present in `nixpkgs-unstable` as per https://github.com/nix-community/home-manager/pull/9708#issuecomment-5085652500).

Assisted-by: Claude:claude-opus-5

/cc @DaVinci42 @pyrox0

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`
    - `nix run .#tests -- home-services`

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
