### PR TITLE
files: batch link creation and target checks

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -191,7 +191,91 @@ in
 
           newGenFiles="$1"
           shift
+
+          # Classify every target using bash builtins only: even one forked
+          # process per file costs several milliseconds on some platforms
+          # (notably darwin), which dominates activation time when a profile
+          # carries hundreds of links. Targets occupied by a regular file or
+          # directory keep the original per-file handling (backup and
+          # identical-content skip) on the slow path below.
+          declare -a symlinkTargets=() symlinkSources=()
+          declare -a linkSources=() linkDirs=()
+          declare -a slowSources=()
           for sourcePath in "$@" ; do
+            relativePath="''${sourcePath#$newGenFiles/}"
+            targetPath="$HOME/$relativePath"
+            if [[ -L "''${targetPath%/*}" ]] ; then
+              # The parent directory is itself a symlink (e.g. a stale
+              # whole-directory link from an older layout). The batched
+              # `ln -n -t` below would refuse it ("Not a directory"), while
+              # the original per-file `ln -T` traverses it; keep upstream
+              # behavior on the slow path.
+              slowSources+=("$sourcePath")
+            elif [[ -L "$targetPath" ]] ; then
+              symlinkTargets+=("$targetPath")
+              symlinkSources+=("$sourcePath")
+            elif [[ -e "$targetPath" ]] ; then
+              slowSources+=("$sourcePath")
+            else
+              linkSources+=("$sourcePath")
+              linkDirs+=("''${targetPath%/*}")
+            fi
+          done
+
+          # Resolve all existing symlinks with a single readlink call and
+          # relink only those not already pointing at the new generation.
+          if [[ ''${#symlinkTargets[@]} -gt 0 ]] ; then
+            i=0
+            while IFS= read -r -d "" currentSource ; do
+              if [[ "$currentSource" != "''${symlinkSources[i]}" ]] ; then
+                linkSources+=("''${symlinkSources[i]}")
+                linkDirs+=("''${symlinkTargets[i]%/*}")
+              fi
+              i=$(( i + 1 ))
+            done < <(readlink -z -- "''${symlinkTargets[@]}")
+
+            # readlink prints no record for an operand that vanished since
+            # the classification loop above, and its exit status is lost
+            # through the process substitution. A missing record shifts
+            # every later result onto the wrong source, so the links after
+            # it would be compared against someone else's target and left
+            # stale. The record count is the only signal that happened.
+            if [[ $i -ne ''${#symlinkTargets[@]} ]] ; then
+              errorEcho "A link target changed while resolving symlinks; retry activation."
+              exit 1
+            fi
+          fi
+
+          # Create all missing parent directories in one mkdir call.
+          declare -A missingDirs=()
+          for targetDir in "''${linkDirs[@]}" ; do
+            [[ -d "$targetDir" ]] || missingDirs[$targetDir]=1
+          done
+          if [[ ''${#missingDirs[@]} -gt 0 ]] ; then
+            run mkdir -p $VERBOSE_ARG -- "''${!missingDirs[@]}" || exit 1
+          fi
+
+          # Group the pending links by parent directory, one ln call per
+          # directory. The link name always equals the source basename, and
+          # -f -n together replace a stale symlink even when it points at a
+          # directory (the case -T guarded against in the per-file version;
+          # a regular directory in the way takes the slow path instead and
+          # fails there just like it always did).
+          declare -A dirBatches=()
+          for i in "''${!linkSources[@]}" ; do
+            dirBatches[''${linkDirs[i]}]+="$i "
+          done
+          for targetDir in "''${!dirBatches[@]}" ; do
+            batch=()
+            for i in ''${dirBatches[$targetDir]} ; do
+              batch+=("''${linkSources[i]}")
+            done
+            run ln -sfn $VERBOSE_ARG -t "$targetDir" -- "''${batch[@]}" || exit 1
+          done
+
+          # Slow path: the target exists and is not a symlink. This is the
+          # original per-file logic, kept verbatim for the rare collisions.
+          for sourcePath in "''${slowSources[@]}" ; do
             relativePath="''${sourcePath#$newGenFiles/}"
             targetPath="$HOME/$relativePath"
             if [[ -e "$targetPath" && ! -L "$targetPath" ]] ; then
@@ -209,7 +293,7 @@ in
             fi
 
             if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s "$sourcePath" "$targetPath" ; then
-              # The target exists but is identical – don't do anything.
+              # The target exists but is identical - don't do anything.
               verboseEcho "Skipping '$targetPath' as it is identical to '$sourcePath'"
             else
               # Place that symlink, --force

--- a/modules/files/check-link-targets.sh
+++ b/modules/files/check-link-targets.sh
@@ -10,6 +10,39 @@ forcedPaths=(@forcedPaths@)
 
 newGenFiles="$1"
 shift
+
+# Check a target that already exists and is not a symlink owned by Home
+# Manager.
+function checkCollision() {
+  local sourcePath="$1"
+  local targetPath="$2"
+
+  if cmp -s "$sourcePath" "$targetPath"; then
+    # First compare the files' content. If they're equal, we're fine.
+    warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be skipped since they are the same"
+  elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_COMMAND" ]] ; then
+    # Next, try to run the custom backup command. Assume this always succeeds.
+    verboseEcho "Existing file '$targetPath' exists and differs from '$sourcePath'. '$HOME_MANAGER_BACKUP_COMMAND' will be used to backup the file."
+  elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
+    # Next, try to move the file to a backup location if configured and possible
+    backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
+    if [[ -e "$backup" && -z "$HOME_MANAGER_BACKUP_OVERWRITE" ]] ; then
+      collisionErrors+=("Existing file '$backup' would be clobbered by backing up '$targetPath'")
+    elif [[ -e "$backup" && -n "$HOME_MANAGER_BACKUP_OVERWRITE" ]] ; then
+      warnEcho "Existing file '$targetPath' is in the way of '$sourcePath' and '$backup' exists. Backup will be clobbered due to HOME_MANAGER_BACKUP_OVERWRITE=1"
+    else
+      warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be moved to '$backup'"
+    fi
+  else
+    # Fail if nothing else works
+    collisionErrors+=("Existing file '$targetPath' would be clobbered")
+  fi
+}
+
+# Classify every target using bash builtins only: even one forked process
+# per file costs several milliseconds on some platforms (notably darwin),
+# which dominates activation time when a profile carries hundreds of links.
+declare -a linkTargets=() linkSources=()
 for sourcePath in "$@" ; do
   relativePath="${sourcePath#$newGenFiles/}"
   targetPath="$HOME/$relativePath"
@@ -24,31 +57,36 @@ for sourcePath in "$@" ; do
 
   if [[ -n $forced ]]; then
     verboseEcho "Skipping collision check for $targetPath"
-  elif [[ -e "$targetPath" \
-      && ! "$(readlink "$targetPath")" == $homeFilePattern ]] ; then
-    # The target file already exists and it isn't a symlink owned by Home Manager.
-    if cmp -s "$sourcePath" "$targetPath"; then
-      # First compare the files' content. If they're equal, we're fine.
-      warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be skipped since they are the same"
-    elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_COMMAND" ]] ; then
-      # Next, try to run the custom backup command. Assume this always succeeds.
-      verboseEcho "Existing file '$targetPath' exists and differs from '$sourcePath'. '$HOME_MANAGER_BACKUP_COMMAND' will be used to backup the file."
-    elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
-      # Next, try to move the file to a backup location if configured and possible
-      backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
-      if [[ -e "$backup" && -z "$HOME_MANAGER_BACKUP_OVERWRITE" ]] ; then
-        collisionErrors+=("Existing file '$backup' would be clobbered by backing up '$targetPath'")
-      elif [[ -e "$backup" && -n "$HOME_MANAGER_BACKUP_OVERWRITE" ]] ; then
-        warnEcho "Existing file '$targetPath' is in the way of '$sourcePath' and '$backup' exists. Backup will be clobbered due to HOME_MANAGER_BACKUP_OVERWRITE=1"
-      else
-        warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be moved to '$backup'"
-      fi
-    else
-      # Fail if nothing else works
-      collisionErrors+=("Existing file '$targetPath' would be clobbered")
-    fi
+  elif [[ -L "$targetPath" && -e "$targetPath" ]] ; then
+    linkTargets+=("$targetPath")
+    linkSources+=("$sourcePath")
+  elif [[ -e "$targetPath" ]] ; then
+    checkCollision "$sourcePath" "$targetPath"
   fi
 done
+
+# Resolve all existing symlinks with a single readlink call. A link into a
+# Home Manager generation is ours; anything else is a collision candidate.
+if [[ ${#linkTargets[@]} -gt 0 ]] ; then
+  i=0
+  while IFS= read -r -d "" currentSource ; do
+    if [[ ! "$currentSource" == $homeFilePattern ]] ; then
+      checkCollision "${linkSources[i]}" "${linkTargets[i]}"
+    fi
+    i=$(( i + 1 ))
+  done < <(readlink -z -- "${linkTargets[@]}")
+
+  # readlink prints no record for an operand that vanished since the
+  # classification loop above, and its exit status is lost through the
+  # process substitution. A missing record shifts every later result onto
+  # the wrong source, so a foreign symlink could be checked against the
+  # wrong target and pass as ours. The record count is the only signal
+  # that happened.
+  if [[ $i -ne ${#linkTargets[@]} ]] ; then
+    errorEcho "A link target changed while resolving symlinks; retry activation."
+    exit 1
+  fi
+fi
 
 if [[ ${#collisionErrors[@]} -gt 0 ]] ; then
   errorEcho "Please do one of the following:


### PR DESCRIPTION
The linkGeneration and checkLinkTargets activation steps forked several
processes per managed file: a dirname command substitution plus mkdir
and ln for every link, and a readlink per existing target during the
collision check. On platforms where fork+exec costs a few milliseconds
(notably darwin) this dominates activation time: a profile with 365
links spent about 3.4s in linkGeneration and 1.1s in checkLinkTargets.

Classify targets with bash builtins, resolve all existing symlinks with
a single readlink -z call, create missing parent directories with one
mkdir -p, and group new links into one ln -sfn -t call per target
directory. Only targets occupied by a regular file or directory fall
back to the original per-file path, preserving the backup command,
extension and overwrite handling, the identical-content skip, the
failure on a real directory in the way (previously via ln -T), and
dry-run output.

On the same 365-link profile the two steps now take about 0.2s on a
full relink and under 0.05s when the generation is unchanged, with an
identical resulting tree.

---

Contributed from a maintained fork; the patch of record is https://github.com/indexable-inc/home-manager/commit/1161352c08fbaf535ac7c9d84f62b4da6ee75733.

Prepared with AI assistance (Claude); directed and reviewed by a human maintainer.

<!-- ix:notify -->
/cc @andrewgazelka @Axionize @harivansh-afk (indexable-inc), who maintain the fork this patch is carried in, so review comments reach someone who can act on them.
<!-- /ix:notify -->
