### PR TITLE
kanata: init service

### DIFF
--- a/modules/misc/news/2026/04/2026-04-22_17-25-11.nix
+++ b/modules/misc/news/2026/04/2026-04-22_17-25-11.nix
@@ -1,0 +1,7 @@
+{
+  time = "2026-04-22T17:25:11+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'services.kanata'.
+  '';
+}

--- a/modules/services/kanata/darwin.nix
+++ b/modules/services/kanata/darwin.nix
@@ -1,0 +1,55 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.kanata;
+
+  allKeyboards = cfg.keyboards // lib.optionalAttrs (cfg.default != null) { default = cfg.default; };
+
+  effectiveConfigFile =
+    name: kbd:
+    if kbd.configFile != null then
+      toString kbd.configFile
+    else
+      "${config.xdg.configHome}/kanata/${name}.kbd";
+
+  mkProgramArguments =
+    name: kbd:
+    [
+      (lib.getExe cfg.package)
+      "--cfg"
+      (effectiveConfigFile name kbd)
+      "--nodelay"
+      "--no-wait"
+    ]
+    ++ lib.optionals (kbd.port != null) [
+      "--port"
+      (toString kbd.port)
+    ]
+    ++ kbd.extraArgs;
+in
+{
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.isDarwin) {
+
+    launchd.agents = lib.mapAttrs' (
+      name: kbd:
+      lib.nameValuePair "kanata-${name}" {
+        enable = true;
+        config = {
+          ProgramArguments = mkProgramArguments name kbd;
+          KeepAlive = {
+            Crashed = true;
+            SuccessfulExit = false;
+          };
+          RunAtLoad = true;
+          ProcessType = "Interactive";
+        };
+      }
+    ) allKeyboards;
+
+  };
+}

--- a/modules/services/kanata/darwin.nix
+++ b/modules/services/kanata/darwin.nix
@@ -8,7 +8,7 @@
 let
   cfg = config.services.kanata;
 
-  allKeyboards = cfg.keyboards // lib.optionalAttrs (cfg.default != null) { default = cfg.default; };
+  allKeyboards = cfg.keyboards // lib.optionalAttrs (cfg.default != null) { inherit (cfg) default; };
 
   effectiveConfigFile =
     name: kbd:

