### PR TITLE
neverest: init module

### DIFF
--- a/modules/misc/news/2026/04/2026-04-22_17-23-04.nix
+++ b/modules/misc/news/2026/04/2026-04-22_17-23-04.nix
@@ -1,0 +1,13 @@
+{
+  time = "2026-04-22T17:23:04+00:00";
+  condition = true;
+  message = ''
+    Two new modules are available:
+
+      - 'programs.neverest' and
+      - 'services.neverest'.
+
+    Neverest is a CLI tool for synchronizing emails between a local
+    m2dir store and a remote IMAP or JMAP server.
+  '';
+}

--- a/modules/programs/neverest/accounts.nix
+++ b/modules/programs/neverest/accounts.nix
@@ -1,0 +1,72 @@
+{ lib, ... }:
+{
+  options.neverest = {
+    enable = lib.mkEnableOption "synchronization using Neverest";
+
+    poolSize = lib.mkOption {
+      type = lib.types.nullOr lib.types.ints.positive;
+      default = null;
+      example = 4;
+      description = ''
+        Maximum concurrent IMAP connections for this account.
+      '';
+    };
+
+    mailboxFilters = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.submodule {
+          options = {
+            include = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              example = [
+                "INBOX"
+                "Sent"
+              ];
+              description = "Mailboxes to include. Mutually exclusive with {option}`exclude`.";
+            };
+            exclude = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              example = [ "Spam" ];
+              description = "Mailboxes to exclude. Mutually exclusive with {option}`include`.";
+            };
+          };
+        }
+      );
+      default = null;
+      description = ''
+        Restrict which mailboxes neverest synchronizes.
+        Set {option}`include` or {option}`exclude`, not both.
+        When null, all mailboxes are synchronized.
+      '';
+    };
+
+    protectServer = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Set `right.folder.permissions.create/delete` and
+        `right.message.permissions.create/delete` to `false`, preventing
+        neverest from modifying mailboxes or messages on the remote
+        IMAP server. Useful when the server is the authoritative source.
+      '';
+    };
+
+    extraConfig = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      example = {
+        right.backend.watch.timeout = 1800;
+      };
+      description = ''
+        Extra configuration merged into this account's TOML section.
+        Keys must follow neverest's actual account schema (`default`,
+        `folder`, `envelope`, `left`, `right` — see the neverest and
+        email-lib source for the full shape); the top-level config and
+        account structs use `deny_unknown_fields`, so unrecognized keys
+        will make neverest fail to parse the config entirely.
+      '';
+    };
+  };
+}

