### PR TITLE
crush: add module

### DIFF
--- a/all-maintainers.nix
+++ b/all-maintainers.nix
@@ -2448,6 +2448,13 @@
     name = "Vincent Haupert";
     source = "nixpkgs";
   };
+  vidhanio = {
+    email = "me@vidhan.io";
+    github = "vidhanio";
+    githubId = 41439633;
+    name = "Vidhan Bhatt";
+    source = "home-manager";
+  };
   vonixxx = {
     email = "vonixxx@tuta.io";
     github = "vonixxx";

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -557,6 +557,12 @@
     github = "superflash41";
     githubId = 102434258;
   };
+  vidhanio = {
+    name = "Vidhan Bhatt";
+    email = "me@vidhan.io";
+    github = "vidhanio";
+    githubId = 41439633;
+  };
   will-lol = {
     name = "William Bradshaw";
     email = "will.bradshaw50@gmail.com";

--- a/modules/misc/news/2026/08/2026-08-04_14-56-06.nix
+++ b/modules/misc/news/2026/08/2026-08-04_14-56-06.nix
@@ -1,0 +1,11 @@
+{
+  time = "2026-08-04T14:56:06+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.crush'.
+
+    Crush is Charm's coding agent for the terminal. The module installs
+    Crush, writes its JSON configuration, and manages Agent Skills. It
+    can also take MCP servers from the shared 'programs.mcp' module.
+  '';
+}

--- a/modules/programs/crush.nix
+++ b/modules/programs/crush.nix
@@ -1,0 +1,194 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    literalExpression
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    ;
+
+  cfg = config.programs.crush;
+
+  jsonFormat = pkgs.formats.json { };
+
+  # Crush expands `$VAR` and `$(command)` in the MCP server command, args, env,
+  # url, and headers, so file references become a command substitution instead
+  # of a wrapper script.
+  toCrushServer =
+    server:
+    lib.hm.mcp.transformMcpServer {
+      inherit server;
+      exclude = [ "enabled" ];
+      extraTransforms = [ lib.hm.mcp.addType ];
+      mkFileRef = path: "$(cat ${lib.escapeShellArg path})";
+    }
+    // lib.optionalAttrs ((server.enabled or null) == false || (server.disabled or false)) {
+      disabled = true;
+    };
+
+  transformedMcpServers = lib.optionalAttrs (cfg.enableMcpIntegration && config.programs.mcp.enable) (
+    lib.mapAttrs (_: toCrushServer) config.programs.mcp.servers
+  );
+
+  mcpServers = transformedMcpServers // (cfg.settings.mcp or { });
+
+  settings = cfg.settings // lib.optionalAttrs (mcpServers != { }) { mcp = mcpServers; };
+
+  skills = if lib.isAttrs cfg.skills then cfg.skills else { };
+in
+{
+  meta.maintainers = [ lib.maintainers.vidhanio ];
+
+  options.programs.crush = {
+    enable = mkEnableOption "Crush, Charm's coding agent for the terminal";
+
+    package = mkPackageOption pkgs "crush" { nullable = true; };
+
+    enableMcpIntegration = mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to integrate the MCP servers config from
+        {option}`programs.mcp.servers` into
+        {option}`programs.crush.settings.mcp`.
+
+        Note: Settings defined in {option}`programs.mcp.servers` are merged
+        with {option}`programs.crush.settings.mcp`, with Crush settings taking
+        precedence.
+      '';
+    };
+
+    settings = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = literalExpression ''
+        {
+          models.large = {
+            model = "claude-sonnet-4-20250514";
+            provider = "anthropic";
+          };
+          providers.deepseek = {
+            type = "openai-compat";
+            base_url = "https://api.deepseek.com/v1";
+            api_key = "$(cat /run/secrets/deepseek-api-key)";
+            models = [
+              {
+                id = "deepseek-chat";
+                name = "Deepseek V3";
+              }
+            ];
+          };
+          lsp.nix.command = "nil";
+          options.disabled_tools = [ "sourcegraph" ];
+          permissions.allowed_tools = [ "view" ];
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/crush/crush.json`.
+        See <https://github.com/charmbracelet/crush> for the documentation.
+
+        Crush expands `$VAR` and `$(command)` in configuration values, so
+        secrets can be read at startup instead of being written to the Nix
+        store.
+
+        Note, `"$schema": "https://charm.land/crush.json"` is automatically
+        added to the configuration.
+      '';
+    };
+
+    skills = mkOption {
+      type = lib.types.either (lib.types.attrsOf (
+        lib.types.oneOf [
+          lib.types.lines
+          lib.types.path
+          lib.types.str
+        ]
+      )) lib.types.path;
+      default = { };
+      description = ''
+        Agent Skills for Crush.
+
+        This option can be either:
+        - An attribute set defining skills
+        - A path to a directory containing skill folders
+
+        If an attribute set is used, the attribute name becomes the skill
+        directory name, and the value is either:
+        - Inline content as a string (creates `crush/skills/<name>/SKILL.md`)
+        - A path to a file (creates `crush/skills/<name>/SKILL.md`)
+        - A path to a directory (creates `crush/skills/<name>/` with all files)
+
+        This also accepts Nix store paths, for example a skill directory from
+        a package.
+
+        If a path is used, it is expected to contain one folder per skill name,
+        each containing a {file}`SKILL.md`. The directory is symlinked to
+        {file}`$XDG_CONFIG_HOME/crush/skills/`.
+      '';
+      example = literalExpression ''
+        {
+          git-release = '''
+            ---
+            name: git-release
+            description: Create consistent releases and changelogs
+            ---
+
+            ## What I do
+
+            - Draft release notes from merged PRs
+            - Propose a version bump
+          ''';
+
+          # A skill can also be a directory containing SKILL.md and other files.
+          data-analysis = ./skills/data-analysis;
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !lib.hm.strings.isPathLike cfg.skills || lib.pathIsDirectory cfg.skills;
+        message = "`programs.crush.skills` must be a directory when set to a path";
+      }
+    ];
+
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile = {
+      "crush/crush.json" = mkIf (settings != { }) {
+        source = jsonFormat.generate "crush.json" (
+          {
+            "$schema" = "https://charm.land/crush.json";
+          }
+          // settings
+        );
+      };
+
+      "crush/skills" = mkIf (lib.hm.strings.isPathLike cfg.skills) {
+        source = cfg.skills;
+        recursive = true;
+      };
+    }
+    // lib.mapAttrs' (
+      name: content:
+      if lib.hm.strings.isPathLike content && lib.pathIsDirectory content then
+        lib.nameValuePair "crush/skills/${name}" {
+          source = content;
+          recursive = true;
+        }
+      else
+        lib.nameValuePair "crush/skills/${name}/SKILL.md" (
+          if lib.hm.strings.isPathLike content then { source = content; } else { text = content; }
+        )
+    ) skills;
+  };
+}

--- a/tests/modules/programs/crush/crush.json
+++ b/tests/modules/programs/crush/crush.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://charm.land/crush.json",
+  "lsp": {
+    "go": {
+      "command": "gopls",
+      "env": {
+        "GOTOOLCHAIN": "go1.24.5"
+      }
+    },
+    "nix": {
+      "command": "nil"
+    }
+  },
+  "mcp": {
+    "filesystem": {
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/tmp"
+      ],
+      "command": "npx",
+      "type": "stdio"
+    }
+  },
+  "models": {
+    "large": {
+      "model": "claude-sonnet-4-20250514",
+      "provider": "anthropic"
+    }
+  },
+  "options": {
+    "disabled_tools": [
+      "sourcegraph"
+    ],
+    "initialize_as": "AGENTS.md"
+  },
+  "permissions": {
+    "allowed_tools": [
+      "view"
+    ]
+  },
+  "providers": {
+    "deepseek": {
+      "api_key": "$(cat /run/secrets/deepseek-api-key)",
+      "base_url": "https://api.deepseek.com/v1",
+      "models": [
+        {
+          "context_window": 64000,
+          "id": "deepseek-chat",
+          "name": "Deepseek V3"
+        }
+      ],
+      "type": "openai-compat"
+    }
+  }
+}

--- a/tests/modules/programs/crush/default.nix
+++ b/tests/modules/programs/crush/default.nix
@@ -1,0 +1,6 @@
+{
+  crush-settings = ./settings.nix;
+  crush-mcp-integration = ./mcp-integration.nix;
+  crush-skills = ./skills.nix;
+  crush-skills-path = ./skills-path.nix;
+}

--- a/tests/modules/programs/crush/git-release-SKILL.md
+++ b/tests/modules/programs/crush/git-release-SKILL.md
@@ -1,0 +1,9 @@
+---
+name: git-release
+description: Create consistent releases and changelogs
+---
+
+## What I do
+
+- Draft release notes from merged PRs
+- Propose a version bump

--- a/tests/modules/programs/crush/mcp-integration.json
+++ b/tests/modules/programs/crush/mcp-integration.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://charm.land/crush.json",
+  "mcp": {
+    "context7": {
+      "headers": {
+        "CONTEXT7_API_KEY": "$CONTEXT7_API_KEY"
+      },
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "disabled-server": {
+      "args": [
+        "test"
+      ],
+      "command": "echo",
+      "disabled": true,
+      "type": "stdio"
+    },
+    "everything": {
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-everything"
+      ],
+      "command": "npx",
+      "env": {
+        "NPM_TOKEN": "$(cat /run/secrets/npm-token)"
+      },
+      "type": "stdio"
+    },
+    "filesystem": {
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/tmp"
+      ],
+      "command": "npx",
+      "type": "stdio"
+    }
+  }
+}

--- a/tests/modules/programs/crush/mcp-integration.nix
+++ b/tests/modules/programs/crush/mcp-integration.nix
@@ -1,0 +1,52 @@
+{
+  programs.mcp = {
+    enable = true;
+    servers = {
+      everything = {
+        command = "npx";
+        args = [
+          "-y"
+          "@modelcontextprotocol/server-everything"
+        ];
+        env.NPM_TOKEN.file = "/run/secrets/npm-token";
+      };
+      context7 = {
+        url = "https://mcp.context7.com/mcp";
+        headers.CONTEXT7_API_KEY = "$CONTEXT7_API_KEY";
+      };
+      disabled-server = {
+        command = "echo";
+        args = [ "test" ];
+        enabled = false;
+      };
+      filesystem = {
+        command = "npx";
+        args = [
+          "-y"
+          "@modelcontextprotocol/server-filesystem"
+          "/other-tmp"
+        ];
+      };
+    };
+  };
+
+  programs.crush = {
+    enable = true;
+    package = null;
+    enableMcpIntegration = true;
+
+    settings.mcp.filesystem = {
+      type = "stdio";
+      command = "npx";
+      args = [
+        "-y"
+        "@modelcontextprotocol/server-filesystem"
+        "/tmp"
+      ];
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/crush/crush.json ${./mcp-integration.json}
+  '';
+}

--- a/tests/modules/programs/crush/pdf-processing-SKILL.md
+++ b/tests/modules/programs/crush/pdf-processing-SKILL.md
@@ -1,0 +1,8 @@
+---
+name: pdf-processing
+description: Extract text and tables from PDF files
+---
+
+## What I do
+
+- Extract text from PDFs with pdfplumber

--- a/tests/modules/programs/crush/settings.nix
+++ b/tests/modules/programs/crush/settings.nix
@@ -1,0 +1,56 @@
+{ config, ... }:
+{
+  programs.crush = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    settings = {
+      models.large = {
+        model = "claude-sonnet-4-20250514";
+        provider = "anthropic";
+      };
+
+      providers.deepseek = {
+        type = "openai-compat";
+        base_url = "https://api.deepseek.com/v1";
+        api_key = "$(cat /run/secrets/deepseek-api-key)";
+        models = [
+          {
+            id = "deepseek-chat";
+            name = "Deepseek V3";
+            context_window = 64000;
+          }
+        ];
+      };
+
+      lsp = {
+        nix.command = "nil";
+        go = {
+          command = "gopls";
+          env.GOTOOLCHAIN = "go1.24.5";
+        };
+      };
+
+      mcp.filesystem = {
+        type = "stdio";
+        command = "npx";
+        args = [
+          "-y"
+          "@modelcontextprotocol/server-filesystem"
+          "/tmp"
+        ];
+      };
+
+      options = {
+        disabled_tools = [ "sourcegraph" ];
+        initialize_as = "AGENTS.md";
+      };
+
+      permissions.allowed_tools = [ "view" ];
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/crush/crush.json ${./crush.json}
+  '';
+}

--- a/tests/modules/programs/crush/skill-dir/SKILL.md
+++ b/tests/modules/programs/crush/skill-dir/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: data-analysis
+description: Analyse tabular data and summarise the results
+---
+
+## What I do
+
+- Load CSV files and report summary statistics
+- See reference.md for the available helpers

--- a/tests/modules/programs/crush/skill-dir/reference.md
+++ b/tests/modules/programs/crush/skill-dir/reference.md
@@ -1,0 +1,3 @@
+# Reference
+
+Helper commands used by the data-analysis skill.

--- a/tests/modules/programs/crush/skills-bulk/code-review/SKILL.md
+++ b/tests/modules/programs/crush/skills-bulk/code-review/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: code-review
+description: Review changes for correctness and style
+---
+
+## What I do
+
+- Summarise the diff
+- Point out defects and missing tests

--- a/tests/modules/programs/crush/skills-path.nix
+++ b/tests/modules/programs/crush/skills-path.nix
@@ -1,0 +1,13 @@
+{
+  programs.crush = {
+    enable = true;
+    package = null;
+
+    skills = ./skills-bulk;
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/crush/skills/code-review/SKILL.md \
+      ${./skills-bulk/code-review/SKILL.md}
+  '';
+}

--- a/tests/modules/programs/crush/skills.nix
+++ b/tests/modules/programs/crush/skills.nix
@@ -1,0 +1,38 @@
+{
+  programs.crush = {
+    enable = true;
+    package = null;
+
+    skills = {
+      git-release = ''
+        ---
+        name: git-release
+        description: Create consistent releases and changelogs
+        ---
+
+        ## What I do
+
+        - Draft release notes from merged PRs
+        - Propose a version bump
+      '';
+
+      pdf-processing = ./pdf-processing-SKILL.md;
+
+      data-analysis = ./skill-dir;
+    };
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/crush/crush.json
+
+    assertFileContent home-files/.config/crush/skills/git-release/SKILL.md \
+      ${./git-release-SKILL.md}
+
+    assertFileContent home-files/.config/crush/skills/pdf-processing/SKILL.md \
+      ${./pdf-processing-SKILL.md}
+
+    assertFileContent home-files/.config/crush/skills/data-analysis/SKILL.md \
+      ${./skill-dir/SKILL.md}
+    assertFileExists home-files/.config/crush/skills/data-analysis/reference.md
+  '';
+}


### PR DESCRIPTION
### Description

This adds a module for [Crush](https://github.com/charmbracelet/crush), Charm's coding agent for the terminal.

This is a fresh implementation of the module proposed in #8714, which the original author closed. Thanks to @digitalrane for the original work, who is credited as a co-author on the module commit.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [X] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
