### PR TITLE
lib: sanitize tabs in KDL, niri: sanitize backslashes in config

### DIFF
--- a/docs/release-notes/rl-2611.md
+++ b/docs/release-notes/rl-2611.md
@@ -33,3 +33,12 @@ changes are only active if the `home.stateVersion` option is set to
   - `programs.zellij.settings`
   - `programs.zellij.themes`
   - `programs.zellij.layouts`
+
+- The KDL options under `programs.zellij` will now escape tabs in string
+  values. For example, the Nix string `"\t"` (corresponding to a single tab)
+  will now generate the KDL string `"\t"`. Previously, this would have generated
+  `"<tab>"` (where `<tab>` denotes a literal tab character). The following
+  options are affected:
+  - `programs.zellij.settings`
+  - `programs.zellij.themes`
+  - `programs.zellij.layouts`

--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -746,6 +746,7 @@ in
   toKDL =
     {
       escapeBackslashes ? false,
+      escapeTabs ? false,
     }:
     let
       inherit (lib)
@@ -776,6 +777,7 @@ in
               ''"''
             ]
             ++ (lib.optional escapeBackslashes "\\")
+            ++ (lib.optional escapeTabs "\t")
           )
           (
             [
@@ -783,6 +785,7 @@ in
               ''\"''
             ]
             ++ (lib.optional escapeBackslashes "\\\\")
+            ++ (lib.optional escapeTabs "\\t")
           );
 
       # OneOf [Int Float String Bool Null] -> String

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -290,6 +290,7 @@ in
       );
       toKDL = lib.hm.generators.toKDL {
         escapeBackslashes = lib.versionAtLeast config.home.stateVersion "26.11";
+        escapeTabs = lib.versionAtLeast config.home.stateVersion "26.11";
       };
     in
     mkIf cfg.enable {

--- a/modules/services/window-managers/niri.nix
+++ b/modules/services/window-managers/niri.nix
@@ -184,7 +184,10 @@ in
 
     xdg.configFile."niri/config.kdl" =
       let
-        settings = lib.trim (lib.hm.generators.toKDL { } cfg.settings);
+        toKDL = lib.hm.generators.toKDL {
+          escapeBackslashes = true;
+        };
+        settings = lib.trim (toKDL cfg.settings);
         configLines = lib.concatStringsSep "\n" (
           lib.filter (line: line != "") [
             cfg.extraConfigEarly

--- a/modules/services/window-managers/niri.nix
+++ b/modules/services/window-managers/niri.nix
@@ -186,6 +186,7 @@ in
       let
         toKDL = lib.hm.generators.toKDL {
           escapeBackslashes = true;
+          escapeTabs = true;
         };
         settings = lib.trim (toKDL cfg.settings);
         configLines = lib.concatStringsSep "\n" (

--- a/tests/lib/generators/tokdl-result-escape-backslashes-tabs.txt
+++ b/tests/lib/generators/tokdl-result-escape-backslashes-tabs.txt
@@ -1,0 +1,48 @@
+rootLevelChild 2
+rootLevelChild 1
+a 1
+argsAndProps 1 2 a=3
+b "string"
+bigFlatItems 23847590283751 1.239000 "multiline \" \" \"\nstring\n" null
+c "multiline string\nwith special characters:\n\t \\\" \" \\\n"
+duplicateChildren {
+	child 2
+	child 1
+}
+extraAttrs 2 true arg1=1 arg2=false {
+	nested {
+		a 1
+		b null
+	}
+}
+flatItems 1 2 "asdf" true null
+listInAttrsInList {
+	list1 {
+		- {
+			a 1
+		}
+		- {
+			b true
+		}
+		- {
+			c null
+			d {
+				- {
+					e "asdfadfasdfasdf"
+				}
+			}
+		}
+	}
+	list2 {
+		- {
+			a 8
+		}
+	}
+}
+nested {
+	- 1 2
+	- true false
+	- 
+	- null
+}
+unsafeString " \" \n \t \\"

--- a/tests/lib/generators/tokdl-result-escape-tabs.txt
+++ b/tests/lib/generators/tokdl-result-escape-tabs.txt
@@ -1,0 +1,48 @@
+rootLevelChild 2
+rootLevelChild 1
+a 1
+argsAndProps 1 2 a=3
+b "string"
+bigFlatItems 23847590283751 1.239000 "multiline \" \" \"\nstring\n" null
+c "multiline string\nwith special characters:\n\t \\" \" \\n"
+duplicateChildren {
+	child 2
+	child 1
+}
+extraAttrs 2 true arg1=1 arg2=false {
+	nested {
+		a 1
+		b null
+	}
+}
+flatItems 1 2 "asdf" true null
+listInAttrsInList {
+	list1 {
+		- {
+			a 1
+		}
+		- {
+			b true
+		}
+		- {
+			c null
+			d {
+				- {
+					e "asdfadfasdfasdf"
+				}
+			}
+		}
+	}
+	list2 {
+		- {
+			a 8
+		}
+	}
+}
+nested {
+	- 1 2
+	- true false
+	- 
+	- null
+}
+unsafeString " \" \n \t \"

--- a/tests/lib/generators/tokdl.nix
+++ b/tests/lib/generators/tokdl.nix
@@ -87,6 +87,13 @@ in
   home.file."tokdl-result-escape-backslashes.txt".text = lib.hm.generators.toKDL {
     escapeBackslashes = true;
   } testData;
+  home.file."tokdl-result-escape-tabs.txt".text = lib.hm.generators.toKDL {
+    escapeTabs = true;
+  } testData;
+  home.file."tokdl-result-escape-backslashes-tabs.txt".text = lib.hm.generators.toKDL {
+    escapeBackslashes = true;
+    escapeTabs = true;
+  } testData;
 
   nmt.script = ''
     assertFileContent \
@@ -96,5 +103,13 @@ in
     assertFileContent \
       home-files/tokdl-result-escape-backslashes.txt \
       ${./tokdl-result-escape-backslashes.txt}
+
+    assertFileContent \
+      home-files/tokdl-result-escape-tabs.txt \
+      ${./tokdl-result-escape-tabs.txt}
+
+    assertFileContent \
+      home-files/tokdl-result-escape-backslashes-tabs.txt \
+      ${./tokdl-result-escape-backslashes-tabs.txt}
   '';
 }


### PR DESCRIPTION
### Description

- Add an option to `lib.hm.generators.toKDL` to sanitize tabs
	- Enabled by default for niri
	- Enabled for `home.stateVersion` 26.11 for zellij
- Sanitize backslashes by default for niri

We really ought to allow breaking changes every once in a while so we aren't stuck in maintenance hell. Not sanitizing backslashes/tabs should be a bug since it does not conform to the KDL specification, so we should have it enabled by default in the generator after the 26.11 release (in my opinion, the option should just be entirely removed then).

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
