### PR TITLE
easyeffects: add global settings and paired presets

### DIFF
--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -15,6 +15,54 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
+  settingType = types.nullOr (
+    types.oneOf [
+      types.bool
+      types.int
+      types.float
+      types.str
+      types.path
+    ]
+  );
+
+  settingsFile = "${config.xdg.configHome}/easyeffects/db/easyeffectsrc";
+
+  nonEmpty = settings: settings != { };
+
+  hasSettings = lib.any nonEmpty (lib.attrValues cfg.settings);
+
+  settingsOption = "`services.easyeffects.settings`";
+
+  settingsCommands = lib.concatStringsSep "\n" (
+    lib.flatten (
+      lib.mapAttrsToList (
+        group: settings:
+        lib.mapAttrsToList (
+          key: value:
+          let
+            formattedValue =
+              if value == null then
+                "--delete"
+              else if builtins.isBool value then
+                "--type bool -- ${builtins.toJSON value}"
+              else
+                "-- ${lib.escapeShellArg (toString value)}";
+          in
+          "${pkgs.kdePackages.kconfig}/bin/kwriteconfig6"
+          + " --file ${lib.escapeShellArg settingsFile}"
+          + " --group ${lib.escapeShellArg group}"
+          + " --key ${lib.escapeShellArg key}"
+          + " ${formattedValue}"
+        ) settings
+      ) cfg.settings
+    )
+  );
+
+  settingsScript = pkgs.writeShellScript "easyeffects-settings" ''
+    ${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg (dirOf settingsFile)}
+    ${settingsCommands}
+  '';
+
   presetType =
     let
       baseType = types.attrsOf jsonFormat.type;
@@ -92,11 +140,34 @@ in
     };
 
     extraPresets = presetOptionType;
+
+    settings = mkOption {
+      type = types.attrsOf (types.attrsOf settingType);
+      default = { };
+      example = literalExpression ''
+        {
+          StreamInputs = {
+            inputDevice = "alsa_input.usb-example";
+            listenToMic = false;
+          };
+          StreamOutputs.useDefaultOutputDevice = true;
+        }
+      '';
+      description = ''
+        Global EasyEffects settings written to its mutable KConfig database.
+        Settings are grouped by KConfig section. A value of `null` deletes the
+        corresponding key. This option requires EasyEffects 8.0.0 or later.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
     assertions = [
       (lib.hm.assertions.assertPlatform "services.easyeffects" pkgs lib.platforms.linux)
+      {
+        assertion = !hasSettings || !olderThan8;
+        message = "${settingsOption} requires EasyEffects 8.0.0 or later.";
+      }
     ];
 
     home.packages = with pkgs; lib.optional olderThan8 at-spi2-core ++ [ cfg.package ]; # Only include if easyeffects version is below 8.0.0
@@ -119,6 +190,7 @@ in
         Description = "Easyeffects daemon";
         After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
+        X-Restart-Triggers = [ (builtins.hashString "sha256" (builtins.toJSON cfg.settings)) ];
       };
 
       Install.WantedBy = [ "graphical-session.target" ];
@@ -134,6 +206,9 @@ in
         Restart = "on-failure";
         RestartSec = 5;
         TimeoutStopSec = 10;
+      }
+      // lib.optionalAttrs hasSettings {
+        ExecStartPre = settingsScript;
       }
       // (
         if olderThan8 then

--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -9,11 +9,61 @@ let
 
   cfg = config.services.easyeffects;
 
-  presetOpts = lib.optionalString (cfg.preset != "") "--load-preset ${cfg.preset}";
+  isSplitPreset = builtins.isAttrs cfg.preset;
+
+  selectedPresets =
+    if isSplitPreset then lib.filterAttrs (_: preset: preset != "") cfg.preset else { };
+
+  presetOpts = lib.optionalString (
+    !isSplitPreset && cfg.preset != ""
+  ) "--load-preset ${lib.escapeShellArg cfg.preset}";
 
   olderThan8 = lib.versionOlder cfg.package.version "8.0.0"; # This version introduces breaking changes and this check is used to stay backwards compatible
 
+  olderThan8_0_9 = lib.versionOlder cfg.package.version "8.0.9";
+
   jsonFormat = pkgs.formats.json { };
