### PR TITLE
syncthing: use partial configuration updates

### DIFF
--- a/modules/misc/news/2026/07/2026-07-29_01-33-48.nix
+++ b/modules/misc/news/2026/07/2026-07-29_01-33-48.nix
@@ -1,0 +1,14 @@
+{ config, ... }:
+{
+  time = "2026-07-29T01:33:48+00:00";
+  condition = config.services.syncthing.enable;
+  message = ''
+    `services.syncthing.settings` now uses partial REST updates for GUI, LDAP,
+    and options. This preserves unspecified values in those objects, including
+    the generated GUI API key.
+
+    Removing a value from the Home Manager configuration no longer resets it
+    in these objects. Set the desired default explicitly to reset a previously
+    configured value. Folders and devices retain replacement semantics.
+  '';
+}

--- a/modules/misc/news/2026/07/2026-07-29_01-33-48.nix
+++ b/modules/misc/news/2026/07/2026-07-29_01-33-48.nix
@@ -4,11 +4,12 @@
   condition = config.services.syncthing.enable;
   message = ''
     `services.syncthing.settings` now uses partial REST updates for GUI, LDAP,
-    and options. This preserves unspecified values in those objects, including
-    the generated GUI API key.
+    options, and PATCH-capable defaults. This preserves unspecified values in
+    those objects, including the generated GUI API key.
 
     Removing a value from the Home Manager configuration no longer resets it
     in these objects. Set the desired default explicitly to reset a previously
-    configured value. Folders and devices retain replacement semantics.
+    configured value. Folders, devices, and default ignore patterns retain
+    replacement semantics.
   '';
 }

