### PR TITLE
vdirsyncer: support read-only local storages

### DIFF
--- a/modules/programs/vdirsyncer/accounts.nix
+++ b/modules/programs/vdirsyncer/accounts.nix
@@ -67,6 +67,17 @@ in
       '';
     };
 
+    localReadOnly = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether vdirsyncer should treat the local storage as read-only.
+
+        Changes that cannot be written to the local storage are handled
+        according to the value of the `partialSync` option.
+      '';
+    };
+
     metadata = mkOption {
       type = types.listOf types.str;
       default = [ ];

--- a/modules/programs/vdirsyncer/default.nix
+++ b/modules/programs/vdirsyncer/default.nix
@@ -36,6 +36,7 @@ let
       (getAttrs [ "type" "fileExt" "encoding" ] a.local)
       // {
         inherit (a.local) path;
+        readOnly = a.vdirsyncer.localReadOnly;
         postHook =
           if a.vdirsyncer.postHook != null then
             (pkgs.writeShellScriptBin "post-hook" a.vdirsyncer.postHook + "/bin/post-hook")
@@ -89,6 +90,8 @@ let
       ''fileext = "${v}"''
     else if (n == "encoding") then
       ''encoding = "${v}"''
+    else if (n == "readOnly") then
+      "read_only = ${lib.boolToString v}"
     else if (n == "postHook") then
       ''post_hook = "${v}"''
     else if (n == "url") then
@@ -275,9 +278,13 @@ in
               "fileExt"
               "encoding"
               "postHook"
+              "readOnly"
             ]
           else if (t == "singlefile") then
-            [ "encoding" ]
+            [
+              "encoding"
+              "readOnly"
+            ]
           else if (t == "google_calendar") then
             [
               "timeRange"

--- a/tests/modules/programs/vdirsyncer/default.nix
+++ b/tests/modules/programs/vdirsyncer/default.nix
@@ -1,0 +1,3 @@
+{
+  vdirsyncer-read-only = ./read-only.nix;
+}

--- a/tests/modules/programs/vdirsyncer/read-only.conf
+++ b/tests/modules/programs/vdirsyncer/read-only.conf
@@ -1,0 +1,53 @@
+[general]
+status_path = "/home/hm-user/.local/share/vdirsyncer/status"
+
+### Pairs
+
+[pair calendar_implicit]
+a = "calendar_implicit_remote"
+b = "calendar_implicit_local"
+collections = null
+
+[pair calendar_readOnly]
+a = "calendar_readOnly_remote"
+b = "calendar_readOnly_local"
+collections = null
+
+[pair calendar_readWrite]
+a = "calendar_readWrite_remote"
+b = "calendar_readWrite_local"
+collections = null
+
+
+### Local storages
+
+[storage calendar_implicit_local]
+fileext = ".ics"
+path = "/home/hm-user/calendars/implicit"
+type = "filesystem"
+
+[storage calendar_readOnly_local]
+fileext = ".ics"
+path = "/home/hm-user/calendars/readOnly"
+read_only = true
+type = "filesystem"
+
+[storage calendar_readWrite_local]
+fileext = ".ics"
+path = "/home/hm-user/calendars/readWrite"
+read_only = false
+type = "filesystem"
+
+### Remote storages
+
+[storage calendar_implicit_remote]
+type = "http"
+url = "https://example.com/implicit.ics"
+
+[storage calendar_readOnly_remote]
+type = "caldav"
+url = "https://example.com/calendars/"
+
+[storage calendar_readWrite_remote]
+type = "http"
+url = "https://example.com/read-write.ics"

--- a/tests/modules/programs/vdirsyncer/read-only.nix
+++ b/tests/modules/programs/vdirsyncer/read-only.nix
@@ -1,0 +1,42 @@
+{
+  programs.vdirsyncer.enable = true;
+
+  accounts.calendar = {
+    basePath = "/home/hm-user/calendars";
+    accounts = {
+      implicit = {
+        vdirsyncer.enable = true;
+        remote = {
+          type = "http";
+          url = "https://example.com/implicit.ics";
+        };
+      };
+
+      readOnly = {
+        vdirsyncer = {
+          enable = true;
+          localReadOnly = true;
+        };
+        remote = {
+          type = "caldav";
+          url = "https://example.com/calendars/";
+        };
+      };
+
+      readWrite = {
+        vdirsyncer = {
+          enable = true;
+          localReadOnly = false;
+        };
+        remote = {
+          type = "http";
+          url = "https://example.com/read-write.ics";
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/vdirsyncer/config ${./read-only.conf}
+  '';
+}


### PR DESCRIPTION
### Description

Add `accounts.{calendar,contact}.accounts.<name>.vdirsyncer.localReadOnly` to let vdirsyncer treat the local side of a pair as read-only. This models vdirsyncer synchronization behavior without implying that the underlying local filesystem is itself read-only.

When set, the option generates `read_only = true` or `read_only = false` in the local storage section. Its default is `null`, so existing configurations remain unchanged.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nixfmt --check`.
- [x] Code tested with `nix-build tests -A build.vdirsyncer-read-only`.
- [x] Test cases added for `true`, `false`, and the unset default.