### PR TITLE
radio-active: honor package and settings options

### DIFF
--- a/modules/programs/radio-active.nix
+++ b/modules/programs/radio-active.nix
@@ -55,15 +55,15 @@ in
         ])
       );
       default = { };
-      example = {
-        loglevel = "debug";
-        limit = 41;
-        sort = "votes";
-        filter = "none";
-        volume = 68;
+      example.AppConfig = {
         filepath = "/home/{user}/recordings/radioactive/";
         filetype = "mp3";
+        filter = "none";
+        limit = 41;
+        loglevel = "debug";
         player = "ffplay";
+        sort = "votes";
+        volume = 68;
       };
       description = ''
         Declare-able configurations for radio-active written to
@@ -87,6 +87,33 @@ in
     let
       player = attrByPath [ "settings" "AppConfig" "player" ] "ffplay" cfg;
 
+      patchPlayer =
+        package: playerName: playerPackage:
+        if package ? overrideAttrs then
+          package.overrideAttrs (
+            _finalAttrs: previousAttrs:
+            let
+              previousPostPatch = previousAttrs.postPatch or null;
+            in
+            {
+              postPatch = lib.optionalString (previousPostPatch != null) "${previousPostPatch}\n" + ''
+                substituteInPlace radioactive/${playerName}.py \
+                  --replace-fail 'self.exe_path = which(self.program_name)' \
+                  'self.exe_path = "${lib.getExe playerPackage}"'
+              '';
+            }
+          )
+        else
+          pkgs.symlinkJoin {
+            name = "${lib.getName package}-${playerName}";
+            paths = [ package ];
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+            postBuild = ''
+              wrapProgram "$out/bin/${baseNameOf (lib.getExe package)}" \
+                --prefix PATH : ${lib.makeBinPath [ playerPackage ]}
+            '';
+          };
+
       knownPlayers = [
         "ffplay"
         "mpv"
@@ -95,49 +122,24 @@ in
     in
     mkIf cfg.enable {
       warnings = lib.optional (builtins.elem player knownPlayers == false) ''
-        Unknown player defined in `config.programs.radio-active.AppConfig.player`
+        Unknown player defined in `programs.radio-active.settings.AppConfig.player`
       '';
 
-      ## TODO: test that dependency `postPatch` modifications works at runtime
-      home.packages =
-        let
-          radio-active =
-            if player == "mpv" then
-              pkgs.radio-active.overrideAttrs (
-                _finalAttrs: previousAttrs: {
-                  postPatch = ''
-                    ${previousAttrs.postPatch}
+      home.packages = lib.optional (cfg.package != null) (
+        if
+          builtins.elem player [
+            "mpv"
+            "vlc"
+          ]
+        then
+          patchPlayer cfg.package player pkgs.${player}
+        else
+          cfg.package
+      );
 
-                    substituteInPlace radioactive/mpv.py \
-                      --replace-fail 'self.exe_path = which(self.program_name)' \
-                      'self.exe_path = "${lib.getExe pkgs.mpv}"'
-                  '';
-                }
-              )
-            else if player == "vlc" then
-              pkgs.radio-active.overrideAttrs (
-                _finalAttrs: previousAttrs: {
-                  postPatch = ''
-                    ${previousAttrs.postPatch}
-
-                    substituteInPlace radioactive/vlc.py \
-                      --replace-fail 'self.exe_path = which(self.program_name)' \
-                      'self.exe_path = "${lib.getExe pkgs.vlc}"'
-                  '';
-                }
-              )
-            else
-              pkgs.radio-active;
-        in
-        mkIf (cfg.package != null) [
-          radio-active
-        ];
-
-      xdg.configFile."radio-active/configs.ini" =
-        lib.mkIf (cfg.settings != { } && cfg.settings.AppConfig != { })
-          {
-            source = iniFormat.generate "radio-active-config" cfg.settings;
-          };
+      xdg.configFile."radio-active/configs.ini" = lib.mkIf (cfg.settings != { }) {
+        source = iniFormat.generate "radio-active-config" cfg.settings;
+      };
 
       home.file.".radio-active-alias" = mkIf (cfg.aliases != { }) {
         text = ''

--- a/modules/programs/radio-active.nix
+++ b/modules/programs/radio-active.nix
@@ -87,32 +87,22 @@ in
     let
       player = attrByPath [ "settings" "AppConfig" "player" ] "ffplay" cfg;
 
-      patchPlayer =
+      wrapPlayer =
         package: playerName: playerPackage:
-        if package ? overrideAttrs then
-          package.overrideAttrs (
-            _finalAttrs: previousAttrs:
-            let
-              previousPostPatch = previousAttrs.postPatch or null;
-            in
-            {
-              postPatch = lib.optionalString (previousPostPatch != null) "${previousPostPatch}\n" + ''
-                substituteInPlace radioactive/${playerName}.py \
-                  --replace-fail 'self.exe_path = which(self.program_name)' \
-                  'self.exe_path = "${lib.getExe playerPackage}"'
-              '';
-            }
-          )
-        else
-          pkgs.symlinkJoin {
-            name = "${lib.getName package}-${playerName}";
-            paths = [ package ];
-            nativeBuildInputs = [ pkgs.makeWrapper ];
-            postBuild = ''
-              wrapProgram "$out/bin/${baseNameOf (lib.getExe package)}" \
-                --prefix PATH : ${lib.makeBinPath [ playerPackage ]}
-            '';
-          };
+        pkgs.symlinkJoin {
+          name = "${lib.getName package}-${playerName}";
+          paths = [ package ];
+          meta = package.meta or { };
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          postBuild = ''
+            for executable in "$out"/bin/*; do
+              if [ -f "$executable" ] && [ -x "$executable" ]; then
+                wrapProgram "$executable" \
+                  --prefix PATH : ${lib.makeBinPath [ playerPackage ]}
+              fi
+            done
+          '';
+        };
 
       knownPlayers = [
         "ffplay"
@@ -132,7 +122,7 @@ in
             "vlc"
           ]
         then
-          patchPlayer cfg.package player pkgs.${player}
+          wrapPlayer cfg.package player pkgs.${player}
         else
           cfg.package
       );

--- a/tests/modules/programs/radio-active/AppConfig_player_mpv.nix
+++ b/tests/modules/programs/radio-active/AppConfig_player_mpv.nix
@@ -1,11 +1,38 @@
 {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
   programs.radio-active = {
     enable = true;
+
+    package = config.lib.test.mkStubPackage {
+      name = "radio-active-custom";
+      buildScript = ''
+        mkdir -p radioactive "$out/bin" "$out/share/radio-active"
+        echo 'self.exe_path = which(self.program_name)' > radioactive/mpv.py
+
+        runHook postPatch
+
+        cp radioactive/mpv.py "$out/share/radio-active/mpv.py"
+        touch "$out/bin/radio-active-custom"
+      '';
+      extraAttrs.postPatch = "echo previous";
+    };
 
     settings.AppConfig.player = "mpv";
   };
 
   nmt.script = ''
+    assertFileExists home-path/bin/radio-active-custom
+    assertFileContent home-path/share/radio-active/mpv.py \
+    ${builtins.toFile "expected.radio-active_mpv.py" ''
+      self.exe_path = "${lib.getExe pkgs.mpv}"
+    ''}
+
     assertFileExists home-files/.config/radio-active/configs.ini
     assertFileContent home-files/.config/radio-active/configs.ini \
     ${builtins.toFile "expected.player_mpv.radio-active_configs.ini" ''

--- a/tests/modules/programs/radio-active/AppConfig_player_mpv.nix
+++ b/tests/modules/programs/radio-active/AppConfig_player_mpv.nix
@@ -1,37 +1,52 @@
-{
-  config,
-  lib,
-  pkgs,
-  ...
-}:
+{ pkgs, ... }:
 
 {
   programs.radio-active = {
     enable = true;
 
-    package = config.lib.test.mkStubPackage {
-      name = "radio-active-custom";
-      buildScript = ''
-        mkdir -p radioactive "$out/bin" "$out/share/radio-active"
-        echo 'self.exe_path = which(self.program_name)' > radioactive/mpv.py
-
-        runHook postPatch
-
-        cp radioactive/mpv.py "$out/share/radio-active/mpv.py"
-        touch "$out/bin/radio-active-custom"
-      '';
-      extraAttrs.postPatch = "echo previous";
-    };
+    package = pkgs.writeShellScriptBin "radio-active-custom" ''
+      set -eu
+      player="$(command -v mpv)"
+      helper="$(command -v radio-helper)"
+      printf '%s\n%s\n' "$player" "$helper"
+      exec "$player"
+    '';
 
     settings.AppConfig.player = "mpv";
   };
 
+  test.stubs.mpv = {
+    outPath = null;
+    buildScript = ''
+      mkdir -p "$out/bin"
+      cat > "$out/bin/mpv" <<'EOF'
+      #!${pkgs.runtimeShell}
+      printf 'selected-mpv\n'
+      EOF
+      chmod +x "$out/bin/mpv"
+    '';
+  };
+
   nmt.script = ''
+    set -eu
     assertFileExists home-path/bin/radio-active-custom
-    assertFileContent home-path/share/radio-active/mpv.py \
-    ${builtins.toFile "expected.radio-active_mpv.py" ''
-      self.exe_path = "${lib.getExe pkgs.mpv}"
-    ''}
+
+    ambientDir=$(mktemp -d)
+    trap 'rm -rf "$ambientDir"' EXIT
+    cat > "$ambientDir/mpv" <<'EOF'
+    #!${pkgs.runtimeShell}
+    printf 'ambient-mpv\n'
+    EOF
+    cat > "$ambientDir/radio-helper" <<'EOF'
+    #!${pkgs.runtimeShell}
+    :
+    EOF
+    chmod +x "$ambientDir/mpv" "$ambientDir/radio-helper"
+    output=$(PATH="$ambientDir" "$TESTED/home-path/bin/radio-active-custom")
+    expected="${pkgs.mpv}/bin/mpv
+    $ambientDir/radio-helper
+    selected-mpv"
+    test "$output" = "$expected"
 
     assertFileExists home-files/.config/radio-active/configs.ini
     assertFileContent home-files/.config/radio-active/configs.ini \

--- a/tests/modules/programs/radio-active/AppConfig_player_vlc.nix
+++ b/tests/modules/programs/radio-active/AppConfig_player_vlc.nix
@@ -1,14 +1,41 @@
 {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
   programs.radio-active = {
     enable = true;
+
+    package = config.lib.test.mkStubPackage {
+      name = "radio-active-custom";
+      buildScript = ''
+        mkdir -p radioactive "$out/bin" "$out/share/radio-active"
+        echo 'self.exe_path = which(self.program_name)' > radioactive/vlc.py
+
+        runHook postPatch
+
+        cp radioactive/vlc.py "$out/share/radio-active/vlc.py"
+        touch "$out/bin/radio-active-custom"
+      '';
+      extraAttrs.postPatch = null;
+    };
 
     settings.AppConfig.player = "vlc";
   };
 
   nmt.script = ''
+    assertFileExists home-path/bin/radio-active-custom
+    assertFileContent home-path/share/radio-active/vlc.py \
+    ${builtins.toFile "expected.radio-active_vlc.py" ''
+      self.exe_path = "${lib.getExe pkgs.vlc}"
+    ''}
+
     assertFileExists home-files/.config/radio-active/configs.ini
     assertFileContent home-files/.config/radio-active/configs.ini \
-    ${builtins.toFile "expected.player_mpv.radio-active_configs.ini" ''
+    ${builtins.toFile "expected.player_vlc.radio-active_configs.ini" ''
       [AppConfig]
       player=vlc
     ''}

--- a/tests/modules/programs/radio-active/AppConfig_player_vlc.nix
+++ b/tests/modules/programs/radio-active/AppConfig_player_vlc.nix
@@ -1,37 +1,52 @@
-{
-  config,
-  lib,
-  pkgs,
-  ...
-}:
+{ pkgs, ... }:
 
 {
   programs.radio-active = {
     enable = true;
 
-    package = config.lib.test.mkStubPackage {
-      name = "radio-active-custom";
-      buildScript = ''
-        mkdir -p radioactive "$out/bin" "$out/share/radio-active"
-        echo 'self.exe_path = which(self.program_name)' > radioactive/vlc.py
-
-        runHook postPatch
-
-        cp radioactive/vlc.py "$out/share/radio-active/vlc.py"
-        touch "$out/bin/radio-active-custom"
-      '';
-      extraAttrs.postPatch = null;
-    };
+    package = pkgs.writeShellScriptBin "radio-active-custom" ''
+      set -eu
+      player="$(command -v vlc)"
+      helper="$(command -v radio-helper)"
+      printf '%s\n%s\n' "$player" "$helper"
+      exec "$player"
+    '';
 
     settings.AppConfig.player = "vlc";
   };
 
+  test.stubs.vlc = {
+    outPath = null;
+    buildScript = ''
+      mkdir -p "$out/bin"
+      cat > "$out/bin/vlc" <<'EOF'
+      #!${pkgs.runtimeShell}
+      printf 'selected-vlc\n'
+      EOF
+      chmod +x "$out/bin/vlc"
+    '';
+  };
+
   nmt.script = ''
+    set -eu
     assertFileExists home-path/bin/radio-active-custom
-    assertFileContent home-path/share/radio-active/vlc.py \
-    ${builtins.toFile "expected.radio-active_vlc.py" ''
-      self.exe_path = "${lib.getExe pkgs.vlc}"
-    ''}
+
+    ambientDir=$(mktemp -d)
+    trap 'rm -rf "$ambientDir"' EXIT
+    cat > "$ambientDir/vlc" <<'EOF'
+    #!${pkgs.runtimeShell}
+    printf 'ambient-vlc\n'
+    EOF
+    cat > "$ambientDir/radio-helper" <<'EOF'
+    #!${pkgs.runtimeShell}
+    :
+    EOF
+    chmod +x "$ambientDir/vlc" "$ambientDir/radio-helper"
+    output=$(PATH="$ambientDir" "$TESTED/home-path/bin/radio-active-custom")
+    expected="${pkgs.vlc}/bin/vlc
+    $ambientDir/radio-helper
+    selected-vlc"
+    test "$output" = "$expected"
 
     assertFileExists home-files/.config/radio-active/configs.ini
     assertFileContent home-files/.config/radio-active/configs.ini \

--- a/tests/modules/programs/radio-active/aliases.nix
+++ b/tests/modules/programs/radio-active/aliases.nix
@@ -1,13 +1,38 @@
 {
   programs.radio-active = {
     enable = true;
+    package = null;
 
     aliases = {
       "Deep House Lounge" = "http://198.15.94.34:8006/stream";
     };
+
+    settings.Favorites = {
+      station = "Deep House Lounge";
+      volume = 42;
+    };
+  };
+
+  test.stubs.radio-active = {
+    name = "radio-active-default";
+    outPath = null;
+    buildScript = ''
+      mkdir -p "$out/bin"
+      touch "$out/bin/radio-active"
+    '';
   };
 
   nmt.script = ''
+    assertPathNotExists home-path/bin/radio-active
+
+    assertFileExists home-files/.config/radio-active/configs.ini
+    assertFileContent home-files/.config/radio-active/configs.ini \
+    ${builtins.toFile "expected.radio-active_favorites.ini" ''
+      [Favorites]
+      station=Deep House Lounge
+      volume=42
+    ''}
+
     assertFileExists home-files/.radio-active-alias
     assertFileContent home-files/.radio-active-alias \
     ${builtins.toFile "expected.radio-active_aliases.ini" ''

--- a/tests/modules/programs/radio-active/default.nix
+++ b/tests/modules/programs/radio-active/default.nix
@@ -5,6 +5,7 @@
   radio-active-AppConfig = ./AppConfig.nix;
   radio-active-AppConfig_all = ./AppConfig_all.nix;
   radio-active-AppConfig_player_mpv = ./AppConfig_player_mpv.nix;
+  radio-active-raw-package = ./raw-package.nix;
 }
 // lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin != true) {
   radio-active-AppConfig_player_vlc = ./AppConfig_player_vlc.nix;

--- a/tests/modules/programs/radio-active/raw-package.nix
+++ b/tests/modules/programs/radio-active/raw-package.nix
@@ -1,0 +1,31 @@
+{ lib, pkgs, ... }:
+
+{
+  programs.radio-active = {
+    enable = true;
+    package =
+      (builtins.derivation {
+        name = "radio-active-raw";
+        system = pkgs.stdenv.hostPlatform.system;
+        builder = "${pkgs.runtimeShell}";
+        args = [
+          "-c"
+          ''
+            ${pkgs.coreutils}/bin/mkdir -p "$out/bin"
+            ${pkgs.coreutils}/bin/touch "$out/bin/radio-active-raw"
+            ${pkgs.coreutils}/bin/chmod +x "$out/bin/radio-active-raw"
+          ''
+        ];
+      })
+      // {
+        meta.mainProgram = "radio-active-raw";
+      };
+    settings.AppConfig.player = "mpv";
+  };
+
+  nmt.script = ''
+    assertFileExists home-path/bin/radio-active-raw
+    assertFileContains home-path/bin/radio-active-raw \
+      ${lib.escapeShellArg (lib.makeBinPath [ pkgs.mpv ])}
+  '';
+}

--- a/tests/modules/programs/radio-active/raw-package.nix
+++ b/tests/modules/programs/radio-active/raw-package.nix
@@ -1,31 +1,57 @@
-{ lib, pkgs, ... }:
+{ pkgs, ... }:
 
 {
   programs.radio-active = {
     enable = true;
-    package =
-      (builtins.derivation {
-        name = "radio-active-raw";
-        system = pkgs.stdenv.hostPlatform.system;
-        builder = "${pkgs.runtimeShell}";
-        args = [
-          "-c"
-          ''
-            ${pkgs.coreutils}/bin/mkdir -p "$out/bin"
-            ${pkgs.coreutils}/bin/touch "$out/bin/radio-active-raw"
-            ${pkgs.coreutils}/bin/chmod +x "$out/bin/radio-active-raw"
-          ''
-        ];
-      })
-      // {
-        meta.mainProgram = "radio-active-raw";
-      };
+    package = builtins.derivation {
+      name = "radio-active-raw";
+      system = pkgs.stdenv.hostPlatform.system;
+      builder = "${pkgs.runtimeShell}";
+      args = [
+        "-c"
+        ''
+          ${pkgs.coreutils}/bin/mkdir -p "$out/bin"
+          ${pkgs.coreutils}/bin/cat > "$out/bin/radio" <<'EOF'
+          #!${pkgs.runtimeShell}
+          player="$(command -v mpv)"
+          printf '%s\n' "$player"
+          exec "$player"
+          EOF
+          ${pkgs.coreutils}/bin/chmod +x "$out/bin/radio"
+          ${pkgs.coreutils}/bin/ln -s radio "$out/bin/radioactive"
+        ''
+      ];
+    };
     settings.AppConfig.player = "mpv";
   };
 
+  test.stubs.mpv = {
+    outPath = null;
+    buildScript = ''
+      mkdir -p "$out/bin"
+      cat > "$out/bin/mpv" <<'EOF'
+      #!${pkgs.runtimeShell}
+      printf 'selected-mpv\n'
+      EOF
+      chmod +x "$out/bin/mpv"
+    '';
+  };
+
   nmt.script = ''
-    assertFileExists home-path/bin/radio-active-raw
-    assertFileContains home-path/bin/radio-active-raw \
-      ${lib.escapeShellArg (lib.makeBinPath [ pkgs.mpv ])}
+    set -eu
+    assertFileExists home-path/bin/radio
+    assertFileExists home-path/bin/radioactive
+
+    ambientDir=$(mktemp -d)
+    trap 'rm -rf "$ambientDir"' EXIT
+    cat > "$ambientDir/mpv" <<'EOF'
+    #!${pkgs.runtimeShell}
+    printf 'ambient-mpv\n'
+    EOF
+    chmod +x "$ambientDir/mpv"
+    expected="${pkgs.mpv}/bin/mpv
+    selected-mpv"
+    test "$(PATH="$ambientDir" "$TESTED/home-path/bin/radio")" = "$expected"
+    test "$(PATH="$ambientDir" "$TESTED/home-path/bin/radioactive")" = "$expected"
   '';
 }


### PR DESCRIPTION
### Description

Honor `programs.radio-active.package` for installation and player-specific
patching, while preserving config and alias generation when the package is
null.

Generate any declared INI section and correct the option example to match the
nested settings type. Custom derivations without `overrideAttrs` remain
installable unchanged.

Adds coverage for null packages, custom mpv/vlc packages, null `postPatch`, raw
derivations, and non-`AppConfig` sections.

Tested with `nix run path:.#tests -- radio-active`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
