### PR TITLE
module/hyprtoolkit: toolkit to configure various wayland applications.

### DIFF
--- a/modules/misc/news/2026/07/2026-07-29_17-24-36.nix
+++ b/modules/misc/news/2026/07/2026-07-29_17-24-36.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+{
+  time = "2026-07-29T11:54:36+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new option is available: 'programs.hyprtoolkit'
+
+    hyprtoolkit is a GUI toolkit for developing applications that
+    run natively on Wayland. It’s specifically made for Hyprland’s needs,
+    but will generally run on any Wayland compositor that supports modern standards.
+
+    See <https://wiki.hypr.land/Hypr-Ecosystem/hyprtoolkit/> for more options.
+  '';
+}

--- a/modules/programs/hyprtoolkit.nix
+++ b/modules/programs/hyprtoolkit.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.hyprtoolkit;
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.rachitvrma ];
+
+  options.programs.hyprtoolkit = {
+    enable = lib.mkEnableOption ''
+      A GUI toolkit for developing applications that run natively on Wayland.
+      It’s specifically made for Hyprland’s needs, but will generally run on
+      any Wayland compositor that supports modern standards.
+    '';
+    package = lib.mkPackageOption pkgs "hyprtoolkit" { nullable = true; };
+    settings = lib.mkOption {
+      type =
+        with lib.types;
+        let
+          valueType =
+            nullOr (oneOf [
+              int
+              str
+              (attrsOf valueType)
+              (listOf valueType)
+            ])
+            // {
+              description = "Hyprtoolkit configuration values";
+            };
+        in
+        valueType;
+      default = { };
+      example = {
+        background = "0xFF181818";
+        base = "0xFF202020";
+        h1_size = 19;
+        h2_size = 15;
+      };
+      description = ''
+        The configuration written to {file}`$XDG_CONFIG_HOME/hypr/hyprtoolkit.conf`.
+        More options can be found here: <https://wiki.hypr.land/Hypr-Ecosystem/hyprtoolkit/>
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.hyprtoolkit" pkgs lib.platforms.linux)
+    ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."hypr/hyprtoolkit.conf" = lib.mkIf (cfg.settings != { }) {
+      text = lib.hm.generators.toHyprconf { attrs = cfg.settings; };
+    };
+  };
+}

--- a/tests/modules/programs/hyprtoolkit/default.nix
+++ b/tests/modules/programs/hyprtoolkit/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  hyprtoolkit-empty-config = ./empty-config.nix;
+  hyprtoolkit-example-config = ./example-config.nix;
+}

--- a/tests/modules/programs/hyprtoolkit/empty-config.nix
+++ b/tests/modules/programs/hyprtoolkit/empty-config.nix
@@ -1,0 +1,7 @@
+{
+  programs.hyprtoolkit.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/hypr"
+  '';
+}

--- a/tests/modules/programs/hyprtoolkit/example-config.nix
+++ b/tests/modules/programs/hyprtoolkit/example-config.nix
@@ -1,0 +1,23 @@
+{
+  programs.hyprtoolkit = {
+    enable = true;
+    settings = {
+      background = "0xFF181818";
+      base = "0xFF202020";
+      h1_size = 19;
+      h2_size = 15;
+      h3_size = 13;
+      font_size = 11;
+      font_family = "Sans Serif";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists \
+      "home-files/.config/hypr/hyprtoolkit.conf"
+
+    assertFileContent \
+      "home-files/.config/hypr/hyprtoolkit.conf" \
+      ${./example-hyprtoolkit.conf}
+  '';
+}

--- a/tests/modules/programs/hyprtoolkit/example-hyprtoolkit.conf
+++ b/tests/modules/programs/hyprtoolkit/example-hyprtoolkit.conf
@@ -1,0 +1,7 @@
+background=0xFF181818
+base=0xFF202020
+font_family=Sans Serif
+font_size=11
+h1_size=19
+h2_size=15
+h3_size=13


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
[hyprtoolkit](https://github.com/hyprwm/hyprtoolkit) is a GUI toolkit for developing applications that run natively on Wayland.
It’s specifically made for Hyprland’s needs, but will generally run on any Wayland compositor that supports modern standards.

(Previously opened as #9736, which got closed and locked by accident while I was still pushing commits — no review had started, so opening fresh here.)
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