+
+  splitPresetType = types.submodule {
+    options = {
+      input = mkOption {
+        type = types.str;
+        default = "";
+        description = "Input preset to load when starting EasyEffects.";
+      };
+
+      output = mkOption {
+        type = types.str;
+        default = "";
+        description = "Output preset to load when starting EasyEffects.";
+      };
+    };
+  };
+
+  splitPresetCommands = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (
+      pipeline: preset: "printf '%s\\n' ${lib.escapeShellArg "load_preset:${pipeline}:${preset}"}"
+    ) selectedPresets
+  );
+
+  loadSplitPresets = pkgs.writeShellScript "easyeffects-load-presets" ''
+    preset_socket=$1
+
+    for _ in {1..100}; do
+      if [[ -S "$preset_socket" ]]; then
+        if {
+          :
+          ${splitPresetCommands}
+        } | ${pkgs.socat}/bin/socat -u -T 1 - UNIX-CONNECT:"$preset_socket"; then
+          exit 0
+        fi
+      fi
+
+      ${pkgs.coreutils}/bin/sleep 0.1
+    done
+
+    exit 1
+  '';
 
   settingType = types.nullOr (
     types.oneOf [
@@ -142,11 +192,23 @@ in
     package = lib.mkPackageOption pkgs "easyeffects" { };
 
     preset = mkOption {
-      type = types.str;
+      type = types.either types.str splitPresetType;
       default = "";
+      example = literalExpression ''
+        {
+          input = "voice";
+          output = "music";
+        }
+      '';
       description = ''
-        Which preset to use when starting easyeffects.
-        Will likely need to launch easyeffects to initially create preset.
+        Preset to load when starting EasyEffects.
+
+        A string loads every input or output preset having that name. An
+        attribute set selects input and output presets independently and
+        requires EasyEffects 8.0.9 or later. An empty string leaves that
+        pipeline unchanged.
+
+        You will likely need to launch EasyEffects to initially create presets.
       '';
     };
 
@@ -178,6 +240,14 @@ in
       {
         assertion = !hasSettings || !olderThan8;
         message = "${settingsOption} requires EasyEffects 8.0.0 or later.";
+      }
+      {
+        assertion = !isSplitPreset || !olderThan8_0_9;
+        message = "Structured `services.easyeffects.preset` requires EasyEffects 8.0.9 or later.";
+      }
+      {
+        assertion = !isSplitPreset || selectedPresets != { };
+        message = "Structured `services.easyeffects.preset` must select at least one input or output preset.";
       }
     ];
 
@@ -221,6 +291,9 @@ in
       }
       // lib.optionalAttrs hasSettings {
         ExecStartPre = settingsScript;
+      }
+      // lib.optionalAttrs isSplitPreset {
+        ExecStartPost = "-${loadSplitPresets} %t/EasyEffectsServer";
       }
       // (
         if olderThan8 then

--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -69,11 +69,14 @@ let
     in
     types.addCheck baseType (
       v:
-      baseType.check v
-      && lib.elem (lib.head (lib.attrNames v)) [
-        "input"
-        "output"
-      ]
+      v != { }
+      && lib.all (
+        pipeline:
+        lib.elem pipeline [
+          "input"
+          "output"
+        ]
+      ) (lib.attrNames v)
     );
 
   presetOptionType = mkOption {
@@ -81,8 +84,8 @@ let
     default = { };
     description = ''
       List of presets to import to easyeffects.
-      Presets are written to input and output folder in `$XDG_DATA_HOME/easyeffects`.
-      Top level block (input/output) determines the folder the file is written to.
+      Presets are written to input and output folders in `$XDG_DATA_HOME/easyeffects`.
+      Each top-level block (`input` or `output`) is written to its corresponding folder.
 
       See community presets at:
       https://github.com/wwmm/easyeffects/wiki/Community-Presets
@@ -106,6 +109,14 @@ let
               release = 20.0;
               "vad-thres" = 50.0;
               wet = 0.0;
+            };
+          };
+          output = {
+            blocklist = [ ];
+            "plugins_order" = [ "limiter#0" ];
+            "limiter#0" = {
+              bypass = false;
+              threshold = -1.0;
             };
           };
         };
@@ -173,15 +184,16 @@ in
     home.packages = with pkgs; lib.optional olderThan8 at-spi2-core ++ [ cfg.package ]; # Only include if easyeffects version is below 8.0.0
 
     xdg.dataFile = lib.mkIf (cfg.extraPresets != null && cfg.extraPresets != { }) (
-      lib.mapAttrs' (
-        k: v:
-        # Assuming only one of either input or output block is defined, having both in same file not seem to be supported by the application since it separates it by folder
-        let
-          folder = builtins.head (builtins.attrNames v);
-        in
-        lib.nameValuePair "easyeffects/${folder}/${k}.json" {
-          source = jsonFormat.generate "${folder}-${k}.json" v;
-        }
+      lib.concatMapAttrs (
+        name: preset:
+        lib.mapAttrs' (
+          pipeline: settings:
+          lib.nameValuePair "easyeffects/${pipeline}/${name}.json" {
+            source = jsonFormat.generate "${pipeline}-${name}.json" {
+              "${pipeline}" = settings;
+            };
+          }
+        ) preset
       ) cfg.extraPresets
     );
 