--- a/modules/services/kanata/default.nix
+++ b/modules/services/kanata/default.nix
@@ -1,0 +1,179 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  hmConfig = config;
+  cfg = config.services.kanata;
+
+  kanataLib = import ./lib.nix { inherit lib pkgs; };
+  inherit (kanataLib) mkKanataConfigText allDevices;
+  inherit
+    (import ./submodules.nix {
+      inherit
+        lib
+        pkgs
+        hmConfig
+        ;
+    })
+    keyboardSubmodule
+    defaultSubmodule
+    ;
+
+  allKeyboards = cfg.keyboards // lib.optionalAttrs (cfg.default != null) { default = cfg.default; };
+in
+{
+  meta.maintainers = with lib.maintainers; [ philocalyst ];
+
+  imports = [
+    ./linux.nix
+    ./darwin.nix
+  ];
+
+  options.services.kanata = {
+
+    enable = lib.mkEnableOption "kanata, a software keyboard remapper";
+
+    package = lib.mkPackageOption pkgs "kanata" {
+      extraDescription = ''
+        ::: {.note}
+        Use `pkgs.kanata-with-cmd` if `danger-enable-cmd yes` appears in any
+        keyboard's {option}`extraDefCfg`.
+        :::
+      '';
+    };
+
+    keyboards = lib.mkOption {
+      type = lib.types.attrsOf keyboardSubmodule;
+      default = { };
+      description = ''
+        Tier 1 per-keyboard remap configurations, keyed by an arbitrary name.
+        Each entry runs as its own kanata service instance and exposes a
+        virtual uinput device at {option}`symlinkPath`.
+
+        On Linux, use {option}`deviceIds` to specify physical keyboards by the
+        ID portion of their {file}`/dev/input/by-id/` path:
+
+        ```nix
+        services.kanata.keyboards.remap_HHKB = {
+          deviceIds = [ "usb-PFU_Limited_HHKB-event-kbd" ];
+          processUnmappedKeys = true;
+          defsrc = [ "muhenkan" "henkan" "kana" ];
+          layers.base = [ "f13" "f14" "f15" ];
+        };
+        ```
+
+        ::: {.note}
+        On Linux the user must belong to the `input` and `uinput` groups.
+        In NixOS, set `hardware.uinput.enable = true`.
+        :::
+
+        ::: {.note}
+        No udev rule or restart-on-hotplug unit is needed: kanata's own Linux
+        input backend watches `/dev/input` (via inotify) and automatically
+        reopens a configured device -- including a {option}`symlinkPath` a
+        Tier 1 keyboard depends on -- if it disappears and later reappears
+        under the same path, without the service ever exiting or restarting.
+        `Restart = "on-failure"` on the generated systemd unit is only a
+        crash-recovery safety net, not part of hot-plug handling.
+        :::
+      '';
+    };
+
+    default = lib.mkOption {
+      type = lib.types.nullOr defaultSubmodule;
+      default = null;
+      description = ''
+        Tier 2 main kanata configuration. Runs as a dedicated service
+        named `kanata-default`.
+
+        On Linux, {option}`devices` defaults to the {option}`symlinkPath`
+        of every entry in {option}`keyboards`, so this config automatically
+        reads from all Tier 1 virtual devices without any manual wiring:
+
+        ```nix
+        services.kanata = {
+          enable = true;
+
+          keyboards.remap_HHKB = {
+            deviceIds = [ "usb-PFU_Limited_HHKB-event-kbd" ];
+            processUnmappedKeys = true;
+            defsrc = [ "muhenkan" "henkan" "kana" ];
+            layers.base = [ "f13" "f14" "f15" ];
+          };
+
+          default = {
+            defsrc = [ "caps" "a" "s" "d" "f" "f13" "f14" "f15" ];
+            layers.base = [ "@cap" "a" "s" "d" "f" "esc" "ret" "spc" ];
+            extraConfig = "(defalias cap (tap-hold 200 200 caps lctl))";
+          };
+        };
+        ```
+
+        Set to `null` (the default) if you do not need a Tier 2 config.
+      '';
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion = cfg.keyboards != { } || cfg.default != null;
+        message = "services.kanata: define at least one keyboard in `keyboards` or set `default`.";
+      }
+      {
+        assertion = lib.all (n: !(lib.hasInfix " " n)) (lib.attrNames cfg.keyboards);
+        message = "services.kanata: keyboard names must not contain spaces.";
+      }
+      {
+        # kanata's `defsrc`/`deflayer` grammar has no quoting mechanism for
+        # names/keys
+        assertion =
+          let
+            hasBadChar =
+              s:
+              lib.any (c: lib.hasInfix c s) [
+                " "
+                "\t"
+                "\n"
+                "("
+                ")"
+                "\""
+              ];
+          in
+          lib.all (kbd: !(lib.any hasBadChar (kbd.defsrc ++ lib.attrNames kbd.layers))) (
+            lib.attrValues allKeyboards
+          );
+        message = ''
+          services.kanata: `defsrc` key names and `layers` names must each be
+          a single bare token with no whitespace, parentheses, or quotes
+        '';
+      }
+      {
+        assertion = lib.all (kbd: lib.all (d: !(lib.hasInfix "\"" d)) (allDevices kbd)) (
+          lib.attrValues allKeyboards
+        );
+        message = ''
+          services.kanata: `devices`/`deviceIds` entries must not contain a
+          literal `"` character -- kanata's config string syntax has no
+          escape mechanism for embedded quotes.
+        '';
+      }
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = lib.mapAttrs' (
+      name: kbd:
+      lib.nameValuePair "kanata/${name}.kbd" {
+        text = mkKanataConfigText name kbd;
+      }
+    ) (lib.filterAttrs (_: kbd: kbd.configFile == null) allKeyboards);
+
+  };
+}

--- a/modules/services/kanata/default.nix
+++ b/modules/services/kanata/default.nix
@@ -23,7 +23,7 @@ let
     defaultSubmodule
     ;
 
