### PR TITLE
tahoe-lafs: enable the user service

### DIFF
--- a/modules/services/tahoe-lafs.nix
+++ b/modules/services/tahoe-lafs.nix
@@ -31,6 +31,8 @@ in
       Service = {
         ExecStart = "${lib.getExe' cfg.package "tahoe"} run -C %h/.tahoe";
       };
+
+      Install.WantedBy = [ "default.target" ];
     };
   };
 }

--- a/tests/modules/services/tahoe-lafs/basic.nix
+++ b/tests/modules/services/tahoe-lafs/basic.nix
@@ -1,0 +1,19 @@
+{
+  services.tahoe-lafs.enable = true;
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/tahoe-lafs.service
+
+    assertFileContent "$serviceFile" ${builtins.toFile "tahoe-lafs.service" ''
+      [Install]
+      WantedBy=default.target
+
+      [Service]
+      ExecStart=@tahoe-lafs@/bin/tahoe run -C %h/.tahoe
+
+      [Unit]
+      Description=Tahoe-LAFS
+    ''}
+    assertFileExists home-files/.config/systemd/user/default.target.wants/tahoe-lafs.service
+  '';
+}

--- a/tests/modules/services/tahoe-lafs/default.nix
+++ b/tests/modules/services/tahoe-lafs/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  tahoe-lafs-basic = ./basic.nix;
+}


### PR DESCRIPTION
### Description

Install the Tahoe-LAFS user service into `default.target` so enabling the module
also creates the wants link and starts it through the user service manager.

Adds a Linux-gated module test covering the service and target link.

Tested with `nix build path:.#test-tahoe-lafs-basic --no-link` and
`nix run .#tests -- tahoe-lafs`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