--- a/modules/programs/neverest/default.nix
+++ b/modules/programs/neverest/default.nix
@@ -1,0 +1,179 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.neverest;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = [ lib.maintainers.philocalyst ];
+
+  options = {
+    programs.neverest = {
+      enable = lib.mkEnableOption "synchronization using Neverest";
+      package = lib.mkPackageOption pkgs "neverest" { };
+    };
+
+    accounts.email.accounts = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule (import ./accounts.nix));
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    let
+      enabledAccounts = lib.filterAttrs (
+        _: a: a.enable && a.neverest.enable
+      ) config.accounts.email.accounts;
+
+      useXdg = !pkgs.stdenv.hostPlatform.isDarwin || config.home.preferXdgDirectories;
+
+      # Neverest's real TOML schema (verified against email-lib 0.24.0 /
+      # neverest 1.0.0-beta serde structs) is:
+      #
+      #   [accounts.<name>.folder]
+      #   filters = "all" | { include = [...] } | { exclude = [...] }
+      #
+      #   [accounts.<name>.left.backend]
+      #   type = "maildir"
+      #   root-dir = "..."
+      #
+      #   [accounts.<name>.right.backend]
+      #   type = "imap"
+      #   host = "..."
+      #   port = 993
+      #   encryption = "tls" | "start-tls" | "none"
+      #   login = "..."
+      #   [accounts.<name>.right.backend.passwd]
+      #   command = "shell command string"   # run via `sh -c`, NOT an argv list
+      #
+      #   [accounts.<name>.right.folder.permissions]
+      #   create = false
+      #   delete = false
+      #   [accounts.<name>.right.message.permissions]
+      #   create = false
+      #   delete = false
+      #
+      # There is no `pool-size`, `mailbox`, or `sasl.plain` key anywhere in
+      # the schema (Config/AccountConfig both use `deny_unknown_fields`, so
+      # any account-level field outside `default`/`folder`/`envelope`/`left`/
+      # `right` is a hard parse error, not silently ignored).
+      generatedConfig = tomlFormat.generate "config.toml" {
+        accounts = builtins.mapAttrs (
+          _: acc:
+          let
+            nv = acc.neverest;
+            tls = acc.imap.tls.enable;
+            port =
+              if acc.imap.port != null then
+                acc.imap.port
+              else if tls then
+                993
+              else
+                143;
+
+            encryption =
+              if !tls then
+                "none"
+              else if acc.imap.tls.useStartTls then
+                "start-tls"
+              else
+                "tls";
+
+            filters = nv.mailboxFilters;
+            folderFilters =
+              if filters == null then
+                null
+              else if filters.include != [ ] then
+                { inherit (filters) include; }
+              else if filters.exclude != [ ] then
+                { inherit (filters) exclude; }
+              else
+                null;
+
+            baseConfig = {
+              left.backend = {
+                type = "maildir";
+                "root-dir" = acc.maildir.absPath;
+              };
+              right.backend = {
+                type = "imap";
+                host = acc.imap.host;
+                inherit port encryption;
+                login = acc.userName;
+                # neverest's `passwd.command` is a single shell command line
+                # (executed via `sh -c`), not an argv array, so the
+                # word-split list from `accounts.email`'s passwordCommand
+                # must be re-quoted into one shell-safe string.
+                passwd.command = lib.escapeShellArgs acc.passwordCommand;
+              };
+            };
+          in
+          builtins.foldl' lib.recursiveUpdate baseConfig [
+            (lib.optionalAttrs (folderFilters != null) { folder.filters = folderFilters; })
+            (lib.optionalAttrs nv.protectServer {
+              right.folder.permissions = {
+                create = false;
+                delete = false;
+              };
+              right.message.permissions = {
+                create = false;
+                delete = false;
+              };
+            })
+            nv.extraConfig
+          ]
+        ) enabledAccounts;
+      };
+    in
+    {
+      assertions =
+        let
+          check =
+            cond: msg:
+            let
+              bad = builtins.attrNames (lib.filterAttrs (_: cond) enabledAccounts);
+            in
+            {
+              assertion = bad == [ ];
+              message = "neverest: ${msg}: ${builtins.concatStringsSep ", " bad}";
+            };
+        in
+        [
+          (check (a: a.maildir == null) "missing maildir configuration")
+          (check (a: a.imap == null) "missing IMAP configuration")
+          (check (a: a.passwordCommand == null) "missing passwordCommand")
+          (check (a: a.userName == null) "missing userName")
+          (check (
+            a:
+            let
+              f = a.neverest.mailboxFilters or { };
+            in
+            (f.include or [ ]) != [ ] && (f.exclude or [ ]) != [ ]
+          ) "mailboxFilters.include and exclude are mutually exclusive")
+        ];
+
+      home.packages = [ cfg.package ];
+
+      xdg.configFile."neverest/config.toml" = lib.mkIf useXdg {
+        source = generatedConfig;
+      };
+
+      home.file."Library/Application Support/neverest/config.toml" = lib.mkIf (!useXdg) {
+        source = generatedConfig;
+      };
+
+      home.activation = lib.mkIf (enabledAccounts != { }) {
+        createNeverestMaildir = lib.hm.dag.entryBetween [ "linkGeneration" ] [ "writeBoundary" ] ''
+          $DRY_RUN_CMD mkdir -m700 -p $VERBOSE_ARG ${
+            builtins.concatStringsSep " " (
+              map (a: lib.escapeShellArg a.maildir.absPath) (builtins.attrValues enabledAccounts)
+            )
+          }
+        '';
+      };
+    }
+  );
+}

