### PR TITLE
module/hyprtoolkit: module for various wayland tools

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -498,6 +498,12 @@
     github = "prescientmoon";
     githubId = 39400800;
   };
+  rachitvrma = {
+    name = "Rachit Kumar Verma";
+    github = "rachitvrma";
+    githubId = 155641117;
+    email = "rachitve6h2g@users.noreply.github.com";
+  };
   rasmus-kirk = {
     name = "Rasmus Kirk";
     email = "mail@rasmuskirk.com";

--- a/modules/misc/news/2026/04/2026-04-18_14-17-21.nix
+++ b/modules/misc/news/2026/04/2026-04-18_14-17-21.nix
@@ -1,0 +1,12 @@
+{
+  time = "2026-04-18T08:47:21+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.wlr-which-key'
+
+    wlr-which-key is a keymap manager for wlroots-based compositors,
+    inspired by which-key.nvim.
+
+    See https://github.com/MaxVerevkin/wlr-which-key for more.
+  '';
+}

--- a/modules/misc/news/2026/07/2026-07-29_17-24-36.nix
+++ b/modules/misc/news/2026/07/2026-07-29_17-24-36.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+{
+  time = "2026-07-29T11:54:36+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new option is available: 'programs.hyprtoolkit'
+
+    hyprtoolkit is a GUI toolkit for developing applications that
+    run natively on Wayland. It’s specifically made for Hyprland’s needs,
+    but will generally run on any Wayland compositor that supports modern standards.
+
+    See <https://wiki.hypr.land/Hypr-Ecosystem/hyprtoolkit/> for more options.
+  '';
+}

--- a/modules/programs/hyprtoolkit.nix
+++ b/modules/programs/hyprtoolkit.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.hyprtoolkit;
+in
+{
+  meta.maintainers = [ lib.maintainers.rachitvrma ];
+
+  options.programs.hyprtoolkit = {
+    enable = lib.mkEnableOption ''
+      A GUI toolkit for developing applications that run natively on Wayland.
+      It’s specifically made for Hyprland’s needs, but will generally run on
+      any Wayland compositor that supports modern standards.
+    '';
+    package = lib.mkPackageOption pkgs "hyprtoolkit" { nullable = true; };
+    settings = lib.mkOption {
+      type =
+        with lib.types;
+        let
+          valueType =
+            nullOr (oneOf [
+              int
+              str
+              (attrsOf valueType)
+              (listOf valueType)
+            ])
+            // {
+              description = "Hyprtoolkit configuration values";
+            };
+        in
+        valueType;
+      default = { };
+      example = {
+        background = "0xFF181818";
+        base = "0xFF202020";
+        h1_size = 19;
+        h2_size = 15;
+      };
+      description = ''
+        The configuration written to {file} $XDG_CONIFG_HOME/hypr/hyprtoolkit.conf.
+        More options can be found here: <https://wiki.hypr.land/Hypr-Ecosystem/hyprtoolkit/>
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.hyprtoolkit" pkgs lib.platforms.linux)
+    ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."hypr/hyprtoolkit.conf" = lib.mkIf (cfg.settings != { }) {
+      text = lib.hm.generators.toHyprconf { attrs = cfg.settings; };
+    };
+  };
+}

--- a/modules/programs/wlr-which-key.nix
+++ b/modules/programs/wlr-which-key.nix
@@ -1,0 +1,120 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkIf mkOption types;
+  cfg = config.programs.wlr-which-key;
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = [ lib.maintainers.rachitvrma ];
+
+  options.programs.wlr-which-key = {
+    enable = lib.mkEnableOption "wlr-which-key, a keymap manager for wlroots-based compositors";
+
+    package = lib.mkPackageOption pkgs "wlr-which-key" { nullable = true; };
+
+    settings = mkOption {
+      inherit (yamlFormat) type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          font = "JetBrainsMono Nerd Font 12";
+          background = "#282828d0";
+          color = "#fbf1c7";
+          border = "#8ec07c";
+          separator = " ➜ ";
+          border_width = 2;
+          corner_r = 10;
+          padding = 15;
+          rows_per_column = 5;
+          column_padding = 25;
+          anchor = "center";
+          margin_right = 0;
+          margin_bottom = 0;
+          margin_left = 0;
+          margin_top = 0;
+          menu = [
+            {
+              key = "p";
+              desc = "Power";
+              submenu = [
+                { key = "s"; desc = "Sleep"; cmd = "systemctl suspend"; }
+                { key = "r"; desc = "Reboot"; cmd = "reboot"; }
+                { key = "o"; desc = "Off"; cmd = "poweroff"; }
+              ];
+            }
+          ];
+        }
+      '';
+      description = ''
+        Main wlr-which-key configuration written to
+        {file}`$XDG_CONFIG_HOME/wlr-which-key/config.yaml`.
+
+        See <https://github.com/MaxVerevkin/wlr-which-key#configuration>
+        for the full list of options.
+      '';
+    };
+
+    inheritSettings = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether all extra menus inherit top-level theming settings
+        (e.g. font, background, border) from {option}`settings` by default.
+
+        Can be overridden per menu via
+        {option}`extraMenus.<name>.inheritSettings`.
+      '';
+    };
+
+    extraMenus = mkOption {
+      type = types.attrsOf yamlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          apps = {
+            anchor = "bottom-left";
+            menu = [
+              { key = "f"; desc = "Firefox"; cmd = "firefox"; }
+              { key = "v"; desc = "Vesktop"; cmd = "vesktop"; }
+              { key = "q"; desc = "Qutebrowser"; cmd = "qutebrowser"; }
+            ];
+          };
+          power = {
+            menu = [
+              { key = "s"; desc = "Sleep"; cmd = "systemctl suspend"; }
+              { key = "r"; desc = "Reboot"; cmd = "reboot"; }
+              { key = "o"; desc = "Off"; cmd = "poweroff"; }
+            ];
+          };
+        }
+      '';
+      description = ''
+        Additional named menu configurations, each written to
+        {file}`$XDG_CONFIG_HOME/wlr-which-key/<name>.yaml`.
+        These can be launched with `wlr-which-key <name>.yaml`.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile = lib.mkMerge [
+      (mkIf (cfg.settings != { }) {
+        "wlr-which-key/config.yaml".source = yamlFormat.generate "wlr-which-key-config" cfg.settings;
+      })
+      (lib.mapAttrs' (
+        name: value:
+        lib.nameValuePair "wlr-which-key/${name}.yaml" {
+          source = yamlFormat.generate "wlr-which-key-${name}" value;
+        }
+      ) cfg.extraMenus)
+    ];
+  };
+}

