### PR TITLE
prismlauncher: a bit of tlc

### DIFF
--- a/modules/misc/news/2026/07/2026-07-31_10-10-14.nix
+++ b/modules/misc/news/2026/07/2026-07-31_10-10-14.nix
@@ -1,0 +1,11 @@
+{ config, ... }:
+{
+  time = "2026-07-31T09:10:14+00:00";
+  condition = config.programs.prismlauncher.enable;
+  message = ''
+    The option `programs.prismlauncher.extraPackages` has been renamed to
+    `programs.prismlauncher.themePackages`.
+
+    Please migrate to the new option to suppress the generated warning.
+  '';
+}

--- a/modules/programs/prismlauncher.nix
+++ b/modules/programs/prismlauncher.nix
@@ -6,88 +6,153 @@
 }:
 
 let
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
-
   inherit (lib)
+    all
+    concatLists
+    concatMap
+    concatMapAttrs
     escapeShellArg
+    getExe
+    getName
+    hm
     listToAttrs
     literalExpression
+    maintainers
+    mapAttrsToList
+    mkEnableOption
     mkIf
     mkOption
+    mkPackageOption
+    mkRenamedOptionModule
+    optional
+    optionalAttrs
+    pathExists
+    pathIsDirectory
     types
     ;
+  inherit (pkgs)
+    buildEnv
+    crudini
+    formats
+    stdenv
+    writeShellScript
+    ;
+
+  concatMapAttrsToList = f: attrs: concatLists (mapAttrsToList f attrs);
+
+  iniFormat = formats.ini { };
+  jsonFormat = formats.json { };
 
   cfg = config.programs.prismlauncher;
 