--- a/modules/services/neverest/default.nix
+++ b/modules/services/neverest/default.nix
@@ -1,0 +1,118 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  meta.maintainers = [ lib.maintainers.philocalyst ];
+
+  options.services.neverest = {
+    enable = lib.mkEnableOption "neverest mail synchronization service";
+
+    frequency = lib.mkOption {
+      type = lib.types.str;
+      default = "hourly";
+      example = "*:0/5";
+      description = ''
+        The interval at which neverest is run.
+
+        On Linux this is passed to the systemd timer as {option}`OnCalendar`.
+        See {manpage}`systemd.time(7)` for the format.
+
+        ${lib.hm.darwin.intervalDocumentation}
+      '';
+    };
+
+    preExec = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      example = "mkdir -p ~/mail";
+      description = "Shell commands run before each neverest invocation.";
+    };
+
+    postExec = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      example = "\${pkgs.notmuch}/bin/notmuch new";
+      description = "Shell commands run after each successful neverest invocation.";
+    };
+  };
+
+  config = lib.mkIf config.services.neverest.enable (
+    let
+      cfg = config.services.neverest;
+
+      # We only need the names of the valid accounts for the script
+      accountNames = builtins.attrNames (
+        lib.filterAttrs (_: a: a.enable && a.neverest.enable) config.accounts.email.accounts
+      );
+
+      useXdg = !pkgs.stdenv.hostPlatform.isDarwin || config.home.preferXdgDirectories;
+      configPath =
+        if useXdg then
+          "${config.xdg.configHome}/neverest/config.toml"
+        else
+          "${config.home.homeDirectory}/Library/Application Support/neverest/config.toml";
+
+      neverestBin = lib.getExe config.programs.neverest.package;
+      confArg = lib.escapeShellArg configPath;
+
+      script = pkgs.writeShellScript "neverest-sync" ''
+        ${cfg.preExec}
+        ${builtins.concatStringsSep "\n" (
+          map (name: "${neverestBin} -c ${confArg} sync ${lib.escapeShellArg name}") accountNames
+        )}
+        ${cfg.postExec}
+      '';
+    in
+    {
+      programs.neverest.enable = true;
+
+      assertions = [
+        (lib.hm.darwin.assertInterval "services.neverest.frequency" cfg.frequency pkgs)
+      ];
+
+      systemd.user = {
+        services.neverest = {
+          Unit.Description = "neverest mail synchronization";
+          Service = {
+            Type = "oneshot";
+            Nice = 19;
+            IOSchedulingClass = "best-effort";
+            IOSchedulingPriority = 7;
+            IOWeight = 100;
+            Restart = "no";
+            LogRateLimitIntervalSec = 0;
+            ExecStart = "${script}";
+          };
+        };
+
+        timers.neverest = {
+          Unit.Description = "neverest mail synchronization timer";
+          Timer = {
+            OnCalendar = cfg.frequency;
+            Unit = "neverest.service";
+            Persistent = true;
+            RandomizedDelaySec = "1m";
+          };
+          Install.WantedBy = [ "timers.target" ];
+        };
+      };
+
+      launchd.agents.neverest = {
+        enable = true;
+        config = {
+          ProgramArguments = [ "${script}" ];
+          ProcessType = "Background";
+          Nice = 19;
+          LowPriorityIO = true;
+          StartCalendarInterval = lib.hm.darwin.mkCalendarInterval cfg.frequency;
+          RunAtLoad = true;
+          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/neverest/launchd-stdout.log";
+          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/neverest/launchd-stderr.log";
+        };
+      };
+    }
+  );
+}

--- a/tests/modules/accounts/email-test-accounts.nix
+++ b/tests/modules/accounts/email-test-accounts.nix
@@ -55,6 +55,7 @@
             "astroid"
             "getmail"
             "himalaya"
+            "neverest"
             "imapnotify"
             "lieer"
             "mbsync"

