### PR TITLE
zk: add `programs.zk.exportNotebookDir` to export `ZK_NOTEBOOK_DIR` env variable

### DIFF
--- a/modules/programs/zk.nix
+++ b/modules/programs/zk.nix
@@ -6,10 +6,9 @@
 }:
 
 let
-
   cfg = config.programs.zk;
   tomlFormat = pkgs.formats.toml { };
-
+  notebookDir = lib.attrByPath [ "notebook" "dir" ] null cfg.settings;
 in
 {
   meta.maintainers = [ lib.hm.maintainers.silmarp ];
@@ -44,10 +43,42 @@ in
         available options and documentation.
       '';
     };
+
+    exportNotebookDir = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to export {env}`ZK_NOTEBOOK_DIR` from
+        {option}`programs.zk.settings.notebook.dir`.
+
+        zk reads the default notebook from its configuration file, so this is
+        only needed for programs that read the environment variable directly,
+        such as editor plugins started outside a notebook directory.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.exportNotebookDir -> notebookDir != null;
+        message = "programs.zk.exportNotebookDir requires programs.zk.settings.notebook.dir.";
+      }
+      {
+        # The exported value is written to a double-quoted shell assignment, so
+        # the shell never expands a leading tilde.
+        assertion = cfg.exportNotebookDir -> !(lib.hasPrefix "~" (toString notebookDir));
+        message = ''
+          programs.zk.settings.notebook.dir must be an absolute path when
+          programs.zk.exportNotebookDir is enabled.
+        '';
+      }
+    ];
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    home.sessionVariables = lib.mkIf cfg.exportNotebookDir {
+      ZK_NOTEBOOK_DIR = notebookDir;
+    };
 
     xdg.configFile."zk/config.toml" = lib.mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "config.toml" cfg.settings;

--- a/tests/modules/programs/zk/default.nix
+++ b/tests/modules/programs/zk/default.nix
@@ -1,1 +1,4 @@
-{ zk = ./zk.nix; }
+{
+  zk = ./zk.nix;
+  zk-export-notebook-dir = ./zk-export-notebook-dir.nix;
+}

--- a/tests/modules/programs/zk/zk-export-notebook-dir.nix
+++ b/tests/modules/programs/zk/zk-export-notebook-dir.nix
@@ -1,0 +1,21 @@
+{
+  programs.zk = {
+    enable = true;
+    settings.notebook.dir = "/home/hm-user/notebook";
+    exportNotebookDir = true;
+  };
+
+  test.stubs.zk = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/zk/config.toml
+    assertFileContains \
+      home-files/.config/zk/config.toml \
+      'dir = "/home/hm-user/notebook"'
+
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileContains \
+      home-path/etc/profile.d/hm-session-vars.sh \
+      'export ZK_NOTEBOOK_DIR="/home/hm-user/notebook"'
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
THE `ZK_NOTEBOOK_DIR` variable allows using zk with a default notebook directory as well as allows other programs to interact better with zk.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