-  iniFormat = pkgs.formats.ini { };
-  jsonFormat = pkgs.formats.json { };
-  isStorePathString = value: builtins.isString value && lib.hasPrefix "${builtins.storeDir}/" value;
-  isPathLike = value: lib.isPath value || isStorePathString value || lib.isDerivation value;
+  dataDir =
+    (if stdenv.hostPlatform.isDarwin then "Library/Application Support" else config.xdg.dataHome)
+    + "/PrismLauncher";
+
+  themePaths = [
+    "/share/PrismLauncher/themes"
+    "/share/PrismLauncher/iconthemes"
+    "/share/PrismLauncher/catpacks"
+  ];
 in
 
 {
-  meta.maintainers = with lib.maintainers; [
+  meta.maintainers = with maintainers; [
     ErinaYip
     mikaeladev
   ];
 
+  imports = [
+    (mkRenamedOptionModule
+      [ "programs" "prismlauncher" "extraPackages" ]
+      [ "programs" "prismlauncher" "themePackages" ]
+    )
+  ];
+
   options.programs.prismlauncher = {
-    enable = lib.mkEnableOption "Prism Launcher";
+    enable = mkEnableOption "Prism Launcher";
 
-    package = lib.mkPackageOption pkgs "prismlauncher" { nullable = true; };
+    package = mkPackageOption pkgs "prismlauncher" { nullable = true; };
 
-    extraPackages = mkOption {
-      type = types.listOf types.package;
-      default = [ ];
+    settings = mkOption {
+      type = types.attrsOf iniFormat.lib.types.atom;
+      default = { };
+      example = {
+        ShowConsole = true;
+        ConsoleMaxLines = 100000;
+      };
       description = ''
-        Additional theme packages to install to the user environment.
-
-        Themes can be sourced from <https://github.com/PrismLauncher/Themes> and should
-        install to `$out/share/PrismLauncher/{themes,iconthemes,catpacks}`.
+        Set of settings to write to {file}`prismlauncher.cfg`.
       '';
     };
 
     icons = mkOption {
-      type = types.listOf types.path;
+      type = with types; listOf path;
       default = [ ];
-      example = literalExpression "[ ./java.png ]";
+      example = literalExpression "[ ./fabulously-optimised.png ]";
       description = ''
         List of paths to instance icons.
+      '';
+    };
 
-        These will be linked in {file}`$XDG_DATA_HOME/PrismLauncher/icons` on Linux and
-        {file}`~/Library/Application Support/PrismLauncher/icons` on macOS.
+    themePackages = mkOption {
+      type = with types; listOf package;
+      default = [ ];
+      description = ''
+        List of theme packages to install.
+
+        Themes may be sourced from Prism Launcher's [theme repository] and must
+        install to either `themes`, `iconthemes`, or `catpacks` within
+        `$out/share/PrismLauncher/`.
+
+        [theme repository]: https://github.com/PrismLauncher/Themes
       '';
     };
 
     themes = mkOption {
-      type = types.attrsOf (
-        types.either types.path (
-          types.submodule {
+      type =
+        let
+          themeSubmodule = types.submodule {
             options = {
               theme = mkOption {
-                inherit (jsonFormat) type;
-                default = { };
+                type = with types; either (attrsOf jsonFormat.type) lines;
+                example = {
+                  name = "Custom";
+                  colors = {
+                    background = "#1a1b26";
+                    foreground = "#c0caf5";
+                  };
+                };
                 description = ''
-                  Contents of the theme's {file}`theme.json`.
+                  Set of [theme attributes] to write to {file}`themes/‹name›/theme.json`.
+
+                  [theme attributes]: https://github.com/PrismLauncher/Themes/blob/main/themes/Catppuccin-Frappe/theme.json
                 '';
               };
 
               style = mkOption {
-                type = types.nullOr (types.either types.lines types.path);
+                type = with types; nullOr (coercedTo path builtins.readFile lines);
                 default = null;
+                example = ''
+                  QWidget {
+                    font-family: "Inter";
+                  }
+                '';
                 description = ''
-                  Contents of, or path to, the theme's {file}`themeStyle.css`.
+                  Lines of [theme styles] to write to {file}`themes/‹name›/themeStyle.css`.
+
+                  [theme styles]: https://github.com/PrismLauncher/Themes/blob/main/themes/Catppuccin-Frappe/themeStyle.css
                 '';
               };
             };
-          }
-        )
-      );
+          };
+        in
+        with types;
+        attrsOf (either path themeSubmodule);
       default = { };
       example = literalExpression ''
         {
-          Tokyo-Night = ./Tokyo-Night;
-
+          # generates a theme at `themes/custom`
           custom = {
             theme = {
               name = "Custom";
@@ -102,107 +167,114 @@ in
               }
             ''';
           };
+          # links `Tokyo-Night` at `themes/tokyo-night`
+          tokyo-night = ./Tokyo-Night;
         }
       '';
       description = ''
-        Prism Launcher widget themes.
+        Set of application themes.
 
-        Attribute names are used as theme directory names. A theme can either be
-        a path to a complete theme directory, or an attribute set used to
-        generate {file}`theme.json` and optionally {file}`themeStyle.css`.
+        Attribute names translate to theme directories, and attribute values
+        describe their contents. Values may either be a path to a complete
+        theme directory, or an attribute set used to generate one.
 
-        These will be linked in {file}`$XDG_DATA_HOME/PrismLauncher/themes` on
-        Linux and {file}`~/Library/Application Support/PrismLauncher/themes` on
-        macOS.
-      '';
-    };
-
-    settings = mkOption {
-      type = types.attrsOf iniFormat.lib.types.atom;
-      default = { };
-      example = {
-        ShowConsole = true;
-        ConsoleMaxLines = 100000;
-      };
-      description = ''
-        Configuration written to {file}`prismlauncher.cfg`.
+        See also:
+        - <https://github.com/PrismLauncher/Themes>
+        - <https://prismlauncher.org/wiki/getting-started/change-themes/#submitting-themes>
       '';
     };
   };
 
-  config =
-    let
-      dataDir =
-        if (isDarwin && !config.xdg.enable) then
-          "Library/Application Support/PrismLauncher"
-        else
-          "${config.xdg.dataHome}/PrismLauncher";
-
-      impureConfigMerger = filePath: staticSettingsFile: emptySettingsFile: ''
-        mkdir -p "$(dirname ${escapeShellArg filePath})"
-
-        if [ ! -e ${escapeShellArg filePath} ]; then
-          cat ${escapeShellArg emptySettingsFile} > ${escapeShellArg filePath}
-        fi
-
-        ${lib.getExe pkgs.crudini} --merge --ini-options=nospace \
-          ${escapeShellArg filePath} < ${escapeShellArg staticSettingsFile}
-      '';
-
-      themeFiles = lib.concatMapAttrs (
-        name: theme:
-        if isPathLike theme then
-          {
-            "${dataDir}/themes/${name}" = {
-              source = theme;
-              recursive = true;
-            };
-          }
-        else
-          {
-            "${dataDir}/themes/${name}/theme.json" = {
-              source = jsonFormat.generate "prismlauncher-${name}-theme.json" theme.theme;
-            };
-          }
-          // lib.optionalAttrs (theme.style != null) {
-            "${dataDir}/themes/${name}/themeStyle.css" =
-              if isPathLike theme.style then { source = theme.style; } else { text = theme.style; };
-          }
-      ) cfg.themes;
-    in
-    mkIf cfg.enable {
-      assertions =
-        lib.mapAttrsToList (name: theme: {
-          assertion = !isPathLike theme || lib.pathIsDirectory theme;
+  config = mkIf cfg.enable {
+    assertions =
+      (concatMapAttrsToList (name: value: [
+        {
+          assertion = !hm.strings.isPathLike value || pathIsDirectory value;
           message = "`programs.prismlauncher.themes.${name}` must be a directory when set to a path.";
-        }) cfg.themes
-        ++ lib.mapAttrsToList (name: theme: {
-          assertion = isPathLike theme || theme.theme != { };
+        }
+        {
+          assertion = hm.strings.isPathLike value || value.theme != { };
           message = "`programs.prismlauncher.themes.${name}.theme` must not be empty.";
-        }) cfg.themes;
+        }
+      ]) cfg.themes)
+      ++ [
+        {
+          assertion = stdenv.hostPlatform.isDarwin -> cfg.settings == { };
+          message = "`programs.prismlauncher.settings` is unsupported on Darwin.";
+        }
+      ];
 
-      home = {
-        packages = lib.mkMerge ([ (mkIf (cfg.package != null) [ cfg.package ]) ] ++ cfg.extraPackages);
+    warnings = concatMap (
+      value:
+      optional (all (x: !x) (map (v: pathExists (value + v)) themePaths)) ''
+        The "${getName value}" package in `programs.prismlauncher.themePackages`
+        does not provide any Prism Launcher theme(s) and will be ignored.
+      ''
+    ) cfg.themePackages;
 
-        activation = lib.mkIf (cfg.settings != { }) {
-          prismlauncherConfigActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-            impureConfigMerger "${dataDir}/prismlauncher.cfg" (iniFormat.generate "prismlauncher-static.cfg" {
-              General = cfg.settings;
-            }) (iniFormat.generate "prismlauncher-empty.cfg" { General = { }; })
-          );
-        };
+    home.packages =
+      (optional (cfg.package != null) cfg.package)
+      ++ optional (cfg.themePackages != [ ]) (buildEnv {
+        name = "prismlauncher-themes";
+        paths = cfg.themePackages;
+        pathsToLink = themePaths;
+      });
 
-        file = lib.mkMerge [
-          (mkIf (cfg.icons != [ ]) (
-            listToAttrs (
-              map (source: {
-                name = "${dataDir}/icons/${baseNameOf source}";
-                value = { inherit source; };
-              }) cfg.icons
-            )
-          ))
-          themeFiles
-        ];
-      };
-    };
+    home.file =
+      (listToAttrs (
+        map (value: {
+          name = "${dataDir}/icons/${baseNameOf value}";
+          value.source = value;
+        }) cfg.icons
+      ))
+      // (concatMapAttrs (
+        name: value:
+        if hm.strings.isPathLike value then
+          { "${dataDir}/themes/${name}".source = value; }
+        else
+          {
+            "${dataDir}/themes/${name}/theme.json".source =
+              jsonFormat.generate "${name}-theme.json" value.theme;
+          }
+          // (optionalAttrs (value.style != null) {
+            "${dataDir}/themes/${name}/themeStyle.css".text = value.style;
+          })
+      ) cfg.themes);
+
+    home.activation.configurePrismLauncher = mkIf (cfg.settings != { }) (
+      let
+        settingsPath = dataDir + "/prismlauncher.cfg";
+        settingsFile = iniFormat.generate "prismlauncher.cfg" { General = cfg.settings; };
+
+        impureMergeScript = writeShellScript "configure-prismlauncher" ''
+          set -euo pipefail
+
+          settingsPath="$1"
+          settingsFile="$2"
+
+          if [ ! -e "$settingsPath" ]; then
+            if [[ -v DRY_RUN ]]; then
+              echo "mkdir -p $(dirname "$settingsPath")"
+              echo "cat $settingsFile > $settingsPath"
+            else
+              mkdir -p "$(dirname "$settingsPath")"
+              cat "$settingsFile" > "$settingsPath"
+            fi
+          else
+            if [[ -v DRY_RUN ]]; then
+              echo "crudini --merge --ini-options=nospace $settingsPath < $settingsFile"
+            else
+              ${getExe crudini} --merge --ini-options=nospace \
+                "$settingsPath" < "$settingsFile"
+            fi
+          fi
+        '';
+      in
+      hm.dag.entryAfter [ "writeBoundary" ] ''
+        ${impureMergeScript} \
+          ${escapeShellArg settingsPath} \
+          ${escapeShellArg settingsFile}
+      ''
+    );
+  };
 }

--- a/modules/programs/prismlauncher.nix
+++ b/modules/programs/prismlauncher.nix
@@ -6,88 +6,145 @@
 }:
 
 let
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
-
   inherit (lib)
+    concatLists
+    concatMapAttrs
     escapeShellArg
+    getExe
+    hm
+    isPath
     listToAttrs
     literalExpression
+    maintainers
+    mapAttrsToList
+    mkEnableOption
     mkIf
     mkOption
+    mkPackageOption
+    mkRenamedOptionModule
+    optional
+    optionalAttrs
+    pathIsDirectory
     types
     ;
+  inherit (pkgs)
+    buildEnv
+    crudini
+    formats
+    stdenv
+    writeShellScript
+    ;
+
+  concatMapAttrsToList = f: attrs: concatLists (mapAttrsToList f attrs);
+
+  iniFormat = formats.ini { };
+  jsonFormat = formats.json { };
 
   cfg = config.programs.prismlauncher;
 
-  iniFormat = pkgs.formats.ini { };
-  jsonFormat = pkgs.formats.json { };
-  isStorePathString = value: builtins.isString value && lib.hasPrefix "${builtins.storeDir}/" value;
-  isPathLike = value: lib.isPath value || isStorePathString value || lib.isDerivation value;
+  dataDir =
+    (if stdenv.hostPlatform.isDarwin then "Library/Application Support" else config.xdg.dataHome)
+    + "/PrismLauncher";
 in
 
 {
-  meta.maintainers = with lib.maintainers; [
+  meta.maintainers = with maintainers; [
     ErinaYip
     mikaeladev
   ];
 
+  imports = [
+    (mkRenamedOptionModule
+      [ "programs" "prismlauncher" "extraPackages" ]
+      [ "programs" "prismlauncher" "themePackages" ]
+    )
+  ];
+
   options.programs.prismlauncher = {
-    enable = lib.mkEnableOption "Prism Launcher";
+    enable = mkEnableOption "Prism Launcher";
 
-    package = lib.mkPackageOption pkgs "prismlauncher" { nullable = true; };
+    package = mkPackageOption pkgs "prismlauncher" { nullable = true; };
 
-    extraPackages = mkOption {
-      type = types.listOf types.package;
-      default = [ ];
+    settings = mkOption {
+      type = types.attrsOf iniFormat.lib.types.atom;
+      default = { };
+      example = {
+        ShowConsole = true;
+        ConsoleMaxLines = 100000;
+      };
       description = ''
-        Additional theme packages to install to the user environment.
-
-        Themes can be sourced from <https://github.com/PrismLauncher/Themes> and should
-        install to `$out/share/PrismLauncher/{themes,iconthemes,catpacks}`.
+        Set of settings to write to {file}`prismlauncher.cfg`.
       '';
     };
 
     icons = mkOption {
-      type = types.listOf types.path;
+      type = with types; listOf path;
       default = [ ];
-      example = literalExpression "[ ./java.png ]";
+      example = literalExpression "[ ./fabulously-optimised.png ]";
       description = ''
         List of paths to instance icons.
+      '';
+    };
 
-        These will be linked in {file}`$XDG_DATA_HOME/PrismLauncher/icons` on Linux and
-        {file}`~/Library/Application Support/PrismLauncher/icons` on macOS.
+    themePackages = mkOption {
+      type = with types; listOf package;
+      default = [ ];
+      description = ''
+        List of theme packages to install.
+
+        Themes may be sourced from Prism Launcher's [theme repository] and must
+        install to either `themes`, `iconthemes`, or `catpacks` within
+        `$out/share/PrismLauncher/`.
+
+        [theme repository]: https://github.com/PrismLauncher/Themes
       '';
     };
 
     themes = mkOption {
-      type = types.attrsOf (
-        types.either types.path (
-          types.submodule {
+      type =
+        let
+          themeSubmodule = types.submodule {
             options = {
               theme = mkOption {
-                inherit (jsonFormat) type;
+                type = with types; either (attrsOf jsonFormat.type) lines;
                 default = { };
+                example = {
+                  name = "Custom";
+                  colors = {
+                    background = "#1a1b26";
+                    foreground = "#c0caf5";
+                  };
+                };
                 description = ''
-                  Contents of the theme's {file}`theme.json`.
+                  Set of [theme attributes] to write to {file}`themes/‹name›/theme.json`.
+
+                  [theme attributes]: https://github.com/PrismLauncher/Themes/blob/main/themes/Catppuccin-Frappe/theme.json
                 '';
               };
 
               style = mkOption {
-                type = types.nullOr (types.either types.lines types.path);
+                type = with types; nullOr (coercedTo path builtins.readFile lines);
                 default = null;
+                example = ''
+                  QWidget {
+                    font-family: "Inter";
+                  }
+                '';
                 description = ''
-                  Contents of, or path to, the theme's {file}`themeStyle.css`.
+                  Lines of [theme styles] to write to {file}`themes/‹name›/themeStyle.css`.
+
+                  [theme styles]: https://github.com/PrismLauncher/Themes/blob/main/themes/Catppuccin-Frappe/themeStyle.css
                 '';
               };
             };
-          }
-        )
-      );
+          };
+        in
+        with types;
+        attrsOf (either path themeSubmodule);
       default = { };
       example = literalExpression ''
         {
-          Tokyo-Night = ./Tokyo-Night;
-
+          # generates a theme at `themes/custom`
           custom = {
             theme = {
               name = "Custom";
@@ -102,107 +159,109 @@ in
               }
             ''';
           };
+          # links `Tokyo-Night` at `themes/tokyo-night`
+          tokyo-night = ./Tokyo-Night;
         }
       '';
       description = ''
-        Prism Launcher widget themes.
+        Set of application themes.
 
-        Attribute names are used as theme directory names. A theme can either be
-        a path to a complete theme directory, or an attribute set used to
-        generate {file}`theme.json` and optionally {file}`themeStyle.css`.
+        Attribute names translate to theme directories, and attribute values
+        describe their contents. Values may either be a path to a complete
+        theme directory, or an attribute set used to generate one.
 
-        These will be linked in {file}`$XDG_DATA_HOME/PrismLauncher/themes` on
-        Linux and {file}`~/Library/Application Support/PrismLauncher/themes` on
-        macOS.
-      '';
-    };
-
-    settings = mkOption {
-      type = types.attrsOf iniFormat.lib.types.atom;
-      default = { };
-      example = {
-        ShowConsole = true;
-        ConsoleMaxLines = 100000;
-      };
-      description = ''
-        Configuration written to {file}`prismlauncher.cfg`.
+        See also:
+        - <https://github.com/PrismLauncher/Themes>
+        - <https://prismlauncher.org/wiki/getting-started/change-themes/#submitting-themes>
       '';
     };
   };
 
-  config =
-    let
-      dataDir =
-        if (isDarwin && !config.xdg.enable) then
-          "Library/Application Support/PrismLauncher"
-        else
-          "${config.xdg.dataHome}/PrismLauncher";
+  config = mkIf cfg.enable {
+    assertions = concatMapAttrsToList (name: value: [
+      {
+        assertion = !isPath value || pathIsDirectory value;
+        message = "`programs.prismlauncher.themes.${name}` must be a directory when set to a path.";
+      }
+      {
+        assertion = hm.strings.isPathLike value || (value.theme != { } && value.theme != "");
+        message = "`programs.prismlauncher.themes.${name}.theme` must not be empty.";
+      }
+    ]) cfg.themes;
 
-      impureConfigMerger = filePath: staticSettingsFile: emptySettingsFile: ''
-        mkdir -p "$(dirname ${escapeShellArg filePath})"
-
-        if [ ! -e ${escapeShellArg filePath} ]; then
-          cat ${escapeShellArg emptySettingsFile} > ${escapeShellArg filePath}
-        fi
-
-        ${lib.getExe pkgs.crudini} --merge --ini-options=nospace \
-          ${escapeShellArg filePath} < ${escapeShellArg staticSettingsFile}
-      '';
-
-      themeFiles = lib.concatMapAttrs (
-        name: theme:
-        if isPathLike theme then
-          {
-            "${dataDir}/themes/${name}" = {
-              source = theme;
-              recursive = true;
-            };
-          }
-        else
-          {
-            "${dataDir}/themes/${name}/theme.json" = {
-              source = jsonFormat.generate "prismlauncher-${name}-theme.json" theme.theme;
-            };
-          }
-          // lib.optionalAttrs (theme.style != null) {
-            "${dataDir}/themes/${name}/themeStyle.css" =
-              if isPathLike theme.style then { source = theme.style; } else { text = theme.style; };
-          }
-      ) cfg.themes;
-    in
-    mkIf cfg.enable {
-      assertions =
-        lib.mapAttrsToList (name: theme: {
-          assertion = !isPathLike theme || lib.pathIsDirectory theme;
-          message = "`programs.prismlauncher.themes.${name}` must be a directory when set to a path.";
-        }) cfg.themes
-        ++ lib.mapAttrsToList (name: theme: {
-          assertion = isPathLike theme || theme.theme != { };
-          message = "`programs.prismlauncher.themes.${name}.theme` must not be empty.";
-        }) cfg.themes;
-
-      home = {
-        packages = lib.mkMerge ([ (mkIf (cfg.package != null) [ cfg.package ]) ] ++ cfg.extraPackages);
-
-        activation = lib.mkIf (cfg.settings != { }) {
-          prismlauncherConfigActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
-            impureConfigMerger "${dataDir}/prismlauncher.cfg" (iniFormat.generate "prismlauncher-static.cfg" {
-              General = cfg.settings;
-            }) (iniFormat.generate "prismlauncher-empty.cfg" { General = { }; })
-          );
-        };
-
-        file = lib.mkMerge [
-          (mkIf (cfg.icons != [ ]) (
-            listToAttrs (
-              map (source: {
-                name = "${dataDir}/icons/${baseNameOf source}";
-                value = { inherit source; };
-              }) cfg.icons
-            )
-          ))
-          themeFiles
+    home.packages =
+      (optional (cfg.package != null) cfg.package)
+      ++ optional (cfg.themePackages != [ ]) (buildEnv {
+        name = "prismlauncher-themes";
+        paths = cfg.themePackages;
+        pathsToLink = [
+          "/share/PrismLauncher/themes"
+          "/share/PrismLauncher/iconthemes"
+          "/share/PrismLauncher/catpacks"
         ];
-      };
-    };
+      });
+
+    home.file =
+      (listToAttrs (
+        map (value: {
+          name = "${dataDir}/icons/${baseNameOf value}";
+          value.source = value;
+        }) cfg.icons
+      ))
+      // (concatMapAttrs (
+        name: value:
+        if hm.strings.isPathLike value then
+          { "${dataDir}/themes/${name}".source = value; }
+        else
+          {
+            "${dataDir}/themes/${name}/theme.json" =
+              if lib.isString value.theme then
+                { text = value.theme; }
+              else
+                { source = jsonFormat.generate "${name}-theme.json" value.theme; };
+          }
+          // (optionalAttrs (value.style != null) {
+            "${dataDir}/themes/${name}/themeStyle.css".text = value.style;
+          })
+      ) cfg.themes);
+
+    home.activation.configurePrismLauncher = mkIf (cfg.settings != { }) (
+      let
+        settingsPath =
+          (if stdenv.hostPlatform.isDarwin then "${config.home.homeDirectory}/${dataDir}" else dataDir)
+          + "/prismlauncher.cfg";
+
+        settingsFile = iniFormat.generate "prismlauncher.cfg" { General = cfg.settings; };
+
+        impureMergeScript = writeShellScript "configure-prismlauncher" ''
+          set -euo pipefail
+
+          settingsPath="$1"
+          settingsFile="$2"
+
+          if [ ! -e "$settingsPath" ]; then
+            if [[ -v DRY_RUN ]]; then
+              echo "mkdir -p $(dirname "$settingsPath")"
+              echo "cat $settingsFile > $settingsPath"
+            else
+              mkdir -p "$(dirname "$settingsPath")"
+              cat "$settingsFile" > "$settingsPath"
+            fi
+          else
+            if [[ -v DRY_RUN ]]; then
+              echo "crudini --merge --ini-options=nospace $settingsPath < $settingsFile"
+            else
+              ${getExe crudini} --merge --ini-options=nospace \
+                "$settingsPath" < "$settingsFile"
+            fi
+          fi
+        '';
+      in
+      hm.dag.entryAfter [ "writeBoundary" ] ''
+        ${impureMergeScript} \
+          ${escapeShellArg settingsPath} \
+          ${escapeShellArg settingsFile}
+      ''
+    );
+  };
 }

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -166,6 +166,7 @@ let
     "podman"
     "poetry"
     "powerline-go"