--- a/tests/modules/programs/neverest/abstractions-configuration.nix
+++ b/tests/modules/programs/neverest/abstractions-configuration.nix
@@ -1,0 +1,108 @@
+{ pkgs, ... }:
+{
+  home.enableNixpkgsReleaseCheck = false;
+
+  test.stubs.neverest = { };
+
+  programs.neverest.enable = true;
+
+  accounts.email = {
+    maildirBasePath = "mail";
+    accounts = {
+      "filtered" = {
+        primary = true;
+        address = "filtered@example.com";
+        userName = "filtered@example.com";
+        passwordCommand = "pass filtered";
+        maildir.path = "filtered";
+        imap = {
+          host = "imap.example.com";
+          tls.enable = true;
+        };
+        neverest = {
+          enable = true;
+          mailboxFilters.include = [
+            "INBOX"
+            "Sent"
+          ];
+        };
+      };
+
+      "protected" = {
+        address = "protected@example.com";
+        userName = "protected@example.com";
+        passwordCommand = "pass protected";
+        maildir.path = "protected";
+        imap = {
+          host = "imap.example.com";
+          tls.enable = true;
+        };
+        neverest = {
+          enable = true;
+          protectServer = true;
+        };
+      };
+
+      # No TLS and no explicit port: exercises the "none" encryption + 143
+      # default port, plus the exclude branch of mailboxFilters.
+      "plaintext" = {
+        address = "plaintext@example.com";
+        userName = "plaintext@example.com";
+        passwordCommand = "pass plaintext";
+        maildir.path = "plaintext";
+        imap = {
+          host = "imap.example.com";
+          tls.enable = false;
+        };
+        neverest = {
+          enable = true;
+          mailboxFilters.exclude = [ "Spam" ];
+        };
+      };
+    };
+  };
+
+  nmt.script =
+    let
+      configFile =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "home-files/Library/Application Support/neverest/config.toml"
+        else
+          "home-files/.config/neverest/config.toml";
+    in
+    ''
+      assertFileExists "${configFile}"
+
+      # mailboxFilters.include produces accounts.<name>.folder.filters.include
+      # (the account-level FolderConfig, not a per-backend key).
+      assertFileRegex "${configFile}" '\[accounts\.filtered\.folder\.filters\]'
+      assertFileRegex "${configFile}" 'include = \["INBOX", "Sent"\]'
+
+      # mailboxFilters.exclude produces the complementary filters section.
+      assertFileRegex "${configFile}" '\[accounts\.plaintext\.folder\.filters\]'
+      assertFileRegex "${configFile}" 'exclude = \["Spam"\]'
+
+      # protectServer = true sets create/delete to false, but only on the
+      # right (IMAP) side's folder and message permissions -- these live
+      # under [accounts.<name>.right.folder.permissions] /
+      # [accounts.<name>.right.message.permissions] per the real
+      # BackendGlobalConfig schema, not a top-level "mailbox"/"imap" key.
+      assertFileRegex "${configFile}" '\[accounts\.protected\.right\.folder\.permissions\]'
+      assertFileRegex "${configFile}" '\[accounts\.protected\.right\.message\.permissions\]'
+      assertFileRegex "${configFile}" 'create = false'
+      assertFileRegex "${configFile}" 'delete = false'
+
+      # Real ImapConfig auth is a flattened "passwd" field (Secret enum),
+      # not "sasl.plain.username/password".
+      assertFileRegex "${configFile}" 'login = '
+      assertFileRegex "${configFile}" '\[accounts\.filtered\.right\.backend\.passwd\]'
+      assertFileRegex "${configFile}" 'command = '
+
+      # host/port/encryption are separate fields, not a "server" URL string.
+      # TLS defaults to "tls" + 993, plaintext to "none" + 143.
+      assertFileRegex "${configFile}" 'encryption = "tls"'
+      assertFileRegex "${configFile}" 'port = 993'
+      assertFileRegex "${configFile}" 'encryption = "none"'
+      assertFileRegex "${configFile}" 'port = 143'
+    '';
+}

--- a/tests/modules/programs/neverest/basic-configuration.nix
+++ b/tests/modules/programs/neverest/basic-configuration.nix
@@ -1,0 +1,72 @@
+{ pkgs, ... }:
+{
+  home.enableNixpkgsReleaseCheck = false;
+
+  test.stubs.neverest = { };
+
+  programs.neverest = {
+    enable = true;
+  };
+
+  accounts.email = {
+    maildirBasePath = "mail";
+    accounts = {
+      "example" = {
+        primary = true;
+        address = "user@example.com";
+        userName = "user@example.com";
+        passwordCommand = "hiq -dF password proto=imaps host=imap.example.com";
+        maildir.path = "example";
+        imap = {
+          host = "imap.example.com";
+          port = 993;
+          tls.enable = true;
+        };
+
+        neverest = {
+          enable = true;
+          poolSize = 3;
+        };
+      };
+
+      "work" = {
+        address = "work@work.com";
+        userName = "work@work.com";
+        passwordCommand = "pass show email/work";
+        maildir.path = "work";
+        imap = {
+          host = "imap.work.com";
+          port = 993;
+          tls.enable = true;
+        };
+
+        neverest = {
+          enable = true;
+          extraConfig = {
+            right.backend.watch.timeout = 1800;
+          };
+        };
+      };
+
+      # An account with neverest disabled to double-check filtering
+      "ignored" = {
+        address = "ignored@domain.com";
+        maildir.path = "ignored";
+        neverest.enable = false;
+      };
+    };
+  };
+
+  nmt.script =
+    let
+      configFile =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "home-files/Library/Application Support/neverest/config.toml"
+        else
+          "home-files/.config/neverest/config.toml";
+    in
+    ''
+      assertFileExists "${configFile}"
+      assertFileContent "${configFile}" ${./neverest-expected.toml}
+    '';
+}

