### PR TITLE
tests: fix integration tests

### DIFF
--- a/tests/integration/standalone/flake-basics.nix
+++ b/tests/integration/standalone/flake-basics.nix
@@ -6,7 +6,7 @@
 
   nodes.machine = {
     imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
-    virtualisation.memorySize = 3072;
+    virtualisation.memorySize = 5120;
     nix = {
       registry.home-manager.to = {
         type = "path";

--- a/tests/integration/standalone/nh.nix
+++ b/tests/integration/standalone/nh.nix
@@ -11,7 +11,7 @@ in
 
   nodes.machine = {
     imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
-    virtualisation.memorySize = 2048;
+    virtualisation.memorySize = 3072;
     environment.systemPackages = [ pkgs.nh ];
     nix = {
       registry.home-manager.to = {


### PR DESCRIPTION
### Description

Seem these test now need to write more to the rw-store.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```