+    "prismlauncher"
     "proton-pass-cli"
     "pubs"
     "pyenv"

--- a/tests/modules/programs/prismlauncher/asserts.nix
+++ b/tests/modules/programs/prismlauncher/asserts.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) mkIf optionals;
+  inherit (pkgs) stdenv;
+in
+
+{
+  programs.prismlauncher = {
+    enable = true;
+
+    settings = mkIf stdenv.hostPlatform.isDarwin {
+      foo = "bar";
+    };
+
+    themes = {
+      foo = ./asserts.nix;
+      baz = {
+        theme = { };
+        style = ./asserts.nix;
+      };
+    };
+
+    themePackages = [ (config.lib.test.mkStubPackage { name = "not-a-theme"; }) ];
+  };
+
+  test.asserts = {
+    assertions.expected = [
+      "`programs.prismlauncher.themes.baz.theme` must not be empty."
+      "`programs.prismlauncher.themes.foo` must be a directory when set to a path."
+    ]
+    ++ (optionals stdenv.hostPlatform.isDarwin [
+      "`programs.prismlauncher.settings` is unsupported on Darwin."
+    ]);
+
+    warnings.expected = [
+      ''
+        The "not-a-theme" package in `programs.prismlauncher.themePackages`
+        does not provide any Prism Launcher theme(s) and will be ignored.
+      ''
+    ];
+  };
+}

