### PR TITLE
easyeffects: add PipeWire unit dependencies

### DIFF
--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -270,8 +270,15 @@ in
     systemd.user.services.easyeffects = {
       Unit = {
         Description = "Easyeffects daemon";
-        After = [ "graphical-session.target" ];
-        PartOf = [ "graphical-session.target" ];
+        After = [
+          "graphical-session.target"
+          "pipewire.service"
+        ];
+        Wants = [ "pipewire.service" ];
+        PartOf = [
+          "graphical-session.target"
+          "pipewire.service"
+        ];
         X-Restart-Triggers = [ (builtins.hashString "sha256" (builtins.toJSON cfg.settings)) ];
       };
 
@@ -283,6 +290,7 @@ in
             "${cfg.package}/bin/easyeffects --gapplication-service ${presetOpts}"
           else
             "${cfg.package}/bin/easyeffects --hide-window --service-mode ${presetOpts}";
+        Environment = lib.optional (!olderThan8) "QT_QPA_PLATFORM=wayland;xcb;offscreen";
         ExecStop = "${cfg.package}/bin/easyeffects --quit";
         KillMode = "mixed";
         Restart = "on-failure";

--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -270,8 +270,15 @@ in
     systemd.user.services.easyeffects = {
       Unit = {
         Description = "Easyeffects daemon";
-        After = [ "graphical-session.target" ];
-        PartOf = [ "graphical-session.target" ];
+        After = [
+          "graphical-session.target"
+          "pipewire.service"
+        ];
+        Wants = [ "pipewire.service" ];
+        PartOf = [
+          "graphical-session.target"
+          "pipewire.service"
+        ];
         X-Restart-Triggers = [ (builtins.hashString "sha256" (builtins.toJSON cfg.settings)) ];
       };
 


### PR DESCRIPTION
Add `pipewire.service` to `After`, `Wants`, and `PartOf` systemd unit configurations to ensure EasyEffects starts after PipeWire and restarts/stops cleanly alongside PipeWire.

Set `QT_QPA_PLATFORM=wayland;xcb;offscreen` environment variable conditionally for EasyEffects 8.0+ (Qt6). This provides a fallback platform backend for Qt without affecting older GTK-based releases (<8.0.0), preventing Qt from aborting with `qFatal` when started prior to or without an active display server connection.

### Description
This PR improves the reliability of `services.easyeffects` and resolves crash/coredump issues when starting the service during login or display server restarts.

On systems using EasyEffects 8.0+ (Qt6), `easyeffects.service` usually starts before the display server was fully initialized, which resulted in process crashes (`SIGABRT` / core dumps) with the following journal error:
```text
    easyeffects[6250]: could not connect to display
    easyeffects[6250]: Could not load the Qt platform plugin "xcb" in "" even though it was
  found.
    easyeffects[6250]: This application failed to start because no Qt platform plugin could
  be initialized.
    Stack trace:
      #3  0x00007f5f874d1382 _Z6qAbortv (libQt6Core.so.6)
      #5  0x00007f5f874d2b9a _ZNK14QMessageLogger5fatalEPKcz (libQt6Core.so.6)
      #6  0x00007f5f87d49827 _ZL13init_platform... (libQt6Gui.so.6)
      #7  0x00007f5f87e0a572 _ZN22QGuiApplicationPrivate25createPlatformIntegrationEv...
 ```
Changes I made to fix said issue:
1. Setted QT_QPA_PLATFORM=wayland;xcb;offscreen in the service environment for EasyEffects (Qt6). When started prior to display server readiness or in headless environments, Qt falls back to offscreen instead of invoking qFatal() and crashing with SIGABRT.
2. Added pipewire.service to After, Wants, and PartOf systemd unit options. This guarantees EasyEffects starts after PipeWire is ready and stops/restarts cleanly alongside PipeWire.

Noticed this while investigating why my machine suddenly freeze at seemingly random. So I had thought, maybe this is the culprit. Not sure yet. But still something fixed for others.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