-  allKeyboards = cfg.keyboards // lib.optionalAttrs (cfg.default != null) { default = cfg.default; };
+  allKeyboards = cfg.keyboards // lib.optionalAttrs (cfg.default != null) { inherit (cfg) default; };
 in
 {
   meta.maintainers = with lib.maintainers; [ philocalyst ];

--- a/modules/services/kanata/lib.nix
+++ b/modules/services/kanata/lib.nix
@@ -1,0 +1,52 @@
+{ lib, pkgs }:
+
+let
+  allDevices =
+    kbd:
+    kbd.devices ++ lib.optionals pkgs.stdenv.isLinux (map (id: "/dev/input/by-id/${id}") kbd.deviceIds);
+
+  mkDefcfg =
+    _name: kbd:
+    let
+      devs = allDevices kbd;
+      quoted = lib.concatMapStringsSep " " (d: "\"${d}\"") devs;
+      devicesLine =
+        if devs != [ ] then
+          if pkgs.stdenv.isLinux then "linux-dev (${quoted})" else "macos-dev-names-include (${quoted})"
+        else
+          "";
+      lines = lib.filter (s: s != "") [
+        devicesLine
+        (lib.optionalString (
+          pkgs.stdenv.isLinux && kbd.continueIfNoDevsFound
+        ) "linux-continue-if-no-devs-found yes")
+        (lib.optionalString kbd.processUnmappedKeys "process-unmapped-keys yes")
+        kbd.extraDefCfg
+      ];
+    in
+    "(defcfg\n  ${lib.concatStringsSep "\n  " lines}\n)";
+
+  mkDefsrc = keys: "(defsrc\n  ${lib.concatStringsSep "\n  " keys}\n)";
+
+  mkLayers =
+    layers:
+    lib.concatStringsSep "\n\n" (
+      lib.mapAttrsToList (
+        layerName: actions: "(deflayer ${layerName}\n  ${lib.concatStringsSep " " actions}\n)"
+      ) layers
+    );
+
+  mkKanataConfigText =
+    name: kbd:
+    lib.concatStringsSep "\n\n" (
+      [ (mkDefcfg name kbd) ]
+      ++ lib.optional (kbd.defsrc != [ ]) (mkDefsrc kbd.defsrc)
+      ++ lib.optional (kbd.layers != { }) (mkLayers kbd.layers)
+      ++ lib.optional (kbd.extraConfig != "") kbd.extraConfig
+    )
+    + "\n";
+
+in
+{
+  inherit mkKanataConfigText allDevices;
+}

--- a/modules/services/kanata/linux.nix
+++ b/modules/services/kanata/linux.nix
@@ -1,0 +1,102 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.kanata;
+
+  # Merge `default` into the keyboard map so we can iterate over both uniformly.
+  allKeyboards = cfg.keyboards // lib.optionalAttrs (cfg.default != null) { default = cfg.default; };
+
+  effectiveConfigFile =
+    name: kbd:
+    if kbd.configFile != null then
+      toString kbd.configFile
+    else
+      "${config.xdg.configHome}/kanata/${name}.kbd";
+
+  mkExecStart =
+    name: kbd:
+    lib.concatStringsSep " " (
+      [
+        (lib.getExe cfg.package)
+        "--cfg"
+        (effectiveConfigFile name kbd)
+        "--nodelay"
+        "--no-wait"
+        "--symlink-path"
+        kbd.symlinkPath
+      ]
+      ++ lib.optionals (kbd.port != null) [
+        "--port"
+        (toString kbd.port)
+      ]
+      ++ kbd.extraArgs
+    );
+
+in
+{
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+
+    # Ensure the directory kanata writes its virtual-device symlinks into exists.
+    systemd.user.tmpfiles.rules = [
+      "d ${config.xdg.stateHome}/kanata 0750 - - - -"
+    ];
+
+    systemd.user.services = lib.mapAttrs' (
+      name: kbd:
+      lib.nameValuePair "kanata-${name}" {
+        Unit = {
+          Description = "kanata keyboard remapper — ${name}";
+          Documentation = [ "https://github.com/jtroo/kanata" ];
+          After = lib.optional (kbd.port != null) "network.target";
+        };
+
+        Service = {
+          ExecStart = mkExecStart name kbd;
+          Restart = "on-failure";
+          RestartSec = 3;
+
+          # Harden to the max: grant only the two device classes kanata needs.
+          # The user must be in the `input` and `uinput` groups so the
+          # kernel honours the DeviceAllow entries below.
+          CapabilityBoundingSet = "";
+          DeviceAllow = [
+            "/dev/uinput rw"
+            "char-input r"
+          ];
+          DevicePolicy = "closed";
+          IPAddressDeny = [ "any" ];
+          IPAddressAllow = lib.optional (kbd.port != null) "localhost";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          PrivateNetwork = kbd.port == null;
+          PrivateTmp = true;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectProc = "invisible";
+          RestrictAddressFamilies = [ "AF_UNIX" ] ++ lib.optional (kbd.port != null) "AF_INET";
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = [ "native" ];
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+            "~@resources"
+          ];
+          UMask = "0077";
+        };
+
+        Install.WantedBy = [ "default.target" ];
+      }
+    ) allKeyboards;
+
+  };
+}

