### PR TITLE
hyprlauncher: preserve launched applications

### DIFF
--- a/modules/services/hyprlauncher.nix
+++ b/modules/services/hyprlauncher.nix
@@ -77,6 +77,8 @@ in
 
       Service = {
         ExecStart = "${lib.getExe cfg.package} -d";
+        # Applications launched by hyprlauncher should outlive the daemon.
+        KillMode = "process";
         Restart = "on-failure";
         RestartSec = "10";
       };

--- a/tests/modules/services/hyprlauncher/settings.nix
+++ b/tests/modules/services/hyprlauncher/settings.nix
@@ -16,5 +16,7 @@
     assertFileExists home-files/.config/hypr/hyprlauncher.conf
     assertFileContent home-files/.config/hypr/hyprlauncher.conf \
       ${./hyprlauncher.conf}
+    assertFileContains home-files/.config/systemd/user/hyprlauncher.service \
+      "KillMode=process"
   '';
 }


### PR DESCRIPTION
### Description

Keep applications launched through hyprlauncher alive when its service stops or restarts.

Launched applications share the service cgroup, so systemd's default kill mode terminated them with the daemon. Use `KillMode=process` to stop only hyprlauncher.

Closes #9675.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
