### PR TITLE
niri: preserve string context in generated config

### DIFF
--- a/modules/services/window-managers/niri.nix
+++ b/modules/services/window-managers/niri.nix
@@ -188,7 +188,7 @@ in
           escapeBackslashes = true;
           escapeTabs = true;
         };
-        settings = lib.trim (toKDL cfg.settings);
+        settings = lib.removeSuffix "\n" (toKDL cfg.settings);
         configLines = lib.concatStringsSep "\n" (
           lib.filter (line: line != "") [
             cfg.extraConfigEarly


### PR DESCRIPTION
lib.trim goes through builtins.match, which discards string context. Any store path placed in wayland.windowManager.niri.settings therefore ends up as inert text in niri/config.kdl: the derivation has no references and no inputDrvs, so nothing roots the referenced packages.

In practice a spawn-at-startup pointing at a package silently stops working after a nixpkgs bump, because the new store path is never realised.

Re-attach the context from the untrimmed string. extraConfigEarly and extraConfig already bypass lib.trim and were unaffected.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
