### PR TITLE
nixbot: migrate from buildbot-nix config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,8 @@
           "x86_64-linux"
         ];
 
+        warn = builtins.warn or nixpkgs.lib.warn;
+
         releaseInfo = nixpkgs.lib.importJSON ./release.json;
 
         docsFor =
@@ -176,8 +178,8 @@
       {
         formatter = forSupportedPkgs (pkgs: pkgs.callPackage ./home-manager/formatter.nix { });
 
-        # TODO: increase buildbot testing scope
-        buildbot = forCI (
+        # TODO: increase nixbot testing scope
+        nixbot = forCI (
           system:
           let
             docs = docsFor nixpkgs.legacyPackages.${system};
@@ -198,6 +200,13 @@
             docs-jsonModuleMaintainers = docs.jsonModuleMaintainers;
             docs-manpages = docs.manPages;
           }
+        );
+
+        # Alias for nixbot, added 2026-07-30
+        buildbot = forCI (
+          system:
+          warn "Home Manager: `buildbot.${system}` has been renamed to `nixbot.${system}`."
+            self.nixbot.${system}
         );
 
         packages = forAllPkgs (

--- a/nixbot.toml
+++ b/nixbot.toml
@@ -1,2 +1,2 @@
-attribute = "buildbot"
+attribute = "nixbot"
 build_branches = ["release-*"]


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

#### Commit 1
Migrate references to "buildbot" to its replacement, "nixbot" and rename the config file to the new name.
While it probably isn't considered "public API", I added a rename alias to the `buildbot` flake output.

#### Commit 2
~~Explicitly configure nixbot's "build on push" branches, now that it no longer builds _all_ branches by default.~~

~~We only need to configure stable branches (`release-*`), because the default branch and merge-queue branches are always build on push, and Pull Requests are always build (using a different non-push event).~~

Superseded by #9746


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
