### PR TITLE
treewide: stdenv.is* -> stdenv.hostPlatform.is*

### DIFF
--- a/modules/lib/darwin.nix
+++ b/modules/lib/darwin.nix
@@ -63,7 +63,7 @@ let
   intervalsString = lib.concatStringsSep ", " intervals;
 
   assertInterval = option: interval: pkgs: {
-    assertion = pkgs.stdenv.isDarwin -> lib.elem interval intervals;
+    assertion = pkgs.stdenv.hostPlatform.isDarwin -> lib.elem interval intervals;
     message = "On Darwin, ${option} must be one of: ${intervalsString}.";
   };
 

--- a/modules/misc/mozilla-messaging-hosts.nix
+++ b/modules/misc/mozilla-messaging-hosts.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  inherit (pkgs.stdenv) isDarwin;
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
   cfg = config.mozilla;
 

--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -143,7 +143,10 @@ in
       # `_pkgs`, see https://github.com/nix-community/home-manager/pull/993
       pkgs = lib.mkOverride lib.modules.defaultOverridePriority _pkgs;
       pkgs_i686 =
-        if _pkgs.stdenv.isLinux && _pkgs.stdenv.hostPlatform.isx86 then _pkgs.pkgsi686Linux else { };
+        if _pkgs.stdenv.hostPlatform.isLinux && _pkgs.stdenv.hostPlatform.isx86 then
+          _pkgs.pkgsi686Linux
+        else
+          { };
     };
   };
 }

--- a/modules/programs/aerc/default.nix
+++ b/modules/programs/aerc/default.nix
@@ -52,7 +52,7 @@ let
   ) config.accounts.email.accounts;
 
   configDir =
-    if (pkgs.stdenv.isDarwin && !config.xdg.enable) then
+    if (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) then
       "Library/Preferences/aerc"
     else
       "${config.xdg.configHome}/aerc";

--- a/modules/programs/bacon.nix
+++ b/modules/programs/bacon.nix
@@ -11,7 +11,7 @@ let
   settingsFormat = pkgs.formats.toml { };
 
   configDir =
-    if pkgs.stdenv.isDarwin then
+    if pkgs.stdenv.hostPlatform.isDarwin then
       "Library/Application Support/org.dystroy.bacon"
     else
       "${config.xdg.configHome}/bacon";

