### PR TITLE
crossover: init at 26.3.0

### DIFF
--- a/all-maintainers.nix
+++ b/all-maintainers.nix
@@ -451,6 +451,14 @@
     name = "Mel Bourgeois";
     source = "nixpkgs";
   };
+  Steinhagen = {
+    email = "rapiteanu.catalin@gmail.com";
+    github = "Steinhagen";
+    githubId = 4029937;
+    matrix = "@catalin:one.ems.host";
+    name = "Viorel-Cătălin Răpițeanu";
+    source = "nixpkgs";
+  };
   SunOfLife1 = {
     github = "SunOfLife1";
     githubId = 30405063;

--- a/modules/programs/crossover/capi20.c
+++ b/modules/programs/crossover/capi20.c
@@ -1,0 +1,80 @@
+/*
+ * Stub implementation of the CAPI 2.0 library (libcapi20.so.3).
+ *
+ * CrossOver ships Wine's capi2032.so with a hard DT_NEEDED on libcapi20.so.3,
+ * the ISDN CAPI 2.0 API. No nixpkgs package provides it (ISDN CAPI hardware
+ * is extinct), and autoPatchelf can never satisfy the dependency, so CrossOver
+ * flags it as a missing 64-bit library. This stub exists only to provide the
+ * SONAME and the entry points capi2032.so imports. Each call reports "CAPI
+ * not installed", which is what a program gets when the real library is
+ * absent; CAPI adapters no longer exist, so nothing can legitimately use it.
+ */
+
+#define CAPIERR_NOTINSTALLED 1001
+
+unsigned capi20_register(
+    unsigned maxLogicalConnection,
+    unsigned maxBDataBlocks,
+    unsigned maxBDataLen,
+    unsigned maxB3Connection,
+    unsigned maxB3Blocks,
+    unsigned maxB3Len,
+    unsigned maxNCCI,
+    unsigned maxController)
+{
+    return CAPIERR_NOTINSTALLED;
+}
+
+unsigned capi20_release(unsigned appl)
+{
+    return CAPIERR_NOTINSTALLED;
+}
+
+unsigned capi20_put_message(unsigned appl, void *message)
+{
+    return CAPIERR_NOTINSTALLED;
+}
+
+unsigned capi20_get_message(unsigned appl, void *message)
+{
+    return CAPIERR_NOTINSTALLED;
+}
+
+unsigned capi20_release_message(unsigned appl, unsigned message)
+{
+    return CAPIERR_NOTINSTALLED;
+}
+
+unsigned capi20_waitformessage(unsigned appl, void *message)
+{
+    return CAPIERR_NOTINSTALLED;
+}
+
+unsigned capi20_get_manufacturer(unsigned controller, char *buf)
+{
+    if (buf)
+        buf[0] = '\0';
+    return CAPIERR_NOTINSTALLED;
+}
+
+unsigned capi20_get_version(unsigned controller, unsigned *version)
+{
+    return CAPIERR_NOTINSTALLED;
+}
+
+unsigned capi20_get_serial_number(unsigned controller, char *buf)
+{
+    if (buf)
+        buf[0] = '\0';
+    return CAPIERR_NOTINSTALLED;
+}
+
+unsigned capi20_isinstalled(void)
+{
+    return CAPIERR_NOTINSTALLED;
+}
+
+unsigned capi20_get_profile(unsigned controller, void *profile)
+{
+    return CAPIERR_NOTINSTALLED;
+}

--- a/modules/programs/crossover/default.nix
+++ b/modules/programs/crossover/default.nix
@@ -1,0 +1,70 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.crossover;
+in
+{
+  meta.maintainers = [ lib.maintainers.rapiteanu ];
+
+  options.programs.crossover = {
+    enable = lib.mkEnableOption "CrossOver";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./package.nix {
+        homeDir = config.home.homeDirectory;
+      };
+      defaultText = lib.literalExpression "pkgs.callPackage ./package.nix { homeDir = config.home.homeDirectory; }";
+      description = ''
+        The CrossOver package to use. The default is a repackaging of the
+        CodeWeavers Fedora rpm with the fixes needed to run on NixOS (see
+        the package file for the full list). The package is unfree, so
+        building it requires `nixpkgs.config.allowUnfree = true` (or
+        `NIXPKGS_ALLOW_UNFREE=1`).
+      '';
+    };
+
+    license = {
+      file = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = lib.literalExpression "./license.txt";
+        description = ''
+          Path to the CrossOver license file (`license.txt`), as produced by
+          a normal CrossOver registration. If both `file` and `signature`
+          are set, CrossOver starts unlocked without any interactive login.
+        '';
+      };
+
+      signature = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = lib.literalExpression "./license.sha256";
+        description = ''
+          Path to the SHA-256 signature of the license file
+          (`license.sha256`), as produced by a normal CrossOver
+          registration.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # The package installs the `crossover` GUI, the wine launchers and the
+    # desktop entry; putting it in home.packages also makes `wine-crossover`
+    # resolvable on $PATH, which the .lnk launchers rely on.
+    home.packages = [ cfg.package ];
+
+    home.file.".cxoffice/etc/license.txt" = lib.mkIf (cfg.license.file != null) {
+      source = cfg.license.file;
+    };
+    home.file.".cxoffice/etc/license.sha256" = lib.mkIf (cfg.license.signature != null) {
+      source = cfg.license.signature;
+    };
+  };
+}

