### PR TITLE
nushell: add autoload scripts option

### DIFF
--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -211,6 +211,49 @@ in
         Inline values can be set with `lib.hm.nushell.mkNushellInline`.
       '';
     };
+
+    autoload = lib.mkOption {
+      type = types.listOf (
+        types.either (types.pathWith { absolute = false; }) (
+          types.submodule {
+            options = {
+              name = lib.mkOption {
+                type = types.strMatching "^[^/\\\\]+\\.nu$";
+                description = "The Nushell filename. Must be a single filename ending in `.nu`.";
+                example = "my-script.nu";
+              };
+              content = lib.mkOption {
+                type = types.either (types.pathWith { absolute = false; }) types.lines;
+                description = "The Nushell script content, either as a relative `.nu` path or inline Nushell text.";
+                example = lib.literalExpression ''
+                  \'\'
+                    echo "loaded"
+                    let x = 1
+                  \'\'
+                '';
+              };
+            };
+          }
+        )
+      );
+      default = [ ];
+      example = lib.literalExpression ''
+        [
+          ./my-module.nu
+          {
+            name = "my-script.nu";
+            content = \'\'
+              echo "loaded"
+              let x = 1
+            \'\';
+          }
+        ]
+      '';
+      description = ''
+        Files are symlinked into the "autoload/" folder in the config directory.
+        Nushell loads the files in the autoload folders at startup.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -307,6 +350,28 @@ in
           "${cfg.configDir}/plugin.msgpackz".source = "${msgPackz}/plugin.msgpackz";
         }
       )
+
+      (lib.mkMerge (
+        map (
+          script:
+          let
+            fileName = if (lib.isPath script) then baseNameOf (toString script) else script.name;
+            content =
+              if (lib.isPath script) then
+                builtins.readFile script
+              else if (lib.isPath script.content) then
+                builtins.readFile script.content
+              else
+                script.content;
+          in
+          assert (
+            builtins.match ".*\\.nu$" (toString fileName) != null
+          ) "ensure the file name has the extension '.nu'; your current file name is ${fileName}";
+          {
+            "${cfg.configDir}/autoload/${fileName}".text = content;
+          }
+        ) cfg.autoload
+      ))
     ];
   };
 }

--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -211,6 +211,49 @@ in
         Inline values can be set with `lib.hm.nushell.mkNushellInline`.
       '';
     };
+
+    autoload = lib.mkOption {
+      type = types.listOf (
+        types.either (types.pathWith { absolute = null; }) (
+          types.addCheck (types.submodule {
+            options = {
+              name = lib.mkOption {
+                type = types.strMatching "^[^/\\\\]+\\.nu$";
+                description = "The Nushell filename. Must be a single filename ending in `.nu`.";
+                example = "my-script.nu";
+              };
+              content = lib.mkOption {
+                type = types.either (types.pathWith { absolute = null; }) types.lines;
+                description = "The Nushell script content, either as a relative `.nu` path or inline Nushell text.";
+                example = lib.literalExpression ''
+                  \'\'
+                    echo "loaded"
+                    let x = 1
+                  \'\'
+                '';
+              };
+            };
+          }) builtins.isAttrs
+        )
+      );
+      default = [ ];
+      example = lib.literalExpression ''
+        [
+          ./my-module.nu
+          {
+            name = "my-script.nu";
+            content = \'\'
+              echo "loaded"
+              let x = 1
+            \'\';
+          }
+        ]
+      '';
+      description = ''
+        Files are symlinked into the "autoload/" folder in the config directory.
+        Nushell loads the files in the autoload folders at startup.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -307,6 +350,24 @@ in
           "${cfg.configDir}/plugin.msgpackz".source = "${msgPackz}/plugin.msgpackz";
         }
       )
+
+      (lib.mkMerge (
+        map (
+          script:
+          let
+            fileName = if (lib.isPath script) then baseNameOf (toString script) else script.name;
+          in
+          {
+            "${cfg.configDir}/autoload/${fileName}" =
+              if (lib.isPath script) then
+                { source = script; }
+              else if (lib.isPath script.content) then
+                { source = script.content; }
+              else
+                { text = script.content; };
+          }
+        ) cfg.autoload
+      ))
     ];
   };
 }

--- a/tests/modules/programs/nushell/autoload-cow
+++ b/tests/modules/programs/nushell/autoload-cow
@@ -1,0 +1,4 @@
+#!/usr/bin/env nu
+def cow [] {
+  print "Mooooooooooo"
+}

--- a/tests/modules/programs/nushell/autoload.nix
+++ b/tests/modules/programs/nushell/autoload.nix
@@ -1,0 +1,38 @@
+{ pkgs, config, ... }: {
+  programs.nushell = {
+    enable = true;
+    autoload = [
+      {
+        name = "cow.nu";
+        content = ''
+          #!/usr/bin/env nu
+          def cow [] {
+            print "Mooooooooooo"
+          }
+        '';
+      }
+      {
+        name = "cow2.nu";
+        content = ./autoload-cow;
+      }
+      ./autoload.nu
+    ];
+  };
+
+  nmt.script =
+    let
+      autoloadDir =
+        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+          "home-files/Library/Application Support/nushell/autoload"
+        else
+          "home-files/.config/nushell/autoload";
+    in
+    ''
+      assertFileExists "${autoloadDir}/cow.nu"
+      assertFileContent "${autoloadDir}/cow.nu" ${./autoload-cow}
+      assertFileExists "${autoloadDir}/cow2.nu"
+      assertFileContent "${autoloadDir}/cow2.nu" ${./autoload-cow}
+      assertFileExists "${autoloadDir}/autoload.nu"
+      assertFileContent "${autoloadDir}/autoload.nu" ${./autoload.nu}
+    '';
+}

--- a/tests/modules/programs/nushell/autoload.nu
+++ b/tests/modules/programs/nushell/autoload.nu
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S nu --stdin
+def autoload-test [] {
+  print "This is a test file for autoload scripts or nushell"
+}

--- a/tests/modules/programs/nushell/default.nix
+++ b/tests/modules/programs/nushell/default.nix
@@ -1,4 +1,5 @@
 {
   nushell-example-settings = ./example-settings.nix;
   nushell-config-dir = ./config-dir.nix;
+  nushell-autoload = ./autoload.nix;
 }


### PR DESCRIPTION


### Description

<!--

Please provide a brief description of your change.

-->
Add a new 'programs.nushell.autoload' option for loading '.nu' files at startup from relative paths or inline content.

This options should used by other modules for their nushell intergrations.

I thought to add this upon seeing this is how devenv@2.2.x recommends intergrating with nushell

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-nushell`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