--- a/tests/modules/programs/prismlauncher/asserts.nix
+++ b/tests/modules/programs/prismlauncher/asserts.nix
@@ -1,0 +1,38 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) mkIf;
+  inherit (pkgs) stdenv;
+in
+
+{
+  programs.prismlauncher = {
+    enable = true;
+
+    settings = mkIf stdenv.hostPlatform.isDarwin {
+      foo = "bar";
+    };
+
+    themes = {
+      foo = ./asserts.nix;
+      baz = {
+        theme = { };
+        style = ./asserts.nix;
+      };
+    };
+
+    themePackages = [ (config.lib.test.mkStubPackage { name = "not-a-theme"; }) ];
+  };
+
+  test.asserts = {
+    assertions.expected = [
+      "`programs.prismlauncher.themes.baz.theme` must not be empty."
+      "`programs.prismlauncher.themes.foo` must be a directory when set to a path."
+    ];
+  };
+}

--- a/tests/modules/programs/prismlauncher/default.nix
+++ b/tests/modules/programs/prismlauncher/default.nix
@@ -1,4 +1,9 @@
+{ lib, pkgs, ... }:
+
 {
-  prismlauncher-settings = ./settings.nix;
+  prismlauncher-asserts = ./asserts.nix;
   prismlauncher-themes = ./themes.nix;
 }
