### PR TITLE
mblaze: add module

### DIFF
--- a/modules/misc/news/2026/08/2026-08-10_14-20-20.nix
+++ b/modules/misc/news/2026/08/2026-08-10_14-20-20.nix
@@ -1,0 +1,22 @@
+{
+  time = "2026-08-10T12:20:20+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.mblaze'.
+
+    mblaze is a suite of Unix utilities to deal with Maildir. Among
+    them is a composer that opens a draft in your editor, quotes the
+    message you are replying to and assembles MIME, which pairs it
+    with a mail program that does none of those.
+
+    mblaze itself reads a single profile, so every account enabled
+    through 'accounts.email.accounts.<name>.mblaze.enable' is given
+    one of its own, picked by pointing the MBLAZE environment
+    variable at it. The primary account is written to ~/.mblaze as
+    well, so that a bare 'mcom' works with no environment set up.
+
+    Messages are handed to the command in
+    'accounts.email.accounts.<name>.mblaze.sendMailCommand', which
+    defaults to msmtp when msmtp is enabled for that account.
+  '';
+}

--- a/modules/programs/mblaze/accounts.nix
+++ b/modules/programs/mblaze/accounts.nix
@@ -1,0 +1,50 @@
+{ config, lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options.mblaze = {
+    enable = lib.mkEnableOption "mblaze for this email account";
+
+    sendMailCommand = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      example = "msmtpq --read-envelope-from --read-recipients";
+      description = ''
+        Command to send a mail, written to the `Sendmail:` entry of the
+        account profile. If msmtp is enabled for the account, then this
+        is set to
+        {command}`msmtpq --read-envelope-from --read-recipients`.
+
+        {manpage}`mcom(1)` appends the `Sendmail-Args:` entry to it,
+        `-t` by default, which asks for the recipients to be collected
+        from the message headers. Set that entry through
+        [](#opt-accounts.email.accounts._name_.mblaze.settings) for a
+        command that takes its arguments differently.
+
+        When left null the entry is omitted and mblaze falls back to
+        `sendmail` from {env}`PATH`.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        Scan-Format = "%c%u%r %-3n %10d %17f %t %2i%s";
+      };
+      description = ''
+        Entries added to this mblaze account profile, as documented in
+        {manpage}`mblaze-profile(5)`. An entry defined here overrides
+        the generated one of the same name, as well as the one defined
+        by [](#opt-programs.mblaze.settings).
+      '';
+    };
+  };
+
+  config = {
+    mblaze.sendMailCommand = lib.mkIf config.msmtp.enable (
+      lib.mkDefault "msmtpq --read-envelope-from --read-recipients"
+    );
+  };
+}

