### PR TITLE
carapace: add `environment` and `extraPackages`

### DIFF
--- a/modules/misc/news/2026/08/2026-08-30_03-30-23.nix
+++ b/modules/misc/news/2026/08/2026-08-30_03-30-23.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+
+{
+  time = "2026-08-30T03:30:23+00:00";
+  condition = config.programs.carapace.enable;
+  message = ''
+    Carapace can now be configured with the
+    `programs.carapace.environment` and `programs.carapace.extraPackages`
+    options. The `programs.carapace.ignoreCase` option has been renamed to
+    `programs.carapace.environment.CARAPACE_MATCH`.
+  '';
+}

--- a/modules/programs/carapace.nix
+++ b/modules/programs/carapace.nix
@@ -7,7 +7,14 @@
 
 let
   cfg = config.programs.carapace;
-  bin = lib.getExe cfg.package;
+  wrapperArgs = lib.flatten (
+    lib.mapAttrsToList (name: value: [
+      "--set"
+      name
+      (if lib.isBool value then (if value then "1" else "0") else toString value)
+    ]) cfg.environment
+  );
+  bin = lib.getExe cfg.finalPackage;
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -15,10 +22,37 @@ in
     bobvanderlinden
   ];
 
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "programs" "carapace" "ignoreCase" ]
+      [ "programs" "carapace" "environment" "CARAPACE_MATCH" ]
+    )
+  ];
+
   options.programs.carapace = {
     enable = lib.mkEnableOption "carapace, a multi-shell multi-command argument completer";
 
     package = lib.mkPackageOption pkgs "carapace" { };
+
+    finalPackage = lib.mkOption {
+      type = lib.types.package;
+      readOnly = true;
+      visible = false;
+      default =
+        if wrapperArgs == [ ] then
+          cfg.package
+        else
+          pkgs.symlinkJoin {
+            name = "carapace-wrapped";
+            paths = [ cfg.package ];
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+            postBuild = ''
+              wrapProgram $out/bin/carapace ${lib.escapeShellArgs wrapperArgs}
+            '';
+            inherit (cfg.package) meta;
+          };
+      description = "The Carapace package with the configured environment.";
+    };
 
     enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
@@ -28,32 +62,31 @@ in
 
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
-    ignoreCase = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
+    environment = lib.mkOption {
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          bool
+          int
+          str
+        ]);
+      default = { };
+      example = {
+        CARAPACE_BRIDGES = "zsh,fish,bash";
+        CARAPACE_MATCH = true;
+      };
       description = ''
-        Whether to enable case-insensitive matching for carapace completions.
-        When enabled, the carapace binary is wrapped with {env}`CARAPACE_MATCH`
-        set to `1`.
+        Environment variables for Carapace. Boolean values are converted to
+        `1` or `0` when the package is wrapped.
+
+        See <https://carapace-sh.github.io/carapace-bin/setup/environment.html>
+        for the available environment variables.
       '';
     };
   };
 
   config = lib.mkIf cfg.enable {
-    programs.carapace.package = lib.mkIf cfg.ignoreCase (
-      pkgs.symlinkJoin {
-        name = "carapace-wrapped";
-        paths = [ pkgs.carapace ];
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-        postBuild = ''
-          wrapProgram $out/bin/carapace \
-            --set CARAPACE_MATCH 1
-        '';
-        meta.mainProgram = "carapace";
-      }
-    );
-
-    home.packages = [ cfg.package ];
+    home.packages = [ cfg.finalPackage ];
 
     programs = {
       bash.initExtra = lib.mkIf cfg.enableBashIntegration ''
@@ -105,7 +138,7 @@ in
             carapaceListFile =
               pkgs.runCommandLocal "carapace-list"
                 {
-                  buildInputs = [ cfg.package ];
+                  buildInputs = [ cfg.finalPackage ];
                 }
                 ''
                   ${bin} --list > $out

--- a/modules/programs/carapace.nix
+++ b/modules/programs/carapace.nix
@@ -13,6 +13,12 @@ let
       name
       (if lib.isBool value then (if value then "1" else "0") else toString value)
     ]) cfg.environment
+    ++ lib.optional (cfg.extraPackages != [ ]) [
+      "--suffix"
+      "PATH"
+      ":"
+      (lib.makeBinPath cfg.extraPackages)
+    ]
   );
   bin = lib.getExe cfg.finalPackage;
 in
@@ -34,6 +40,23 @@ in
 
     package = lib.mkPackageOption pkgs "carapace" { };
 
