### PR TITLE
moor: init

### DIFF
--- a/modules/misc/news/2026/08/2026-08-31_18-36-46.nix
+++ b/modules/misc/news/2026/08/2026-08-31_18-36-46.nix
@@ -1,0 +1,11 @@
+{
+  time = "2026-08-31T18:36:46+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.moor'.
+
+    moor is a terminal pager. The module can configure moor through the
+    `programs.moor.options` option and set it as the Jujutsu pager through
+    `programs.moor.enableJujutsuIntegration`.
+  '';
+}

--- a/modules/programs/moor.nix
+++ b/modules/programs/moor.nix
@@ -1,0 +1,63 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.moor;
+in
+{
+  meta.maintainers = with lib.maintainers; [ wini ];
+
+  options.programs.moor = {
+    enable = lib.mkEnableOption "moor, a modern pager for humans";
+
+    package = lib.mkPackageOption pkgs "moor" { };
+
+    options = lib.mkOption {
+      type =
+        with lib.types;
+        let
+          scalar = oneOf [
+            bool
+            int
+            str
+          ];
+          attrs = attrsOf (either scalar (listOf scalar));
+        in
+        coercedTo attrs (lib.cli.toCommandLineGNU { }) (listOf str);
+      default = [ ];
+      description = "Options to be set via {env}`$MOOR`.";
+      example = {
+        no-linenumbers = true;
+        no-statusbar = true;
+        quit-if-one-screen = true;
+      };
+    };
+
+    enableJujutsuIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable Jujutsu integration for moor.
+
+        When enabled, moor will be configured as Jujutsu's pager.
+      '';
+    };
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      home.packages = [ cfg.package ];
+      home.sessionVariables = {
+        PAGER = lib.mkDefault (lib.getExe cfg.package);
+        MOOR = lib.mkIf (cfg.options != [ ]) (lib.concatStringsSep " " cfg.options);
+      };
+    })
+
+    (lib.mkIf (cfg.enable && cfg.enableJujutsuIntegration) {
+      programs.jujutsu.settings.ui.pager = lib.getExe cfg.package;
+    })
+  ];
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -127,6 +127,7 @@ let
     "micro"
     "mise"
     "mistral-vibe"
+    "moor"
     "mpv"
     "msmtp"
     "mu"

--- a/tests/modules/programs/moor/basic.nix
+++ b/tests/modules/programs/moor/basic.nix
@@ -1,0 +1,19 @@
+{
+  programs.moor = {
+    enable = true;
+    options = {
+      no-linenumbers = true;
+      no-search-line-highlight = true;
+      no-statusbar = true;
+      quit-if-one-screen = true;
+      terminal-fg = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+      'MOOR="--no-linenumbers --no-search-line-highlight --no-statusbar --quit-if-one-screen --terminal-fg"'
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+      'PAGER="@moor@/bin/moor"'
+  '';
+}

--- a/tests/modules/programs/moor/default.nix
+++ b/tests/modules/programs/moor/default.nix
@@ -1,0 +1,5 @@
+{
+  moor-basic = ./basic.nix;
+  moor-jujutsu-integration = ./jujutsu-integration.nix;
+  moor-no-jujutsu-integration = ./no-jujutsu-integration.nix;
+}

--- a/tests/modules/programs/moor/jujutsu-integration.nix
+++ b/tests/modules/programs/moor/jujutsu-integration.nix
@@ -1,0 +1,16 @@
+{
+  programs.moor = {
+    enable = true;
+    enableJujutsuIntegration = true;
+  };
+
+  programs.jujutsu.enable = true;
+
+  nmt.script = ''
+    assertFileExists home-files/.config/jj/config.toml
+    assertFileContent home-files/.config/jj/config.toml ${builtins.toFile "expected" ''
+      [ui]
+      pager = "@moor@/bin/moor"
+    ''}
+  '';
+}

--- a/tests/modules/programs/moor/no-jujutsu-integration.nix
+++ b/tests/modules/programs/moor/no-jujutsu-integration.nix
@@ -1,0 +1,18 @@
+{
+  programs.moor = {
+    enable = true;
+    enableJujutsuIntegration = false;
+  };
+
+  programs.jujutsu = {
+    enable = true;
+    settings.user.name = "Home Manager";
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/jj/config.toml ${builtins.toFile "expected" ''
+      [user]
+      name = "Home Manager"
+    ''}
+  '';
+}


### PR DESCRIPTION
## Description

Adds a module for the [`moor`](https://github.com/walles/moor) pager. Mostly modeled after the `less` module.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```text
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)