### PR TITLE
hyprland: fix session cleanup with systemd integration enabled

### DIFF
--- a/modules/services/window-managers/hyprland/default.nix
+++ b/modules/services/window-managers/hyprland/default.nix
@@ -592,6 +592,7 @@ in
           ++ lib.optional cfg.systemd.enableXdgAutostart "xdg-desktop-autostart.target";
           After = [ "graphical-session-pre.target" ];
           Before = lib.mkIf cfg.systemd.enableXdgAutostart [ "xdg-desktop-autostart.target" ];
+          PropagatesStopTo = [ "graphical-session.target" ];
         };
       };
     };

--- a/modules/services/window-managers/hyprland/lib.nix
+++ b/modules/services/window-managers/hyprland/lib.nix
@@ -108,6 +108,7 @@ in
       text =
         optionalString config.systemd.enable ''
           exec-once = ${systemdActivationCommand}
+          exec-shutdown = systemctl --user stop hyprland-session.target
         ''
         + optionalString (config.plugins != [ ]) (pluginsToHyprconf config.plugins)
         + optionalString (config.settings != { }) (

--- a/modules/services/window-managers/hyprland/lib.nix
+++ b/modules/services/window-managers/hyprland/lib.nix
@@ -171,6 +171,14 @@ in
             ${concatMapStrings (command: "  hl.exec_cmd(${toLua command})\n") startupCommands}end)
           '';
 
+      renderShutdownHook = optionalString config.systemd.enable (
+        renderSection "shutdown" ''
+          hl.on("hyprland.shutdown", function()
+            os.execute("systemctl --user stop hyprland-session.target && sleep 0.1")
+          end)
+        ''
+      );
+
       renderLuaFiles =
         let
           autoloadFiles = filterAttrs (_: file: file.autoLoad) config.extraLuaFiles;
@@ -232,6 +240,7 @@ in
       + renderSettings
       + renderSubmaps
       + renderStartHook
+      + renderShutdownHook
       + renderSection "extraConfig" config.extraConfig;
 
       onChange = lib.mkIf (config.package != null) reloadConfig;

--- a/tests/modules/services/hyprland/lua-config.lua
+++ b/tests/modules/services/hyprland/lua-config.lua
@@ -142,6 +142,11 @@ hl.on("hyprland.start", function()
   hl.exec_cmd("@dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target")
 end)
 
+-- shutdown
+hl.on("hyprland.shutdown", function()
+  os.execute("systemctl --user stop hyprland-session.target && sleep 0.1")
+end)
+
 -- extraConfig
 local mainMod = "SUPER"
 local terminal = "kitty"

--- a/tests/modules/services/hyprland/multiple-devices-config.conf
+++ b/tests/modules/services/hyprland/multiple-devices-config.conf
@@ -1,4 +1,5 @@
 exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
+exec-shutdown = systemctl --user stop hyprland-session.target
 exec-once=hyprctl plugin load /path/to/plugin1
 exec-once=hyprctl plugin load /nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
 $mod=SUPER

--- a/tests/modules/services/hyprland/null-package-config.conf
+++ b/tests/modules/services/hyprland/null-package-config.conf
@@ -1,4 +1,5 @@
 exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
+exec-shutdown = systemctl --user stop hyprland-session.target
 exec-once=hyprctl plugin load /path/to/plugin1
 exec-once=hyprctl plugin load /nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
 cursor {

--- a/tests/modules/services/hyprland/simple-config.conf
+++ b/tests/modules/services/hyprland/simple-config.conf
@@ -1,4 +1,5 @@
 exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
+exec-shutdown = systemctl --user stop hyprland-session.target
 exec-once=hyprctl plugin load /path/to/plugin1
 exec-once=hyprctl plugin load /nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
 $mod=SUPER

--- a/tests/modules/services/hyprland/sourceFirst-false-config.conf
+++ b/tests/modules/services/hyprland/sourceFirst-false-config.conf
@@ -1,4 +1,5 @@
 exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
+exec-shutdown = systemctl --user stop hyprland-session.target
 bezier=smoothOut, 0.36, 0, 0.66, -0.56
 bezier=smoothIn, 0.25, 1, 0.5, 1
 bezier=overshot, 0.4,0.8,0.2,1.2

--- a/tests/modules/services/hyprland/submaps-config.conf
+++ b/tests/modules/services/hyprland/submaps-config.conf
@@ -1,4 +1,5 @@
 exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
+exec-shutdown = systemctl --user stop hyprland-session.target
 $mod=SUPER
 bind=$mod, S, submap, resize
 bind=$mod, M, submap, move_focus


### PR DESCRIPTION
Add a shutdown handler when systemd integration is enabled to execute `systemctl --user stop hyprland-session.target && sleep 0.1` on exit. This ensures systemd user services bound to `hyprland-session.target` are terminated cleanly when Hyprland shuts down.

### Description
When Hyprland is managed via Home Manager with systemd.enable = true, starting the compositor activates, it leverages hyprland-session.target to launch graphical user services (bars, notification daemons, wallpaper utilities, etc.).

However, when Hyprland shuts down or exits, hyprland-session.target was not being explicitly stopped. As a result, background user services bound to the session target could remain running after logout, leading to unclean session shutdowns and stale background processes.

This change adds a shutdown handler to execute systemctl --user stop hyprland-session.target && sleep 0.1 upon session exit, allowing background services to terminate gracefully.

Reference: https://wiki.hypr.land/Useful-Utilities/Systemd-start/

I noticed this problem a while ago, but resorted to uwsm as a bandaid fix instead of looking at the root of the issue.  With this, now tools like `hyprshutdown` will do proper exit and cleanup. Before, if you ran `hyprshutdown` on a non uwsm session and tried to login again, you would find yourself in a broken session.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