--- a/modules/services/kanata/linux.nix
+++ b/modules/services/kanata/linux.nix
@@ -9,7 +9,7 @@ let
   cfg = config.services.kanata;
 
   # Merge `default` into the keyboard map so we can iterate over both uniformly.
-  allKeyboards = cfg.keyboards // lib.optionalAttrs (cfg.default != null) { default = cfg.default; };
+  allKeyboards = cfg.keyboards // lib.optionalAttrs (cfg.default != null) { inherit (cfg) default; };
 
   effectiveConfigFile =
     name: kbd:

--- a/modules/services/kanata/submodules.nix
+++ b/modules/services/kanata/submodules.nix
@@ -1,0 +1,175 @@
+{
+  lib,
+  pkgs,
+  hmConfig,
+}:
+
+let
+  commonOptions = {
+
+    devices = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Full input device paths (Linux: {file}`/dev/input/by-id/…`, or a
+        {option}`symlinkPath` from another keyboard) or device name substrings
+        (macOS). Prefer {option}`deviceIds` for physical keyboards on Linux.
+        An empty list lets kanata auto-detect all keyboards.
+      '';
+    };
+
+    deviceIds = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "usb-PFU_Limited_HHKB_Professional_JP-event-kbd" ];
+      description = ''
+        Physical keyboard IDs as listed under {file}`/dev/input/by-id/`.
+        The {file}`/dev/input/by-id/` prefix is added automatically.
+        Linux only; ignored on macOS (use {option}`devices` there instead).
+      '';
+    };
+
+    continueIfNoDevsFound = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Do not exit when no matching input devices are found at startup.
+        Useful when the keyboard may not be connected yet (e.g. Tier 2
+        configs waiting for Tier 1 virtual-device symlinks).
+      '';
+    };
+
+    processUnmappedKeys = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Pass keys not listed in `defsrc` through unchanged. Enable on
+        Tier 1 remap keyboards so only the bridging keys are intercepted.
+      '';
+    };
+
+    defsrc = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "caps"
+        "a"
+        "s"
+        "d"
+        "f"
+      ];
+      description = "Keys to intercept, as kanata key names. Rendered as a `(defsrc …)` block.";
+    };
+
+    layers = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+      default = { };
+      example = lib.literalExpression ''{ base = [ "lctl" "a" "s" "d" "f" ]; }'';
+      description = ''
+        Layer definitions as `layer-name TO list-of-actions`. Each entry
+        becomes a `(deflayer name …)` block. Every layer must have the same
+        number of entries as `defsrc`. Layers are emitted in alphabetical
+        key order; name your base layer so it sorts first (e.g. `"base"`
+        or `"_default"`).
+      '';
+    };
+
+    extraConfig = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = ''
+        Raw kanata configuration appended after the generated blocks. Use
+        this for `defalias`, `defvar`, `deffakekeys`, etc.
+      '';
+    };
+
+    extraDefCfg = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      example = "danger-enable-cmd yes";
+      description = "Extra lines placed inside the `(defcfg …)` block.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.nullOr lib.types.port;
+      default = null;
+      example = 7070;
+      description = "TCP port for the kanata command server. `null` disables it (default).";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Extra command-line arguments passed verbatim to kanata.";
+    };
+
+    configFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a kanata configuration file. When set explicitly the
+        generated config (from `defsrc`, `layers`, `extraConfig`, etc.)
+        is ignored. When `null` (the default), a config file is generated
+        from the other options and written to
+        {file}`$XDG_CONFIG_HOME/kanata/<name>.kbd`.
+      '';
+    };
+
+  };
+
+in
+{
+  keyboardSubmodule = lib.types.submodule (
+    { name, ... }:
+    {
+      options = commonOptions // {
+
+        symlinkPath = lib.mkOption {
+          type = lib.types.str;
+          readOnly = true;
+          default = "${hmConfig.xdg.stateHome}/kanata/${name}";
+          defaultText = lib.literalMD "`\${config.xdg.stateHome}/kanata/<name>`";
+          description = ''
+            Path where kanata writes the virtual uinput device symlink on
+            Linux (via `--symlink-path`). Known at evaluation time, so it
+            can be referenced in {option}`services.kanata.default.devices`
+            or another keyboard's `devices` list.
+          '';
+        };
+
+      };
+    }
+  );
+
+  defaultSubmodule = lib.types.submodule (_: {
+    options = commonOptions // {
+
+      devices = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = lib.optionals pkgs.stdenv.isLinux (
+          lib.mapAttrsToList (_: kbd: kbd.symlinkPath) hmConfig.services.kanata.keyboards
+        );
+        defaultText = lib.literalMD "All `keyboards.*.symlinkPath` values (Linux only).";
+        description = ''
+          Full input device paths to monitor. Defaults to the virtual-device
+          symlinks of all {option}`keyboards` entries on Linux, which is the
+          correct setup for a Tier 2 config in a tiered multi-keyboard pipeline.
+
+          Override this if you need to monitor additional or different devices.
+        '';
+      };
+
+      symlinkPath = lib.mkOption {
+        type = lib.types.str;
+        readOnly = true;
+        default = "${hmConfig.xdg.stateHome}/kanata/default";
+        defaultText = lib.literalMD "`\${config.xdg.stateHome}/kanata/default`";
+        description = ''
+          Path where kanata writes the virtual uinput device symlink on Linux.
+          Provided for symmetry; rarely needed since `default` is Tier 2.
+        '';
+      };
+
+    };
+  });
+}