--- a/tests/modules/programs/wlr-which-key/default.nix
+++ b/tests/modules/programs/wlr-which-key/default.nix
@@ -1,0 +1,6 @@
+{ lib, pkgs, ... }:
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  wlr-which-key-empty-config = ./empty-config.nix;
+  wlr-which-key-example-config = ./example-config.nix;
+  wlr-which-key-example-extramenu = ./example-extramenu.nix;
+}

--- a/tests/modules/programs/wlr-which-key/empty-config.nix
+++ b/tests/modules/programs/wlr-which-key/empty-config.nix
@@ -1,0 +1,8 @@
+{
+  programs.wlr-which-key = {
+    enable = true;
+  };
+  nmt.script = ''
+    assertPathNotExists home-files/.config/wlr-which-key
+  '';
+}

--- a/tests/modules/programs/wlr-which-key/example-config.nix
+++ b/tests/modules/programs/wlr-which-key/example-config.nix
@@ -1,0 +1,37 @@
+{
+  programs.wlr-which-key = {
+    enable = true;
+    settings = {
+      font = "monospace 12";
+      background = "#141617d0";
+      color = "#ddc7a1";
+      border = "#d3869b";
+
+      border_width = 2;
+      corner_r = 10;
+      rows_per_column = 25;
+      anchor = "bottom-right";
+
+      inhibit_compositor_keyboard_shortcuts = true;
+
+      menu = [
+        {
+          key = "c";
+          desc = "clipboard";
+          cmd = "noctalia msg panel-toggle clipboard";
+        }
+        {
+          key = "Return";
+          desc = "Terminal";
+          cmd = "xdg-terminal-exec || kitty";
+        }
+      ];
+    };
+  };
+  nmt.script = ''
+    local configFile=home-files/.config/wlr-which-key/config.yaml
+    assertFileExists $configFile
+    assertFileContent $configFile \
+      ${./example-config.yaml}
+  '';
+}

--- a/tests/modules/programs/wlr-which-key/example-config.yaml
+++ b/tests/modules/programs/wlr-which-key/example-config.yaml
@@ -1,0 +1,16 @@
+anchor: bottom-right
+background: '#141617d0'
+border: '#d3869b'
+border_width: 2
+color: '#ddc7a1'
+corner_r: 10
+font: monospace 12
+inhibit_compositor_keyboard_shortcuts: true
+menu:
+- cmd: noctalia msg panel-toggle clipboard
+  desc: clipboard
+  key: c
+- cmd: xdg-terminal-exec || kitty
+  desc: Terminal
+  key: Return
+rows_per_column: 25

--- a/tests/modules/programs/wlr-which-key/example-extramenu.nix
+++ b/tests/modules/programs/wlr-which-key/example-extramenu.nix
@@ -1,0 +1,40 @@
+{
+  programs.wlr-which-key = {
+    enable = true;
+    extraMenus = {
+      browsers = {
+        font = "monospace 12";
+        background = "#141617d0";
+        color = "#ddc7a1";
+        border = "#d3869b";
+
+        border_width = 2;
+        corner_r = 10;
+        rows_per_column = 5;
+        column_padding = 25;
+        anchor = "bottom-right";
+
+        inhibit_compositor_keyboard_shortcuts = true;
+
+        menu = [
+          {
+            key = "f";
+            desc = "Firefox";
+            cmd = "firefox";
+          }
+          {
+            key = "q";
+            desc = "Qutebrowser";
+            cmd = "qutebrowser";
+          }
+        ];
+      };
+    };
+  };
+
+  nmt.script = ''
+    local configFile=home-files/.config/wlr-which-key/browsers.yaml
+    assertFileExists $configFile
+    assertFileContent $configFile ${./example-extramenu.yaml}
+  '';
+}

--- a/tests/modules/programs/wlr-which-key/example-extramenu.yaml
+++ b/tests/modules/programs/wlr-which-key/example-extramenu.yaml
@@ -1,0 +1,17 @@
+anchor: bottom-right
+background: '#141617d0'
+border: '#d3869b'
+border_width: 2
+color: '#ddc7a1'
+column_padding: 25
+corner_r: 10
+font: monospace 12
+inhibit_compositor_keyboard_shortcuts: true
+menu:
+- cmd: firefox
+  desc: Firefox
+  key: f
+- cmd: qutebrowser
+  desc: Qutebrowser
+  key: q
+rows_per_column: 5


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
[hyprtoolkit](https://github.com/hyprwm/hyprtoolkit) is a GUI toolkit for developing applications that run natively on Wayland.
It’s specifically made for Hyprland’s needs, but will generally run on any Wayland compositor that supports modern standards.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
