### PR TITLE
claude-code: allow hooks to accept a path like skills/commands

### DIFF
--- a/modules/programs/claude-code/lib.nix
+++ b/modules/programs/claude-code/lib.nix
@@ -6,7 +6,8 @@ in
   mkHelpers =
     { configDir }:
     let
-      mkSourceEntry = content: if lib.isPath content then { source = content; } else { text = content; };
+      mkSourceEntry =
+        content: if lib.hm.strings.isPathLike content then { source = content; } else { text = content; };
 
       mkMarketplaceEntry = _name: content: {
         source = {
@@ -22,10 +23,7 @@ in
         attrs:
         lib.mapAttrs' (
           name: content:
-          lib.nameValuePair "${configDir}/hooks/${name}" {
-            text = content;
-            executable = true;
-          }
+          lib.nameValuePair "${configDir}/hooks/${name}" ((mkSourceEntry content) // { executable = true; })
         ) attrs;
 
       mkInstalledMarketplaceEntry =

--- a/modules/programs/claude-code/options.nix
+++ b/modules/programs/claude-code/options.nix
@@ -278,25 +278,24 @@ in
       '';
     };
 
-    hooks = mkOption {
-      type = lib.types.attrsOf lib.types.lines;
-      default = { };
+    hooks = mkContentOption {
       description = ''
         Custom hooks for Claude Code.
-        The attribute name becomes the hook filename, and the value is the hook script content.
+        The attribute name becomes the hook filename, and the value is either:
+        - Inline content as a string
+        - A path to a file containing the hook script content
         Hooks are stored in the {file}`hooks/` subdirectory of
-        {option}`programs.claude-code.configDir`.
+        {option}`programs.claude-code.configDir` and made executable.
       '';
-      example = {
-        pre-edit = ''
-          #!/usr/bin/env bash
-          echo "About to edit file: $1"
-        '';
-        post-commit = ''
-          #!/usr/bin/env bash
-          echo "Committed with message: $1"
-        '';
-      };
+      example = literalExpression ''
+        {
+          pre-edit = '''
+            #!/usr/bin/env bash
+            echo "About to edit file: $1"
+          ''';
+          post-commit = ./hooks/post-commit.sh;
+        }
+      '';
     };
 
     rules = mkContentOption {

--- a/tests/modules/programs/claude-code/default.nix
+++ b/tests/modules/programs/claude-code/default.nix
@@ -21,6 +21,7 @@
   claude-code-skills-subdir = ./skills-subdir.nix;
   claude-code-agents-path = ./agents-path.nix;
   claude-code-commands-path = ./commands-path.nix;
+  claude-code-hooks-path = ./hooks-path.nix;
   claude-code-skills-path = ./skills-path.nix;
   claude-code-legacy-memory-text = ./legacy-memory-text.nix;
   claude-code-legacy-memory-source-and-skills-dir = ./legacy-memory-source-and-skills-dir.nix;

--- a/tests/modules/programs/claude-code/hooks-path.nix
+++ b/tests/modules/programs/claude-code/hooks-path.nix
@@ -1,0 +1,34 @@
+{ pkgs, ... }:
+let
+  derivation-hook = pkgs.writeShellScript "derivation-hook" ''
+    echo "About to edit file: $1"
+  '';
+in
+{
+  programs.claude-code = {
+    enable = true;
+    hooks = {
+      inline-hook = ''
+        #!/usr/bin/env bash
+        echo "About to edit file: $1"
+      '';
+      test-hook = ./hooks/test-hook;
+      inherit derivation-hook;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.claude/hooks/inline-hook
+    assertFileIsExecutable home-files/.claude/hooks/inline-hook
+
+    assertFileExists home-files/.claude/hooks/test-hook
+    assertFileIsExecutable home-files/.claude/hooks/test-hook
+    assertFileContent home-files/.claude/hooks/test-hook \
+      ${./hooks/test-hook}
+
+    assertFileExists home-files/.claude/hooks/derivation-hook
+    assertFileIsExecutable home-files/.claude/hooks/derivation-hook
+    assertFileContent home-files/.claude/hooks/derivation-hook \
+      ${derivation-hook}
+  '';
+}

--- a/tests/modules/programs/claude-code/mixed-content.nix
+++ b/tests/modules/programs/claude-code/mixed-content.nix
@@ -31,6 +31,13 @@
       '';
       path-skill = ./test-skill.md;
     };
+    hooks = {
+      inline-hook = ''
+        #!/usr/bin/env bash
+        echo "This hook is defined inline."
+      '';
+      path-hook = ./hooks/test-hook;
+    };
   };
 
   nmt.script = ''
@@ -40,6 +47,8 @@
     assertFileExists home-files/.claude/agents/path-agent.md
     assertFileExists home-files/.claude/skills/inline-skill/SKILL.md
     assertFileExists home-files/.claude/skills/path-skill/SKILL.md
+    assertFileExists home-files/.claude/hooks/inline-hook
+    assertFileExists home-files/.claude/hooks/path-hook
 
     assertFileContent home-files/.claude/commands/path-command.md \
       ${./test-command.md}
@@ -47,5 +56,9 @@
       ${./test-agent.md}
     assertFileContent home-files/.claude/skills/path-skill/SKILL.md \
       ${./test-skill.md}
+    assertFileContent home-files/.claude/hooks/path-hook \
+      ${./hooks/test-hook}
+    assertFileIsExecutable home-files/.claude/hooks/inline-hook
+    assertFileIsExecutable home-files/.claude/hooks/path-hook
   '';
 }


### PR DESCRIPTION
### Description

`programs.claude-code.hooks` now accepts a path to a file in addition to inline content, matching `agents`, `commands`, and `rules`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
