### PR TITLE
positron: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -227,6 +227,12 @@
     github = "glmlm";
     githubId = 91877885;
   };
+  hectorgray = {
+    name = "Hector Gray";
+    email = "nix.giant993@passmail.net";
+    github = "hectorgray";
+    githubId = 194114763;
+  };
   henrisota = {
     email = "henrisota@users.noreply.github.com";
     github = "henrisota";

--- a/modules/misc/news/2026/08/2026-08-14_01-10-43.nix
+++ b/modules/misc/news/2026/08/2026-08-14_01-10-43.nix
@@ -1,0 +1,11 @@
+{
+  time = "2026-08-13T13:10:43+00:00";
+  condition = true;
+
+  message = ''
+    A new module is available: 'programs.positron'.
+
+    Positron is a data science IDE based on Visual Studio Code with built-in
+    support for R and Python.
+  '';
+}

--- a/modules/programs/positron.nix
+++ b/modules/programs/positron.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+
+{
+  meta.maintainers = [ lib.maintainers.hectorgray ];
+
+  imports = [
+    (import ./vscode/mkVscodeModule.nix {
+      modulePath = [
+        "programs"
+        "positron"
+      ];
+
+      name = "Positron";
+      packageName = "positron-bin";
+      nameShort = "Positron";
+      dataFolderName = ".positron";
+      skipVersionCheck = true;
+    })
+  ];
+}

--- a/modules/programs/vscode/default.nix
+++ b/modules/programs/vscode/default.nix
@@ -14,6 +14,7 @@ let
     windsurf = "programs.windsurf";
     kiro = "programs.kiro";
     antigravity = "programs.antigravity";
+    positron-bin = "programs.positron";
   };
 in
 {

--- a/tests/modules/programs/positron/default.nix
+++ b/tests/modules/programs/positron/default.nix
@@ -1,0 +1,40 @@
+{ pkgs, ... }:
+
+let
+  package = pkgs.writeScriptBin "positron" "" // {
+    pname = "positron-bin";
+    version = "2026.07.1-5";
+  };
+in
+
+{
+  positron-paths =
+    { pkgs, ... }:
+    let
+      argvPath = ".positron/argv.json";
+
+      settingsPath =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "Library/Application Support/Positron/User/settings.json"
+        else
+          ".config/Positron/User/settings.json";
+    in
+    {
+      programs.positron = {
+        inherit package;
+
+        enable = true;
+        argvSettings.enable-crash-reporter = false;
+
+        profiles.default = {
+          enableUpdateCheck = false;
+          enableExtensionUpdateCheck = false;
+        };
+      };
+
+      nmt.script = ''
+        assertFileExists "home-files/${argvPath}"
+        assertFileExists "home-files/${settingsPath}"
+      '';
+    };
+}


### PR DESCRIPTION
### Description

Adds `programs.positron`, generated from the existing `mkVscodeModule` factory. Positron is a data science IDE based on VS Code.

I set `skipVersionCheck` for correctness; it's not necessary but Positron uses calendar versioning (`2026.07.1-5`) instead of the VS Code standard.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [X] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)