### PR TITLE
easyeffects: handle null extra presets

### DIFF
--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -101,7 +101,7 @@ in
 
     home.packages = with pkgs; lib.optional olderThan8 at-spi2-core ++ [ cfg.package ]; # Only include if easyeffects version is below 8.0.0
 
-    xdg.dataFile = lib.mkIf (cfg.extraPresets != { }) (
+    xdg.dataFile = lib.mkIf (cfg.extraPresets != null && cfg.extraPresets != { }) (
       lib.mapAttrs' (
         k: v:
         # Assuming only one of either input or output block is defined, having both in same file not seem to be supported by the application since it separates it by folder

--- a/tests/modules/services/easyeffects/default.nix
+++ b/tests/modules/services/easyeffects/default.nix
@@ -3,4 +3,5 @@
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   easyeffects-service = ./service.nix;
   easyeffects-example-preset = ./example-preset.nix;
+  easyeffects-null-presets = ./null-presets.nix;
 }

--- a/tests/modules/services/easyeffects/null-presets.nix
+++ b/tests/modules/services/easyeffects/null-presets.nix
@@ -1,0 +1,13 @@
+{
+  services.easyeffects = {
+    enable = true;
+    extraPresets = null;
+  };
+
+  test.stubs.easyeffects = { };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.local/share/easyeffects/input
+    assertPathNotExists home-files/.local/share/easyeffects/output
+  '';
+}


### PR DESCRIPTION
### Description

Treat `services.easyeffects.extraPresets = null` like an empty preset set.
The option type already permits null, but preset generation attempted to map it
as an attribute set.

Keeps paired preset behavior unchanged; #9716 can evolve that separately.

Tested with `nix run path:.#tests -- easyeffects`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