--- a/tests/modules/programs/neverest/default.nix
+++ b/tests/modules/programs/neverest/default.nix
@@ -1,0 +1,5 @@
+{
+  programs-neverest = ./basic-configuration.nix;
+  programs-neverest-abstractions = ./abstractions-configuration.nix;
+  programs-neverest-prefer-xdg = ./prefer-xdg.nix;
+}

--- a/tests/modules/programs/neverest/neverest-expected.toml
+++ b/tests/modules/programs/neverest/neverest-expected.toml
@@ -1,0 +1,30 @@
+[accounts.example.left.backend]
+root-dir = "/Users/testuser/mail/example"
+type = "maildir"
+
+[accounts.example.right.backend]
+encryption = "tls"
+host = "imap.example.com"
+login = "user@example.com"
+port = 993
+type = "imap"
+
+[accounts.example.right.backend.passwd]
+command = "hiq -dF password 'proto=imaps' 'host=imap.example.com'"
+
+[accounts.work.left.backend]
+root-dir = "/Users/testuser/mail/work"
+type = "maildir"
+
+[accounts.work.right.backend]
+encryption = "tls"
+host = "imap.work.com"
+login = "work@work.com"
+port = 993
+type = "imap"
+
+[accounts.work.right.backend.passwd]
+command = "pass show email/work"
+
+[accounts.work.right.backend.watch]
+timeout = 1800

--- a/tests/modules/programs/neverest/prefer-xdg.nix
+++ b/tests/modules/programs/neverest/prefer-xdg.nix
@@ -1,0 +1,29 @@
+_: {
+  home.enableNixpkgsReleaseCheck = false;
+  home.preferXdgDirectories = true;
+
+  test.stubs.neverest = { };
+
+  programs.neverest.enable = true;
+
+  accounts.email = {
+    maildirBasePath = "mail";
+    accounts."example" = {
+      primary = true;
+      address = "user@example.com";
+      userName = "user@example.com";
+      passwordCommand = "pass example";
+      maildir.path = "example";
+      imap = {
+        host = "imap.example.com";
+        tls.enable = true;
+      };
+      neverest.enable = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/.config/neverest/config.toml"
+    assertPathNotExists "home-files/Library/Application Support/neverest/config.toml"
+  '';
+}

--- a/tests/modules/services/neverest/darwin-configuration.nix
+++ b/tests/modules/services/neverest/darwin-configuration.nix
@@ -1,0 +1,34 @@
+{ config, ... }:
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  home.enableNixpkgsReleaseCheck = false;
+
+  accounts.email.accounts."hm@example.com" = {
+    maildir.path = "hm-example.com";
+    neverest.enable = true;
+  };
+
+  programs.neverest = {
+    package = config.lib.test.mkStubPackage {
+      name = "neverest";
+      outPath = "@neverest@";
+    };
+  };
+
+  services.neverest = {
+    enable = true;
+    frequency = "hourly";
+  };
+
+  nmt.script =
+    let
+      plistFileName = "org.nix-community.home.neverest.plist";
+    in
+    ''
+      serviceFile="LaunchAgents/${plistFileName}"
+      serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+      assertFileExists "$serviceFile"
+      assertFileContent "$serviceFileNormalized" ${./neverest.plist}
+    '';
+}

--- a/tests/modules/services/neverest/default.nix
+++ b/tests/modules/services/neverest/default.nix
@@ -1,0 +1,9 @@
+{ lib, pkgs, ... }:
+(lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+  neverest-service-darwin = ./darwin-configuration.nix;
+  neverest-exec-darwin = ./exec-configuration.nix;
+})
+// (lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  neverest-service-linux = ./linux-configuration.nix;
+  neverest-exec-linux = ./exec-configuration.nix;
+})

