### PR TITLE
vdirsyncer: add local read-only news

### DIFF
--- a/modules/misc/news/2026/08/2026-08-12_07-12-58.nix
+++ b/modules/misc/news/2026/08/2026-08-12_07-12-58.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+{
+  time = "2026-08-12T12:12:58+00:00";
+  condition = config.programs.vdirsyncer.enable;
+  message = ''
+    Vdirsyncer can now treat local calendar and contact storages as read-only.
+
+    Set `accounts.calendar.accounts.<name>.vdirsyncer.localReadOnly` or
+    `accounts.contact.accounts.<name>.vdirsyncer.localReadOnly` to configure
+    this behavior.
+  '';
+}


### PR DESCRIPTION
### Description

Adds a follow-up news entry for #9790. The entry appears only for users who enable `programs.vdirsyncer` and documents both `localReadOnly` option paths.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)