### PR TITLE
docs: link release note highlights to module pages

### DIFF
--- a/docs/home-manager-manual.nix
+++ b/docs/home-manager-manual.nix
@@ -48,8 +48,8 @@ stdenv.mkDerivation {
     runHook preBuild
 
     mkdir -p source
-    python3 ${./mdbook/convert-markup.py} "$src/manual" source
-    python3 ${./mdbook/convert-markup.py} \
+    python3 ${./mdbook}/convert-markup.py "$src/manual" source
+    python3 ${./mdbook}/convert-markup.py \
       --base-depth 1 \
       "$src/release-notes" \
       source/release-notes

--- a/docs/mdbook/convert-markup.py
+++ b/docs/mdbook/convert-markup.py
@@ -8,6 +8,8 @@ import shutil
 import sys
 from pathlib import Path
 
+from option_links import OPTION_LINK, option_label, option_target
+
 
 SIMPLE_ROLES = (
     "command",
@@ -23,9 +25,6 @@ HEADING_ANCHOR = re.compile(r"^(#{1,6}\s+)(.*)\s+\{#([^}]+)\}\s*$")
 INLINE_ANCHOR = re.compile(r"\[\]\{#([^}]+)\}")
 OPTION_ROLE = re.compile(r"(?<![$`])\{option\}`([^`]*)`")
 SIMPLE_ROLE = re.compile(r"(?<![$`])\{(" + "|".join(SIMPLE_ROLES) + r")\}`([^`]*)`")
-OPTION_LINK = re.compile(
-    r"\[(?P<label>[^\]]*)\]\(#(?P<anchor>(?:opt|nixos-opt|nix-darwin-opt)-[^)]+)\)"
-)
 LEFTOVER_ROLE = re.compile(
     r"(?<![$`])\{(" + "|".join(("option", *SIMPLE_ROLES)) + r")\}`[^`]*`"
 )
@@ -33,45 +32,6 @@ FENCE = re.compile(r"^\s*(`{3,})(.*)$")
 FENCE_CLOSE = re.compile(r"^\s*`{3,}\s*$")
 ADMONITION_OPEN = re.compile(r"^\s*:::\s*\{\.(note|warning|example)\}\s*$")
 ADMONITION_CLOSE = re.compile(r"^\s*:::\s*$")
-DEEP_SPLIT_NAMESPACES = {"programs", "services"}
-
-
-def option_target(anchor: str, current_file: Path, base_depth: int) -> str:
-    if anchor.startswith("nix-darwin-opt-"):
-        option = anchor.removeprefix("nix-darwin-opt-")
-        option = option.replace("<", "_").replace(">", "_")
-        anchor = f"nix-darwin-opt-{option}"
-        base = "options/nix-darwin"
-    elif anchor.startswith("nixos-opt-"):
-        option = anchor.removeprefix("nixos-opt-")
-        option = option.replace("<", "_").replace(">", "_")
-        anchor = f"nixos-opt-{option}"
-        base = "options/nixos"
-    else:
-        option = anchor.removeprefix("opt-")
-        option = option.replace("<", "_").replace(">", "_")
-        anchor = f"opt-{option}"
-        base = "options/home-manager"
-
-    page_parts = option_page_parts(option)
-    prefix = "../" * (base_depth + len(current_file.parent.parts))
-    return f"{prefix}{base}/{'/'.join(page_parts)}.md#{anchor}"
-
-
-def option_page_parts(option_name: str) -> list[str]:
-    parts = option_name.split(".")
-    namespace = parts[0]
-    if namespace in DEEP_SPLIT_NAMESPACES and len(parts) > 1:
-        return parts[:2]
-    return [namespace]
-
-
-def option_label(anchor: str) -> str:
-    if anchor.startswith("nix-darwin-opt-"):
-        return anchor.removeprefix("nix-darwin-opt-")
-    if anchor.startswith("nixos-opt-"):
-        return anchor.removeprefix("nixos-opt-")
-    return anchor.removeprefix("opt-")
 
 
 def markdown_label(value: str) -> str:

--- a/docs/mdbook/option_links.py
+++ b/docs/mdbook/option_links.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Shared helpers for turning option anchors into mdbook links.
+
+Both the manual conversion and the option page rendering refer to options
+through `opt-`, `nixos-opt-` and `nix-darwin-opt-` anchors. The options are
+split over one page per namespace, and per module for the namespaces in
+`DEEP_SPLIT_NAMESPACES`, so an anchor has to be resolved to a page before it
+can be linked to.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+OPTION_LINK = re.compile(
+    r"\[(?P<label>[^\]]*)\]\(#(?P<anchor>(?:opt|nixos-opt|nix-darwin-opt)-[^)]+)\)"
+)
+OPTION_HREF = re.compile(r'href="#(?P<anchor>(?:opt|nixos-opt|nix-darwin-opt)-[^"]+)"')
+DEEP_SPLIT_NAMESPACES = {"programs", "services"}
+ANCHOR_BASES = (
+    ("nix-darwin-opt-", "options/nix-darwin"),
+    ("nixos-opt-", "options/nixos"),
+    ("opt-", "options/home-manager"),
+)
+
+
+def option_label(anchor: str) -> str:
+    """Return the option name an anchor refers to."""
+    for prefix, _ in ANCHOR_BASES:
+        if anchor.startswith(prefix):
+            return anchor.removeprefix(prefix)
+    return anchor
+
+
+def option_page_parts(option_name: str) -> list[str]:
+    """Return the path segments of the page documenting an option."""
+    parts = option_name.split(".")
+    namespace = parts[0]
+    if namespace in DEEP_SPLIT_NAMESPACES and len(parts) > 1:
+        return parts[:2]
+    return [namespace]
+
+
+def option_fragment(option_name: str, page_parts: list[str], anchor: str) -> str:
+    """Return the URL fragment addressing an option on its page.
+
+    A `programs.foo` or `services.foo` path names a module rather than an
+    option, so its page holds no matching anchor and the fragment is empty,
+    which links to the page itself.
+    """
+    if len(page_parts) > 1 and option_name.split(".") == page_parts:
+        return ""
+    return f"#{anchor}"
+
+
+def option_target(anchor: str, current_file: Path, base_depth: int = 0) -> str:
+    """Return a link from `current_file` to the option an anchor refers to.
+
+    `base_depth` is the depth of `current_file` below the manual source root.
+    """
+    for prefix, base in ANCHOR_BASES:
+        if anchor.startswith(prefix):
+            option = anchor.removeprefix(prefix).replace("<", "_").replace(">", "_")
+            anchor = f"{prefix}{option}"
+            break
+    else:
+        raise ValueError(f"not an option anchor: {anchor}")
+
+    page_parts = option_page_parts(option)
+    prefix = "../" * (base_depth + len(current_file.parent.parts))
+    fragment = option_fragment(option, page_parts, anchor)
+    return f"{prefix}{base}/{'/'.join(page_parts)}.md{fragment}"

--- a/docs/mdbook/options.nix
+++ b/docs/mdbook/options.nix
@@ -15,7 +15,7 @@ pkgs.runCommand "home-manager-mdbook-options"
     passAsFile = [ "optionDocsJson" ];
   }
   ''
-    python3 ${./render-options.py} \
+    python3 ${./.}/render-options.py \
       "$optionDocsJsonPath" \
       ${manpageUrls} \
       ${revision} \

--- a/docs/mdbook/render-options.py
+++ b/docs/mdbook/render-options.py
@@ -2,41 +2,17 @@
 from __future__ import annotations
 
 import json
-import re
 import subprocess
 import sys
 from pathlib import Path
 
-
-OPTION_LINK = re.compile(
-    r"\[(?P<label>[^\]]*)\]\(#(?P<anchor>(?:opt|nixos-opt|nix-darwin-opt)-[^)]+)\)"
+from option_links import (
+    OPTION_HREF,
+    OPTION_LINK,
+    option_label,
+    option_page_parts,
+    option_target,
 )
-OPTION_HREF = re.compile(r'href="#(?P<anchor>(?:opt|nixos-opt|nix-darwin-opt)-[^"]+)"')
-DEEP_SPLIT_NAMESPACES = {"programs", "services"}
-
-
-def option_label(anchor: str) -> str:
-    if anchor.startswith("nix-darwin-opt-"):
-        return anchor.removeprefix("nix-darwin-opt-")
-    if anchor.startswith("nixos-opt-"):
-        return anchor.removeprefix("nixos-opt-")
-    return anchor.removeprefix("opt-")
-
-
-def option_target(anchor: str, current_file: Path) -> str:
-    if anchor.startswith("nix-darwin-opt-"):
-        option = anchor.removeprefix("nix-darwin-opt-")
-        base = "options/nix-darwin"
-    elif anchor.startswith("nixos-opt-"):
-        option = anchor.removeprefix("nixos-opt-")
-        base = "options/nixos"
-    else:
-        option = anchor.removeprefix("opt-")
-        base = "options/home-manager"
-
-    page_parts = option_page_parts(option)
-    prefix = "../" * len(current_file.parent.parts)
-    return f"{prefix}{base}/{'/'.join(page_parts)}.md#{anchor}"
 
 
 def rewrite_option_links(text: str, current_file: Path) -> str:
@@ -55,14 +31,6 @@ def rewrite_option_links(text: str, current_file: Path) -> str:
 
 def namespace_for(option_name: str) -> str:
     return option_name.split(".", 1)[0]
-
-
-def option_page_parts(option_name: str) -> list[str]:
-    parts = option_name.split(".")
-    namespace = parts[0]
-    if namespace in DEEP_SPLIT_NAMESPACES and len(parts) > 1:
-        return parts[:2]
-    return [namespace]
 
 
 def option_group_for(option_name: str) -> str:

--- a/docs/release-notes/rl-2605.md
+++ b/docs/release-notes/rl-2605.md
@@ -17,7 +17,7 @@ This release has the following notable changes:
 - New options were added for `services.podman.useDefaultMachine` and podman
   machine management on Darwin.
 
-- The [](#opt-programs.rclone.enable) module now supports launchd-backed config,
+- The [](#opt-programs.rclone) module now supports launchd-backed config,
   mount, and serve agents on Darwin. The new
   `programs.rclone.remotes.<name>.serve` option can manage `rclone serve`
   sidecar services on both Linux and Darwin. On non-systemd platforms,

--- a/docs/release-notes/rl-2611.md
+++ b/docs/release-notes/rl-2611.md
@@ -7,7 +7,7 @@ section is therefore not final.
 
 This release has the following notable changes:
 
-- The [](#opt-programs.uv.enable) module can now install uv-managed Python
+- The [](#opt-programs.uv) module can now install uv-managed Python
   versions and tools through the new `programs.uv.python.versions`,
   `programs.uv.python.default`, and `programs.uv.tool.packages` options. Unpinned
   entries track the latest release on each activation while pinned ones stay put,


### PR DESCRIPTION
Fixes two slightly irritating links. Both highlights describe a module but link to its `enable` option, so they render as "The `programs.uv.enable` module ..." and "The `programs.rclone.enable` module ...".

Pointing the anchor at `programs.uv` / `programs.rclone` targets the module's options page and renders the module name as the label — `docs/mdbook/convert-markup.py` maps `programs.<name>` to that page and derives the label from the anchor.

Follow-up to #9507 and #9452, which introduced these entries.