--- a/tests/modules/services/easyeffects/default.nix
+++ b/tests/modules/services/easyeffects/default.nix
@@ -4,4 +4,5 @@ lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   easyeffects-service = ./service.nix;
   easyeffects-example-preset = ./example-preset.nix;
   easyeffects-null-presets = ./null-presets.nix;
+  easyeffects-settings-old-version = ./settings-old-version.nix;
 }

--- a/tests/modules/services/easyeffects/default.nix
+++ b/tests/modules/services/easyeffects/default.nix
@@ -5,4 +5,6 @@ lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   easyeffects-example-preset = ./example-preset.nix;
   easyeffects-null-presets = ./null-presets.nix;
   easyeffects-settings-old-version = ./settings-old-version.nix;
+  easyeffects-split-presets = ./split-presets.nix;
+  easyeffects-split-presets-old-version = ./split-presets-old-version.nix;
 }

--- a/tests/modules/services/easyeffects/example-preset-output.json
+++ b/tests/modules/services/easyeffects/example-preset-output.json
@@ -1,0 +1,12 @@
+{
+  "output": {
+    "blocklist": [],
+    "limiter#0": {
+      "bypass": false,
+      "threshold": -1.0
+    },
+    "plugins_order": [
+      "limiter#0"
+    ]
+  }
+}

--- a/tests/modules/services/easyeffects/example-preset.nix
+++ b/tests/modules/services/easyeffects/example-preset.nix
@@ -1,3 +1,9 @@
+{ options, ... }:
+
+let
+  presetType =
+    options.services.easyeffects.extraPresets.type.nestedTypes.elemType.nestedTypes.elemType;
+in
 {
   services.easyeffects = {
     enable = true;
@@ -19,14 +25,32 @@
             wet = 0.0;
           };
         };
+        output = {
+          blocklist = [ ];
+          "plugins_order" = [ "limiter#0" ];
+          "limiter#0" = {
+            bypass = false;
+            threshold = -1.0;
+          };
+        };
       };
     };
   };
 
   test.stubs.easyeffects = { };
 
-  nmt.script = ''
-    assertFileContent \
-      home-files/.local/share/easyeffects/input/example-preset.json "${./example-preset.json}"
-  '';
+  nmt.script =
+    assert
+      !(presetType.check {
+        input = { };
+        outpt = { };
+      });
+    assert !(presetType.check { });
+    ''
+      inputPreset=home-files/.local/share/easyeffects/input/example-preset.json
+      outputPreset=home-files/.local/share/easyeffects/output/example-preset.json
+
+      assertFileContent "$inputPreset" "${./example-preset.json}"
+      assertFileContent "$outputPreset" "${./example-preset-output.json}"
+    '';
 }

--- a/tests/modules/services/easyeffects/service.nix
+++ b/tests/modules/services/easyeffects/service.nix
@@ -11,6 +11,7 @@ in
 {
   services.easyeffects = {
     enable = true;
+    preset = "music";
     inherit settings;
   };
 
@@ -20,7 +21,8 @@ in
     serviceFile=home-files/.config/systemd/user/easyeffects.service
 
     assertFileExists $serviceFile
-    assertFileRegex $serviceFile 'ExecStart=.*/bin/easyeffects'
+    assertFileRegex $serviceFile \
+      'ExecStart=.*/bin/easyeffects .*--load-preset music'
     assertFileContains $serviceFile \
       'X-Restart-Triggers=${builtins.hashString "sha256" (builtins.toJSON settings)}'
 

--- a/tests/modules/services/easyeffects/service.nix
+++ b/tests/modules/services/easyeffects/service.nix
@@ -1,6 +1,17 @@
+let
+  settings = {
+    StreamInputs = {
+      inputDevice = "alsa_input.usb-example";
+      listenToMic = false;
+      obsoleteKey = null;
+    };
+    StreamOutputs.useDefaultOutputDevice = true;
+  };
+in
 {
   services.easyeffects = {
     enable = true;
+    inherit settings;
   };
 
   test.stubs.easyeffects = { };
@@ -10,5 +21,26 @@
 
     assertFileExists $serviceFile
     assertFileRegex $serviceFile 'ExecStart=.*/bin/easyeffects'
+    assertFileContains $serviceFile \
+      'X-Restart-Triggers=${builtins.hashString "sha256" (builtins.toJSON settings)}'
+
+    settingsScript=$(sed -n \
+      's|^ExecStartPre=\([^ ]*\).*|\1|p' "$TESTED/$serviceFile")
+    assertFileExists "$settingsScript"
+
+    settingsFile='/home/hm-user/.config/easyeffects/db/easyeffectsrc'
+    settingsCommand="kwriteconfig6 .*--file $settingsFile"
+    inputCommand="$settingsCommand --group StreamInputs"
+    outputCommand="$settingsCommand --group StreamOutputs"
+
+    assertFileRegex "$settingsScript" \
+      "$inputCommand --key inputDevice -- alsa_input.usb-example"
+    assertFileRegex "$settingsScript" \
+      "$inputCommand --key listenToMic --type bool -- false"
+    assertFileRegex "$settingsScript" \
+      "$inputCommand --key obsoleteKey --delete"
+    assertFileRegex "$settingsScript" \
+      "$outputCommand --key useDefaultOutputDevice --type bool -- true"
+    assertFileNotRegex activate "$settingsCommand"
   '';
 }

--- a/tests/modules/services/easyeffects/settings-old-version.nix
+++ b/tests/modules/services/easyeffects/settings-old-version.nix
@@ -1,0 +1,13 @@
+{ config, ... }:
+
+{
+  services.easyeffects = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { version = "7.2.0"; };
+    settings.StreamOutputs.useDefaultOutputDevice = true;
+  };
+
+  test.asserts.assertions.expected = [
+    "`services.easyeffects.settings` requires EasyEffects 8.0.0 or later."
+  ];
+}