+// (lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  prismlauncher-settings = ./settings.nix;
+})

--- a/tests/modules/programs/prismlauncher/default.nix
+++ b/tests/modules/programs/prismlauncher/default.nix
@@ -1,4 +1,5 @@
 {
+  prismlauncher-asserts = ./asserts.nix;
   prismlauncher-settings = ./settings.nix;
   prismlauncher-themes = ./themes.nix;
 }

--- a/tests/modules/programs/prismlauncher/inline-theme.json
+++ b/tests/modules/programs/prismlauncher/inline-theme.json
@@ -1,8 +1,0 @@
-{
-  "colors": {
-    "accent": "#7aa2f7",
-    "background": "#1a1b26",
-    "foreground": "#c0caf5"
-  },
-  "name": "Inline Theme"
-}

--- a/tests/modules/programs/prismlauncher/inline-themeStyle.css
+++ b/tests/modules/programs/prismlauncher/inline-themeStyle.css
@@ -1,3 +1,0 @@
-QWidget {
-  font-family: "Inter";
-}

--- a/tests/modules/programs/prismlauncher/settings.nix
+++ b/tests/modules/programs/prismlauncher/settings.nix
@@ -2,20 +2,26 @@
   config,
   lib,
   pkgs,
+  realPkgs,
   ...
 }:
 
 let
