### PR TITLE
fontconfig: build font caches with the default fonts config

### DIFF
--- a/modules/misc/fontconfig.nix
+++ b/modules/misc/fontconfig.nix
@@ -279,6 +279,12 @@ in
         default = { };
         description = ''
           Config files that will be installed to {file}`~/.config/fontconfig/conf.d/`.
+
+          Except for the `fonts` entry, these files are also loaded when the
+          caches for the fonts installed through {option}`home.packages` are
+          generated. As a consequence, they must not refer to
+          {option}`home.path`, otherwise the evaluation ends in an infinite
+          recursion.
         '';
         example = {
           tamzen-disable-antialiasing = {
@@ -321,33 +327,62 @@ in
       (pkgs.runCommandLocal "dummy-fc-dir2" { } "mkdir -p $out/lib/fontconfig")
     ];
 
-    home.extraProfileCommands = ''
-      if [[ -d $out/lib/X11/fonts || -d $out/share/fonts ]]; then
-        export FONTCONFIG_FILE="$(pwd)/fonts.conf"
+    # The generated configuration is included when generating the caches
+    # because, since fontconfig 2.18.3, the alias configuration determines the
+    # generic family of the aliased fonts in the caches. Caches lacking this
+    # classification break generic-family matching for the aliased fonts.
+    #
+    # The `fonts` entry is excluded since it refers to the profile being built
+    # here, it only declares font and cache directories anyway, which are
+    # irrelevant when the caches are generated.
+    home.extraProfileCommands =
+      let
+        configFiles = lib.sortOn (file: file.target) (
+          lib.filter (file: file.enable) (lib.attrValues (removeAttrs cfg.configFile [ "fonts" ]))
+        );
+        includes = lib.concatMapStringsSep "\n  " (
+          file: ''<include ignore_missing="yes">${file.source}</include>''
+        ) configFiles;
+      in
+      ''
+        if [[ -d $out/lib/X11/fonts || -d $out/share/fonts ]]; then
+          export FONTCONFIG_FILE="$(pwd)/fonts.conf"
 
-        cat > $FONTCONFIG_FILE << EOF
-      <?xml version='1.0'?>
-      <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
-      <fontconfig>
-        <dir>$out/lib/X11/fonts</dir>
-        <dir>$out/share/fonts</dir>
-        <cachedir>$out/lib/fontconfig/cache</cachedir>
-      </fontconfig>
-      EOF
+          cat > $FONTCONFIG_FILE << EOF
+        <?xml version='1.0'?>
+        <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+        <fontconfig>
+          <dir>$out/lib/X11/fonts</dir>
+          <dir>$out/share/fonts</dir>
+          <cachedir>$out/lib/fontconfig/cache</cachedir>
+          ${includes}
+        </fontconfig>
+        EOF
 
-        ${lib.getBin pkgs.fontconfig}/bin/fc-cache -f
-        rm -f $out/lib/fontconfig/cache/CACHEDIR.TAG
-        rmdir --ignore-fail-on-non-empty -p $out/lib/fontconfig/cache
+          # Normalize the mtimes to their post-registration value. Otherwise,
+          # fc-cache considers the just generated caches outdated and
+          # regenerates them through a code path that does not apply the
+          # configuration's scan rules, i.e. the fonts' generic family
+          # classification is lost.
+          for fontDir in $out/lib/X11/fonts $out/share/fonts; do
+            if [[ -d $fontDir ]]; then
+              find "$fontDir" -exec touch --no-dereference --date=@1 {} +
+            fi
+          done
 
-        rm "$FONTCONFIG_FILE"
-        unset FONTCONFIG_FILE
-      fi
+          ${lib.getBin pkgs.fontconfig}/bin/fc-cache -f
+          rm -f $out/lib/fontconfig/cache/CACHEDIR.TAG
+          rmdir --ignore-fail-on-non-empty -p $out/lib/fontconfig/cache
 
-      # Remove the fontconfig directory if no files were available.
-      if [[ -d $out/lib/fontconfig ]] ; then
-        rmdir --ignore-fail-on-non-empty -p $out/lib/fontconfig
-      fi
-    '';
+          rm "$FONTCONFIG_FILE"
+          unset FONTCONFIG_FILE
+        fi
+
+        # Remove the fontconfig directory if no files were available.
+        if [[ -d $out/lib/fontconfig ]] ; then
+          rmdir --ignore-fail-on-non-empty -p $out/lib/fontconfig
+        fi
+      '';
 
     fonts.fontconfig.configFile = {
       fonts =


### PR DESCRIPTION
fontconfig 2.18 introduced generic-family matching, which ranks above weakly bound aliases: a font whose cached generic family is unknown loses to any font classified into the requested generic family (typically Noto Sans), even when the default fonts aliases prefer it.

Since fontconfig 2.18.3, the alias configuration determines the generic family of the aliased fonts in the caches: every `<alias>`/`<prefer>` pair implicitly generates `<match target="scan">` rules that record the preferred fonts' generic family when a cache is built [1].

Home Manager pre-builds the caches for profile fonts using a minimal configuration without any alias configuration, so the classification never reached the caches and the aliases were ignored for fonts installed through `home.packages`. Therefore, include the generated configuration files when running `fc-cache`. The `fonts` file is excluded since it refers to the profile being built, it only declares font and cache directories anyway, which are irrelevant at scan time.

The mtimes of the profile's font directories are normalized to their post-registration value before running `fc-cache`. Otherwise `fc-cache` considers the just-written caches outdated and regenerates them through a code path that does not apply the configuration's scan rules, losing the classification again. It also makes the caches finally validate at runtime, where the store-registered mtimes never matched the recorded checksums before.

This is a no-op for fontconfig <= 2.18.2, where the alias configuration plays no role at scan time.

Related https://github.com/NixOS/nixpkgs/pull/551126

[1]: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/a4bacb7103d67ce68655dd3140bfaf5c0bd81a17

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