--- a/tests/modules/services/easyeffects/split-presets-old-version.nix
+++ b/tests/modules/services/easyeffects/split-presets-old-version.nix
@@ -1,0 +1,13 @@
+{ config, ... }:
+
+{
+  services.easyeffects = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { version = "8.0.8"; };
+    preset.input = "home";
+  };
+
+  test.asserts.assertions.expected = [
+    "Structured `services.easyeffects.preset` requires EasyEffects 8.0.9 or later."
+  ];
+}

--- a/tests/modules/services/easyeffects/split-presets.nix
+++ b/tests/modules/services/easyeffects/split-presets.nix
@@ -1,0 +1,34 @@
+{ config, ... }:
+
+{
+  services.easyeffects = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { version = "8.0.9"; };
+    preset = {
+      input = "home";
+      output = "Discord Voice";
+    };
+  };
+
+  test.stubs.easyeffects = { };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/easyeffects.service
+
+    assertFileExists "$serviceFile"
+    assertFileNotRegex "$serviceFile" 'ExecStart=.*--load-preset'
+    assertFileRegex "$serviceFile" \
+      'ExecStartPost=.*-easyeffects-load-presets %t/EasyEffectsServer'
+
+    presetLoader=$(sed -n \
+      's|^ExecStartPost=-\([^ ]*\).*|\1|p' "$TESTED/$serviceFile")
+
+    assertFileExists "$presetLoader"
+    assertFileContains "$presetLoader" \
+      "printf '%s\\n' load_preset:input:home"
+    assertFileContains "$presetLoader" \
+      "printf '%s\\n' 'load_preset:output:Discord Voice'"
+    assertFileContains "$presetLoader" \
+      'socat -u -T 1 - UNIX-CONNECT:"$preset_socket"'
+  '';
+}


### PR DESCRIPTION
### Description

Add `services.easyeffects.settings` for declaratively managing global EasyEffects 8 settings.

Settings are grouped by KConfig section and written to EasyEffects' mutable database during Home Manager activation using `kwriteconfig6`. Boolean, integer, float, string, and path values are supported. Setting a value to `null` deletes the corresponding key.

Using activation instead of `xdg.configFile` keeps the database writable by EasyEffects. An assertion rejects non-empty settings when using EasyEffects versions older than 8.0.0.

Also allow one `services.easyeffects.extraPresets.<name>` entry to contain both `input` and `output` blocks. Each block is generated as a separate preset file in its corresponding directory:

```text
$XDG_DATA_HOME/easyeffects/input/<name>.json
$XDG_DATA_HOME/easyeffects/output/<name>.json
```

Existing one-sided input or output presets remain compatible.

Finally, extend `services.easyeffects.preset` with a structured form for selecting different startup presets for the input and output pipelines:

```nix
services.easyeffects.preset = {
  input = "voice";
  output = "music";
};
```

The existing string form remains supported. The structured form requires EasyEffects 8.0.0 or later and must select at least one pipeline; an empty string leaves that pipeline unchanged. After the service starts, Home Manager sends the pipeline-specific load commands to EasyEffects' local service socket.

Tests cover:

- String and boolean global settings.
- Key deletion using `null`.
- Generated activation commands.
- Unsupported EasyEffects version assertions.
- One-sided and paired input/output preset generation with exact JSON output.
- Backwards-compatible string startup presets.
- Pipeline-specific startup preset commands.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      and targeted `nix run .#tests -- easyeffects`.

- [x] Test cases updated/added.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```