--- a/tests/modules/services/neverest/exec-configuration.nix
+++ b/tests/modules/services/neverest/exec-configuration.nix
@@ -1,0 +1,53 @@
+{ config, pkgs, ... }:
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  home.enableNixpkgsReleaseCheck = false;
+
+  accounts.email.accounts."hm@example.com" = {
+    maildir.path = "hm-example.com";
+    neverest.enable = true;
+  };
+
+  programs.neverest = {
+    package = config.lib.test.mkStubPackage {
+      name = "neverest";
+      outPath = "@neverest@";
+    };
+  };
+
+  services.neverest = {
+    enable = true;
+    frequency = "hourly";
+    preExec = ''
+      echo "pre-exec 1"
+      echo "pre-exec 2"
+    '';
+    postExec = ''
+      echo "post-exec 1"
+    '';
+  };
+
+  nmt.script =
+    let
+      serviceFile =
+        if pkgs.stdenv.hostPlatform.isLinux then
+          "home-files/.config/systemd/user/neverest.service"
+        else
+          "LaunchAgents/org.nix-community.home.neverest.plist";
+    in
+    ''
+      assertFileExists "${serviceFile}"
+
+      # Follow ExecStart to the generated sync script and verify it actually
+      # carries the pre/post hooks and a per-account sync invocation — the
+      # service-file tests only cover the unit wiring, not the script body.
+      # nmt's asserts resolve relative paths against $TESTED; raw grep does not.
+      script=$(grep -hoE '/nix/store/[a-z0-9]+-neverest-sync' "$TESTED/${serviceFile}" | head -n1)
+      assertFileExists "$script"
+      assertFileRegex "$script" 'pre-exec 1'
+      assertFileRegex "$script" 'pre-exec 2'
+      assertFileRegex "$script" 'neverest -c .* sync hm@example\.com'
+      assertFileRegex "$script" 'post-exec 1'
+    '';
+}

--- a/tests/modules/services/neverest/linux-configuration.nix
+++ b/tests/modules/services/neverest/linux-configuration.nix
@@ -1,0 +1,34 @@
+{ config, ... }:
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  home.enableNixpkgsReleaseCheck = false;
+
+  accounts.email.accounts."hm@example.com" = {
+    maildir.path = "hm-example.com";
+    neverest.enable = true;
+  };
+
+  programs.neverest = {
+    package = config.lib.test.mkStubPackage {
+      name = "neverest";
+      outPath = "@neverest@";
+    };
+  };
+
+  services.neverest = {
+    enable = true;
+    frequency = "hourly";
+  };
+
+  nmt.script = ''
+    serviceFile="home-files/.config/systemd/user/neverest.service"
+    serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+    assertFileExists "$serviceFile"
+    assertFileContent "$serviceFileNormalized" ${./neverest.service}
+
+    timerFile="home-files/.config/systemd/user/neverest.timer"
+    assertFileExists "$timerFile"
+    assertFileContent "$timerFile" ${./neverest.timer}
+  '';
+}

--- a/tests/modules/services/neverest/neverest.plist
+++ b/tests/modules/services/neverest/neverest.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>org.nix-community.home.neverest</string>
+	<key>LowPriorityIO</key>
+	<true/>
+	<key>Nice</key>
+	<integer>19</integer>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sh</string>
+		<string>-c</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec /nix/store/00000000000000000000000000000000-neverest-sync</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/home/hm-user/Library/Logs/neverest/launchd-stderr.log</string>
+	<key>StandardOutPath</key>
+	<string>/home/hm-user/Library/Logs/neverest/launchd-stdout.log</string>
+	<key>StartCalendarInterval</key>
+	<array>
+		<dict>
+			<key>Minute</key>
+			<integer>0</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/tests/modules/services/neverest/neverest.service
+++ b/tests/modules/services/neverest/neverest.service
@@ -1,0 +1,12 @@
+[Service]
+ExecStart=/nix/store/00000000000000000000000000000000-neverest-sync
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+IOWeight=100
+LogRateLimitIntervalSec=0
+Nice=19
+Restart=no
+Type=oneshot
+
+[Unit]
+Description=neverest mail synchronization

--- a/tests/modules/services/neverest/neverest.timer
+++ b/tests/modules/services/neverest/neverest.timer
@@ -1,0 +1,11 @@
+[Install]
+WantedBy=timers.target
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+RandomizedDelaySec=1m
+Unit=neverest.service
+
+[Unit]
+Description=neverest mail synchronization


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
