### PR TITLE
home-manager-auto-upgrade: respect nix.package

### DIFF
--- a/modules/services/home-manager-auto-upgrade.nix
+++ b/modules/services/home-manager-auto-upgrade.nix
@@ -11,6 +11,9 @@ let
 
   homeManagerPackage = config.programs.home-manager.package;
 
+  nixPackage =
+    if config.nix.enable && config.nix.package != null then config.nix.package else pkgs.nix;
+
   preSwitchCommandsStateVersion = lib.hm.deprecations.mkStateVersionOptionDefault {
     inherit (config.home) stateVersion;
     inherit config options;
@@ -44,9 +47,9 @@ let
   autoUpgradeApp = pkgs.writeShellApplication {
     name = "home-manager-auto-upgrade";
 
-    runtimeInputs = with pkgs; [
+    runtimeInputs = [
       homeManagerPackage
-      nix
+      nixPackage
     ];
 
     text =

--- a/tests/modules/services/home-manager-auto-upgrade/default.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/default.nix
@@ -5,4 +5,5 @@ lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   home-manager-auto-upgrade-current-flake-configuration = ./current-flake-configuration.nix;
   home-manager-auto-upgrade-deprecated-flake-configuration = ./deprecated-flake-configuration.nix;
   home-manager-auto-upgrade-flake-configuration = ./flake-configuration.nix;
+  home-manager-auto-upgrade-nix-package = ./nix-package.nix;
 }

--- a/tests/modules/services/home-manager-auto-upgrade/nix-package.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/nix-package.nix
@@ -1,0 +1,18 @@
+{ config, ... }:
+
+{
+  nix.package = config.lib.test.mkStubPackage { name = "my-test-nix"; };
+
+  services.home-manager.autoUpgrade = {
+    enable = true;
+    frequency = "daily";
+  };
+
+  nmt.script = ''
+    serviceFile="home-files/.config/systemd/user/home-manager-auto-upgrade.service"
+    assertFileExists "$serviceFile"
+
+    scriptPath=$(grep -oP 'ExecStart=\K.+' "$TESTED/$serviceFile")
+    assertFileRegex "$scriptPath" "my-test-nix"
+  '';
+}


### PR DESCRIPTION
### Description

The generated `home-manager-auto-upgrade` script takes its `nix` from
`pkgs.nix` regardless of `nix.package`:

```nix
runtimeInputs = with pkgs; [
  homeManagerPackage
  nix
];
```

So a configuration that sets an alternative Nix runs the *scheduled* upgrade
with a different implementation than everything else the module system
generates, and pulls a second Nix into the closure.

`modules/services/nix-gc.nix` already resolves this correctly, so this applies
the same pattern rather than inventing one:

```nix
nixPackage =
  if config.nix.enable && config.nix.package != null then config.nix.package else pkgs.nix;
```

Found on a standalone home-manager host (Debian) with `nix.package = pkgs.lix`
and a Lix daemon — the generated unit baked in `nix-2.34.8`. With the change,
the same config produces `lix-2.95.2`. It is not a functional break, since the
implementations interoperate over the daemon protocol, but it is silent and it
defeats the purpose of setting the option.

The added test sets `nix.package` to a stub and asserts the generated script
references it; it fails on `master` and passes with the fix.

### Checklist

- [x] Change is backwards compatible.

  `nix.package` defaults to `null`, which still falls back to `pkgs.nix`. The
  four pre-existing `home-manager-auto-upgrade` tests pass unchanged.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

  `nix run .#tests -- home-manager-auto-upgrade` — 5/5 pass.

- [x] Test cases updated/added.

  `tests/modules/services/home-manager-auto-upgrade/nix-package.nix`.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```