--- a/modules/programs/crossover/package.nix
+++ b/modules/programs/crossover/package.nix
@@ -1,0 +1,420 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  addDriverRunpath,
+  autoPatchelfHook,
+  makeDesktopItem,
+  rpmextract,
+  wrapGAppsHook3,
+  # The license lives at $homeDir/.cxoffice/etc (see installPhase).
+  homeDir,
+  # Both package sets, since the dlopen list is applied per bitness.
+  pkgs,
+  pkgsi686Linux,
+  gobject-introspection,
+  python3,
+  # Resolved through $PATH at runtime, not linked against.
+  gzip,
+  openssl,
+  perl,
+  xdg-utils,
+  alsa-lib,
+  freetype,
+  gst_all_1,
+  gtk3,
+  lcms2,
+  libGLU,
+  libgphoto2,
+  libice,
+  libpcap,
+  libpng,
+  libpulseaudio,
+  libsm,
+  libunwind,
+  libusb1,
+  libxcursor,
+  libxext,
+  libxi,
+  libxrandr,
+  ocl-icd,
+  pcsclite,
+  runCommand,
+  sane-backends,
+  vte,
+  zlib,
+}:
+
+let
+  pname = "crossover";
+  version = "26.3.0";
+
+  # New releases: the redirect URL 302s to the current rpm, so the version
+  # can be read off the Location header.
+  src = fetchurl {
+    url = "https://media.codeweavers.com/pub/crossover/cxlinux/demo/crossover-${version}-1.rpm";
+    hash = "sha256-M4pHI/sjlOqjr2jz1I0OPPW1p359wKZVcKVnNA9TpNo=";
+  };
+
+  # pycairo is required: checkgtk.py treats a missing cairo foreign as
+  # "GTK 3 support missing", which blocks the GUI.
+  pythonEnv = python3.withPackages (ps: [
+    ps.pygobject3
+    ps.pycairo
+  ]);
+
+  # Libraries Wine loads with dlopen() rather than linking to, so
+  # autoPatchelf cannot infer them. Named by attribute path so the list
+  # applies to both package sets.
+  dlopenLibNames = [
+    "SDL2"
+    "alsa-lib"
+    "cups"
+    "dbus"
+    "fontconfig"
+    "freetype"
+    "glib"
+    "gnutls"
+    "gst_all_1.gst-plugins-base"
+    "gst_all_1.gst-plugins-good"
+    "gst_all_1.gstreamer"
+    "krb5" # libgssapi_krb5 / libkrb5, for AD-authenticating apps
+    "libGL"
+    "libXinerama"
+    "libglvnd"
+    "libgphoto2"
+    "libpulseaudio"
+    "libunwind"
+    "libusb1"
+    "libv4l" # webcams
+    "libx11"
+    "libxcomposite"
+    "libxcursor"
+    "libxext"
+    "libxfixes"
+    "libxi"
+    "libxkbcommon"
+    "libxrandr"
+    "libxrender"
+    "libxxf86vm"
+    # cxdiag flags this one as required; the library is tiny and silencing
+    # the warning is simpler than arguing about nscd.
+    "nssmdns"
+    "ocl-icd"
+    "pcsclite"
+    "sane-backends"
+    "systemdLibs" # libudev.so.1
+    "unixodbc"
+    "vulkan-loader"
+    "wayland"
+    # C++ apps dlopen() libstdc++ themselves; cxdiag flags it as missing.
+    "stdenv.cc.cc.lib"
+  ];
+
+  # lib.getLib: autoPatchelf appends "$dep/lib" verbatim, and gnutls /
+  # gstreamer / pcsclite default to a `bin` output with an empty lib/.
+  dlopenLibs =
+    set: map (path: lib.getLib (lib.getAttrFromPath (lib.splitString "." path) set)) dlopenLibNames;
+
+  # The rpm ships a complete 32-bit Wine for win32 bottles; without i686
+  # libraries in scope autoPatchelf leaves every ELF32 file unpatched.
+  libs32 = dlopenLibs pkgsi686Linux;
+
+  # Two SONAMEs nixpkgs does not ship: libcapi20.so.3 (dead ISDN CAPI 2.0,
+  # stubbed to answer "CAPI not installed") and libpcap.so.0.8 (a symlink to
+  # the modern libpcap 1.x ABI, which WinPcap works against). Both per
+  # bitness.
+  mkCapi20Stub =
+    stdenv':
+    stdenv'.mkDerivation {
+      pname = "libcapi20-stub";
+      inherit version;
+      src = ./capi20.c;
+      dontUnpack = true;
+      buildPhase = ''
+        $CC -shared -fPIC -Wl,-soname,libcapi20.so.3 -o libcapi20.so.3 $src
+      '';
+      installPhase = ''
+        mkdir -p $out/lib
+        cp libcapi20.so.3 $out/lib/
+      '';
+      meta.description = "Stub of the obsolete ISDN CAPI 2.0 library (libcapi20.so.3)";
+    };
+  capi20Stub64 = mkCapi20Stub stdenv;
+  capi20Stub32 = mkCapi20Stub pkgsi686Linux.stdenv;
+
+  mkPcap08Compat =
+    libpcap':
+    runCommand "libpcap-0.8-compat" { } ''
+      mkdir -p $out/lib
+      ln -s ${lib.getLib libpcap'}/lib/libpcap.so.1 $out/lib/libpcap.so.0.8
+    '';
+  pcap08Compat64 = mkPcap08Compat libpcap;
+  pcap08Compat32 = mkPcap08Compat pkgsi686Linux.libpcap;
+
+  compatLibs64 = [
+    capi20Stub64
+    pcap08Compat64
+  ];
+  compatLibs32 = [
+    capi20Stub32
+    pcap08Compat32
+  ];
+
+  # GStreamer plugins are only seen on GST_PLUGIN_SYSTEM_PATH; the 32-bit
+  # plugin dirs have to be stated explicitly, hence one list per bitness.
+  gstPluginPkgs = set: [
+    set.gst_all_1.gst-plugins-base
+    set.gst_all_1.gst-plugins-good
+    set.gst_all_1.gst-plugins-bad # h264parse
+    set.gst_all_1.gst-plugins-ugly # asfdemux
+    set.gst_all_1.gst-libav # avdec_eac3 / avdec_vp9
+  ];
+
+  gstPluginDirs64 = map (p: "${lib.getLib p}/lib/gstreamer-1.0") (gstPluginPkgs pkgs);
+  gstPluginDirs32 = map (p: "${lib.getLib p}/lib/gstreamer-1.0") (gstPluginPkgs pkgsi686Linux);
+  gstPluginDirs = gstPluginDirs64 ++ gstPluginDirs32;
+
+  # The rpm ships a NoDisplay wine.desktop that only launches a given .exe;
+  # this is the entry for the CrossOver control panel itself.
+  desktopItem = makeDesktopItem {
+    name = "crossover";
+    desktopName = "CrossOver";
+    comment = "Run your Windows® app on Linux";
+    exec = "crossover";
+    icon = "crossover";
+    categories = [ "System" ];
+    # The control panel's Wayland app_id is ".crossover-wrapped" (the
+    # wrapper-renamed script), which taskbars match against this key.
+    startupWMClass = ".crossover-wrapped";
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs = [
+    rpmextract
+    autoPatchelfHook
+    gobject-introspection # collects the typelibs below into GI_TYPELIB_PATH
+    wrapGAppsHook3
+    # patchShebangs resolves both interpreters: perl for the launchers,
+    # pythonEnv (not bare python3) for the GUI so gi/pycairo still import.
+    perl
+    pythonEnv
+  ];
+
+  buildInputs = [
+    alsa-lib
+    freetype
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-libav
+    gtk3
+    lcms2
+    libGLU
+    libgphoto2
+    libice
+    libpng
+    libpulseaudio
+    libsm
+    libunwind
+    libusb1
+    libxcursor
+    libxext
+    libxi
+    libxrandr
+    ocl-icd
+    openssl
+    pcsclite
+    sane-backends
+    vte # provides Vte-2.91.typelib, which the install wizard needs
+    zlib
+  ];
+
+  # dlopenLibs goes on appendRunpaths, not runtimeDependencies: the latter
+  # is only applied to executables, but the dlopen()s happen from shared
+  # objects (e.g. lib/wine/x86_64-unix/win32u.so).
+  runtimeDependencies = dlopenLibs pkgs ++ libs32 ++ compatLibs64 ++ compatLibs32;
+
+  # The GL/Vulkan driver is host state, referenced by path; the plugin dirs
+  # must be searchable too, not just libgstreamer.
+  appendRunpaths = [
+    "${addDriverRunpath.driverLink}/lib"
+    "${addDriverRunpath.driverLink}-32/lib"
+  ]
+  ++ map (p: "${p}/lib") (dlopenLibs pkgs ++ libs32)
+  ++ map (p: "${p}/lib") (compatLibs64 ++ compatLibs32)
+  ++ gstPluginDirs;
+
+  # The compat libs are provided by RUNPATH above, not by patchelf
+  # resolving the pre-1.0 libpcap SONAME.
+  autoPatchelfIgnoreMissingDeps = [
+    "libcapi20.so.3"
+    "libpcap.so.0.8"
+  ];
+
+  unpackPhase = ''
+    rpmextract $src
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -pv $out
+    cp -R ./opt/cxoffice/* $out/
+
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/*.desktop $out/share/applications/
+
+    for size in 16 32 48 64 128 256; do
+      mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
+      cp ./opt/cxoffice/share/icons/''${size}x''${size}/crossover.png \
+        $out/share/icons/hicolor/''${size}x''${size}/apps/crossover.png
+    done
+
+    # perl launchers and bottle-template scripts have #!/usr/bin/perl
+    # shebangs, and the GUI #!/usr/bin/env python3; --build is required
+    # because strictDeps puts neither interpreter on HOST_PATH.
+    patchShebangs --build $out
+
+    # makeWrapper renames every executable to '.<name>-wrapped', and the
+    # perl launchers infer their identity from $0; cxname0() strips the
+    # rename so `wine` is not mistaken for a winelib app.
+    substituteInPlace $out/lib/perl/CXLog.pm \
+      --replace-fail '    $name0 =~ s+^.*/++;' \
+                     '    $name0 =~ s+^.*/++; $name0 =~ s/^\.//; $name0 =~ s/-wrapped$//;'
+
+    # Python 3.14 defaults multiprocessing to forkserver, which pickles the
+    # GTK-holding worker targets; force fork back.
+    substituteInPlace $out/lib/python/crossoverui.py \
+      --replace-fail 'import multiprocessing' \
+                     'import multiprocessing
+    multiprocessing.set_start_method("fork", force=True)'
+    substituteInPlace $out/lib/python/packageview.py \
+      --replace-fail 'import multiprocessing' \
+                     'import multiprocessing
+    multiprocessing.set_start_method("fork", force=True)'
+
+    # The license is normally written to $CX_ROOT/etc as root via `cxsu`
+    # (kdesu/gksu/kdesudo/xdg-su), none of which exist on NixOS. Redirect
+    # the license handling to the user's writable cellar instead.
+    # bin/cxregister is still the rpm's python script here; the wrap phase
+    # renames it to .cxregister-wrapped, so patching it here reaches it.
+    substituteInPlace $out/bin/cxregister $out/lib/python/demoutils.py \
+      --replace-fail 'os.path.join(cxutils.CX_ROOT, "etc"' \
+                     'os.path.join(cxproduct.get_user_dir(), "etc"'
+    # The cellar's etc dir does not exist yet, whereas $CX_ROOT/etc does.
+    substituteInPlace $out/bin/cxregister \
+      --replace-fail '        shutil.copyfile(src_license, dst_license)' \
+                     '        os.makedirs(etc_dir, exist_ok=True)
+            shutil.copyfile(src_license, dst_license)'
+    substituteInPlace $out/lib/python/crossoverui.py \
+      --replace-fail 'os.path.join(cxutils.CX_ROOT, "etc"' \
+                     'os.path.join(cxproduct.get_user_dir(), "etc"' \
+      --replace-fail "os.path.join(cxutils.CX_ROOT, 'etc'" \
+                     "os.path.join(cxproduct.get_user_dir(), 'etc'"
+    substituteInPlace $out/lib/python/cxregisterui.py \
+      --replace-fail 'os.path.join(cxutils.CX_ROOT, "etc"' \
+                     'os.path.join(cxproduct.get_user_dir(), "etc"'
+    # The patched files reference cxproduct, which cxregister only imports
+    # lazily in main() (after install() runs) and the others never import.
+    substituteInPlace $out/bin/cxregister \
+      --replace-fail 'import cxlog' \
+                     'import cxlog
+    import cxproduct'
+    substituteInPlace $out/lib/python/demoutils.py \
+      --replace-fail 'import cxconfig' \
+                     'import cxconfig
+    import cxproduct'
+    substituteInPlace $out/lib/python/cxregisterui.py \
+      --replace-fail 'import cxutils' \
+                     'import cxutils
+    import cxproduct'
+
+    # winemenubuilder.exe bakes the absolute store path of this build into
+    # the .lnk launchers it writes; every rebuild changes that path. Rewrite
+    # them, whenever cxmenu runs, to invoke bare `wine-crossover` (added in
+    # postFixup) on $PATH, which always resolves to the current build.
+    # bin/cxmenu is still the rpm's perl script here; the wrap phase renames
+    # it to .cxmenu-wrapped.
+    substituteInPlace $out/bin/cxmenu \
+      --replace-fail '    cxlog("-> Finalization took ", CXLog::cxtime()-$start, " seconds\n");
+    }
+
+    exit $rc;' \
+                     '    cxlog("-> Finalization took ", CXLog::cxtime()-$start, " seconds\n");
+    }
+
+    if (defined $ENV{WINEPREFIX} and -d "$ENV{WINEPREFIX}/desktopdata/cxmenu")
+    {
+        CXUtils::cxsystem("find", "$ENV{WINEPREFIX}/desktopdata/cxmenu",
+                          "-type", "f", "-name", "*.lnk",
+                          "-exec", "sed", "-i", "-E",
+                          q!s#"/nix/store/[a-z0-9]{32}-crossover-[^"]*/bin/wine"#wine-crossover#!,
+                          "{}", "+");
+    }
+
+    exit $rc;'
+
+    # winewrapper.exe (32- and 64-bit) runs its own demo check against
+    # $CX_ROOT/etc/license.txt in the read-only store; bridge it to the
+    # cellar with symlinks. license.sig is only created for accounts
+    # without a SHA-256 signature; the dangling symlink is harmless.
+    mkdir -p $out/etc
+    ln -s ${homeDir}/.cxoffice/etc/license.txt $out/etc/license.txt
+    ln -s ${homeDir}/.cxoffice/etc/license.sha256 $out/etc/license.sha256
+    ln -s ${homeDir}/.cxoffice/etc/license.sig $out/etc/license.sig
+
+    runHook postInstall
+  '';
+
+  # auto-patchelf skips files whose ELF class does not match the target
+  # linker, so the 32-bit Wine needs a second pass with the i686 bintools.
+  # autoPatchelfLibs is the DT_NEEDED search path (runtimeDependencies only
+  # extends RUNPATH), filled from buildInputs; a subshell keeps the i686
+  # additions out of the 64-bit pass.
+  postFixup = ''
+    (
+      export NIX_BINTOOLS=${pkgsi686Linux.stdenv.cc.bintools}
+      autoPatchelfLibs+=(${lib.concatMapStringsSep " " (p: "${p}/lib") libs32})
+      autoPatchelf -- "$out"
+    )
+    # A non-colliding name for the wine launcher: plain `wine` is taken by
+    # the nixpkgs wine package in the profile merge.
+    ln -s wine $out/bin/wine-crossover
+  '';
+
+  # Fed to wrapGAppsHook3 rather than makeWrapperArgs: with
+  # __structuredAttrs the latter reaches makeWrapper unsplit. --prefix, not
+  # --suffix, so a python3 earlier on the user's PATH cannot shadow it.
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${
+        lib.makeBinPath [
+          pythonEnv
+          openssl.bin
+          gzip
+          perl
+          xdg-utils
+        ]
+      }"
+      # The wrapper is shared by both bitnesses, so the 32-bit plugin dirs
+      # ride along; each process skips the foreign-ELF-class ones.
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "${lib.concatStringsSep ":" gstPluginDirs32}"
+    )
+  '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "Run your Windows® app on Linux";
+    homepage = "https://www.codeweavers.com/crossover";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    mainProgram = "crossover";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/tests/modules/programs/crossover/basic-configuration.nix
+++ b/tests/modules/programs/crossover/basic-configuration.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+{
+  programs.crossover = {
+    enable = true;
+    # The real derivation downloads the (unfree) CodeWeavers rpm; the test
+    # only exercises the module wiring, so stand in a trivial package.
+    package = pkgs.writeTextDir "bin/crossover" "";
+    license = {
+      file = pkgs.writeText "license.txt" "license";
+      signature = pkgs.writeText "license.sha256" "signature";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-path/bin/crossover
+    assertFileContent home-files/.cxoffice/etc/license.txt ${pkgs.writeText "expected-license.txt" "license"}
+    assertFileContent home-files/.cxoffice/etc/license.sha256 ${pkgs.writeText "expected-signature.txt" "signature"}
+  '';
+}

--- a/tests/modules/programs/crossover/default.nix
+++ b/tests/modules/programs/crossover/default.nix
@@ -1,0 +1,3 @@
+_: {
+  crossover-basic-configuration = ./basic-configuration.nix;
+}


### PR DESCRIPTION
### Description

Add a module for CodeWeavers CrossOver, repackaged from the Fedora rpm with the fixes needed to run on NixOS:

- Python/GTK3 GUI and perl launchers with their interpreters on PATH,
- dlopen()ed host libraries on the Wine RUNPATH, 64- and 32-bit,
- libcapi20.so.3 / libpcap.so.0.8 compat libraries,
- licensing: license files in the user's cellar, bridged to Wine's own demo check; declarative licensing via programs.crossover.license,
- desktop shortcuts rewritten to invoke wine-crossover on $PATH so they survive store-path changes.

Co-authored-by: shymega (1334592)
Assisted-by: Claude Code (claude-sonnet-5)
Assisted-by: OpenCode (deepseek-v4-flash-0731)

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
