### PR TITLE
hyprland: add XDPH settings

### DIFF
--- a/modules/services/window-managers/hyprland/default.nix
+++ b/modules/services/window-managers/hyprland/default.nix
@@ -30,6 +30,10 @@ let
       description = "Hyprland configuration value";
     };
 
+  xdphSettings = lib.converge (lib.filterAttrsRecursive (
+    _: value: value != null && value != { }
+  )) cfg.xdph.settings;
+
   reloadConfig = ''
     (
       XDG_RUNTIME_DIR=''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
@@ -103,6 +107,110 @@ in
                 `wayland.windowManager.hyprland.finalPackage` override'';
       description = ''
         The xdg-desktop-portal-hyprland package after overriding its hyprland input.
+      '';
+    };
+
+    xdph.settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf settingValueType;
+        options = {
+          general = lib.mkOption {
+            type = lib.types.submodule {
+              freeformType = lib.types.attrsOf settingValueType;
+              options.toplevel_dynamic_bind = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = null;
+                description = ''
+                  Whether to bind the foreign toplevel manager dynamically
+                  when a screencasting session is created.
+                '';
+              };
+            };
+            default = { };
+            description = "General XDPH settings.";
+          };
+
+          screencopy = lib.mkOption {
+            type = lib.types.submodule {
+              freeformType = lib.types.attrsOf settingValueType;
+              options = {
+                max_fps = lib.mkOption {
+                  type = lib.types.nullOr lib.types.ints.unsigned;
+                  default = null;
+                  description = ''
+                    Maximum frames per second for screencasting. A value of
+                    zero disables the limit.
+                  '';
+                };
+
+                allow_token_by_default = lib.mkOption {
+                  type = lib.types.nullOr lib.types.bool;
+                  default = null;
+                  description = ''
+                    Whether to enable restore tokens by default in the share
+                    picker.
+                  '';
+                };
+
+                custom_picker_binary = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  description = ''
+                    Custom share picker command. The command must produce output
+                    compatible with {command}`hyprland-share-picker`.
+                  '';
+                };
+
+                force_shm = lib.mkOption {
+                  type = lib.types.nullOr lib.types.bool;
+                  default = null;
+                  description = ''
+                    Whether to always use shared memory instead of DMA-BUF for
+                    screencasting.
+                  '';
+                };
+
+                cursor_mode = lib.mkOption {
+                  type = lib.types.nullOr (
+                    lib.types.enum [
+                      0
+                      1
+                      2
+                    ]
+                  );
+                  default = null;
+                  description = ''
+                    Default cursor mode for clients that do not specify one.
+                    Zero uses the protocol default, one hides the cursor, and
+                    two embeds it in the stream.
+                  '';
+                };
+              };
+            };
+            default = { };
+            description = "XDPH screencasting settings.";
+          };
+        };
+      };
+      default = { };
+      example = {
+        general.toplevel_dynamic_bind = true;
+        screencopy = {
+          max_fps = 60;
+          allow_token_by_default = true;
+          custom_picker_binary = "hyprland-share-picker";
+          force_shm = false;
+          cursor_mode = 2;
+        };
+      };
+      description = ''
+        xdg-desktop-portal-hyprland configuration written to
+        {file}`$XDG_CONFIG_HOME/hypr/xdph.conf`.
+
+        These settings require a portal package compatible with XDPH's
+        configuration format. They are generated even when
+        {option}`wayland.windowManager.hyprland.portalPackage` is `null`, so
+        the portal package may be managed by NixOS.
       '';
     };
 
@@ -573,6 +681,9 @@ in
         hyprlangConfigFile
         luaConfigFile
         extraLuaFiles
+        (lib.optionalAttrs (xdphSettings != { }) {
+          "hypr/xdph.conf".text = lib.hm.generators.toHyprconf { attrs = xdphSettings; };
+        })
       ];
 
       xdg.portal = {

--- a/tests/modules/services/hyprland/default.nix
+++ b/tests/modules/services/hyprland/default.nix
@@ -14,6 +14,8 @@ lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   hyprland-inconsistent-config = ./inconsistent-config.nix;
   hyprland-submaps-config = ./submaps-config.nix;
   hyprland-submaps-on-dispatch = ./submaps-on-dispatch.nix;
+  hyprland-xdph-no-settings = ./xdph-no-settings.nix;
+  hyprland-xdph-settings = ./xdph-settings.nix;
   hyprland-lua-config = ./lua-config.nix;
   hyprland-lua-files-assertions = ./lua-files-assertions.nix;
   hyprland-lua-files-config = ./lua-files-config.nix;

--- a/tests/modules/services/hyprland/xdph-no-settings.nix
+++ b/tests/modules/services/hyprland/xdph-no-settings.nix
@@ -1,0 +1,12 @@
+{
+  wayland.windowManager.hyprland = {
+    enable = true;
+    package = null;
+    portalPackage = null;
+    systemd.enable = false;
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/hypr/xdph.conf
+  '';
+}

--- a/tests/modules/services/hyprland/xdph-settings.nix
+++ b/tests/modules/services/hyprland/xdph-settings.nix
@@ -1,0 +1,24 @@
+{
+  wayland.windowManager.hyprland = {
+    enable = true;
+    package = null;
+    portalPackage = null;
+    systemd.enable = false;
+
+    xdph.settings.general.toplevel_dynamic_bind = true;
+
+    xdph.settings.screencopy = {
+      max_fps = 60;
+      allow_token_by_default = true;
+      custom_picker_binary = "hyprland-share-picker";
+      force_shm = true;
+      cursor_mode = 2;
+    };
+  };
+
+  nmt.script = ''
+    config=home-files/.config/hypr/xdph.conf
+    assertFileExists "$config"
+    assertFileContent "$config" ${./xdph.conf}
+  '';
+}

--- a/tests/modules/services/hyprland/xdph.conf
+++ b/tests/modules/services/hyprland/xdph.conf
@@ -1,0 +1,11 @@
+general {
+  toplevel_dynamic_bind=true
+}
+
+screencopy {
+  allow_token_by_default=true
+  cursor_mode=2
+  custom_picker_binary=hyprland-share-picker
+  force_shm=true
+  max_fps=60
+}


### PR DESCRIPTION
### Description

Add `wayland.windowManager.hyprland.xdph.settings` for generating `$XDG_CONFIG_HOME/hypr/xdph.conf`.

The option provides typed definitions for all [currently supported XDPH settings](https://wiki.hypr.land/Hypr-Ecosystem/xdg-desktop-portal-hyprland/#configuration) while retaining a free-form escape hatch for future settings. Configuration is also generated when `portalPackage = null`, allowing NixOS to manage the portal package.

No configuration file is generated when the settings are empty.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nixfmt`.

- [x] Code tested through the full Hyprland NMT test suite and the documentation build.

- [x] Test cases updated/added.

- [x] Commit messages follow the required `{component}: {description}` format.