### PR TITLE
ci: do not publish GH pages in forks

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -6,7 +6,9 @@ on:
   workflow_dispatch:
 jobs:
   publish:
-    if: github.event_name != 'schedule' || github.repository_owner == 'nix-community'
+    if: github.repository_owner == 'nix-community'
+        || github.event_name == 'workflow_dispatch'
+        || vars.PUBLISH_GITHUB_PAGES_ON_PUSH == 'true'
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
### Description

Fixes the condition so that github_pages.yml only runs in the nix-community/home-manager repository or in forks via the `workflow_dispatch` event.

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
