### PR TITLE
chromium: add support for brave-origin

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -15,6 +15,7 @@ let
     google-chrome-beta = "Google Chrome Beta";
     google-chrome-dev = "Google Chrome Dev";
     brave = "Brave Browser";
+    brave-origin = "Brave Origin";
     vivaldi = "Vivaldi Browser";
     microsoft-edge = "Microsoft Edge";
   };
@@ -234,11 +235,13 @@ let
         google-chrome-beta = "Google/Chrome Beta";
         google-chrome-dev = "Google/Chrome Dev";
         brave = "BraveSoftware/Brave-Browser";
+        brave-origin = "BraveSoftware/Brave-Origin";
         microsoft-edge = "Microsoft Edge";
       };
 
       linuxDirs = {
         brave = "BraveSoftware/Brave-Browser";
+        brave-origin = "BraveSoftware/Brave-Origin";
       };
 
       configDir =

--- a/tests/modules/programs/chromium/brave-origin-package-routing-linux.nix
+++ b/tests/modules/programs/chromium/brave-origin-package-routing-linux.nix
@@ -1,0 +1,28 @@
+{ config, ... }:
+let
+  extensionId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+in
+{
+  programs.chromium = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "brave-origin";
+    };
+    extensions = [
+      {
+        id = extensionId;
+      }
+    ];
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      "home-files/.config/BraveSoftware/Brave-Origin/External Extensions/${extensionId}.json" \
+      ${builtins.toFile "chromium-brave-origin-extension.json" (
+        builtins.toJSON {
+          external_update_url = "https://clients2.google.com/service/update2/crx";
+        }
+      )}
+    assertPathNotExists "home-files/.config/chromium/External Extensions/${extensionId}.json"
+  '';
+}

--- a/tests/modules/programs/chromium/default.nix
+++ b/tests/modules/programs/chromium/default.nix
@@ -9,6 +9,7 @@
 }
 // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   chromium-brave-package-routing-linux = ./brave-package-routing-linux.nix;
+  chromium-brave-origin-package-routing-linux = ./brave-origin-package-routing-linux.nix;
   chromium-google-chrome-extensions-linux = ./google-chrome-extensions-linux.nix;
   chromium-ungoogled-chromium-extensions-linux = ./ungoogled-chromium-extensions-linux.nix;
 }


### PR DESCRIPTION
### Description

Adds `brave-origin` to the list of supported chromium-based browsers, along with its respective Linux and Darwin directory mappings.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