--- a/modules/misc/news/2026/07/2026-07-29_01-33-48.nix
+++ b/modules/misc/news/2026/07/2026-07-29_01-33-48.nix
@@ -1,0 +1,15 @@
+{ config, ... }:
+{
+  time = "2026-07-29T01:33:48+00:00";
+  condition = config.services.syncthing.enable;
+  message = ''
+    `services.syncthing.settings` now uses partial REST updates for GUI, LDAP,
+    options, and PATCH-capable defaults. This preserves unspecified values in
+    those objects, including the generated GUI API key.
+
+    Removing a value from the Home Manager configuration no longer resets it
+    in these objects. Set the desired default explicitly to reset a previously
+    configured value. Folders, devices, and default ignore patterns retain
+    replacement semantics.
+  '';
+}

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -319,7 +319,7 @@ let
           "devices"
         ])
         (map (subOption: ''
-          curl -X PUT -d ${
+          curl -X PATCH -d ${
             lib.escapeShellArg (builtins.toJSON cleanedConfig.${subOption})
           } ${curlAddressArgs "/rest/config/${subOption}"}
         ''))
@@ -794,6 +794,11 @@ in
         description = ''
           Extra configuration options for Syncthing.
           See <https://docs.syncthing.net/users/config.html>.
+          GUI, LDAP, options, and PATCH-capable defaults are updated partially.
+          Values omitted from those objects, including values removed from a
+          previous Home Manager configuration, remain unchanged in Syncthing.
+          Set the desired default explicitly to reset such a value. Folders,
+          devices, and default ignore patterns retain replacement semantics.
           Note that this attribute set does not exactly match the documented
           XML format. Instead, this is the format of the JSON REST API. There
           are slight differences. For example, this XML:

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -310,16 +310,17 @@ let
     +
       /*
         Now we update the other settings defined in cleanedConfig which are not
-        "folders" or "devices".
+        "folders", "devices", or "defaults".
       */
       (lib.pipe cleanedConfig [
         builtins.attrNames
         (lib.subtractLists [
           "folders"
           "devices"
+          "defaults"
         ])
         (map (subOption: ''
-          curl -X PUT -d ${
+          curl -X PATCH -d ${
             lib.escapeShellArg (builtins.toJSON cleanedConfig.${subOption})
           } ${curlAddressArgs "/rest/config/${subOption}"}
         ''))
@@ -794,6 +795,11 @@ in
         description = ''
           Extra configuration options for Syncthing.
           See <https://docs.syncthing.net/users/config.html>.
+          GUI, LDAP, and options are updated partially.
+          Values omitted from those objects, including values removed from a
+          previous Home Manager configuration, remain unchanged in Syncthing.
+          Set the desired default explicitly to reset such a value. Folders and
+          devices retain replacement semantics.
           Note that this attribute set does not exactly match the documented
           XML format. Instead, this is the format of the JSON REST API. There
           are slight differences. For example, this XML:

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -310,13 +310,14 @@ let
     +
       /*
         Now we update the other settings defined in cleanedConfig which are not
-        "folders" or "devices".
+        "folders", "devices", or "defaults".
       */
       (lib.pipe cleanedConfig [
         builtins.attrNames
         (lib.subtractLists [
           "folders"
           "devices"
+          "defaults"
         ])
         (map (subOption: ''
           curl -X PATCH -d ${
@@ -325,6 +326,27 @@ let
         ''))
         (lib.concatStringsSep "\n")
       ])
+    +
+      # Handle the "defaults" option separately, as it has multiple sub-endpoints.
+      (lib.optionalString (cleanedConfig ? defaults) (
+        lib.pipe cleanedConfig.defaults [
+          builtins.attrNames
+          (map (
+            subOption:
+            let
+              # See https://docs.syncthing.net/rest/config.html. The ignores
+              # endpoint only supports PUT; folder and device support PATCH.
+              method = if subOption == "ignores" then "PUT" else "PATCH";
+            in
+            ''
+              curl -X ${method} -d ${
+                lib.escapeShellArg (builtins.toJSON cleanedConfig.defaults.${subOption})
+              } ${curlAddressArgs "/rest/config/defaults/${subOption}"}
+            ''
+          ))
+          (lib.concatStringsSep "\n")
+        ]
+      ))
     + lib.optionalString hasCustomGuiAddress ''
       curl -X PATCH -d '{"address": "'${cfg.guiAddress}'"}' ${curlAddressArgs "/rest/config/gui"}
     ''

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -157,6 +157,27 @@ let
 
     ''
     +
+      # POST initializes omitted fields from the current defaults, so update them first.
+      (lib.optionalString (cleanedConfig ? defaults) (
+        lib.pipe cleanedConfig.defaults [
+          builtins.attrNames
+          (map (
+            subOption:
+            let
+              # See https://docs.syncthing.net/rest/config.html. The ignores
+              # endpoint only supports PUT; folder and device support PATCH.
+              method = if subOption == "ignores" then "PUT" else "PATCH";
+            in
+            ''
+              curl -X ${method} -d ${
+                lib.escapeShellArg (builtins.toJSON cleanedConfig.defaults.${subOption})
+              } ${curlAddressArgs "/rest/config/defaults/${subOption}"}
+            ''
+          ))
+          (lib.concatStringsSep "\n")
+        ]
+      ))
+    +
 
       /*
         Syncthing's rest API for the folders and devices is almost identical.
@@ -795,11 +816,11 @@ in
         description = ''
           Extra configuration options for Syncthing.
           See <https://docs.syncthing.net/users/config.html>.
-          GUI, LDAP, and options are updated partially.
+          GUI, LDAP, options, and PATCH-capable defaults are updated partially.
           Values omitted from those objects, including values removed from a
           previous Home Manager configuration, remain unchanged in Syncthing.
-          Set the desired default explicitly to reset such a value. Folders and
-          devices retain replacement semantics.
+          Set the desired default explicitly to reset such a value. Folders,
+          devices, and default ignore patterns retain replacement semantics.
           Note that this attribute set does not exactly match the documented
           XML format. Instead, this is the format of the JSON REST API. There
           are slight differences. For example, this XML:

--- a/tests/modules/services/syncthing/config-settings.nix
+++ b/tests/modules/services/syncthing/config-settings.nix
@@ -9,18 +9,37 @@ in
 {
   services.syncthing = {
     enable = true;
-    settings.gui.theme = "black";
+    settings = {
+      gui.theme = "black";
+      ldap.address = "ldap://localhost";
+      options.localAnnounceEnabled = false;
+      defaults = {
+        device.name = "Default Device";
+        folder.path = "/tmp/syncthing-default";
+        ignores.lines = [ "*.tmp" ];
+      };
+    };
   };
 
   nmt.script = ''
     serviceFile=${serviceFile}
     assertFileExists "$serviceFile"
 
-    updateScript=$(grep -o '/nix/store/[^ <]*-merge-syncthing-config' "$TESTED/$serviceFile")
+    updateScript=$(grep -o '/nix/store/[^ <]*-merge-syncthing-config' "$TESTED/$serviceFile" | head -n 1)
     assertFileContains "$updateScript" \
       "curl -X PATCH -d '{\"theme\":\"black\"}' 127.0.0.1:8384/rest/config/gui"
+    assertFileContains "$updateScript" \
+      "curl -X PATCH -d '{\"address\":\"ldap://localhost\"}' 127.0.0.1:8384/rest/config/ldap"
+    assertFileContains "$updateScript" \
+      "curl -X PATCH -d '{\"localAnnounceEnabled\":false}' 127.0.0.1:8384/rest/config/options"
+    assertFileContains "$updateScript" \
+      "curl -X PATCH -d '{\"name\":\"Default Device\"}' 127.0.0.1:8384/rest/config/defaults/device"
+    assertFileContains "$updateScript" \
+      "curl -X PATCH -d '{\"path\":\"/tmp/syncthing-default\"}' 127.0.0.1:8384/rest/config/defaults/folder"
+    assertFileContains "$updateScript" \
+      "curl -X PUT -d '{\"lines\":[\"*.tmp\"]}' 127.0.0.1:8384/rest/config/defaults/ignores"
 
-    if grep -qF "curl -X PUT" "$(_abs "$updateScript")"; then
+    if grep -Eq 'curl -X PUT .*rest/config/(gui|ldap|options)' "$(_abs "$updateScript")"; then
       fail "Syncthing settings should use partial updates"
     fi
   '';

--- a/tests/modules/services/syncthing/config-settings.nix
+++ b/tests/modules/services/syncthing/config-settings.nix
@@ -1,0 +1,34 @@
+{ pkgs, ... }:
+let
+  serviceFile =
+    if pkgs.stdenv.hostPlatform.isLinux then
+      "home-files/.config/systemd/user/syncthing-init.service"
+    else
+      "LaunchAgents/org.nix-community.home.syncthing-init.plist";
+in
+{
+  services.syncthing = {
+    enable = true;
+    settings = {
+      gui.theme = "black";
+      ldap.address = "ldap://localhost";
+      options.localAnnounceEnabled = false;
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=${serviceFile}
+    assertFileExists "$serviceFile"
+
+    updateScript=$(grep -o '/nix/store/[^ <]*-merge-syncthing-config' "$TESTED/$serviceFile" | head -n 1)
+    assertFileContains "$updateScript" \
+      "curl -X PATCH -d '{\"theme\":\"black\"}' 127.0.0.1:8384/rest/config/gui"
+    assertFileContains "$updateScript" \
+      "curl -X PATCH -d '{\"address\":\"ldap://localhost\"}' 127.0.0.1:8384/rest/config/ldap"
+    assertFileContains "$updateScript" \
+      "curl -X PATCH -d '{\"localAnnounceEnabled\":false}' 127.0.0.1:8384/rest/config/options"
+    if grep -Eq 'curl -X PUT .*rest/config/(gui|ldap|options)' "$(_abs "$updateScript")"; then
+      fail "Syncthing settings should use partial updates"
+    fi
+  '';
+}

--- a/tests/modules/services/syncthing/config-settings.nix
+++ b/tests/modules/services/syncthing/config-settings.nix
@@ -1,0 +1,27 @@
+{ pkgs, ... }:
+let
+  serviceFile =
+    if pkgs.stdenv.hostPlatform.isLinux then
+      "home-files/.config/systemd/user/syncthing-init.service"
+    else
+      "LaunchAgents/org.nix-community.home.syncthing-init.plist";
+in
+{
+  services.syncthing = {
+    enable = true;
+    settings.gui.theme = "black";
+  };
+
+  nmt.script = ''
+    serviceFile=${serviceFile}
+    assertFileExists "$serviceFile"
+
+    updateScript=$(grep -o '/nix/store/[^ <]*-merge-syncthing-config' "$TESTED/$serviceFile")
+    assertFileContains "$updateScript" \
+      "curl -X PATCH -d '{\"theme\":\"black\"}' 127.0.0.1:8384/rest/config/gui"
+
+    if grep -qF "curl -X PUT" "$(_abs "$updateScript")"; then
+      fail "Syncthing settings should use partial updates"
+    fi
+  '';
+}

--- a/tests/modules/services/syncthing/config-settings.nix
+++ b/tests/modules/services/syncthing/config-settings.nix
@@ -13,6 +13,13 @@ in
       gui.theme = "black";
       ldap.address = "ldap://localhost";
       options.localAnnounceEnabled = false;
+      devices.test.id = "7CFNTQM-IMTJBHJ-3UWRDIU-ZGQJFR6-VCXZ3NB-XUH3KZO-N52ITXR-LAIYUAU";
+      folders.test.path = "/home/hm-user/sync";
+      defaults = {
+        device.name = "Default Device";
+        folder.path = "/tmp/syncthing-default";
+        ignores.lines = [ "*.tmp" ];
+      };
     };
   };
 
@@ -27,6 +34,21 @@ in
       "curl -X PATCH -d '{\"address\":\"ldap://localhost\"}' 127.0.0.1:8384/rest/config/ldap"
     assertFileContains "$updateScript" \
       "curl -X PATCH -d '{\"localAnnounceEnabled\":false}' 127.0.0.1:8384/rest/config/options"
+    assertFileContains "$updateScript" \
+      "curl -X PATCH -d '{\"name\":\"Default Device\"}' 127.0.0.1:8384/rest/config/defaults/device"
+    assertFileContains "$updateScript" \
+      "curl -X PATCH -d '{\"path\":\"/tmp/syncthing-default\"}' 127.0.0.1:8384/rest/config/defaults/folder"
+    assertFileContains "$updateScript" \
+      "curl -X PUT -d '{\"lines\":[\"*.tmp\"]}' 127.0.0.1:8384/rest/config/defaults/ignores"
+
+    for kind in device folder; do
+      defaultsLine=$(grep -n "rest/config/defaults/$kind$" "$updateScript" | cut -d: -f1)
+      objectLine=$(grep -n "curl --json @- -X POST .*rest/config/''${kind}s$" "$updateScript" | cut -d: -f1)
+      test -n "$defaultsLine" && test -n "$objectLine"
+      test "$defaultsLine" -lt "$objectLine" \
+        || fail "Syncthing $kind defaults must be applied before creating objects"
+    done
+
     if grep -Eq 'curl -X PUT .*rest/config/(gui|ldap|options)' "$(_abs "$updateScript")"; then
       fail "Syncthing settings should use partial updates"
     fi

--- a/tests/modules/services/syncthing/default.nix
+++ b/tests/modules/services/syncthing/default.nix
@@ -1,5 +1,6 @@
 { lib, pkgs, ... }:
 {
+  syncthing-config-settings = ./config-settings.nix;
   syncthing-extra-options = ./extra-options.nix;
 }
 // (lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (import ./linux/default.nix))


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Use PATCH for partial Syncthing GUI, LDAP, and options updates so generated values such as the API key are preserved. Route defaults through their documented sub-endpoints, using PUT only for default ignore patterns.[^declarative]

Apply defaults before creating devices and folders so their first configuration uses the declared templates.

Closes #9659.

[^declarative]: A more declarative alternative would fetch each current object, preserve only known Syncthing-generated fields, merge them into the declared settings, then PUT the complete object. This would reset removed settings, but requires maintaining a correct allowlist of generated fields; missing or newly added fields could be reset unintentionally.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible. Partial updates preserve omitted settings; see the news entry and option description.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
