### PR TITLE
ci: restore maintainer update push trigger

### DIFF
--- a/.github/workflows/update-maintainers.yml
+++ b/.github/workflows/update-maintainers.yml
@@ -2,9 +2,9 @@ name: Update maintainers list
 on:
   push:
     branches:
-      - main
+      - master
     paths:
-      - lib/maintainers.nix
+      - modules/lib/maintainers.nix
   schedule:
     # Update every Monday at 9 AM UTC
     - cron: "0 9 * * 1"


### PR DESCRIPTION
### Description

Restore the maintainer update push trigger to `master` and
`modules/lib/maintainers.nix`.

The filters regressed in #7433. Scheduled and manual runs continued, masking
that pushes no longer triggered the workflow.

Validated with `nix fmt`, `actionlint -shellcheck=`, and `git diff --check`.
No repository test harness covers GitHub event filters.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