-  configPath = ".local/share/PrismLauncher/prismlauncher.cfg";
+  inherit (lib) escapeShellArg mkForce;
+  inherit (pkgs) stdenv writeScript writeText;
 
-  preexistingConfig = pkgs.writeText "preexisting.cfg" ''
+  settingsPath =
+    (if stdenv.hostPlatform.isDarwin then "Library/Application Support" else ".local/share")
+    + "/PrismLauncher/prismlauncher.cfg";
+
+  existingSettings = writeText "prismlauncher-existing.cfg" ''
     [General]
     ApplicationTheme=system
     MaxMemAlloc=8192
     MinMemAlloc=512
   '';
 
-  expectedConfig = pkgs.writeText "expected.cfg" ''
+  expectedSettings = writeText "prismlauncher-expected.cfg" ''
     [General]
     ApplicationTheme=dark
     MaxMemAlloc=8192
@@ -24,13 +30,12 @@ let
     ShowConsole=true
   '';
 
-  activationScript = pkgs.writeScript "activation" config.home.activation.prismlauncherConfigActivation.data;
+  activationScript = writeScript "configurePrismLauncher" config.home.activation.configurePrismLauncher.data;
 in
 
 {
   programs.prismlauncher = {
     enable = true;
-    package = config.lib.test.mkStubPackage { };
 
     settings = {
       ApplicationTheme = "dark";
@@ -39,27 +44,42 @@ in
     };
   };
 
-  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+  home.homeDirectory = mkForce "/@TMPDIR@/hm-user";
+
+  # activation script depends on crudini to merge settings
+  test.unstubs = [ (_self: _super: { inherit (realPkgs) crudini; }) ];
 
   nmt.script = ''
-    export HOME=$TMPDIR/hm-user
+    export HOME="$TMPDIR"/hm-user
 
-    # write preexisting config
-    mkdir -p $HOME/.local/share/PrismLauncher
-    cat ${preexistingConfig} > $HOME/${configPath}
+    settingsPath=~/${escapeShellArg settingsPath}
+    existingFile=${existingSettings}
+    expectedFile=${expectedSettings}
+
+    # write existing config
+    mkdir -p "$(dirname "$settingsPath")"
+    cat "$existingFile" > "$settingsPath"
+
+    # validate the existing config
+    assertFileExists "$settingsPath"
+    assertFileContent "$settingsPath" "$existingFile"
+
+    # prepare the activation script
+    substitute ${activationScript} ~/activate --subst-var TMPDIR
+    chmod +x ~/activate
 
     # run the activation script
-    substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
-    chmod +x $TMPDIR/activate
-    $TMPDIR/activate
+    ~/activate
 
     # validate the merged config
-    assertFileExists "$HOME/${configPath}"
-    assertFileContent "$HOME/${configPath}" "${expectedConfig}"
+    assertFileExists "$settingsPath"
+    assertFileContent "$settingsPath" "$expectedFile"
 
-    # test idempotence
-    $TMPDIR/activate
-    assertFileExists "$HOME/${configPath}"
-    assertFileContent "$HOME/${configPath}" "${expectedConfig}"
+    # run the activation script AGAIN
+    ~/activate
+
+    # validate again to check idempotence
+    assertFileExists "$settingsPath"
+    assertFileContent "$settingsPath" "$expectedFile"
   '';
 }

