### PR TITLE
ortie: add module

### DIFF
--- a/modules/misc/news/2026/08/2026-08-11_22-39-07.nix
+++ b/modules/misc/news/2026/08/2026-08-11_22-39-07.nix
@@ -1,0 +1,12 @@
+{
+  time = "2026-08-11T22:39:07+00:00";
+  message = ''
+    A new module is available: 'programs.ortie'.
+
+    Ortie is a CLI to manage OAuth 2.0 tokens: it runs the grant flows,
+    refreshes access tokens and reads them back through the credential
+    manager commands of your choice.
+
+    See https://github.com/pimalaya/ortie for more.
+  '';
+}

--- a/modules/programs/ortie.nix
+++ b/modules/programs/ortie.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.ortie;
+  tomlFormat = pkgs.formats.toml { };
+
+in
+{
+  meta.maintainers = with lib.maintainers; [ soywod ];
+
+  options.programs.ortie = {
+    enable = lib.mkEnableOption "Ortie, a CLI to manage OAuth 2.0 tokens";
+
+    package = lib.mkPackageOption pkgs "ortie" { nullable = true; };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule { freeformType = tomlFormat.type; };
+      default = { };
+      example = lib.literalExpression ''
+        {
+          accounts.personal = {
+            default = true;
+            client-id = "1234-abcd.apps.googleusercontent.com";
+            client-secret.command = "pass show ortie/personal-client-secret";
+            endpoints.authorization = "https://accounts.google.com/o/oauth2/v2/auth";
+            endpoints.token = "https://oauth2.googleapis.com/token";
+            scopes = [ "https://mail.google.com/" ];
+            extras.access_type = "offline";
+            auto-refresh = true;
+            storage.read.command = [ "pass" "show" "ortie/personal" ];
+            storage.write.command = "pass insert -m -f ortie/personal";
+          };
+        }
+      '';
+      description = ''
+        Ortie configuration.
+
+        Every OAuth 2.0 account is declared as an attribute of `accounts`,
+        which is the only section the configuration file accepts. The account
+        marked `default` is the one used when `--account <NAME>` is omitted.
+
+        Beware that the generated file lands in the world-readable Nix store,
+        so read secrets through a command rather than inlining them: prefer
+        `client-secret.command` over `client-secret.raw`.
+
+        See <https://github.com/pimalaya/ortie/blob/master/config.sample.toml>
+        for supported values.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."ortie/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "ortie-config.toml" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/ortie/default.nix
+++ b/tests/modules/programs/ortie/default.nix
@@ -1,0 +1,4 @@
+{
+  ortie-empty-settings = ./empty-settings.nix;
+  ortie-example-settings = ./example-settings.nix;
+}

--- a/tests/modules/programs/ortie/empty-settings.nix
+++ b/tests/modules/programs/ortie/empty-settings.nix
@@ -1,0 +1,10 @@
+{
+  programs.ortie = {
+    enable = true;
+    package = null;
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/ortie
+  '';
+}

--- a/tests/modules/programs/ortie/example-settings-expected.toml
+++ b/tests/modules/programs/ortie/example-settings-expected.toml
@@ -1,0 +1,43 @@
+[accounts.personal]
+auto-refresh = true
+client-id = "1234-abcd.apps.googleusercontent.com"
+default = true
+grant = "authorization-code"
+pkce = "s256"
+scopes = ["https://mail.google.com/"]
+
+[accounts.personal.client-secret]
+command = "pass show ortie/personal-client-secret"
+
+[accounts.personal.endpoints]
+authorization = "https://accounts.google.com/o/oauth2/v2/auth"
+token = "https://oauth2.googleapis.com/token"
+
+[accounts.personal.extras]
+access_type = "offline"
+
+[accounts.personal.hooks.on-refresh.success]
+command = "logger 'ortie refreshed a token'"
+
+[accounts.personal.storage.read]
+command = ["pass", "show", "ortie/personal"]
+
+[accounts.personal.storage.write]
+command = "pass insert -m -f ortie/personal"
+
+[accounts.work]
+client-id = "00000000-0000-0000-0000-000000000000"
+grant = "client-credentials"
+scopes = ["https://graph.microsoft.com/.default"]
+
+[accounts.work.client-secret]
+command = ["secret-tool", "lookup", "oauth", "work"]
+
+[accounts.work.endpoints]
+token = "https://login.microsoftonline.com/tenant/oauth2/v2.0/token"
+
+[accounts.work.storage.read]
+command = ["secret-tool", "lookup", "token", "work"]
+
+[accounts.work.storage.write]
+command = "secret-tool store --label ortie token work"

--- a/tests/modules/programs/ortie/example-settings.nix
+++ b/tests/modules/programs/ortie/example-settings.nix
@@ -1,0 +1,54 @@
+{ config, ... }:
+{
+  programs.ortie = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    settings = {
+      accounts.personal = {
+        default = true;
+        client-id = "1234-abcd.apps.googleusercontent.com";
+        client-secret.command = "pass show ortie/personal-client-secret";
+        grant = "authorization-code";
+        endpoints.authorization = "https://accounts.google.com/o/oauth2/v2/auth";
+        endpoints.token = "https://oauth2.googleapis.com/token";
+        scopes = [ "https://mail.google.com/" ];
+        pkce = "s256";
+        extras.access_type = "offline";
+        auto-refresh = true;
+        storage.read.command = [
+          "pass"
+          "show"
+          "ortie/personal"
+        ];
+        storage.write.command = "pass insert -m -f ortie/personal";
+        hooks.on-refresh.success.command = "logger 'ortie refreshed a token'";
+      };
+
+      accounts.work = {
+        grant = "client-credentials";
+        client-id = "00000000-0000-0000-0000-000000000000";
+        client-secret.command = [
+          "secret-tool"
+          "lookup"
+          "oauth"
+          "work"
+        ];
+        endpoints.token = "https://login.microsoftonline.com/tenant/oauth2/v2.0/token";
+        scopes = [ "https://graph.microsoft.com/.default" ];
+        storage.read.command = [
+          "secret-tool"
+          "lookup"
+          "token"
+          "work"
+        ];
+        storage.write.command = "secret-tool store --label ortie token work";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/ortie/config.toml
+    assertFileContent home-files/.config/ortie/config.toml ${./example-settings-expected.toml}
+  '';
+}


### PR DESCRIPTION
### Description

Ortie is a CLI to manage OAuth 2.0 tokens.

https://github.com/pimalaya/ortie

The PR is in draft, waiting for upstream merge: https://github.com/NixOS/nixpkgs/pull/551635

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

@bobberb