### PR TITLE
secretspec: init

### DIFF
--- a/modules/misc/news/2026/08/2026-08-03_17-00-29.nix
+++ b/modules/misc/news/2026/08/2026-08-03_17-00-29.nix
@@ -1,0 +1,9 @@
+_: {
+  time = "2026-08-03T15:00:29+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.secretspec'.
+
+    Secretspec is a declarative interface for every secret provider. The module supports configuration via `programs.secretspec.settings`.
+  '';
+}

--- a/modules/programs/secretspec.nix
+++ b/modules/programs/secretspec.nix
@@ -1,0 +1,50 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+
+  cfg = config.programs.secretspec;
+  tomlFormat = pkgs.formats.toml { };
+
+in
+{
+  meta.maintainers = [ lib.maintainers.yethal ];
+
+  options.programs.secretspec = {
+    enable = lib.mkEnableOption "secretspec";
+
+    package = lib.mkPackageOption pkgs "secretspec" { nullable = true; };
+
+    settings = lib.mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = {
+        defaults = {
+          provider = "keyring";
+          profile = "default";
+          providers = {
+            dotenv = "dotenv://";
+          };
+        };
+      };
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/secretspec/config.toml`.
+
+        See <https://secretspec.dev/reference/cli/#config-global-show> for
+        available options and documentation.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."secretspec/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "config.toml" cfg.settings;
+    };
+  };
+}

--- a/modules/programs/secretspec.nix
+++ b/modules/programs/secretspec.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+
+  cfg = config.programs.secretspec;
+  tomlFormat = pkgs.formats.toml { };
+
+in
+{
+  meta.maintainers = [ lib.maintainers.yethal ];
+
+  options.programs.secretspec = {
+    enable = lib.mkEnableOption "secretspec";
+
+    package = lib.mkPackageOption pkgs "secretspec" { nullable = true; };
+
+    settings = lib.mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = {
+        provider = "keyring";
+        profile = "default";
+        providers = {
+          dotenv = "dotenv://";
+        };
+      };
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/secretspec/config.toml`.
+
+        See <https://secretspec.dev/reference/cli/#config-global-show> for
+        available options and documentation.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."secretspec/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "config.toml" { defaults = cfg.settings; }; # per-user secretspec configuration nests all settings under "global" key
+    };
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -182,6 +182,7 @@ let
     "sapling"
     "sbt"
     "scmpuff"
+    "secretspec"
     "senpai"
     "sftpman"
     "sioyek"

--- a/tests/modules/programs/secretspec/default.nix
+++ b/tests/modules/programs/secretspec/default.nix
@@ -1,0 +1,1 @@
+{ secretspec = ./secretspec.nix; }

--- a/tests/modules/programs/secretspec/expected.toml
+++ b/tests/modules/programs/secretspec/expected.toml
@@ -1,0 +1,10 @@
+[audit]
+enabled = false
+
+[defaults]
+profile = "default"
+provider = "keyring"
+
+[defaults.providers]
+aws = "awssm://"
+dotenv = "dotenv://"

--- a/tests/modules/programs/secretspec/expected.toml
+++ b/tests/modules/programs/secretspec/expected.toml
@@ -1,0 +1,7 @@
+[defaults]
+profile = "default"
+provider = "keyring"
+
+[defaults.providers]
+aws = "awssm://"
+dotenv = "dotenv://"

--- a/tests/modules/programs/secretspec/secretspec.nix
+++ b/tests/modules/programs/secretspec/secretspec.nix
@@ -1,0 +1,21 @@
+{
+  programs.secretspec = {
+    enable = true;
+    settings = {
+      defaults = {
+        provider = "keyring";
+        profile = "default";
+        providers = {
+          dotenv = "dotenv://";
+          aws = "awssm://";
+        };
+      };
+      audit.enabled = false;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/secretspec/config.toml
+    assertFileContent home-files/.config/secretspec/config.toml ${./expected.toml}
+  '';
+}

--- a/tests/modules/programs/secretspec/secretspec.nix
+++ b/tests/modules/programs/secretspec/secretspec.nix
@@ -1,0 +1,18 @@
+{
+  programs.secretspec = {
+    enable = true;
+    settings = {
+      provider = "keyring";
+      profile = "default";
+      providers = {
+        dotenv = "dotenv://";
+        aws = "awssm://";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/secretspec/config.toml
+    assertFileContent home-files/.config/secretspec/config.toml ${./expected.toml}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