--- a/tests/modules/services/kanata/darwin/basic-expected.kbd
+++ b/tests/modules/services/kanata/darwin/basic-expected.kbd
@@ -1,0 +1,12 @@
+(defcfg
+  macos-dev-names-include ("Example Keyboard")
+)
+
+(defsrc
+  caps
+  a
+)
+
+(deflayer base
+  esc a
+)

--- a/tests/modules/services/kanata/darwin/basic-expected.plist
+++ b/tests/modules/services/kanata/darwin/basic-expected.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>KeepAlive</key>
+	<dict>
+		<key>Crashed</key>
+		<true/>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+	<key>Label</key>
+	<string>org.nix-community.home.kanata-main</string>
+	<key>ProcessType</key>
+	<string>Interactive</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sh</string>
+		<string>-c</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec @kanata@/bin/dummy --cfg /home/hm-user/.config/kanata/main.kbd --nodelay --no-wait</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/modules/services/kanata/darwin/basic.nix
+++ b/tests/modules/services/kanata/darwin/basic.nix
@@ -1,5 +1,4 @@
-{ pkgs, ... }:
-{
+_: {
   test.stubs.kanata = { };
 
   services.kanata = {

--- a/tests/modules/services/kanata/darwin/basic.nix
+++ b/tests/modules/services/kanata/darwin/basic.nix
@@ -1,0 +1,31 @@
+{ pkgs, ... }:
+{
+  test.stubs.kanata = { };
+
+  services.kanata = {
+    enable = true;
+    keyboards.main = {
+      devices = [ "Example Keyboard" ];
+      defsrc = [
+        "caps"
+        "a"
+      ];
+      layers.base = [
+        "esc"
+        "a"
+      ];
+    };
+  };
+
+  nmt.script = ''
+    plistFile="LaunchAgents/org.nix-community.home.kanata-main.plist"
+    assertFileExists "$plistFile"
+
+    plistFile="$(normalizeStorePaths "$plistFile")"
+    assertFileContent "$plistFile" ${./basic-expected.plist}
+
+    assertFileContent \
+      home-files/.config/kanata/main.kbd \
+      ${./basic-expected.kbd}
+  '';
+}

--- a/tests/modules/services/kanata/darwin/default.nix
+++ b/tests/modules/services/kanata/darwin/default.nix
@@ -1,0 +1,3 @@
+{
+  kanata-darwin-basic = ./basic.nix;
+}

--- a/tests/modules/services/kanata/default.nix
+++ b/tests/modules/services/kanata/default.nix
@@ -1,0 +1,3 @@
+{ lib, pkgs, ... }:
+(lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (import ./linux/default.nix))
+// (lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin (import ./darwin/default.nix))

--- a/tests/modules/services/kanata/linux/basic-expected.kbd
+++ b/tests/modules/services/kanata/linux/basic-expected.kbd
@@ -1,0 +1,18 @@
+(defcfg
+  linux-dev ("/dev/input/by-id/usb-Example_KB-event-kbd")
+  linux-continue-if-no-devs-found yes
+)
+
+(defsrc
+  caps
+  a
+  s
+  d
+  f
+)
+
+(deflayer base
+  @cap a s d f
+)
+
+(defalias cap (tap-hold 200 200 caps lctl))

--- a/tests/modules/services/kanata/linux/basic-expected.service
+++ b/tests/modules/services/kanata/linux/basic-expected.service
@@ -1,0 +1,35 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+CapabilityBoundingSet=
+DeviceAllow=/dev/uinput rw
+DeviceAllow=char-input r
+DevicePolicy=closed
+ExecStart=@kanata@/bin/kanata --cfg @home-manager-files@/.config/kanata/main.kbd --nodelay --no-wait --symlink-path @home-manager-files@/.local/state/kanata/main
+IPAddressDeny=any
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateNetwork=true
+PrivateTmp=true
+ProcSubset=pid
+ProtectClock=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectProc=invisible
+Restart=on-failure
+RestartSec=3
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+SystemCallFilter=~@resources
+UMask=0077
+
+[Unit]
+Description=kanata keyboard remapper — main
+Documentation=https://github.com/jtroo/kanata

--- a/tests/modules/services/kanata/linux/basic.nix
+++ b/tests/modules/services/kanata/linux/basic.nix
@@ -1,0 +1,38 @@
+{ pkgs, ... }:
+{
+  test.stubs.kanata = { };
+
+  services.kanata = {
+    enable = true;
+    keyboards.main = {
+      deviceIds = [ "usb-Example_KB-event-kbd" ];
+      defsrc = [
+        "caps"
+        "a"
+        "s"
+        "d"
+        "f"
+      ];
+      layers.base = [
+        "@cap"
+        "a"
+        "s"
+        "d"
+        "f"
+      ];
+      extraConfig = "(defalias cap (tap-hold 200 200 caps lctl))";
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/kanata-main.service
+    assertFileExists "$serviceFile"
+
+    serviceFile=$(normalizeStorePaths "$serviceFile")
+    assertFileContent "$serviceFile" ${./basic-expected.service}
+
+    assertFileContent \
+      home-files/.config/kanata/main.kbd \
+      ${./basic-expected.kbd}
+  '';
+}

--- a/tests/modules/services/kanata/linux/basic.nix
+++ b/tests/modules/services/kanata/linux/basic.nix
@@ -1,5 +1,4 @@
-{ pkgs, ... }:
-{
+_: {
   test.stubs.kanata = { };
 
   services.kanata = {

--- a/tests/modules/services/kanata/linux/custom-config-file.nix
+++ b/tests/modules/services/kanata/linux/custom-config-file.nix
@@ -1,0 +1,21 @@
+{ pkgs, ... }:
+{
+  test.stubs.kanata = { };
+
+  services.kanata = {
+    enable = true;
+    keyboards.custom = {
+      configFile = pkgs.writeText "my-kanata.kbd" ''
+        (defcfg linux-dev "/dev/input/by-id/usb-Example_KB-event-kbd")
+        (defsrc caps)
+        (deflayer base esc)
+      '';
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/kanata-custom.service
+    assertFileExists "$serviceFile"
+    assertFileRegex "$serviceFile" 'ExecStart=.*--cfg.*my-kanata\.kbd'
+  '';
+}

--- a/tests/modules/services/kanata/linux/default-only.nix
+++ b/tests/modules/services/kanata/linux/default-only.nix
@@ -1,0 +1,26 @@
+{ ... }:
+{
+  test.stubs.kanata = { };
+
+  # No `keyboards` entries — just a standalone `default` config.
+  services.kanata = {
+    enable = true;
+    default = {
+      deviceIds = [ "usb-Example_KB-event-kbd" ];
+      defsrc = [
+        "caps"
+        "a"
+      ];
+      layers.base = [
+        "esc"
+        "a"
+      ];
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/kanata-default.service
+    assertFileExists "$serviceFile"
+    assertFileRegex "$serviceFile" 'ExecStart=.*--symlink-path.*kanata/default'
+  '';
+}

--- a/tests/modules/services/kanata/linux/default-only.nix
+++ b/tests/modules/services/kanata/linux/default-only.nix
@@ -1,5 +1,4 @@
-{ ... }:
-{
+_: {
   test.stubs.kanata = { };
 
   # No `keyboards` entries — just a standalone `default` config.

--- a/tests/modules/services/kanata/linux/default.nix
+++ b/tests/modules/services/kanata/linux/default.nix
@@ -1,0 +1,6 @@
+{
+  kanata-linux-basic = ./basic.nix;
+  kanata-linux-tiered = ./tiered.nix;
+  kanata-linux-custom-config-file = ./custom-config-file.nix;
+  kanata-linux-default-only = ./default-only.nix;
+}

--- a/tests/modules/services/kanata/linux/tiered.nix
+++ b/tests/modules/services/kanata/linux/tiered.nix
@@ -1,0 +1,47 @@
+{ ... }:
+{
+  test.stubs.kanata = { };
+
+  services.kanata = {
+    enable = true;
+
+    keyboards.remap = {
+      deviceIds = [ "usb-Example_KB-event-kbd" ];
+      processUnmappedKeys = true;
+      defsrc = [
+        "muhenkan"
+        "henkan"
+      ];
+      layers.base = [
+        "f13"
+        "f14"
+      ];
+    };
+
+    # `default.devices` is auto-wired to keyboards.remap.symlinkPath on Linux.
+    default = {
+      defsrc = [
+        "caps"
+        "f13"
+        "f14"
+      ];
+      layers.base = [
+        "@cap"
+        "esc"
+        "ret"
+      ];
+      extraConfig = "(defalias cap (tap-hold 200 200 caps lctl))";
+    };
+  };
+
+  nmt.script = ''
+    remapService=home-files/.config/systemd/user/kanata-remap.service
+    defaultService=home-files/.config/systemd/user/kanata-default.service
+
+    assertFileExists "$remapService"
+    assertFileExists "$defaultService"
+
+    assertFileRegex "$remapService"  'ExecStart=.*--symlink-path.*kanata/remap'
+    assertFileRegex "$defaultService" 'ExecStart=.*--symlink-path.*kanata/default'
+  '';
+}

--- a/tests/modules/services/kanata/linux/tiered.nix
+++ b/tests/modules/services/kanata/linux/tiered.nix
@@ -1,5 +1,4 @@
-{ ... }:
-{
+_: {
   test.stubs.kanata = { };
 
   services.kanata = {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
