### PR TITLE
pistol: revert config path for macOS

### DIFF
--- a/modules/programs/pistol.nix
+++ b/modules/programs/pistol.nix
@@ -10,7 +10,10 @@ let
   cfg = config.programs.pistol;
 
   configDir =
-    if pkgs.stdenv.hostPlatform.isDarwin then "Library/Preferences" else config.xdg.configHome;
+    if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
+      "Library/Application Support"
+    else
+      config.xdg.configHome;
 
   configFile = lib.concatStringsSep "\n" (
     map (

--- a/modules/programs/pistol.nix
+++ b/modules/programs/pistol.nix
@@ -10,6 +10,12 @@ let
   cfg = config.programs.pistol;
 
   configDir =
+    # NOTE: This intentionally diverges from the documentation
+    # pistol's README claims that the default is Library/Preferences
+    # However, this is part of a default set for XDG_CONFIG_DIRS,
+    # which gets overwritten by, e.g., nix-darwin.
+    # In such cases, the only directory checked is `XDG_CONFIG_HOME`,
+    # which falls back to Library/Application Support/.
     if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
       "Library/Application Support"
     else

--- a/tests/modules/programs/pistol/associations.nix
+++ b/tests/modules/programs/pistol/associations.nix
@@ -19,6 +19,8 @@
     ];
   };
 
+  xdg.enable = false;
+
   nmt.script =
     let
       expected = builtins.toFile "config-expected" ''

--- a/tests/modules/programs/pistol/associations.nix
+++ b/tests/modules/programs/pistol/associations.nix
@@ -27,7 +27,7 @@
         fpath .*.md$ sh: bat --paging=never --color=always %pistol-filename% | head -8'';
       path =
         if pkgs.stdenv.hostPlatform.isDarwin then
-          "home-files/Library/Preferences/pistol/pistol.conf"
+          "home-files/Library/Application Support/pistol/pistol.conf"
         else
           "home-files/.config/pistol/pistol.conf";
     in

--- a/tests/modules/programs/pistol/default.nix
+++ b/tests/modules/programs/pistol/default.nix
@@ -2,5 +2,6 @@
   pistol-associations = ./associations.nix;
   pistol-config = ./config.nix;
   pistol-double-association = ./double-association.nix;
+  pistol-honors-xdg = ./honors-xdg.nix;
   pistol-missing-association = ./missing-association.nix;
 }

--- a/tests/modules/programs/pistol/honors-xdg.nix
+++ b/tests/modules/programs/pistol/honors-xdg.nix
@@ -1,0 +1,23 @@
+_: {
+  programs.pistol = {
+    enable = true;
+    associations = [
+      {
+        mime = "application/json";
+        command = "bat %pistol-filename%";
+      }
+    ];
+  };
+
+  xdg.enable = true;
+
+  nmt.script =
+    let
+      expected = builtins.toFile "config-expected" "application/json bat %pistol-filename%";
+      path = "home-files/.config/pistol/pistol.conf";
+    in
+    ''
+      assertFileExists '${path}'
+      assertFileContent '${path}' '${expected}'
+    '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Switch back from ~/Library/Preferences/ to ~/Library/Application Support/. The original switch was in #7790; this PR is a revert of that.

This fixes pistol config file resolution when XDG_CONFIG_DIRS is set, such as by nix-darwin.[^1] In such cases, the underlying library used by pistol to resolve its config file location wipes its default list, which includes ~/Library/Preferences/.[^2][^3][^4] It additionally checks `XDG_CONFIG_HOME`,[^5] or ~/Library/Application Support/ if that is unset.[^6]

To support the scenario of `XDG_CONFIG_HOME` being present, add an additional check for `!config.xdg.enable`. This is the same pattern used in `modules/programs/navi.nix`.

[^1]: https://github.com/nix-darwin/nix-darwin/blob/15abb8c98f336cd8bd840d71059adebabe60bf04/modules/environment/default.nix#L157
[^2]: https://github.com/adrg/xdg/blob/b1241e93d6d49a821dada3ee2ecc09bc91f5e65c/paths_darwin.go#L16
[^3]: https://github.com/adrg/xdg/blob/b1241e93d6d49a821dada3ee2ecc09bc91f5e65c/paths_darwin.go#L26-L31
[^4]: https://github.com/adrg/xdg/blob/b1241e93d6d49a821dada3ee2ecc09bc91f5e65c/internal/pathutil/pathutil.go#L107-L114
[^5]: https://github.com/adrg/xdg/blob/b1241e93d6d49a821dada3ee2ecc09bc91f5e65c/base_dirs.go#L68-L70
[^6]: https://github.com/adrg/xdg/blob/b1241e93d6d49a821dada3ee2ecc09bc91f5e65c/paths_darwin.go#L25

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible:
    Most likely. Technically a bug fix, and defaults in github.com/adrg/xdg should ensure existing users without `XDG_CONFIG_DIRS` set should not notice a difference. Can add a state version gate if necessary.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
