### PR TITLE
rift-wm: init

### DIFF
--- a/modules/misc/news/2026/08/2026-08-05_02-16-25.nix
+++ b/modules/misc/news/2026/08/2026-08-05_02-16-25.nix
@@ -1,0 +1,8 @@
+{ config, pkgs, ... }:
+{
+  time = "2026-08-04T16:16:25+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin && config.programs.rift-wm.enable;
+  message = ''
+    A new module is availble for darwin: `programs.rift-wm'.
+  '';
+}

--- a/modules/programs/rift-wm.nix
+++ b/modules/programs/rift-wm.nix
@@ -1,0 +1,88 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    types
+    ;
+
+  cfg = config.programs.rift-wm;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = [ lib.maintainers.eveeifyeve ];
+
+  options.programs.rift-wm = {
+    enable = mkEnableOption "rift-wm";
+    package = mkPackageOption pkgs "rift-wm" { };
+
+    settings = mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      description = ''
+        Settings written to {file}`config.toml`. See the rift
+        documentation for details.
+      '';
+    };
+
+    launchd = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Configure the launchd agent to manage the Rift-wm process.
+
+          The first time this is enabled, macOS will prompt you to allow this background
+          item in System Settings.
+
+          You can verify the service is running correctly from your terminal.
+          Run: `launchctl list | grep rift-wm`
+
+          - A running process will show a Process ID (PID) and a status of 0, for example:
+            `12345	0	org.nix-community.home.rift-wm`
+
+          - If the service has crashed or failed to start, the PID will be a dash and the
+            status will be a non-zero number, for example:
+            `-	1	org.nix-community.home.rift-wm`
+
+          In case of failure, check the logs with `cat /tmp/rift-wm.err.log`.
+
+          For more detailed service status, run `launchctl print gui/$(id -u)/org.nix-community.home.rift-wm`.
+        '';
+      };
+      keepAlive = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether the launchd service should be kept alive.";
+      };
+    };
+
+    config = lib.mkIf cfg.enable {
+      assertions = [
+        (lib.hm.assertions.assertPlatform "programs.rift-wm" pkgs lib.platforms.darwin)
+      ];
+
+      home.packages = [ cfg.package ];
+      xdg.configFile."rift/config.toml" = lib.mkIf (cfg.settings != { }) {
+        source = tomlFormat.generate "rift-config.toml" cfg.settings;
+      };
+
+      launchd.agents.rift-wm = {
+        inherit (cfg.launchd) enable;
+        config = {
+          Program = "${cfg.package}/bin/rift";
+          KeepAlive = cfg.launchd.keepAlive;
+          RunAtLoad = true;
+          StandardOutPath = "/tmp/rift-wm.log";
+          StandardErrorPath = "/tmp/rift-wm.err.log";
+        };
+      };
+    };
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -175,6 +175,7 @@ let
     "ranger"
     "retext"
     "retroarch-bare"
+    "rift-wm"
     "rio"
     "ripgrep"
     "ruff"

--- a/tests/modules/programs/rift-wm/default.nix
+++ b/tests/modules/programs/rift-wm/default.nix
@@ -1,0 +1,6 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+  rift-wm = ./normal.nix;
+  rift-wm-settings = ./settings.nix;
+}

--- a/tests/modules/programs/rift-wm/normal.nix
+++ b/tests/modules/programs/rift-wm/normal.nix
@@ -1,0 +1,11 @@
+{ config, ... }:
+{
+  programs.rift-wm = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "rift-wm"; };
+  };
+
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/rift"
+  '';
+}

--- a/tests/modules/programs/rift-wm/service-expected.plist
+++ b/tests/modules/programs/rift-wm/service-expected.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Label</key>
+	<string>org.nix-community.home.rift-wm</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sh</string>
+		<string>-c</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec /nix/store/00000000000000000000000000000000-rift-wm/bin/rift-wm</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/tmp/rift-wm.err.log</string>
+	<key>StandardOutPath</key>
+	<string>/tmp/rift-wm.log</string>
+</dict>
+</plist>

--- a/tests/modules/programs/rift-wm/settings-expected.toml
+++ b/tests/modules/programs/rift-wm/settings-expected.toml
@@ -1,0 +1,32 @@
+[animate]
+value = true
+
+[hot_reload]
+value = true
+
+[layout.mode]
+value = "bsp"
+
+[layout.gaps.outer.top]
+value = 0.5
+
+[layout.gaps.outer.left]
+value = 0.5
+
+[layout.gaps.outer.right]
+value = 0.5
+
+[layout.gaps.outer.bottom]
+value = 0.5
+
+[keys."Alt + H".move_focus]
+value = "left"
+
+[keys."Alt + Shift + Left".join_window]
+value = "left"
+
+[keys."Alt + 1".switch_to_workspace]
+value = 1
+
+[keys."comb1 + S".switch_to_workspace]
+value = 2

--- a/tests/modules/programs/rift-wm/settings.nix
+++ b/tests/modules/programs/rift-wm/settings.nix
@@ -1,0 +1,36 @@
+{ config, ... }:
+{
+  programs.rift-wm = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "rift-wm"; };
+    launchd.enable = true;
+    settings = {
+      animate = true;
+      hot_reload = true;
+      layout = {
+        mode = "bsp";
+        gaps.outer = {
+          top = 0.5;
+          left = 0.5;
+          right = 0.5;
+          bottom = 0.5;
+        };
+      };
+
+      keys = {
+        "Alt + H".move_focus = "left";
+        "Alt + Shift + Left".join_window = "left";
+        "Alt + 1".switch_to_workspace = 1;
+        "comb1 + S".switch_to_workspace = 2;
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent "home-files/.config/rift/config.toml" ${./settings-expected.toml}
+
+    serviceFile=$(normalizeStorePaths LaunchAgents/org.nix-community.home.rift-wm.plist)
+    assertFileExists $serviceFile
+    assertFileContent "$serviceFile" ${./service-expected.plist}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
