### PR TITLE
mise: allow mutable global configuration

### DIFF
--- a/modules/programs/mise.nix
+++ b/modules/programs/mise.nix
@@ -7,6 +7,10 @@
 let
   inherit (lib) getExe mkIf mkOption;
   cfg = config.programs.mise;
+  globalConfigPath =
+    if cfg.enableMutableConfig then "mise/conf.d/50-home-manager.toml" else "mise/config.toml";
+  mutableConfigDir = "${config.xdg.configHome}/mise";
+  mutableConfigPath = "${mutableConfigDir}/config.toml";
   tomlFormat = pkgs.formats.toml { };
 in
 {
@@ -51,6 +55,34 @@ in
 
       enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
+      enableMutableConfig = mkOption {
+        type = lib.types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to leave {file}`$XDG_CONFIG_HOME/mise/config.toml` mutable
+          so it can be updated by commands such as {command}`mise use --global`.
+
+          When enabled, {option}`programs.mise.globalConfig` is written to
+          {file}`$XDG_CONFIG_HOME/mise/conf.d/50-home-manager.toml` instead,
+          leaving the main configuration file unmanaged. The numeric prefix
+          gives user-managed fragments predictable ordering around the Home
+          Manager fragment. An empty mutable configuration file is created
+          because global Mise commands otherwise try to update an existing
+          global fragment, including the read-only Home Manager fragment.
+
+          Keep settings in the mutable file and
+          {option}`programs.mise.globalConfig` disjoint. Mise may resolve
+          conflicts between the global file and {file}`conf.d` differently
+          depending on the current directory.
+
+          Before disabling this option while
+          {option}`programs.mise.globalConfig` is non-empty, remove or back up
+          the mutable configuration file. Home Manager otherwise treats it as a
+          file collision.
+        '';
+      };
+
       globalConfig = mkOption {
         inherit (tomlFormat) type;
 
@@ -74,7 +106,10 @@ in
           };
         '';
         description = ''
-          Config written to {file}`$XDG_CONFIG_HOME/mise/config.toml`.
+          Global configuration written to
+          {file}`$XDG_CONFIG_HOME/mise/config.toml`, or
+          {file}`$XDG_CONFIG_HOME/mise/conf.d/50-home-manager.toml` when
+          {option}`programs.mise.enableMutableConfig` is enabled.
 
           See <https://mise.jdx.dev/configuration.html> and
           <https://mise.jdx.dev/configuration/settings.html>
@@ -108,8 +143,17 @@ in
       pkgs.usage
     ];
 
+    home.activation.miseMutableConfig = mkIf cfg.enableMutableConfig (
+      lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+        if [[ ! -e ${lib.escapeShellArg mutableConfigPath} && ! -L ${lib.escapeShellArg mutableConfigPath} ]]; then
+          run mkdir -p ${lib.escapeShellArg mutableConfigDir}
+          run touch ${lib.escapeShellArg mutableConfigPath}
+        fi
+      ''
+    );
+
     xdg.configFile = {
-      "mise/config.toml" = mkIf (cfg.globalConfig != { }) {
+      ${globalConfigPath} = mkIf (cfg.globalConfig != { }) {
         source = tomlFormat.generate "mise-config" cfg.globalConfig;
       };
     };

--- a/tests/modules/programs/mise/default.nix
+++ b/tests/modules/programs/mise/default.nix
@@ -2,6 +2,7 @@
   mise-default-settings = ./default-settings.nix;
   mise-custom-settings = ./custom-settings.nix;
   mise-custom-settings-renamed = ./custom-settings-renamed.nix;
+  mise-mutable-config = ./mutable-config.nix;
   mise-bash-integration = ./bash-integration.nix;
   mise-zsh-integration = ./zsh-integration.nix;
   mise-fish-integration = ./fish-integration.nix;

--- a/tests/modules/programs/mise/mutable-config.nix
+++ b/tests/modules/programs/mise/mutable-config.nix
@@ -1,0 +1,69 @@
+{
+  config,
+  lib,
+  pkgs,
+  realPkgs,
+  ...
+}:
+let
+  activationScript = pkgs.writeScript "mise-mutable-config-activation" (
+    config.home.activation.miseMutableConfig.data
+  );
+  homeManagerConfig = config.xdg.configFile."mise/conf.d/50-home-manager.toml".source;
+  mise = lib.getExe realPkgs.mise;
+  userConfig = pkgs.writeText "mise-user-config" ''
+    [env]
+    USER_TEST = "mutable"
+  '';
+in
+lib.mkIf config.test.enableBig {
+  programs.mise = {
+    package = config.lib.test.mkStubPackage { name = "mise"; };
+    enable = true;
+    enableMutableConfig = true;
+    globalConfig.env.HM_TEST = "home-manager";
+  };
+
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/mise/config.toml
+    assertFileExists home-files/.config/mise/conf.d/50-home-manager.toml
+    assertFileContent home-files/.config/mise/conf.d/50-home-manager.toml \
+      ${pkgs.writeText "mise.config.expected" ''
+        [env]
+        HM_TEST = "home-manager"
+      ''}
+
+    export HOME=$TMPDIR/hm-user
+    export XDG_CONFIG_HOME=$HOME/.config
+    export MISE_CACHE_DIR=$TMPDIR/mise-cache
+    export MISE_DATA_DIR=$TMPDIR/mise-data
+    export MISE_OFFLINE=1
+    export MISE_STATE_DIR=$TMPDIR/mise-state
+    mkdir -p $HOME/.config/mise/conf.d
+    ln -s ${homeManagerConfig} $HOME/.config/mise/conf.d/50-home-manager.toml
+
+    substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+    function run() { "$@"; }
+
+    source $TMPDIR/activate
+    assertFileExists $HOME/.config/mise/config.toml
+    [[ ! -s $HOME/.config/mise/config.toml ]] \
+      || fail "mutable config should initially be empty"
+
+    MISE_YES=1 ${mise} set --global USER_TEST=mutable
+    assertFileContent $HOME/.config/mise/config.toml ${userConfig}
+
+    mkdir -p $HOME/work
+    cd $HOME/work
+    envOutput="$(${mise} env --shell bash)"
+    [[ "$envOutput" == *"export HM_TEST=home-manager"* ]] \
+      || fail "Home Manager config should be loaded"
+    [[ "$envOutput" == *"export USER_TEST=mutable"* ]] \
+      || fail "mutable config should be loaded"
+
+    source $TMPDIR/activate
+    assertFileContent $HOME/.config/mise/config.toml ${userConfig}
+  '';
+}


### PR DESCRIPTION
### Description

Add `programs.mise.enableMutableConfig`. When enabled, Home Manager keeps declared settings in `mise/conf.d/home-manager.toml` and leaves `mise/config.toml` writable for commands such as `mise use --global`.

Settings in the two files should remain disjoint because Mise conflict precedence can vary with the current directory.

Closes #9721.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)