### PR TITLE
firefox: more precise documentation of StoreID

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -459,17 +459,16 @@ in
               storeId = mkOption {
                 type = types.nullOr (types.strMatching "[0-9a-f]{8}");
                 default = null;
+                example = "e41de5fe";
                 description = ''
-                  Store ID. Either null, or the first segment of a UUID string.
+                  Store ID. Either null, or the first segment of a UUID string (8 lowercase hex characters).
 
-                  If this value is set, then profile.ini is created
-                  with predictable StoreIDs.
+                  If this value is set, then profiles.ini is created with predictable StoreIDs.
+                  'toolkit.profiles.storeID' is also set accordingly.
 
-                  This is useful to keep the StoreID static,
-                  which helps to bridge the firefox profiles and the new
-                  firefox switchable profile implementations.
-
-                  This should be set to a string of 8 lowercase hex characters.
+                  A predictable StoreID helps bridge the old and new firefox profile implementations.
+                  The StoreID is the name of the sqlite database in "Profile Groups" holding the new
+                  profiles' metadata.
                 '';
               };
 


### PR DESCRIPTION
### Description

I wanted to make better use of firefox profiles and quickly realized it's not nix friendly see https://github.com/nix-community/home-manager/issues/6934.

I tried to make the doc more explicit at the risk of it getting outdated. Since at this stage the option is useless without technical understanding I think it's worth being more explicit.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