--- a/modules/programs/browserpass.nix
+++ b/modules/programs/browserpass.nix
@@ -35,7 +35,9 @@ in
     home.file = lib.mergeAttrsList (
       lib.concatMap (
         x:
-        with pkgs.stdenv;
+        let
+          inherit (pkgs.stdenv.hostPlatform) isDarwin;
+        in
         if x == "brave" then
           let
             dir =

--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -227,7 +227,7 @@ let
         if builtins.hasAttr packageName supportedBrowsers then packageName else browser;
 
       isProprietaryChrome = lib.hasPrefix "google-chrome" effectiveBrowser;
-      supportsUserExtensions = !isProprietaryChrome || pkgs.stdenv.isDarwin;
+      supportsUserExtensions = !isProprietaryChrome || pkgs.stdenv.hostPlatform.isDarwin;
 
       darwinDirs = {
         chromium = "Chromium";
@@ -245,7 +245,7 @@ let
       };
 
       configDir =
-        if pkgs.stdenv.isDarwin then
+        if pkgs.stdenv.hostPlatform.isDarwin then
           "Library/Application Support/" + (darwinDirs."${effectiveBrowser}" or effectiveBrowser)
         else
           "${config.xdg.configHome}/" + (linuxDirs."${effectiveBrowser}" or effectiveBrowser);
@@ -274,7 +274,7 @@ let
       };
 
       plasmaSupportEnabled =
-        pkgs.stdenv.isLinux && lib.elem browser plasmaSupportedBrowsers && cfg.plasmaSupport;
+        pkgs.stdenv.hostPlatform.isLinux && lib.elem browser plasmaSupportedBrowsers && cfg.plasmaSupport;
 
       nativeMessagingHosts = lib.unique (
         cfg.nativeMessagingHosts ++ lib.optional plasmaSupportEnabled cfg.plasmaBrowserIntegrationPackage
@@ -294,14 +294,14 @@ let
           message = "Cannot set `commandLineArgs` when `package` is null for ${browser}.";
         }
         {
-          assertion = !(isProprietaryChrome && pkgs.stdenv.isLinux && cfg.extensions != [ ]);
+          assertion = !(isProprietaryChrome && pkgs.stdenv.hostPlatform.isLinux && cfg.extensions != [ ]);
           message = "Cannot set `extensions` for `${effectiveBrowser}` on Linux. Google Chrome only loads external extensions from system-managed directories, which Home Manager does not manage.";
         }
         {
           assertion =
             !(
               isProprietaryChrome
-              && pkgs.stdenv.isDarwin
+              && pkgs.stdenv.hostPlatform.isDarwin
               && !builtins.all (
                 ext: ext.crxPath == null && ext.version == null && ext.updateUrl == chromeWebStoreUpdateUrl
               ) cfg.extensions

--- a/modules/programs/cudatext.nix
+++ b/modules/programs/cudatext.nix
@@ -131,7 +131,7 @@ in
   config =
     let
       settingsPath =
-        if pkgs.stdenv.isDarwin then
+        if pkgs.stdenv.hostPlatform.isDarwin then
           "Library/Application Support/CudaText/settings"
         else
           "${lib.removePrefix config.home.homeDirectory config.xdg.configHome}/cudatext/settings";

--- a/modules/programs/iamb.nix
+++ b/modules/programs/iamb.nix
@@ -8,7 +8,7 @@ let
   cfg = config.programs.iamb;
   tomlFormat = pkgs.formats.toml { };
   configDir =
-    if pkgs.stdenv.isDarwin && !config.xdg.enable then
+    if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
       "Library/Application Support"
     else
       config.xdg.configHome;

--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -13,7 +13,7 @@ let
 
   # jj v0.29+ deprecated support for "~/Library/Application Support" on Darwin.
   configDir =
-    if pkgs.stdenv.isDarwin && !(lib.versionAtLeast packageVersion "0.29.0") then
+    if pkgs.stdenv.hostPlatform.isDarwin && !(lib.versionAtLeast packageVersion "0.29.0") then
       "Library/Application Support"
     else
       config.xdg.configHome;

--- a/modules/programs/man/default.nix
+++ b/modules/programs/man/default.nix
@@ -33,7 +33,7 @@ in
       package = mkOption {
         type = with types; nullOr package;
         default =
-          if pkgs.stdenv.isDarwin && lib.versionAtLeast config.home.stateVersion "26.05" then
+          if pkgs.stdenv.hostPlatform.isDarwin && lib.versionAtLeast config.home.stateVersion "26.05" then
             null
           else if cfg.man-db.enable then
             pkgs.man
@@ -42,7 +42,7 @@ in
           else
             null;
         defaultText = lib.literalExpression ''
-          if pkgs.stdenv.isDarwin && lib.versionAtLeast config.home.stateVersion "26.05" then
+          if pkgs.stdenv.hostPlatform.isDarwin && lib.versionAtLeast config.home.stateVersion "26.05" then
             null
           else if cfg.man-db.enable then
             pkgs.man

--- a/modules/programs/navi.nix
+++ b/modules/programs/navi.nix
@@ -12,7 +12,7 @@ let
   yamlFormat = pkgs.formats.yaml { };
 
   configDir =
-    if pkgs.stdenv.isDarwin && !config.xdg.enable then
+    if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
       "Library/Application Support"
     else
       config.xdg.configHome;

--- a/modules/programs/neovim/default.nix
+++ b/modules/programs/neovim/default.nix
@@ -213,8 +213,8 @@ in
 
       waylandSupport = mkOption {
         type = types.bool;
-        default = pkgs.stdenv.isLinux;
-        defaultText = literalExpression "pkgs.stdenv.isLinux";
+        default = pkgs.stdenv.hostPlatform.isLinux;
+        defaultText = literalExpression "pkgs.stdenv.hostPlatform.isLinux";
         description = ''
           Whether to enable Wayland clipboard support.
         '';

--- a/modules/programs/nix-search-tv.nix
+++ b/modules/programs/nix-search-tv.nix
@@ -71,8 +71,8 @@ in
     programs.television.channels.nix-search-tv = lib.mkIf cfg.enableTelevisionIntegration (
       let
         nix-search-tv-path = if cfg.package != null then lib.getExe cfg.package else "nix-search-tv";
-        keybinding_modifier = if pkgs.stdenv.isDarwin then "alt" else "ctrl";
-        opener = if pkgs.stdenv.isDarwin then "open" else "xdg-open";
+        keybinding_modifier = if pkgs.stdenv.hostPlatform.isDarwin then "alt" else "ctrl";
+        opener = if pkgs.stdenv.hostPlatform.isDarwin then "open" else "xdg-open";
       in
       {
         metadata = {

--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -50,12 +50,12 @@ in
     configDir = lib.mkOption {
       type = types.either types.str types.path;
       default =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "Library/Application Support/nushell"
         else
           "${config.xdg.configHome}/nushell";
       defaultText = lib.literalExpression ''
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "Library/Application Support/nushell"
         else
           "''${config.xdg.configHome}/nushell";

--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -558,7 +558,7 @@ in
         activation.obsidian =
           let
             obsidianConfigDir =
-              if pkgs.stdenv.isDarwin then
+              if pkgs.stdenv.hostPlatform.isDarwin then
                 "${config.home.homeDirectory}/Library/Application Support/obsidian"
               else
                 "${config.xdg.configHome}/obsidian";

--- a/modules/programs/poetry.nix
+++ b/modules/programs/poetry.nix
@@ -15,7 +15,8 @@ let
 
   tomlFormat = pkgs.formats.toml { };
 
-  configDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else config.xdg.configHome;
+  configDir =
+    if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else config.xdg.configHome;
 
   cfg = config.programs.poetry;
 

--- a/modules/programs/tealdeer.nix
+++ b/modules/programs/tealdeer.nix
@@ -9,7 +9,8 @@ let
 
   cfg = config.programs.tealdeer;
 
-  configDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else config.xdg.configHome;
+  configDir =
+    if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else config.xdg.configHome;
 
   tomlFormat = pkgs.formats.toml { };
 

--- a/modules/programs/tex-fmt.nix
+++ b/modules/programs/tex-fmt.nix
@@ -13,7 +13,8 @@ let
     mkOption
     ;
 
-  configDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else config.xdg.configHome;
+  configDir =
+    if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else config.xdg.configHome;
 
   tomlFormat = pkgs.formats.toml { };
   cfg = config.programs.tex-fmt;

--- a/modules/programs/tiny.nix
+++ b/modules/programs/tiny.nix
@@ -8,7 +8,7 @@ let
   cfg = config.programs.tiny;
   format = pkgs.formats.yaml { };
   configDir =
-    if pkgs.stdenv.isDarwin then
+    if pkgs.stdenv.hostPlatform.isDarwin then
       "Library/Application Support/tiny"
     else
       "${config.xdg.configHome}/tiny";

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -306,7 +306,7 @@ in
       };
 
       secureSocket = mkOption {
-        default = pkgs.stdenv.isLinux;
+        default = pkgs.stdenv.hostPlatform.isLinux;
         type = types.bool;
         description = ''
           Store tmux socket under {file}`/run`, which is more

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -131,7 +131,9 @@ in
         VISUAL = editorBin;
       };
 
-    home.packages = optional (cfg.client.enable && pkgs.stdenv.isLinux) (lib.hiPrio clientDesktopItem);
+    home.packages = optional (cfg.client.enable && pkgs.stdenv.hostPlatform.isLinux) (
+      lib.hiPrio clientDesktopItem
+    );
 
     systemd.user.services.emacs = {
       Unit = {

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -60,7 +60,7 @@ let
       hash = lib.substring 0 24 (hexStringToBase32 (builtins.hashString "sha1" homedir));
       subdir = if homedir == options.programs.gpg.homedir.default then "${dir}" else "d.${hash}/${dir}";
     in
-    if pkgs.stdenv.isDarwin then
+    if pkgs.stdenv.hostPlatform.isDarwin then
       "/private/var/run/org.nix-community.home.gpg-agent/${subdir}"
     else
       "%t/gnupg/${subdir}";

--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -113,7 +113,7 @@ in
 
     assertions = [
       {
-        assertion = pkgs.stdenv.isDarwin -> (lib.length cfg.dates == 1);
+        assertion = pkgs.stdenv.hostPlatform.isDarwin -> (lib.length cfg.dates == 1);
         message = "On Darwin, `nix.gc.dates` must contain a single element.";
       }
       (lib.hm.darwin.assertInterval "nix.gc.dates.*" (lib.elemAt cfg.dates 0) pkgs)

--- a/modules/services/proton-pass-agent.nix
+++ b/modules/services/proton-pass-agent.nix
@@ -58,7 +58,7 @@ in
   config =
     let
       socketPath =
-        if pkgs.stdenv.isDarwin then
+        if pkgs.stdenv.hostPlatform.isDarwin then
           "$(${lib.getExe pkgs.getconf} DARWIN_USER_TEMP_DIR)/${cfg.socket}"
         else
           "$XDG_RUNTIME_DIR/${cfg.socket}";
@@ -67,7 +67,7 @@ in
         "ssh-agent"
         "start"
         "--socket-path"
-        "${if pkgs.stdenv.isDarwin then socketPath else "%t/${cfg.socket}"}"
+        "${if pkgs.stdenv.hostPlatform.isDarwin then socketPath else "%t/${cfg.socket}"}"
       ]
       ++ cfg.extraArgs;
     in
@@ -80,7 +80,7 @@ in
           bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
           fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
           nushell = "$env.SSH_AUTH_SOCK = ${
-            if pkgs.stdenv.isDarwin then
+            if pkgs.stdenv.hostPlatform.isDarwin then
               ''$"(${lib.getExe pkgs.getconf} DARWIN_USER_TEMP_DIR)/${cfg.socket}"''
             else
               ''$"($env.XDG_RUNTIME_DIR)/${cfg.socket}"''

--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -65,7 +65,7 @@ in
       initialization =
         let
           socketPath =
-            if pkgs.stdenv.isDarwin then
+            if pkgs.stdenv.hostPlatform.isDarwin then
               "$(${lib.getExe pkgs.getconf} DARWIN_USER_TEMP_DIR)/${cfg.socket}"
             else
               "$XDG_RUNTIME_DIR/${cfg.socket}";
@@ -74,7 +74,7 @@ in
           bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
           fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
           nushell = "$env.SSH_AUTH_SOCK = ${
-            if pkgs.stdenv.isDarwin then
+            if pkgs.stdenv.hostPlatform.isDarwin then
               ''$"(${lib.getExe pkgs.getconf} DARWIN_USER_TEMP_DIR)/${cfg.socket}"''
             else
               ''$"($env.XDG_RUNTIME_DIR)/${cfg.socket}"''

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -20,13 +20,13 @@ let
 
   # syncthing's configuration directory (see https://docs.syncthing.net/users/config.html)
   syncthingDir =
-    if pkgs.stdenv.isDarwin then
+    if pkgs.stdenv.hostPlatform.isDarwin then
       "$HOME/Library/Application Support/Syncthing"
     else
       "\${XDG_STATE_HOME:-$HOME/.local/state}/syncthing";
 
   syncthingDirShell =
-    if pkgs.stdenv.isDarwin then
+    if pkgs.stdenv.hostPlatform.isDarwin then
       ''
         syncthing_dir="${syncthingDir}"
       ''

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -550,7 +550,7 @@ in
     systemd = {
       enable = mkOption {
         type = types.bool;
-        default = pkgs.stdenv.isLinux;
+        default = pkgs.stdenv.hostPlatform.isLinux;
         example = false;
         description = ''
           Whether to enable {file}`sway-session.target` on

--- a/modules/services/yubikey-agent.nix
+++ b/modules/services/yubikey-agent.nix
@@ -27,7 +27,7 @@ in
       initialization =
         let
           socketPath =
-            if pkgs.stdenv.isDarwin then
+            if pkgs.stdenv.hostPlatform.isDarwin then
               "/tmp/yubikey-agent.sock"
             else
               "\${XDG_RUNTIME_DIR:-/run/user/$UID}/yubikey-agent/yubikey-agent.sock";
@@ -36,7 +36,7 @@ in
           bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
           fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
           nushell = "$env.SSH_AUTH_SOCK = ${
-            if pkgs.stdenv.isDarwin then
+            if pkgs.stdenv.hostPlatform.isDarwin then
               "/tmp/yubikey-agent.sock"
             else
               ''$"($env.XDG_RUNTIME_DIR | default $"/run/user/(id -u)")/yubikey-agent/yubikey-agent.sock"''

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -247,8 +247,8 @@ in
   options = {
     systemd.user = {
       enable = mkEnableOption "the user systemd service manager" // {
-        default = pkgs.stdenv.isLinux;
-        defaultText = literalExpression "pkgs.stdenv.isLinux";
+        default = pkgs.stdenv.hostPlatform.isLinux;
+        defaultText = literalExpression "pkgs.stdenv.hostPlatform.isLinux";
       };
 
       systemctlPath = mkOption {

--- a/tests/modules/programs/aerc/encode-url.nix
+++ b/tests/modules/programs/aerc/encode-url.nix
@@ -4,7 +4,7 @@
     nmt.script =
       let
         dir =
-          if (pkgs.stdenv.isDarwin && !config.xdg.enable) then
+          if (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) then
             "home-files/Library/Preferences/aerc"
           else
             "home-files/.config/aerc";

--- a/tests/modules/programs/aerc/oauth.nix
+++ b/tests/modules/programs/aerc/oauth.nix
@@ -4,7 +4,7 @@
     nmt.script =
       let
         dir =
-          if (pkgs.stdenv.isDarwin && !config.xdg.enable) then
+          if (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) then
             "home-files/Library/Preferences/aerc"
           else
             "home-files/.config/aerc";

--- a/tests/modules/programs/aerc/settings.nix
+++ b/tests/modules/programs/aerc/settings.nix
@@ -4,7 +4,7 @@
     nmt.script =
       let
         dir =
-          if (pkgs.stdenv.isDarwin && !config.xdg.enable) then
+          if (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) then
             "home-files/Library/Preferences/aerc"
           else
             "home-files/.config/aerc";

--- a/tests/modules/programs/atuin/nushell-fzf-order.nix
+++ b/tests/modules/programs/atuin/nushell-fzf-order.nix
@@ -44,7 +44,7 @@
   nmt.script =
     let
       nushellConfigFile =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "home-files/Library/Application Support/nushell/config.nu"
         else
           "home-files/.config/nushell/config.nu";

--- a/tests/modules/programs/atuin/nushell.nix
+++ b/tests/modules/programs/atuin/nushell.nix
@@ -22,7 +22,7 @@
   nmt.script =
     let
       configDir =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "home-files/Library/Application Support/nushell"
         else
           "home-files/.config/nushell";

--- a/tests/modules/programs/bacon/bacon.nix
+++ b/tests/modules/programs/bacon/bacon.nix
@@ -1,7 +1,10 @@
 { pkgs, ... }:
 let
   configDir =
-    if pkgs.stdenv.isDarwin then "Library/Application Support/org.dystroy.bacon" else ".config/bacon";
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/org.dystroy.bacon"
+    else
+      ".config/bacon";
 in
 {
   programs.bacon = {

--- a/tests/modules/programs/bacon/empty-config.nix
+++ b/tests/modules/programs/bacon/empty-config.nix
@@ -1,7 +1,10 @@
 { pkgs, ... }:
 let
   configDir =
-    if pkgs.stdenv.isDarwin then "Library/Application Support/org.dystroy.bacon" else ".config/bacon";
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/org.dystroy.bacon"
+    else
+      ".config/bacon";
 in
 {
   programs.bacon.enable = true;

--- a/tests/modules/programs/carapace/nushell.nix
+++ b/tests/modules/programs/carapace/nushell.nix
@@ -17,7 +17,7 @@
   nmt.script =
     let
       configDir =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "home-files/Library/Application Support/nushell"
         else
           "home-files/.config/nushell";

--- a/tests/modules/programs/clock-rs/empty-settings.nix
+++ b/tests/modules/programs/clock-rs/empty-settings.nix
@@ -8,7 +8,7 @@
     nmt.script =
       let
         configDir =
-          if pkgs.stdenv.isDarwin then
+          if pkgs.stdenv.hostPlatform.isDarwin then
             "home-files/Library/Application Support/clock-rs"
           else
             "home-files/.config/clock-rs";

--- a/tests/modules/programs/clock-rs/example-settings.nix
+++ b/tests/modules/programs/clock-rs/example-settings.nix
@@ -28,7 +28,7 @@
     nmt.script =
       let
         configDir =
-          if pkgs.stdenv.isDarwin then
+          if pkgs.stdenv.hostPlatform.isDarwin then
             "home-files/Library/Application Support/clock-rs"
           else
             "home-files/.config/clock-rs";

--- a/tests/modules/programs/cudatext/example-config.nix
+++ b/tests/modules/programs/cudatext/example-config.nix
@@ -81,7 +81,7 @@
   nmt.script =
     let
       settingsPath =
-        if pkgs.stdenv.isDarwin then
+        if pkgs.stdenv.hostPlatform.isDarwin then
           "home-files/Library/Application Support/CudaText/settings"
         else
           "home-files/.config/cudatext/settings";

--- a/tests/modules/programs/devenv/basic-config.nix
+++ b/tests/modules/programs/devenv/basic-config.nix
@@ -29,7 +29,7 @@
   nmt.script =
     let
       nushellConfigFile =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "home-files/Library/Application Support/nushell/config.nu"
         else
           "home-files/.config/nushell/config.nu";

--- a/tests/modules/programs/dircolors/settings.nix
+++ b/tests/modules/programs/dircolors/settings.nix
@@ -21,7 +21,7 @@
     nmt.script =
       let
         nushellConfigDir =
-          if pkgs.stdenv.isDarwin && !config.xdg.enable then
+          if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
             "home-files/Library/Application Support/nushell"
           else
             "home-files/.config/nushell";

--- a/tests/modules/programs/dircolors/xdg-config-settings.nix
+++ b/tests/modules/programs/dircolors/xdg-config-settings.nix
@@ -23,7 +23,7 @@
     nmt.script =
       let
         nushellConfigDir =
-          if pkgs.stdenv.isDarwin && !config.xdg.enable then
+          if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
             "home-files/Library/Application Support/nushell"
           else
             "home-files/.config/nushell";

--- a/tests/modules/programs/direnv/basic-config.nix
+++ b/tests/modules/programs/direnv/basic-config.nix
@@ -48,7 +48,7 @@ in
   nmt.script =
     let
       nushellConfigFile =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "home-files/Library/Application Support/nushell/config.nu"
         else
           "home-files/.config/nushell/config.nu";

--- a/tests/modules/programs/fzf/nushell-history-command.nix
+++ b/tests/modules/programs/fzf/nushell-history-command.nix
@@ -28,7 +28,7 @@
   nmt.script =
     let
       nushellConfigFile =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "home-files/Library/Application Support/nushell/config.nu"
         else
           "home-files/.config/nushell/config.nu";

--- a/tests/modules/programs/fzf/nushell-integration.nix
+++ b/tests/modules/programs/fzf/nushell-integration.nix
@@ -40,7 +40,7 @@
   nmt.script =
     let
       nushellConfigFile =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "home-files/Library/Application Support/nushell/config.nu"
         else
           "home-files/.config/nushell/config.nu";

--- a/tests/modules/programs/fzf/nushell-widget-overrides.nix
+++ b/tests/modules/programs/fzf/nushell-widget-overrides.nix
@@ -31,7 +31,7 @@
   nmt.script =
     let
       nushellConfigFile =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "home-files/Library/Application Support/nushell/config.nu"
         else
           "home-files/.config/nushell/config.nu";

--- a/tests/modules/programs/git/git-with-maintenance.nix
+++ b/tests/modules/programs/git/git-with-maintenance.nix
@@ -8,7 +8,7 @@ lib.mkMerge [
     };
   }
 
-  (lib.mkIf pkgs.stdenv.isDarwin {
+  (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     nmt.script = ''
       serviceFile=LaunchAgents/org.nix-community.home.git-maintenance-hourly.plist
       assertFileExists "$serviceFile"

--- a/tests/modules/programs/go/example-config.nix
+++ b/tests/modules/programs/go/example-config.nix
@@ -23,7 +23,8 @@
 
   nmt.script =
     let
-      goCfgDir = if !pkgs.stdenv.isDarwin then ".config/go" else "Library/Application Support/go";
+      goCfgDir =
+        if !pkgs.stdenv.hostPlatform.isDarwin then ".config/go" else "Library/Application Support/go";
     in
     ''
       assertFileExists "home-files/${goCfgDir}/env"

--- a/tests/modules/programs/go/go-telemetry.nix
+++ b/tests/modules/programs/go/go-telemetry.nix
@@ -12,7 +12,7 @@
   nm.script =
     let
       modeFileDir =
-        if !pkgs.stdenv.isDarwin then
+        if !pkgs.stdenv.hostPlatform.isDarwin then
           ".config/go/telemetry"
         else
           "Library/Application Support/go/telemetry";

--- a/tests/modules/programs/go/old-options.nix
+++ b/tests/modules/programs/go/old-options.nix
@@ -29,7 +29,8 @@
 
   nmt.script =
     let
-      goCfgDir = if !pkgs.stdenv.isDarwin then ".config/go" else "Library/Application Support/go";
+      goCfgDir =
+        if !pkgs.stdenv.hostPlatform.isDarwin then ".config/go" else "Library/Application Support/go";
     in
     ''
       assertFileExists "home-files/${goCfgDir}/env"

--- a/tests/modules/programs/go/suboptions-unset.nix
+++ b/tests/modules/programs/go/suboptions-unset.nix
@@ -14,7 +14,8 @@
 
   nmt.script =
     let
-      goCfgDir = if !pkgs.stdenv.isDarwin then ".config/go" else "Library/Application Support/go";
+      goCfgDir =
+        if !pkgs.stdenv.hostPlatform.isDarwin then ".config/go" else "Library/Application Support/go";
     in
     ''
       assertFileExists "home-files/${goCfgDir}/env"

--- a/tests/modules/programs/gurk-rs/basic-config.nix
+++ b/tests/modules/programs/gurk-rs/basic-config.nix
@@ -20,7 +20,7 @@
   nmt.script =
     let
       configFile =
-        if pkgs.stdenv.isDarwin then
+        if pkgs.stdenv.hostPlatform.isDarwin then
           "home-files/Library/Application\\ Support/gurk/gurk.toml"
         else
           "home-files/.config/gurk/gurk.toml";

--- a/tests/modules/programs/jujutsu/empty-config.nix
+++ b/tests/modules/programs/jujutsu/empty-config.nix
@@ -10,7 +10,7 @@ let
 
   # jj v0.29+ deprecated support for "~/Library/Application Support" on Darwin.
   configDir =
-    if pkgs.stdenv.isDarwin && !(lib.versionAtLeast packageVersion "0.29.0") then
+    if pkgs.stdenv.hostPlatform.isDarwin && !(lib.versionAtLeast packageVersion "0.29.0") then
       "Library/Application Support"
     else
       ".config";

--- a/tests/modules/programs/jujutsu/example-config.nix
+++ b/tests/modules/programs/jujutsu/example-config.nix
@@ -10,7 +10,7 @@ let
 
   # jj v0.29+ deprecated support for "~/Library/Application Support" on Darwin.
   configDir =
-    if pkgs.stdenv.isDarwin && !(lib.versionAtLeast packageVersion "0.29.0") then
+    if pkgs.stdenv.hostPlatform.isDarwin && !(lib.versionAtLeast packageVersion "0.29.0") then
       "Library/Application Support"
     else
       ".config";

--- a/tests/modules/programs/k9s/empty-settings.nix
+++ b/tests/modules/programs/k9s/empty-settings.nix
@@ -3,11 +3,12 @@
 {
   programs.k9s.enable = true;
 
-  xdg.enable = lib.mkIf pkgs.stdenv.isDarwin false;
+  xdg.enable = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin false;
 
   nmt.script =
     let
-      configDir = if !pkgs.stdenv.isDarwin then ".config/k9s" else "Library/Application Support/k9s";
+      configDir =
+        if !pkgs.stdenv.hostPlatform.isDarwin then ".config/k9s" else "Library/Application Support/k9s";
     in
     ''
       assertPathNotExists home-files/${configDir}

--- a/tests/modules/programs/k9s/example-settings.nix
+++ b/tests/modules/programs/k9s/example-settings.nix
@@ -6,7 +6,7 @@
 }:
 
 {
-  xdg.enable = lib.mkIf pkgs.stdenv.isDarwin false;
+  xdg.enable = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin false;
 
   programs.k9s = {
     enable = true;
@@ -95,7 +95,8 @@
 
   nmt.script =
     let
-      configDir = if !pkgs.stdenv.isDarwin then ".config/k9s" else "Library/Application Support/k9s";
+      configDir =
+        if !pkgs.stdenv.hostPlatform.isDarwin then ".config/k9s" else "Library/Application Support/k9s";
     in
     ''
       assertFileExists "home-files/${configDir}/config.yaml"

--- a/tests/modules/programs/mergiraf/jujutsu-integration.nix
+++ b/tests/modules/programs/mergiraf/jujutsu-integration.nix
@@ -10,7 +10,7 @@ let
 
   # jj v0.29+ deprecated support for "~/Library/Application Support" on Darwin.
   configDir =
-    if pkgs.stdenv.isDarwin && !(lib.versionAtLeast packageVersion "0.29.0") then
+    if pkgs.stdenv.hostPlatform.isDarwin && !(lib.versionAtLeast packageVersion "0.29.0") then
       "Library/Application Support"
     else
       ".config";

--- a/tests/modules/programs/mullvad-vpn/basic-config.nix
+++ b/tests/modules/programs/mullvad-vpn/basic-config.nix
@@ -19,7 +19,7 @@
   nmt.script =
     let
       configFile =
-        if pkgs.stdenv.isDarwin then
+        if pkgs.stdenv.hostPlatform.isDarwin then
           "home-files/Library/Application\\ Support/Mullvad\\ VPN/gui_settings.json"
         else
           "home-files/.config/Mullvad\\ VPN/gui_settings.json";

--- a/tests/modules/programs/nheko/nheko-empty-settings.nix
+++ b/tests/modules/programs/nheko/nheko-empty-settings.nix
@@ -2,7 +2,10 @@
 
 let
   configDir =
-    if pkgs.stdenv.isDarwin then "home-files/Library/Application Support" else "home-files/.config";
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "home-files/Library/Application Support"
+    else
+      "home-files/.config";
 in
 {
   programs.nheko.enable = true;

--- a/tests/modules/programs/nheko/nheko-example-settings.nix
+++ b/tests/modules/programs/nheko/nheko-example-settings.nix
@@ -2,7 +2,10 @@
 
 let
   configDir =
-    if pkgs.stdenv.isDarwin then "home-files/Library/Application Support" else "home-files/.config";
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "home-files/Library/Application Support"
+    else
+      "home-files/.config";
 in
 {
   programs.nheko = {

--- a/tests/modules/programs/nix-search-tv/television.nix
+++ b/tests/modules/programs/nix-search-tv/television.nix
@@ -9,8 +9,8 @@
 
   nmt.script =
     let
-      keybinding_modifier = if pkgs.stdenv.isDarwin then "alt" else "ctrl";
-      opener = if pkgs.stdenv.isDarwin then "open" else "xdg-open";
+      keybinding_modifier = if pkgs.stdenv.hostPlatform.isDarwin then "alt" else "ctrl";
+      opener = if pkgs.stdenv.hostPlatform.isDarwin then "open" else "xdg-open";
     in
     ''
       assertFileExists home-files/.config/television/cable/nix-search-tv.toml

--- a/tests/modules/programs/nix-your-shell/enable-shells.nix
+++ b/tests/modules/programs/nix-your-shell/enable-shells.nix
@@ -25,7 +25,7 @@
   nmt.script =
     let
       nushellConfigDir =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "home-files/Library/Application Support/nushell"
         else
           "home-files/.config/nushell";

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -65,7 +65,7 @@
   nmt.script =
     let
       configDir =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "home-files/Library/Application Support/nushell"
         else
           "home-files/.config/nushell";

--- a/tests/modules/programs/oh-my-posh/nushell.nix
+++ b/tests/modules/programs/oh-my-posh/nushell.nix
@@ -21,7 +21,7 @@
   nmt.script =
     let
       configFile =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "home-files/Library/Application Support/nushell/config.nu"
         else
           "home-files/.config/nushell/config.nu";

--- a/tests/modules/programs/poetry/custom-settings.nix
+++ b/tests/modules/programs/poetry/custom-settings.nix
@@ -11,7 +11,8 @@
 
   nmt.script =
     let
-      expectedConfDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+      expectedConfDir =
+        if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else ".config";
       expectedConfigPath = "home-files/${expectedConfDir}/pypoetry/config.toml";
       expectedConfigContent = pkgs.writeText "poetry.config-custom.expected" ''
         [virtualenvs]

--- a/tests/modules/programs/poetry/default-settings.nix
+++ b/tests/modules/programs/poetry/default-settings.nix
@@ -7,7 +7,8 @@
 
   nmt.script =
     let
-      expectedConfDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+      expectedConfDir =
+        if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else ".config";
       expectedConfigPath = "home-files/${expectedConfDir}/pypoetry/config.toml";
     in
     ''

--- a/tests/modules/programs/rclone/basic-configuration.nix
+++ b/tests/modules/programs/rclone/basic-configuration.nix
@@ -8,13 +8,13 @@ lib.mkMerge [
     };
   }
 
-  (lib.mkIf pkgs.stdenv.isLinux {
+  (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     nmt.script = ''
       assertFileExists home-files/.config/systemd/user/rclone-config.service
     '';
   })
 
-  (lib.mkIf pkgs.stdenv.isDarwin {
+  (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     nmt.script = ''
       assertFileExists LaunchAgents/org.nix-community.home.rclone-config.plist
     '';

--- a/tests/modules/programs/sapling/sapling-basic.nix
+++ b/tests/modules/programs/sapling/sapling-basic.nix
@@ -10,7 +10,7 @@
   nmt.script =
     let
       configfile =
-        if pkgs.stdenv.isDarwin then
+        if pkgs.stdenv.hostPlatform.isDarwin then
           "Library/Preferences/sapling/sapling.conf"
         else
           ".config/sapling/sapling.conf";

--- a/tests/modules/programs/sapling/sapling-most.nix
+++ b/tests/modules/programs/sapling/sapling-most.nix
@@ -20,7 +20,7 @@
   nmt.script =
     let
       configfile =
-        if pkgs.stdenv.isDarwin then
+        if pkgs.stdenv.hostPlatform.isDarwin then
           "Library/Preferences/sapling/sapling.conf"
         else
           ".config/sapling/sapling.conf";

--- a/tests/modules/programs/senpai/empty-settings.nix
+++ b/tests/modules/programs/senpai/empty-settings.nix
@@ -1,7 +1,7 @@
 { config, pkgs, ... }:
 let
   targetPath =
-    if pkgs.stdenv.isDarwin then
+    if pkgs.stdenv.hostPlatform.isDarwin then
       "home-files/Library/Application Support/senpai/senpai.scfg"
     else
       "home-files/.config/senpai/senpai.scfg";

--- a/tests/modules/programs/senpai/example-settings.nix
+++ b/tests/modules/programs/senpai/example-settings.nix
@@ -1,7 +1,7 @@
 { config, pkgs, ... }:
 let
   targetPath =
-    if pkgs.stdenv.isDarwin then
+    if pkgs.stdenv.hostPlatform.isDarwin then
       "home-files/Library/Application Support/senpai/senpai.scfg"
     else
       "home-files/.config/senpai/senpai.scfg";

--- a/tests/modules/programs/streamlink/streamlink-custom-plugins.nix
+++ b/tests/modules/programs/streamlink/streamlink-custom-plugins.nix
@@ -20,10 +20,13 @@
   nmt.script =
     let
       configDir =
-        if pkgs.stdenv.isDarwin then "Library/Application Support/streamlink" else ".config/streamlink";
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "Library/Application Support/streamlink"
+        else
+          ".config/streamlink";
 
       pluginDir =
-        if pkgs.stdenv.isDarwin then
+        if pkgs.stdenv.hostPlatform.isDarwin then
           "Library/Application Support/streamlink/plugins"
         else
           ".local/share/streamlink/plugins";

--- a/tests/modules/programs/superfile/empty-settings.nix
+++ b/tests/modules/programs/superfile/empty-settings.nix
@@ -3,12 +3,15 @@
 {
   programs.superfile.enable = true;
 
-  xdg.enable = lib.mkIf pkgs.stdenv.isDarwin false;
+  xdg.enable = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin false;
 
   nmt.script =
     let
       configDir =
-        if !pkgs.stdenv.isDarwin then ".config/superfile" else "Library/Application Support/superfile";
+        if !pkgs.stdenv.hostPlatform.isDarwin then
+          ".config/superfile"
+        else
+          "Library/Application Support/superfile";
     in
     ''
       assertPathNotExists home-files/${configDir}

--- a/tests/modules/programs/superfile/example-settings.nix
+++ b/tests/modules/programs/superfile/example-settings.nix
@@ -6,7 +6,7 @@
 }:
 
 {
-  xdg.enable = lib.mkIf pkgs.stdenv.isDarwin false;
+  xdg.enable = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin false;
 
   programs.superfile = {
     enable = true;
@@ -65,11 +65,17 @@
   nmt.script =
     let
       configSubPath =
-        if !pkgs.stdenv.isDarwin then ".config/superfile" else "Library/Application Support/superfile";
+        if !pkgs.stdenv.hostPlatform.isDarwin then
+          ".config/superfile"
+        else
+          "Library/Application Support/superfile";
       configBasePath = "home-files/" + configSubPath;
 
       dataSubPath =
-        if !pkgs.stdenv.isDarwin then ".local/share/superfile" else "Library/Application Support/superfile";
+        if !pkgs.stdenv.hostPlatform.isDarwin then
+          ".local/share/superfile"
+        else
+          "Library/Application Support/superfile";
       dataBasePath = "home-files/" + dataSubPath;
     in
     ''

--- a/tests/modules/programs/superfile/partial-theme-settings.nix
+++ b/tests/modules/programs/superfile/partial-theme-settings.nix
@@ -2,7 +2,7 @@
 # test that the first skin name (alphabetically) is used in the config file
 { pkgs, lib, ... }:
 {
-  xdg.enable = lib.mkIf pkgs.stdenv.isDarwin false;
+  xdg.enable = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin false;
 
   programs.superfile = {
     enable = true;
@@ -41,7 +41,10 @@
   nmt.script =
     let
       configSubPath =
-        if !pkgs.stdenv.isDarwin then ".config/superfile" else "Library/Application Support/superfile";
+        if !pkgs.stdenv.hostPlatform.isDarwin then
+          ".config/superfile"
+        else
+          "Library/Application Support/superfile";
       configBasePath = "home-files/" + configSubPath;
     in
     ''

--- a/tests/modules/programs/tealdeer/custom-settings.nix
+++ b/tests/modules/programs/tealdeer/custom-settings.nix
@@ -17,7 +17,8 @@
 
     nmt.script =
       let
-        expectedConfDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+        expectedConfDir =
+          if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else ".config";
         expectedConfigPath = "home-files/${expectedConfDir}/tealdeer/config.toml";
       in
       ''

--- a/tests/modules/programs/tealdeer/default-settings.nix
+++ b/tests/modules/programs/tealdeer/default-settings.nix
@@ -8,7 +8,8 @@
 
     nmt.script =
       let
-        expectedConfDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+        expectedConfDir =
+          if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else ".config";
         expectedConfigPath = "home-files/${expectedConfDir}/tealdeer/config.toml";
       in
       ''

--- a/tests/modules/programs/tex-fmt/custom-settings.nix
+++ b/tests/modules/programs/tex-fmt/custom-settings.nix
@@ -13,7 +13,8 @@
 
     nmt.script =
       let
-        expectedConfDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+        expectedConfDir =
+          if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else ".config";
         expectedConfigPath = "home-files/${expectedConfDir}/tex-fmt/tex-fmt.toml";
       in
       ''

--- a/tests/modules/programs/tex-fmt/default-settings.nix
+++ b/tests/modules/programs/tex-fmt/default-settings.nix
@@ -7,7 +7,8 @@
 
     nmt.script =
       let
-        expectedConfDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+        expectedConfDir =
+          if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else ".config";
         expectedConfigPath = "home-files/${expectedConfDir}/tex-fmt/tex-fmt.toml";
       in
       ''

--- a/tests/modules/programs/yazi/nushell-integration-enabled.nix
+++ b/tests/modules/programs/yazi/nushell-integration-enabled.nix
@@ -24,7 +24,7 @@ in
   nmt.script =
     let
       configPath =
-        if pkgs.stdenv.isDarwin && !config.xdg.enable then
+        if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
           "home-files/Library/Application Support/nushell/config.nu"
         else
           "home-files/.config/nushell/config.nu";

--- a/tests/modules/services/gpg-agent/default-homedir.nix
+++ b/tests/modules/services/gpg-agent/default-homedir.nix
@@ -6,7 +6,7 @@
   ...
 }:
 
-lib.mkIf pkgs.stdenv.isLinux {
+lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
   services.gpg-agent.enable = true;
   services.gpg-agent.pinentryPackage = pkgs.pinentry-gnome3;
   programs.gpg.enable = true;

--- a/tests/modules/services/gpg-agent/override-homedir.nix
+++ b/tests/modules/services/gpg-agent/override-homedir.nix
@@ -1,7 +1,7 @@
 { config, pkgs, ... }:
 
 let
-  inherit (pkgs.stdenv) isDarwin;
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
 in
 {
   services.gpg-agent.enable = true;

--- a/tests/modules/services/gpg-agent/pinentry-program.nix
+++ b/tests/modules/services/gpg-agent/pinentry-program.nix
@@ -5,7 +5,7 @@
   ...
 }:
 
-lib.mkIf pkgs.stdenv.isLinux {
+lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
   services.gpg-agent.enable = true;
   services.gpg-agent.pinentry = {
     package = pkgs.pinentry-all;

--- a/tests/modules/services/syncthing/extra-options.nix
+++ b/tests/modules/services/syncthing/extra-options.nix
@@ -15,7 +15,7 @@ lib.mkMerge [
     };
   }
 
-  (lib.mkIf pkgs.stdenv.isLinux {
+  (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     nmt.script = ''
       assertFileExists home-files/.config/systemd/user/syncthing.service
       assertPathNotExists home-files/.config/systemd/user/syncthing-init.service
@@ -25,7 +25,7 @@ lib.mkMerge [
     '';
   })
 
-  (lib.mkIf pkgs.stdenv.isDarwin {
+  (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     nmt.script = ''
       serviceFile=LaunchAgents/org.nix-community.home.syncthing.plist
       assertFileExists "$serviceFile"


### PR DESCRIPTION
Nixpkgs officialy deprecated the former.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
