### PR TITLE
ludusavi: make backup timer persistent

### DIFF
--- a/modules/services/ludusavi.nix
+++ b/modules/services/ludusavi.nix
@@ -127,7 +127,10 @@ in
       };
       timers.ludusavi = {
         Unit.Description = "Run a game save backup with Ludusavi";
-        Timer.OnCalendar = cfg.frequency;
+        Timer = {
+          OnCalendar = cfg.frequency;
+          Persistent = true;
+        };
         Install.WantedBy = [ "timers.target" ];
       };
     };


### PR DESCRIPTION
### Description
- `services.ludusavi`'s systemd user timer had no `Persistent` setting, so if the machine was off/asleep at the scheduled `OnCalendar` time (e.g. midnight for the default "daily" frequency), the backup would simply be skipped until the next scheduled run.
- Set `Timer.Persistent = true` so systemd runs the backup shortly after boot/login if a scheduled run was missed, per `systemd.timer(5)`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