--- a/modules/programs/mblaze/default.nix
+++ b/modules/programs/mblaze/default.nix
@@ -1,0 +1,181 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+  cfg = config.programs.mblaze;
+
+  enabledAccounts = lib.filterAttrs (
+    _: account: account.enable && account.mblaze.enable
+  ) config.accounts.email.accounts;
+
+  # exactly one account is primary, asserted in modules/accounts/email.nix,
+  # and it may be one that leaves mblaze disabled, in which case no account
+  # owns ~/.mblaze
+  primaryAccountName = lib.findFirst (name: enabledAccounts.${name}.primary) null (
+    lib.attrNames enabledAccounts
+  );
+
+  # mblaze reads one profile, from $MBLAZE or from ~/.mblaze when that is unset,
+  # so an account is selected by pointing $MBLAZE at its own directory. The
+  # primary account is written to both places, which keeps a bare `mcom` working
+  # with no environment set up.
+  accountDir = name: "${config.xdg.configHome}/mblaze/${name}";
+  stateDir = name: "${config.xdg.dataHome}/mblaze/${name}";
+
+  # `maildir` carries a default path for every account whether or not anything
+  # ever populates it, so a local maildir only counts once a synchroniser is set
+  # up to fill it
+  hasLocalMaildir =
+    account:
+    !isNull account.maildir
+    && (
+      account.mbsync.enable
+      || account.offlineimap.enable
+      || account.getmail.enable
+      || account.lieer.enable
+      || account.mujmap.enable
+    );
+
+  mkMailbox = account: "${account.realName} <${account.address}>";
+
+  mkAliases =
+    account: map (alias: if lib.isString alias then alias else alias.address) account.aliases;
+
+  mkDrafts =
+    name: account:
+    if hasLocalMaildir account && !isNull account.folders.drafts then
+      "${account.maildir.absPath}/${account.folders.drafts}"
+    else
+      "${stateDir name}/drafts";
+
+  mkOutbox =
+    account:
+    if !hasLocalMaildir account || isNull account.folders.sent then
+      null
+    else
+      "${account.maildir.absPath}/${account.folders.sent}";
+
+  mkProfile =
+    name: account:
+    let
+      aliases = mkAliases account;
+
+      entries = lib.filterAttrs (_: value: !isNull value) (
+        {
+          Local-Mailbox = mkMailbox account;
+          Reply-From = mkMailbox account;
+          Alternate-Mailboxes = if aliases == [ ] then null else lib.concatStringsSep ", " aliases;
+          FQDN = lib.last (lib.splitString "@" account.address);
+          Maildir = if hasLocalMaildir account then account.maildir.absPath else null;
+          Drafts = mkDrafts name account;
+          Outbox = mkOutbox account;
+          Sendmail = account.mblaze.sendMailCommand;
+          Editor = cfg.editor;
+        }
+        // cfg.settings
+        // account.mblaze.settings
+      );
+    in
+    lib.concatStringsSep "\n" (lib.mapAttrsToList (key: value: "${key}: ${value}") entries) + "\n";
+
+  mkSignature =
+    account:
+    if
+      account.signature.showSignature == "append"
+      && isNull account.signature.command
+      && account.signature.text != ""
+    then
+      account.signature.text
+    else
+      null;
+
+  mkFiles =
+    dir: name: account:
+    {
+      "${dir}/profile".text = mkProfile name account;
+    }
+    // lib.optionalAttrs (!isNull (mkSignature account)) {
+      "${dir}/signature".text = mkSignature account;
+    };
+
+in
+{
+  meta.maintainers = [ lib.maintainers.soywod ];
+
+  options = {
+    programs.mblaze = {
+      enable = lib.mkEnableOption "mblaze, unix utilities to deal with Maildir";
+
+      package = lib.mkPackageOption pkgs "mblaze" { };
+
+      editor = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "nvim";
+        description = ''
+          Editor {manpage}`mcom(1)` opens drafts with, written to the
+          `Editor:` entry of every generated profile. When left null
+          mblaze falls back to {env}`MBLAZE_EDITOR`, then {env}`VISUAL`,
+          then {env}`EDITOR`.
+        '';
+      };
+
+      settings = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        example = {
+          Scan-Format = "%c%u%r %-3n %10d %17f %t %2i%s";
+        };
+        description = ''
+          Entries added to every generated profile, as documented in
+          {manpage}`mblaze-profile(5)`. An entry defined here overrides
+          the generated one of the same name, and is in turn overridden
+          by [](#opt-accounts.email.accounts._name_.mblaze.settings).
+        '';
+      };
+
+      accountDirs = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        internal = true;
+        description = ''
+          Generated map of account name to the directory holding that
+          account's profile, to be exported as {env}`MBLAZE`. Read by
+          modules that drive mblaze on behalf of another program.
+        '';
+      };
+    };
+
+    accounts.email.accounts = mkOption {
+      type = with types; attrsOf (submodule (import ./accounts.nix));
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs.mblaze.accountDirs = lib.mapAttrs (name: _: accountDir name) enabledAccounts;
+
+    xdg.configFile = lib.mkMerge (
+      lib.mapAttrsToList (name: account: mkFiles "mblaze/${name}" name account) enabledAccounts
+    );
+
+    # ~/.mblaze is where mblaze looks when $MBLAZE is unset, so the primary
+    # account is reachable without any environment set up
+    home.file = lib.optionalAttrs (!isNull primaryAccountName) (
+      mkFiles ".mblaze" primaryAccountName enabledAccounts.${primaryAccountName}
+    );
+
+    # `Drafts:` has to exist before mcom can deliver a draft into it, and
+    # mdeliver does not create it
+    home.activation.mblazeDrafts = lib.mkIf (enabledAccounts != { }) (
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        run ${cfg.package}/bin/mmkdir ${lib.escapeShellArgs (lib.mapAttrsToList mkDrafts enabledAccounts)}
+      ''
+    );
+  };
+}

--- a/tests/modules/accounts/email-test-accounts.nix
+++ b/tests/modules/accounts/email-test-accounts.nix
@@ -57,6 +57,7 @@
             "himalaya"
             "imapnotify"
             "lieer"
+            "mblaze"
             "mbsync"
             "meli"
             "msmtp"