--- a/tests/modules/programs/prismlauncher/theme-dir/theme.json
+++ b/tests/modules/programs/prismlauncher/theme-dir/theme.json
@@ -1,7 +1,0 @@
-{
-  "name": "Theme Dir",
-  "colors": {
-    "background": "#1a1b26",
-    "foreground": "#c0caf5"
-  }
-}

--- a/tests/modules/programs/prismlauncher/theme-dir/themeStyle.css
+++ b/tests/modules/programs/prismlauncher/theme-dir/themeStyle.css
@@ -1,3 +1,0 @@
-QWidget {
-  font-family: "Inter";
-}

--- a/tests/modules/programs/prismlauncher/themes.nix
+++ b/tests/modules/programs/prismlauncher/themes.nix
@@ -1,48 +1,65 @@
-{ config, ... }:
+{ pkgs, ... }:
+
+let
+  inherit (pkgs)
+    formats
+    runCommand
+    stdenv
+    writeText
+    ;
+
+  jsonFormat = formats.json { };
+
+  themeAttrs = {
+    theme = {
+      name = "Custom";
+      colors = {
+        background = "#1a1b26";
+        foreground = "#c0caf5";
+      };
+    };
+    style = ''
+      QWidget {
+        font-family: "Inter";
+      }
+    '';
+  };
+
+  expectedTheme = jsonFormat.generate "theme.json" themeAttrs.theme;
+  expectedStyle = writeText "themeStyle.css" themeAttrs.style;
+
+  themeDir = runCommand "foobar-theme" { } ''
+    mkdir $out
+    ln -s ${expectedTheme} $out/theme.json
+    ln -s ${expectedStyle} $out/themeStyle.css
+  '';
+
+  dataDir =
+    (if stdenv.hostPlatform.isDarwin then "Library/Application Support" else ".local/share")
+    + "/PrismLauncher";
+in
 
 {
   programs.prismlauncher = {
     enable = true;
-    package = config.lib.test.mkStubPackage { };
 
     themes = {
-      theme-dir = ./theme-dir;
-
-      inline-theme = {
-        theme = {
-          name = "Inline Theme";
-          colors = {
-            accent = "#7aa2f7";
-            background = "#1a1b26";
-            foreground = "#c0caf5";
-          };
-        };
-        style = ''
-          QWidget {
-            font-family: "Inter";
-          }
-        '';
-      };
+      theme-attrs = themeAttrs;
+      theme-dir = themeDir;
     };
   };
 
   nmt.script = ''
-    assertFileExists home-files/.local/share/PrismLauncher/themes/theme-dir/theme.json
-    assertFileContent \
-      home-files/.local/share/PrismLauncher/themes/theme-dir/theme.json \
-      ${./theme-dir/theme.json}
-    assertFileExists home-files/.local/share/PrismLauncher/themes/theme-dir/themeStyle.css
-    assertFileContent \
-      home-files/.local/share/PrismLauncher/themes/theme-dir/themeStyle.css \
-      ${./theme-dir/themeStyle.css}
+    basePath='home-files/${dataDir}/themes'
 
-    assertFileExists home-files/.local/share/PrismLauncher/themes/inline-theme/theme.json
-    assertFileContent \
-      home-files/.local/share/PrismLauncher/themes/inline-theme/theme.json \
-      ${./inline-theme.json}
-    assertFileExists home-files/.local/share/PrismLauncher/themes/inline-theme/themeStyle.css
-    assertFileContent \
-      home-files/.local/share/PrismLauncher/themes/inline-theme/themeStyle.css \
-      ${./inline-themeStyle.css}
+    assertFileExists "$basePath/theme-attrs/theme.json"
+    assertFileContent "$basePath/theme-attrs/theme.json" ${expectedTheme}
+    assertFileExists "$basePath/theme-attrs/themeStyle.css"
+    assertFileContent "$basePath/theme-attrs/themeStyle.css" ${expectedStyle}
+
+    assertFileExists "$basePath/theme-dir/theme.json"
+    assertFileContent "$basePath/theme-dir/theme.json" ${expectedTheme}
+    assertFileExists "$basePath/theme-dir/themeStyle.css"
+    assertFileContent "$basePath/theme-dir/themeStyle.css" ${expectedStyle}
   '';
 }


### PR DESCRIPTION
simplifies some things, complicates some others, adds new tests for new asserts, renames `extraPackages` to `themePackages`; more or less a big refactor to make it prettier.

i wanted to deprecate `themes.‹name›.style`'s path type but i couldn't figure out a way to trigger a warning without somehow annotating the coerced type. i've just added the coercion for now, open to wisdom on going about fully removing it.

also gutted the repetitive "These will be linked at <...>" descriptions, dunno what i was on

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
