### PR TITLE
carapace: add environmentVariables option, deprecate ignoreCase

### DIFF
--- a/modules/programs/carapace.nix
+++ b/modules/programs/carapace.nix
@@ -8,6 +8,19 @@
 let
   cfg = config.programs.carapace;
   bin = lib.getExe cfg.package;
+
+  # `ignoreCase` is a deprecated shorthand for CARAPACE_MATCH = "1"; using it
+  # together with `environmentVariables.CARAPACE_MATCH` is rejected by the
+  # assertion below.
+  envVars = cfg.environmentVariables // lib.optionalAttrs cfg.ignoreCase { CARAPACE_MATCH = "1"; };
+
+  setArgs = lib.concatLists (
+    lib.mapAttrsToList (k: v: [
+      "--set"
+      k
+      v
+    ]) envVars
+  );
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -33,21 +46,76 @@ in
       default = false;
       description = ''
         Whether to enable case-insensitive matching for carapace completions.
-        When enabled, the carapace binary is wrapped with {env}`CARAPACE_MATCH`
-        set to `1`.
+        Equivalent to setting
+        {option}`programs.carapace.environmentVariables.CARAPACE_MATCH` to
+        `1`.
+
+        ::: {.warning}
+        This option is deprecated and will be removed in a future release.
+        Use {option}`programs.carapace.environmentVariables.CARAPACE_MATCH`
+        instead.
+        :::
+      '';
+    };
+
+    environmentVariables = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = {
+        CARAPACE_MATCH = "1";
+        CARAPACE_EXCLUDES = "wt";
+      };
+      description = ''
+        Environment variables to bake into the {command}`carapace` binary
+        (e.g. {env}`CARAPACE_MATCH`, {env}`CARAPACE_EXCLUDES`). Keys are full
+        variable names — no prefix is added — mirroring
+        {option}`home.sessionVariables`.
+
+        The variables are applied by wrapping the binary with
+        {command}`makeWrapper`, so they take effect both at completion time and
+        during the build-time {command}`carapace --list` used to disable fish's
+        built-in completions for fish < 4.0. This is preferable to setting the
+        same variables via {option}`home.sessionVariables`, which would neither
+        influence that build-time {command}`--list` nor scope the variables to
+        the carapace process.
+
+        Note that {env}`CARAPACE_BRIDGES` and {env}`CARAPACE_EXCLUDES` change
+        which completers carapace registers: {env}`CARAPACE_BRIDGES` may
+        require running {command}`carapace --clear-cache` after a change and
+        notably expands the build-time completion list (and thus the number of
+        completion files generated for fish < 4.0), while the remaining
+        variables only affect runtime behaviour (matching, styling, …) and do
+        not touch the cache.
       '';
     };
   };
 
   config = lib.mkIf cfg.enable {
-    programs.carapace.package = lib.mkIf cfg.ignoreCase (
+    warnings = lib.optional cfg.ignoreCase ''
+      `programs.carapace.ignoreCase' is deprecated and will be removed in a
+      future release. Please use `programs.carapace.environmentVariables.CARAPACE_MATCH'
+      (set to "1") instead.
+    '';
+
+    assertions = [
+      {
+        assertion = !(cfg.ignoreCase && cfg.environmentVariables ? CARAPACE_MATCH);
+        message = ''
+          `programs.carapace.ignoreCase' must not be used together with
+          `programs.carapace.environmentVariables.CARAPACE_MATCH' because
+          `ignoreCase' is a deprecated shorthand for
+          `environmentVariables.CARAPACE_MATCH = "1"'. Please set only one.
+        '';
+      }
+    ];
+
+    programs.carapace.package = lib.mkIf (envVars != { }) (
       pkgs.symlinkJoin {
-        name = "carapace-wrapped";
+        name = "carapace";
         paths = [ pkgs.carapace ];
         nativeBuildInputs = [ pkgs.makeWrapper ];
         postBuild = ''
-          wrapProgram $out/bin/carapace \
-            --set CARAPACE_MATCH 1
+          wrapProgram $out/bin/carapace ${lib.escapeShellArgs setArgs}
         '';
         meta.mainProgram = "carapace";
       }

--- a/tests/modules/programs/carapace/default.nix
+++ b/tests/modules/programs/carapace/default.nix
@@ -3,4 +3,8 @@
   carapace-zsh = ./zsh.nix;
   carapace-fish = ./fish.nix;
   carapace-nushell = ./nushell.nix;
+  carapace-environment-variables = ./environment-variables.nix;
+  carapace-environment-variables-empty = ./environment-variables-empty.nix;
+  carapace-environment-variables-conflict = ./environment-variables-conflict.nix;
+  carapace-ignore-case = ./ignore-case.nix;
 }

--- a/tests/modules/programs/carapace/environment-variables-conflict.nix
+++ b/tests/modules/programs/carapace/environment-variables-conflict.nix
@@ -1,0 +1,33 @@
+# `ignoreCase` and `environmentVariables.CARAPACE_MATCH` are mutually
+# exclusive; setting both must trip the assertion.
+{
+  programs.carapace = {
+    enable = true;
+    enableBashIntegration = true;
+    ignoreCase = true;
+    environmentVariables.CARAPACE_MATCH = "1";
+  };
+
+  test.stubs.carapace = {
+    name = "carapace";
+    outPath = null;
+    buildScript = ''
+      mkdir -p $out/bin
+      touch $out/bin/carapace
+      chmod +x $out/bin/carapace
+    '';
+  };
+
+  # `ignoreCase` also emits the deprecation warning; this test focuses on the
+  # mutual-exclusion assertion, so disable the warning check.
+  test.asserts.warnings.enable = false;
+
+  test.asserts.assertions.expected = [
+    ''
+      `programs.carapace.ignoreCase' must not be used together with
+      `programs.carapace.environmentVariables.CARAPACE_MATCH' because
+      `ignoreCase' is a deprecated shorthand for
+      `environmentVariables.CARAPACE_MATCH = "1"'. Please set only one.
+    ''
+  ];
+}

--- a/tests/modules/programs/carapace/environment-variables-empty.nix
+++ b/tests/modules/programs/carapace/environment-variables-empty.nix
@@ -1,0 +1,23 @@
+# With no environment variables (and `ignoreCase` off) the binary must NOT be
+# wrapped.
+{
+  programs.carapace = {
+    enable = true;
+    enableBashIntegration = true;
+  };
+
+  test.stubs.carapace = {
+    name = "carapace";
+    # Keep a real store path so the (unwrapped) stub is buildable in home-path.
+    outPath = null;
+    buildScript = ''
+      mkdir -p $out/bin
+      touch $out/bin/carapace
+      chmod +x $out/bin/carapace
+    '';
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-path/bin/.carapace-wrapped
+  '';
+}

--- a/tests/modules/programs/carapace/environment-variables.nix
+++ b/tests/modules/programs/carapace/environment-variables.nix
@@ -1,0 +1,29 @@
+{
+  programs.carapace = {
+    enable = true;
+    enableBashIntegration = true;
+    environmentVariables = {
+      CARAPACE_MATCH = "1";
+      CARAPACE_EXCLUDES = "wt";
+    };
+  };
+
+  test.stubs.carapace = {
+    name = "carapace";
+    # Keep a real store path so the wrapping `symlinkJoin` can build the stub.
+    outPath = null;
+    buildScript = ''
+      mkdir -p $out/bin
+      touch $out/bin/carapace
+      chmod +x $out/bin/carapace
+    '';
+  };
+
+  nmt.script = ''
+    # The binary is wrapped via makeWrapper, which renames the original to
+    # .carapace-wrapped and installs the wrapper script in its place.
+    assertFileExists home-path/bin/.carapace-wrapped
+    assertFileRegex home-path/bin/carapace "export CARAPACE_MATCH='1'"
+    assertFileRegex home-path/bin/carapace "export CARAPACE_EXCLUDES='wt'"
+  '';
+}

--- a/tests/modules/programs/carapace/ignore-case.nix
+++ b/tests/modules/programs/carapace/ignore-case.nix
@@ -1,0 +1,34 @@
+# Regression test: the deprecated `ignoreCase` option must keep working as a
+# shorthand for `environmentVariables.CARAPACE_MATCH = "1"`, and using it must
+# emit a deprecation warning.
+{
+  programs.carapace = {
+    enable = true;
+    enableBashIntegration = true;
+    ignoreCase = true;
+  };
+
+  test.stubs.carapace = {
+    name = "carapace";
+    # Keep a real store path so the wrapping `symlinkJoin` can build the stub.
+    outPath = null;
+    buildScript = ''
+      mkdir -p $out/bin
+      touch $out/bin/carapace
+      chmod +x $out/bin/carapace
+    '';
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      `programs.carapace.ignoreCase' is deprecated and will be removed in a
+      future release. Please use `programs.carapace.environmentVariables.CARAPACE_MATCH'
+      (set to "1") instead.
+    ''
+  ];
+
+  nmt.script = ''
+    assertFileExists home-path/bin/.carapace-wrapped
+    assertFileRegex home-path/bin/carapace "export CARAPACE_MATCH='1'"
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add a generic `program.carapace.environmentVariables` option that bakes arbitrary `CARAPACE_*` variables into the wrapped carapace binary via `makeWrapper`, generalising the existing `program.carapace.ignoreCase` -> `CARAPACE_MATCH` wrapping.

Deprecate `program.carapace.ignoreCase`: it is now a shorthand for `program.carapace.environmentVariables.CARAPACE_MATCH = "1"` that emits a warning, and combining it with an explicit `environmentVariables.CARAPACE_MATCH` is rejected by an assertion since the two would be contradictory.

Assisted-by: Claude-Code:GLM-5.2

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
