### PR TITLE
lorri: update deprecated `stdenv.*` aliases

### DIFF
--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -61,7 +61,7 @@ in
         home.packages = [ cfg.package ];
       }
 
-      (lib.mkIf pkgs.stdenv.isLinux (
+      (lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
         let
           extraEnvList = lib.mapAttrsToList (k: v: "${k}=${v}") cfg.extraEnvVariables;
         in
@@ -170,7 +170,7 @@ in
         }
       ))
 
-      (lib.mkIf pkgs.stdenv.isDarwin {
+      (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
         warnings =
           if cfg.enableNotifications then
             [


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

update deprecated `stdenv.*` alias

FIXES: #9661

CONTRIBUTES: #9806

CC:
- @isomarcte as the author, @rycee as the committer, @khaneliman as a reviewer: #9661
- @Gerschtli @nyarly as maintainers of lorri

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
