### PR TITLE
comodoro: 0.1.2 -> 2.0.0

### DIFF
--- a/modules/misc/news/2026/08/2026-08-14_22-30-00.nix
+++ b/modules/misc/news/2026/08/2026-08-14_22-30-00.nix
@@ -1,0 +1,26 @@
+{ config, ... }:
+{
+  time = "2026-08-14T22:30:00+00:00";
+  condition = config.programs.comodoro.enable || config.services.comodoro.enable;
+  message = ''
+    Comodoro has been updated to 2.0.0, which breaks both the
+    configuration file and the command line. See the
+    [upstream changelog](https://github.com/pimalaya/comodoro/blob/v2.0.0/CHANGELOG.md).
+
+    In {option}`programs.comodoro.settings`, the `presets` table became
+    `accounts`, so a preset named `pomodoro` is now written as
+    `settings.accounts.pomodoro`. Within an account, `timer-precision`
+    became `precision`, `hooks.<name>.cmd` became
+    `hooks.<name>.command`, and the `preset` field naming predefined
+    cycles is gone: write the `cycles` out, or generate them with
+    `comodoro configure`. Accounts written against Comodoro 1.x keep
+    `unix-socket` as an alias of the `socket` table.
+
+    {option}`services.comodoro.preset` has been renamed to
+    {option}`services.comodoro.account` and
+    {option}`services.comodoro.protocols` to
+    {option}`services.comodoro.transports`. Both are optional now: an
+    unset account serves the one marked `default`, and unset transports
+    serve the one the account marks as default.
+  '';
+}

--- a/modules/programs/comodoro.nix
+++ b/modules/programs/comodoro.nix
@@ -14,16 +14,34 @@ in
   meta.maintainers = with lib.maintainers; [ soywod ];
 
   options.programs.comodoro = {
-    enable = lib.mkEnableOption "Comodoro, a CLI to manage your time";
+    enable = lib.mkEnableOption "Comodoro, a CLI to manage timers";
 
     package = lib.mkPackageOption pkgs "comodoro" { nullable = true; };
 
     settings = lib.mkOption {
       type = lib.types.submodule { freeformType = tomlFormat.type; };
       default = { };
+      example = lib.literalExpression ''
+        {
+          accounts.pomodoro = {
+            default = true;
+            cycles = [
+              {
+                name = "Work";
+                duration = 1500;
+              }
+              {
+                name = "Rest";
+                duration = 300;
+              }
+            ];
+          };
+        }
+      '';
       description = ''
-        Comodoro configuration.
-        See <https://pimalaya.org/comodoro/cli/configuration/> for supported values.
+        Comodoro configuration, a table of named accounts.
+        See <https://github.com/pimalaya/comodoro/blob/master/config.sample.toml>
+        for the annotated field reference.
       '';
     };
   };

--- a/modules/services/comodoro.nix
+++ b/modules/services/comodoro.nix
@@ -8,14 +8,17 @@
 let
   cfg = config.services.comodoro;
 
-  args = with cfg; {
-    inherit preset;
-    protocols = if lib.isList protocols then lib.concatStringsSep " " protocols else protocols;
-  };
-
 in
 {
   meta.maintainers = with lib.maintainers; [ soywod ];
+
+  imports = [
+    (lib.mkRenamedOptionModule [ "services" "comodoro" "preset" ] [ "services" "comodoro" "account" ])
+    (lib.mkRenamedOptionModule
+      [ "services" "comodoro" "protocols" ]
+      [ "services" "comodoro" "transports" ]
+    )
+  ];
 
   options.services.comodoro = {
     enable = lib.mkEnableOption "Comodoro server";
@@ -33,17 +36,33 @@ in
       '';
     };
 
-    preset = lib.mkOption {
-      type = lib.types.nonEmptyStr;
+    account = lib.mkOption {
+      type = with lib.types; nullOr nonEmptyStr;
+      default = null;
+      example = "pomodoro";
       description = ''
-        Use configuration from the given preset as defined in the configuration file.
+        Serve the timer of the given account, as named in the `accounts` table
+        of the configuration file. When null, the account marked `default` is
+        served.
       '';
     };
 
-    protocols = lib.mkOption {
-      type = with lib.types; nonEmptyListOf nonEmptyStr;
+    transports = lib.mkOption {
+      type =
+        with lib.types;
+        listOf (enum [
+          "socket"
+          "tcp"
+        ]);
+      default = [ ];
+      example = [
+        "socket"
+        "tcp"
+      ];
       description = ''
-        Define protocols the server should use to accept requests.
+        Accept requests on the given transports. Naming both serves the same
+        timer over both at once. When empty, the transport the account marks as
+        default is served.
       '';
     };
   };
@@ -53,14 +72,25 @@ in
 
     systemd.user.services.comodoro = {
       Unit = {
-        Description = "Comodoro server";
+        Description = "Comodoro timer server";
         After = [ "network.target" ];
       };
       Install = {
         WantedBy = [ "default.target" ];
       };
       Service = {
-        ExecStart = with args; "${cfg.package}/bin/comodoro server start ${preset} ${protocols}";
+        ExecStart = lib.concatStringsSep " " (
+          [ (lib.getExe cfg.package) ]
+          ++ lib.optionals (cfg.account != null) [
+            "--account"
+            cfg.account
+          ]
+          ++ [
+            "server"
+            "start"
+          ]
+          ++ cfg.transports
+        );
         ExecSearchPath = "/bin";
         Restart = "always";
         RestartSec = 10;

--- a/tests/modules/programs/comodoro/comodoro.nix
+++ b/tests/modules/programs/comodoro/comodoro.nix
@@ -2,7 +2,9 @@
   programs.comodoro = {
     enable = true;
     settings = {
-      test-preset = {
+      accounts.example = {
+        default = true;
+
         cycles = [
           {
             name = "Work";
@@ -14,12 +16,17 @@
           }
         ];
 
-        tcp-host = "localhost";
-        tcp-port = 8080;
+        precision = "minute";
 
-        on-server-start = "echo server started";
-        on-timer-stop = "echo timer stopped";
-        on-work-begin = "echo work cycle began";
+        socket.default = true;
+        tcp.host = "localhost";
+        tcp.port = 8080;
+
+        hooks.on-timer-stop.command = "echo timer stopped";
+        hooks.on-work-begin.notify = {
+          summary = "Comodoro";
+          body = "Work started!";
+        };
       };
     };
   };

--- a/tests/modules/programs/comodoro/expected.toml
+++ b/tests/modules/programs/comodoro/expected.toml
@@ -1,14 +1,25 @@
-[test-preset]
-on-server-start = "echo server started"
-on-timer-stop = "echo timer stopped"
-on-work-begin = "echo work cycle began"
-tcp-host = "localhost"
-tcp-port = 8080
+[accounts.example]
+default = true
+precision = "minute"
 
-[[test-preset.cycles]]
+[[accounts.example.cycles]]
 duration = 1500
 name = "Work"
 
-[[test-preset.cycles]]
+[[accounts.example.cycles]]
 duration = 500
 name = "Rest"
+
+[accounts.example.hooks.on-timer-stop]
+command = "echo timer stopped"
+
+[accounts.example.hooks.on-work-begin.notify]
+body = "Work started!"
+summary = "Comodoro"
+
+[accounts.example.socket]
+default = true
+
+[accounts.example.tcp]
+host = "localhost"
+port = 8080

--- a/tests/modules/services/comodoro/comodoro-defaults.nix
+++ b/tests/modules/services/comodoro/comodoro-defaults.nix
@@ -1,0 +1,8 @@
+{
+  services.comodoro.enable = true;
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/comodoro.service)
+    assertFileContent "$serviceFile" ${./expected-defaults.service}
+  '';
+}

--- a/tests/modules/services/comodoro/comodoro.nix
+++ b/tests/modules/services/comodoro/comodoro.nix
@@ -1,8 +1,11 @@
 {
   services.comodoro = {
     enable = true;
-    preset = "preset";
-    protocols = [ "tcp" ];
+    account = "pomodoro";
+    transports = [
+      "socket"
+      "tcp"
+    ];
   };
 
   nmt.script = ''

--- a/tests/modules/services/comodoro/default.nix
+++ b/tests/modules/services/comodoro/default.nix
@@ -2,4 +2,5 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   comodoro-service = ./comodoro.nix;
+  comodoro-service-defaults = ./comodoro-defaults.nix;
 }

--- a/tests/modules/services/comodoro/expected-defaults.service
+++ b/tests/modules/services/comodoro/expected-defaults.service
@@ -3,7 +3,7 @@ WantedBy=default.target
 
 [Service]
 ExecSearchPath=/bin
-ExecStart=@comodoro@/bin/comodoro --account pomodoro server start socket tcp
+ExecStart=@comodoro@/bin/comodoro server start
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
### Description

https://github.com/pimalaya/comodoro/releases/tag/v2.0.0

I opened the PR in draft, because upstream is not yet ready: https://github.com/NixOS/nixpkgs/pull/552802

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
