### PR TITLE
pnpm: init

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -558,6 +558,11 @@
     github = "superflash41";
     githubId = 102434258;
   };
+  typeparameter = {
+    name = "Drew Davis";
+    github = "typeparameter";
+    githubId = 9686215;
+  };
   vidhanio = {
     name = "Vidhan Bhatt";
     email = "me@vidhan.io";

--- a/modules/misc/news/2026/09/2026-09-12_16-32-53.nix
+++ b/modules/misc/news/2026/09/2026-09-12_16-32-53.nix
@@ -1,0 +1,11 @@
+{
+  time = "2026-09-12T23:32:53+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.pnpm'.
+
+    Fast, disk space efficient package manager for JavaScript.
+
+    See <https://pnpm.io> for more details.
+  '';
+}

--- a/modules/programs/pnpm.nix
+++ b/modules/programs/pnpm.nix
@@ -1,0 +1,63 @@
+# https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/pnpm/default.nix
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkIf mkOption types;
+
+  cfg = config.programs.pnpm;
+
+  # https://pnpm.io/11.x/settings#storedir
+  defaultPnpmHome =
+    if config.xdg.enable then
+      "${config.xdg.dataHome}/pnpm"
+    else if pkgs.stdenv.hostPlatform.isDarwin then
+      "${config.home.homeDirectory}/Library/pnpm"
+    else
+      "${config.home.homeDirectory}/.local/share/pnpm";
+in
+{
+  meta.maintainers = with lib.maintainers; [ typeparameter ];
+
+  options = {
+    programs.pnpm = {
+      enable = lib.mkEnableOption "{command}`pnpm` user config";
+
+      package = lib.mkPackageOption pkgs "pnpm" { nullable = true; };
+
+      pnpmHome = mkOption {
+        type = types.str;
+        default = defaultPnpmHome;
+        defaultText = lib.literalExpression ''
+          if config.xdg.enable then
+            "''${config.xdg.dataHome}/pnpm"
+          else if pkgs.stdenv.hostPlatform.isDarwin then
+            "''${config.home.homeDirectory}/Library/pnpm"
+          else
+            "''${config.home.homeDirectory}/.local/share/pnpm"
+        '';
+        example = lib.literalExpression "\${config.home.homeDirectory}/.pnpm";
+        description = ''
+          The pnpm home directory. This sets {env}`PNPM_HOME`, which controls
+          the default locations of pnpm's package store, globally installed
+          packages, and global executables.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home = {
+      packages = mkIf (cfg.package != null) [ cfg.package ];
+
+      sessionVariables = {
+        PNPM_HOME = cfg.pnpmHome;
+      };
+
+      sessionPath = [ "${cfg.pnpmHome}/bin" ];
+    };
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -168,6 +168,7 @@ let
     "pimsync"
     "pistol"
     "pls"
+    "pnpm"
     "podman"
     "poetry"
     "pomo"

--- a/tests/modules/programs/pnpm/custom-home.nix
+++ b/tests/modules/programs/pnpm/custom-home.nix
@@ -1,0 +1,16 @@
+{
+  programs.pnpm = {
+    enable = true;
+    pnpmHome = "/home/hm-user/.pnpm";
+  };
+
+  nmt.script = ''
+    hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
+
+    assertFileExists $hmSessVars
+    assertFileContains $hmSessVars \
+      'export PNPM_HOME="/home/hm-user/.pnpm"'
+    assertFileContains $hmSessVars \
+      'export PATH="/home/hm-user/.pnpm/bin''${PATH:+:}$PATH"'
+  '';
+}

--- a/tests/modules/programs/pnpm/default-configuration.nix
+++ b/tests/modules/programs/pnpm/default-configuration.nix
@@ -1,0 +1,13 @@
+{
+  programs.pnpm.enable = true;
+
+  nmt.script = ''
+    hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
+
+    assertFileExists $hmSessVars
+    assertFileContains $hmSessVars \
+      'export PNPM_HOME="/home/hm-user/.local/share/pnpm"'
+    assertFileContains $hmSessVars \
+      'export PATH="/home/hm-user/.local/share/pnpm/bin''${PATH:+:}$PATH"'
+  '';
+}

--- a/tests/modules/programs/pnpm/default.nix
+++ b/tests/modules/programs/pnpm/default.nix
@@ -1,0 +1,5 @@
+{
+  pnpm-default-configuration = ./default-configuration.nix;
+  pnpm-custom-home = ./custom-home.nix;
+  pnpm-xdg-disabled = ./xdg-disabled.nix;
+}

--- a/tests/modules/programs/pnpm/xdg-disabled.nix
+++ b/tests/modules/programs/pnpm/xdg-disabled.nix
@@ -1,0 +1,27 @@
+{ pkgs, ... }:
+
+let
+  expectedPnpmHome =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "/home/hm-user/Library/pnpm"
+    else
+      "/home/hm-user/.local/share/pnpm";
+in
+{
+  programs.pnpm.enable = true;
+
+  xdg = {
+    enable = false;
+    dataHome = "/home/hm-user/custom-data-home";
+  };
+
+  nmt.script = ''
+    hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
+
+    assertFileExists $hmSessVars
+    assertFileContains $hmSessVars \
+      'export PNPM_HOME="${expectedPnpmHome}"'
+    assertFileContains $hmSessVars \
+      'export PATH="${expectedPnpmHome}/bin''${PATH:+:}$PATH"'
+  '';
+}


### PR DESCRIPTION
### Description

Adds [`pnpm`](https://pnpm.io/) as a configurable program.

The primary motivation for using this instead of simply adding `pkgs.pnpm` to `home.packages` is to ensure that globally-installed packages are available on the user's `$PATH`.

As this is my first contribution to Home Manager, I'm receptive to any and all suggestions on how to improve this module!

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