+    extraPackages = lib.mkOption {
+      type = with lib.types; listOf package;
+      default = [ ];
+      example = lib.literalExpression ''
+        with pkgs; [
+          inshellisense
+          fish
+        ]
+      '';
+      description = ''
+        Extra packages available to Carapace. This can be used to make
+        completers listed in
+        {option}`programs.carapace.environment.CARAPACE_BRIDGES`
+        available.
+      '';
+    };
+
     finalPackage = lib.mkOption {
       type = lib.types.package;
       readOnly = true;
@@ -51,7 +74,7 @@ in
             '';
             inherit (cfg.package) meta;
           };
-      description = "The Carapace package with the configured environment.";
+      description = "The Carapace package with the configured environment and extra packages.";
     };
 
     enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };

--- a/modules/programs/carapace.nix
+++ b/modules/programs/carapace.nix
@@ -7,12 +7,41 @@
 
 let
   cfg = config.programs.carapace;
-  bin = lib.getExe cfg.package;
+  finalPackage =
+    if cfg.environment == { } then
+      cfg.package
+    else
+      let
+        wrapperArgs = lib.flatten (
+          lib.mapAttrsToList (name: value: [
+            "--set"
+            "CARAPACE_${lib.toUpper name}"
+            value
+          ]) cfg.environment
+        );
+      in
+      pkgs.symlinkJoin {
+        name = "carapace-wrapped";
+        paths = [ cfg.package ];
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        postBuild = ''
+          wrapProgram $out/bin/carapace ${lib.escapeShellArgs wrapperArgs}
+        '';
+        inherit (cfg.package) meta;
+      };
+  bin = lib.getExe finalPackage;
 in
 {
   meta.maintainers = with lib.maintainers; [
     weathercold
     bobvanderlinden
+  ];
+
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "programs" "carapace" "ignoreCase" ]
+      [ "programs" "carapace" "environment" "match" ]
+    )
   ];
 
   options.programs.carapace = {
@@ -28,32 +57,36 @@ in
 
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
-    ignoreCase = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
+    environment = lib.mkOption {
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          bool
+          int
+          str
+        ]);
+      apply = lib.mapAttrs (
+        _name: value: if lib.isBool value then (if value then "1" else "0") else toString value
+      );
+      default = { };
+      example = {
+        bridges = "zsh,fish,bash";
+        match = true;
+      };
       description = ''
-        Whether to enable case-insensitive matching for carapace completions.
-        When enabled, the carapace binary is wrapped with {env}`CARAPACE_MATCH`
-        set to `1`.
+        Environment variables for Carapace. The package is wrapped with each
+        attribute name uppercased and prefixed by `CARAPACE_`. For example,
+        `match = true` sets
+        {env}`CARAPACE_MATCH` to `1`.
+
+        See <https://carapace-sh.github.io/carapace-bin/setup/environment.html>
+        for the available environment variables.
       '';
     };
   };
 
   config = lib.mkIf cfg.enable {
-    programs.carapace.package = lib.mkIf cfg.ignoreCase (
-      pkgs.symlinkJoin {
-        name = "carapace-wrapped";
-        paths = [ pkgs.carapace ];
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-        postBuild = ''
-          wrapProgram $out/bin/carapace \
-            --set CARAPACE_MATCH 1
-        '';
-        meta.mainProgram = "carapace";
-      }
-    );
-
-    home.packages = [ cfg.package ];
+    home.packages = [ finalPackage ];
 
     programs = {
       bash.initExtra = lib.mkIf cfg.enableBashIntegration ''
@@ -105,7 +138,7 @@ in
             carapaceListFile =
               pkgs.runCommandLocal "carapace-list"
                 {
-                  buildInputs = [ cfg.package ];
+                  buildInputs = [ finalPackage ];
                 }
                 ''
                   ${bin} --list > $out

--- a/modules/programs/carapace.nix
+++ b/modules/programs/carapace.nix
@@ -8,7 +8,7 @@
 let
   cfg = config.programs.carapace;
   finalPackage =
-    if cfg.environment == { } then
+    if cfg.environment == { } && cfg.extraPackages == [ ] then
       cfg.package
     else
       let
@@ -18,6 +18,12 @@ let
             "CARAPACE_${lib.toUpper name}"
             value
           ]) cfg.environment