--- a/tests/modules/programs/mblaze/basic.nix
+++ b/tests/modules/programs/mblaze/basic.nix
@@ -1,0 +1,68 @@
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  accounts.email.accounts = {
+    "hm@example.com" = {
+      aliases = [ "webmaster@example.com" ];
+      signature = {
+        showSignature = "append";
+        text = "Sent with home-manager";
+      };
+      mblaze.enable = true;
+    };
+
+    hm-account = {
+      mblaze = {
+        enable = true;
+        sendMailCommand = "/bin/mysendmail --read-recipients";
+        settings.Scan-Format = "%c%u%r %-3n %10d %17f %t %2i%s";
+      };
+    };
+  };
+
+  programs.mblaze = {
+    enable = true;
+    editor = "nvim";
+  };
+
+  nmt.script = ''
+    primary=home-files/.mblaze/profile
+
+    # the primary account is also written where mblaze looks when
+    # MBLAZE is unset
+    assertFileExists $primary
+    assertFileContains $primary 'Local-Mailbox: H. M. Test <hm@example.com>'
+    assertFileContains $primary 'Reply-From: H. M. Test <hm@example.com>'
+    assertFileContains $primary 'Alternate-Mailboxes: webmaster@example.com'
+    assertFileContains $primary 'FQDN: example.com'
+    assertFileContains $primary 'Editor: nvim'
+
+    # no synchroniser fills the account maildir, so drafts go to state
+    assertFileContains $primary 'Drafts: /home/hm-user/.local/share/mblaze/hm@example.com/drafts'
+    assertFileNotRegex $primary '^Outbox:'
+    assertFileNotRegex $primary '^Maildir:'
+
+    # no send command and no msmtp: mblaze falls back to sendmail
+    assertFileNotRegex $primary '^Sendmail'
+
+    # parsing of a profile halts on the first empty line
+    assertFileNotRegex $primary '^$'
+
+    assertFileContent home-files/.mblaze/signature \
+      ${builtins.toFile "signature" "Sent with home-manager"}
+
+    # the same account is reachable through MBLAZE as well
+    assertFileContains home-files/.config/mblaze/hm@example.com/profile \
+      'Local-Mailbox: H. M. Test <hm@example.com>'
+
+    secondary=home-files/.config/mblaze/hm-account/profile
+
+    assertFileExists $secondary
+    assertFileContains $secondary 'Local-Mailbox: H. M. Test Jr. <hm@example.org>'
+    assertFileContains $secondary 'Sendmail: /bin/mysendmail --read-recipients'
+    assertFileContains $secondary 'Scan-Format: %c%u%r %-3n %10d %17f %t %2i%s'
+
+    # a non-primary account is reachable through MBLAZE only
+    assertPathNotExists home-files/.mblaze/hm-account
+  '';
+}

--- a/tests/modules/programs/mblaze/default.nix
+++ b/tests/modules/programs/mblaze/default.nix
@@ -1,0 +1,4 @@
+{
+  mblaze-basic = ./basic.nix;
+  mblaze-maildir = ./maildir.nix;
+}

--- a/tests/modules/programs/mblaze/maildir.nix
+++ b/tests/modules/programs/mblaze/maildir.nix
@@ -1,0 +1,43 @@
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  accounts.email.accounts = {
+    "hm@example.com" = {
+      mbsync.enable = true;
+      msmtp.enable = true;
+      mblaze.enable = true;
+    };
+
+    hm-account = {
+      mujmap.enable = true;
+      folders.drafts = null;
+      mblaze.enable = true;
+    };
+  };
+
+  programs = {
+    mblaze.enable = true;
+    msmtp.enable = true;
+  };
+
+  nmt.script = ''
+    profile=home-files/.mblaze/profile
+
+    # a synchronised maildir is where drafts and sent copies belong
+    assertFileContains $profile 'Maildir: /home/hm-user/Mail/hm@example.com'
+    assertFileContains $profile 'Drafts: /home/hm-user/Mail/hm@example.com/Drafts'
+    assertFileContains $profile 'Outbox: /home/hm-user/Mail/hm@example.com/Sent'
+
+    # an msmtp account needs no explicit send command
+    assertFileContains $profile 'Sendmail: msmtpq --read-envelope-from --read-recipients'
+
+    mujmap=home-files/.config/mblaze/hm-account/profile
+
+    # mujmap fills the account maildir as well
+    assertFileContains $mujmap 'Maildir: /home/hm-user/Mail/hm-account'
+    assertFileContains $mujmap 'Outbox: /home/hm-user/Mail/hm-account/Sent'
+
+    # an account with no drafts folder keeps its drafts out of the maildir
+    assertFileContains $mujmap 'Drafts: /home/hm-user/.local/share/mblaze/hm-account/drafts'
+  '';
+}


### PR DESCRIPTION
### Description

Added the `mblaze` program. `mblaze` is a group of Unix utilities to deal with Maildir; it has also sending capabilities. `mblaze` does not support multi-accounting natively, so this module helps supporting it.

https://github.com/leahneukirchen/mblaze

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)
