### PR TITLE
pomo: init module

### DIFF
--- a/modules/misc/news/2026/07/2026-07-28_20-12-31.nix
+++ b/modules/misc/news/2026/07/2026-07-28_20-12-31.nix
@@ -1,0 +1,12 @@
+{
+  time = "2026-07-28T14:42:31+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.pomo'
+
+    Customizable TUI Pomodoro timer with ASCII art, progress bar,
+    desktop notifications, and productivity statistics.
+
+    See <https://github.com/Bahaaio/pomo> for more details.
+  '';
+}

--- a/modules/programs/pomo.nix
+++ b/modules/programs/pomo.nix
@@ -1,0 +1,67 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    ;
+  cfg = config.programs.pomo;
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = [ lib.maintainers.rachitvrma ];
+
+  options.programs.pomo = {
+    enable = mkEnableOption ''
+      pomo, a TUI Pomodoro timer with ASCII Art, progress bar,
+      desktop notifications, and productivity stats.
+    '';
+
+    package = mkPackageOption pkgs "pomo" { nullable = true; };
+
+    settings = mkOption {
+      inherit (yamlFormat) type;
+      default = { };
+      example = {
+        onSessionEnd = "ask";
+
+        asciiArt = {
+          enabled = true;
+          font = "mono12";
+          color = "#5A56E0";
+        };
+
+        work = {
+          duration = "25m";
+          title = "work session";
+          notification = {
+            enabled = true;
+            urgent = false;
+            title = "work finished 🎉";
+            message = "time to take a break";
+          };
+        };
+      };
+
+      description = ''
+        Configuration written to
+        {file}`$HOME/.config/pomo/pomo.yml`
+        See <https://github.com/Bahaaio/pomo/blob/main/pomo.yaml>
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    home.file.".config/pomo/pomo.yaml" = mkIf (cfg.settings != { }) {
+      source = yamlFormat.generate "hm_pomo.yaml" cfg.settings;
+    };
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -167,6 +167,7 @@ let
     "pls"
     "podman"
     "poetry"
+    "pomo"
     "powerline-go"
     "proton-pass-cli"
     "pubs"

--- a/tests/modules/programs/pomo/default.nix
+++ b/tests/modules/programs/pomo/default.nix
@@ -1,0 +1,5 @@
+{
+  pomo-empty-settings = ./empty-settings.nix;
+  pomo-example-settings = ./example-settings.nix;
+  pomo-xdg-config-home = ./xdg-config-home.nix;
+}

--- a/tests/modules/programs/pomo/empty-settings.nix
+++ b/tests/modules/programs/pomo/empty-settings.nix
@@ -1,0 +1,6 @@
+{
+  programs.pomo.enable = true;
+  nmt.script = ''
+    assertPathNotExists home-files/.config/pomo
+  '';
+}

--- a/tests/modules/programs/pomo/example-settings-expected.yaml
+++ b/tests/modules/programs/pomo/example-settings-expected.yaml
@@ -1,0 +1,27 @@
+%YAML 1.1
+---
+asciiArt:
+  color: '#5A56E0'
+  enabled: true
+  font: mono12
+break:
+  duration: 5m
+  notification:
+    enabled: true
+    message: back to work!
+    title: break over 😴
+    urgent: false
+  title: break session
+longBreak:
+  after: 4
+  duration: 20m
+  enabled: true
+onSessionEnd: ask
+work:
+  duration: 25m
+  notification:
+    enabled: true
+    message: time to take a break
+    title: work finished 🎉
+    urgent: false
+  title: work session

--- a/tests/modules/programs/pomo/example-settings.nix
+++ b/tests/modules/programs/pomo/example-settings.nix
@@ -1,0 +1,44 @@
+{
+  programs.pomo = {
+    enable = true;
+    settings = {
+      onSessionEnd = "ask";
+      asciiArt = {
+        enabled = true;
+        font = "mono12";
+        color = "#5A56E0";
+      };
+      work = {
+        duration = "25m";
+        title = "work session";
+        notification = {
+          enabled = true;
+          urgent = false;
+          title = "work finished 🎉";
+          message = "time to take a break";
+        };
+      };
+      break = {
+        duration = "5m";
+        title = "break session";
+        notification = {
+          enabled = true;
+          urgent = false;
+          title = "break over 😴";
+          message = "back to work!";
+        };
+      };
+      longBreak = {
+        enabled = true;
+        after = 4;
+        duration = "20m";
+      };
+    };
+  };
+  nmt.script = ''
+    local configFile=home-files/.config/pomo/pomo.yaml
+
+    assertFileExists $configFile
+    assertFileContent $configFile ${./example-settings-expected.yaml}
+  '';
+}

--- a/tests/modules/programs/pomo/xdg-config-home.nix
+++ b/tests/modules/programs/pomo/xdg-config-home.nix
@@ -1,0 +1,11 @@
+{ config, ... }:
+{
+  xdg.configHome = "${config.home.homeDirectory}/.xdgconfig";
+  programs.pomo = {
+    enable = true;
+    settings.work.duration = "25m";
+  };
+  nmt.script = ''
+    assertFileExists home-files/.config/pomo/pomo.yaml
+  '';
+}


### PR DESCRIPTION


### Description

<!--

Please provide a brief description of your change.

-->
A TUI Pomodoro timer with ASCII art, progress bar, desktop notifications, and productivity stats.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