+          ++ lib.optional (cfg.extraPackages != [ ]) [
+            "--suffix"
+            "PATH"
+            ":"
+            (lib.makeBinPath cfg.extraPackages)
+          ]
         );
       in
       pkgs.symlinkJoin {
@@ -48,6 +54,22 @@ in
     enable = lib.mkEnableOption "carapace, a multi-shell multi-command argument completer";
 
     package = lib.mkPackageOption pkgs "carapace" { };
+
+    extraPackages = lib.mkOption {
+      type = with lib.types; listOf package;
+      default = [ ];
+      example = lib.literalExpression ''
+        with pkgs; [
+          inshellisense
+          fish
+        ]
+      '';
+      description = ''
+        Extra packages available to Carapace. This can be used to make
+        completers listed in {option}`programs.carapace.environment.bridges`
+        available.
+      '';
+    };
 
     enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
 

--- a/tests/modules/programs/carapace/default.nix
+++ b/tests/modules/programs/carapace/default.nix
@@ -3,4 +3,6 @@
   carapace-zsh = ./zsh.nix;
   carapace-fish = ./fish.nix;
   carapace-nushell = ./nushell.nix;
+  carapace-environment = ./environment.nix;
+  carapace-ignore-case-renamed = ./ignore-case-renamed.nix;
 }

--- a/tests/modules/programs/carapace/environment.nix
+++ b/tests/modules/programs/carapace/environment.nix
@@ -14,11 +14,17 @@
     enableZshIntegration = false;
     package =
       pkgs.writeShellScriptBin "carapace" ''
+        command -v inshellisense >/dev/null
+        command -v fish >/dev/null
         printf '%s\n' "$CARAPACE_BRIDGES" "$CARAPACE_DESCRIPTION_LENGTH" "$CARAPACE_HIDDEN" "$CARAPACE_LENIENT" "$CARAPACE_MATCH"
       ''
       // {
         meta.mainProgram = "carapace";
       };
+    extraPackages = lib.map (name: pkgs.writeShellScriptBin name "") [
+      "inshellisense"
+      "fish"
+    ];
     environment = {
       CARAPACE_BRIDGES = "inshellisense,fish";
       CARAPACE_DESCRIPTION_LENGTH = 100;

--- a/tests/modules/programs/carapace/environment.nix
+++ b/tests/modules/programs/carapace/environment.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 
 {
   programs.carapace = {
@@ -9,11 +9,17 @@
     enableZshIntegration = false;
     package =
       pkgs.writeShellScriptBin "carapace" ''
+        command -v inshellisense >/dev/null
+        command -v fish >/dev/null
         printf '%s\n' "$CARAPACE_BRIDGES" "$CARAPACE_HIDDEN" "$CARAPACE_LENIENT" "$CARAPACE_MATCH"
       ''
       // {
         meta.mainProgram = "carapace";
       };
+    extraPackages = lib.map (name: pkgs.writeShellScriptBin name "") [
+      "inshellisense"
+      "fish"
+    ];
     environment = {
       bridges = "inshellisense,fish";
       hidden = 2;

--- a/tests/modules/programs/carapace/environment.nix
+++ b/tests/modules/programs/carapace/environment.nix
@@ -1,0 +1,51 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  programs.carapace = {
+    enable = true;
+    enableBashIntegration = false;
+    enableFishIntegration = false;
+    enableNushellIntegration = false;
+    enableZshIntegration = false;
+    package =
+      pkgs.writeShellScriptBin "carapace" ''
+        printf '%s\n' "$CARAPACE_BRIDGES" "$CARAPACE_DESCRIPTION_LENGTH" "$CARAPACE_HIDDEN" "$CARAPACE_LENIENT" "$CARAPACE_MATCH"
+      ''
+      // {
+        meta.mainProgram = "carapace";
+      };
+    environment = {
+      CARAPACE_BRIDGES = "inshellisense,fish";
+      CARAPACE_DESCRIPTION_LENGTH = 100;
+      CARAPACE_HIDDEN = 2;
+      CARAPACE_LENIENT = false;
+      CARAPACE_MATCH = true;
+    };
+  };
+
+  nmt.script = ''
+    package=${config.programs.carapace.package}
+    finalPackage=${config.programs.carapace.finalPackage}
+    if [[ "$package" == "$finalPackage" ]]; then
+      fail "Expected finalPackage ($finalPackage) to differ from package ($package)"
+    fi
+
+    if [[ ${lib.boolToString config.programs.carapace.environment.CARAPACE_MATCH} != true ]]; then
+      fail "Expected CARAPACE_MATCH to read back as a Boolean"
+    fi
+
+    "$TESTED/home-path/bin/carapace" > "$TMPDIR/environment.actual"
+    assertFileContent "$TMPDIR/environment.actual" ${pkgs.writeText "environment.expected" ''
+      inshellisense,fish
+      100
+      2
+      0
+      1
+    ''}
+  '';
+}

--- a/tests/modules/programs/carapace/environment.nix
+++ b/tests/modules/programs/carapace/environment.nix
@@ -1,0 +1,34 @@
+{ pkgs, ... }:
+
+{
+  programs.carapace = {
+    enable = true;
+    enableBashIntegration = false;
+    enableFishIntegration = false;
+    enableNushellIntegration = false;
+    enableZshIntegration = false;
+    package =
+      pkgs.writeShellScriptBin "carapace" ''
+        printf '%s\n' "$CARAPACE_BRIDGES" "$CARAPACE_HIDDEN" "$CARAPACE_LENIENT" "$CARAPACE_MATCH"
+      ''
+      // {
+        meta.mainProgram = "carapace";
+      };
+    environment = {
+      bridges = "inshellisense,fish";
+      hidden = 2;
+      lenient = false;
+      match = true;
+    };
+  };
+
+  nmt.script = ''
+    "$TESTED/home-path/bin/carapace" > "$TMPDIR/environment.actual"
+    assertFileContent "$TMPDIR/environment.actual" ${pkgs.writeText "environment.expected" ''
+      inshellisense,fish
+      2
+      0
+      1
+    ''}
+  '';
+}

