### PR TITLE
git: add allowedSigners option

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -62,6 +62,22 @@ in
         };
 
         signing = {
+          allowedSigners = mkOption {
+            type = types.lines;
+            default = "";
+            example = ''
+              user@example.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI...
+            '';
+            description = ''
+              SSH public keys trusted when verifying signed commits and tags.
+
+              Each line must follow the allowed signers format described in
+              {manpage}`ssh-keygen(1)`. When non-empty, the content is written
+              to {file}`$XDG_CONFIG_HOME/git/allowed_signers` and configured as
+              Git's `gpg.ssh.allowedSignersFile` setting.
+            '';
+          };
+
           key = mkOption {
             type = types.nullOr types.str;
             default = null;
@@ -482,6 +498,12 @@ in
             })
           ];
         };
+      })
+
+      (mkIf (cfg.signing.allowedSigners != "") {
+        xdg.configFile."git/allowed_signers".text = cfg.signing.allowedSigners;
+        programs.git.iniContent.gpg.ssh.allowedSignersFile =
+          mkDefault "${config.xdg.configHome}/git/allowed_signers";
       })
 
       (mkIf (cfg.hooks != { }) {

--- a/tests/modules/programs/git/default.nix
+++ b/tests/modules/programs/git/default.nix
@@ -2,6 +2,7 @@
   git-with-email = ./git-with-email.nix;
   git-with-most-options = ./git.nix;
   git-with-msmtp = ./git-with-msmtp.nix;
+  git-with-allowed-signers = ./git-with-allowed-signers.nix;
   git-with-signing-key-id-legacy = ./git-with-signing-key-id-legacy.nix;
   git-with-signing-key-id = ./git-with-signing-key-id.nix;
   git-without-signing-key-id = ./git-without-signing-key-id.nix;

--- a/tests/modules/programs/git/git-allowed-signers-expected
+++ b/tests/modules/programs/git/git-allowed-signers-expected
@@ -1,0 +1,1 @@
+user@example.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey

--- a/tests/modules/programs/git/git-with-allowed-signers-expected.conf
+++ b/tests/modules/programs/git/git-with-allowed-signers-expected.conf
@@ -1,0 +1,6 @@
+[gpg]
+	format = "ssh"
+
+[gpg "ssh"]
+	allowedSignersFile = "/home/hm-user/.config/git/allowed_signers"
+	program = "path-to-ssh"

--- a/tests/modules/programs/git/git-with-allowed-signers.nix
+++ b/tests/modules/programs/git/git-with-allowed-signers.nix
@@ -1,0 +1,19 @@
+{
+  programs.git = {
+    enable = true;
+    signing = {
+      allowedSigners = ''
+        user@example.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey
+      '';
+      format = "ssh";
+      signer = "path-to-ssh";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/allowed_signers
+    assertFileContent home-files/.config/git/allowed_signers ${./git-allowed-signers-expected}
+    assertFileExists home-files/.config/git/config
+    assertFileContent home-files/.config/git/config ${./git-with-allowed-signers-expected.conf}
+  '';
+}


### PR DESCRIPTION
### Description

Git requires `gpg.ssh.allowedSignersFile` to trust SSH signatures during commit and tag verification. Until now, Home Manager users had to manage both the allowed signers file and its Git setting separately:

```nix
xdg.configFile."git/allowed_signers".text = ''
  user@example.com namespaces="git" ssh-ed25519 AAAA...
'';

programs.git.settings.gpg.ssh.allowedSignersFile =
  "${config.xdg.configHome}/git/allowed_signers";
```

This change adds `programs.git.signing.allowedSigners`:

```nix
programs.git.signing.allowedSigners = ''
  user@example.com namespaces="git" ssh-ed25519 AAAA...
'';
```

When non-empty, Home Manager:

1. Writes its content to `$XDG_CONFIG_HOME/git/allowed_signers`.
2. Configures that path as Git's `gpg.ssh.allowedSignersFile`.

The option uses `types.lines`, preserving the complete OpenSSH allowed signers syntax, including multiple principals, `cert-authority`, namespace restrictions, and validity intervals.

The generated Git setting uses `mkDefault`. Users can therefore override `gpg.ssh.allowedSignersFile` through `programs.git.settings` when the file is managed externally.

The option defaults to an empty string, so existing configurations remain unchanged and no additional file or Git setting is generated by default.

The option does not require `programs.git.signing.format = "ssh"`. A user may sign their own commits using another format while still verifying SSH-signed commits from other contributors.

A module test verifies both the generated allowed signers file and resulting Git configuration.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

  Targeted validation performed with:

  ```console
  nix build path:.#test-git-with-allowed-signers -L
  nix build path:.#docs-json -L
  ```

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)