--- a/tests/modules/programs/carapace/ignore-case-renamed.nix
+++ b/tests/modules/programs/carapace/ignore-case-renamed.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  options,
+  pkgs,
+  ...
+}:
+
+{
+  programs.carapace = {
+    enable = true;
+    enableBashIntegration = false;
+    enableFishIntegration = false;
+    enableNushellIntegration = false;
+    enableZshIntegration = false;
+    package =
+      pkgs.writeShellScriptBin "carapace" ''
+        printf '%s\n' "$CARAPACE_MATCH"
+      ''
+      // {
+        meta.mainProgram = "carapace";
+      };
+    ignoreCase = true;
+  };
+
+  test.asserts.warnings.expected = [
+    "The option `programs.carapace.ignoreCase' defined in ${lib.showFiles options.programs.carapace.ignoreCase.files} has been renamed to `programs.carapace.environment.CARAPACE_MATCH'."
+  ];
+
+  nmt.script = ''
+    "$TESTED/home-path/bin/carapace" > "$TMPDIR/match.actual"
+    assertFileContent "$TMPDIR/match.actual" ${pkgs.writeText "match.expected" ''
+      1
+    ''}
+  '';
+}

--- a/tests/modules/programs/carapace/ignore-case-renamed.nix
+++ b/tests/modules/programs/carapace/ignore-case-renamed.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  options,
+  pkgs,
+  ...
+}:
+
+{
+  programs.carapace = {
+    enable = true;
+    enableBashIntegration = false;
+    enableFishIntegration = false;
+    enableNushellIntegration = false;
+    enableZshIntegration = false;
+    package =
+      pkgs.writeShellScriptBin "carapace" ''
+        printf '%s\n' "$CARAPACE_MATCH"
+      ''
+      // {
+        meta.mainProgram = "carapace";
+      };
+    ignoreCase = true;
+  };
+
+  test.asserts.warnings.expected = [
+    "The option `programs.carapace.ignoreCase' defined in ${lib.showFiles options.programs.carapace.ignoreCase.files} has been renamed to `programs.carapace.environment.match'."
+  ];
+
+  nmt.script = ''
+    "$TESTED/home-path/bin/carapace" > "$TMPDIR/match.actual"
+    assertFileContent "$TMPDIR/match.actual" ${pkgs.writeText "match.expected" ''
+      1
+    ''}
+  '';
+}


### PR DESCRIPTION
### Description

Added `programs.carapace.settings` for configuring Carapace through `CARAPACE_*` environment variables applied to its wrapped binary.

Setting names are uppercased and prefixed with `CARAPACE_`, and boolean values are converted to `1` or `0`.

Consequently, the existing `programs.carapace.ignoreCase` option has been superseded by `programs.carapace.settings.match`, with an evaluation warning for existing users.

Also added `programs.carapace.extraPackages`, which appends packages to the wrapped binary's `PATH`. This makes bridged completers configured through `programs.carapace.settings.bridges` easily available to carapace without having to install them globally.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```text
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
