### PR TITLE
copyq: add settings

### DIFF
--- a/modules/services/copyq.nix
+++ b/modules/services/copyq.nix
@@ -9,6 +9,8 @@ let
 
   cfg = config.services.copyq;
 
+  iniFormat = pkgs.formats.ini { };
+
 in
 {
   meta.maintainers = [ lib.maintainers.DamienCassou ];
@@ -37,31 +39,71 @@ in
       example = false;
       description = "Force the CopyQ to use the X backend on wayland";
     };
-  };
 
-  config = lib.mkIf cfg.enable {
-    assertions = [
-      (lib.hm.assertions.assertPlatform "services.copyq" pkgs lib.platforms.linux)
-    ];
-
-    home.packages = [ cfg.package ];
-
-    systemd.user.services.copyq = {
-      Unit = {
-        Description = "CopyQ clipboard management daemon";
-        PartOf = [ "graphical-session.target" ];
-        After = [ "graphical-session.target" ];
-      };
-
-      Service = {
-        ExecStart = "${cfg.package}/bin/copyq";
-        Restart = "on-failure";
-        Environment = lib.optional cfg.forceXWayland "QT_QPA_PLATFORM=xcb";
-      };
-
-      Install = {
-        WantedBy = [ cfg.systemdTarget ];
-      };
+    settings = lib.mkOption {
+      type = iniFormat.type.nestedTypes.elemType;
+      default = { };
+      description = "Copyq configuration. Run `copyq config` to list available options.";
+      example = lib.literalExpression ''
+        {
+          disable_tray = true;
+          hide_main_window = true;
+          hide_tabs = true;
+          hide_toolbar = true;
+          autostart = false;
+        }
+      '';
     };
   };
+
+  config =
+    let
+
+      executablePath = lib.meta.getExe cfg.package;
+
+    in
+    lib.mkIf cfg.enable {
+      assertions = [
+        (lib.hm.assertions.assertPlatform "services.copyq" pkgs lib.platforms.linux)
+      ];
+
+      home.packages = [ cfg.package ];
+
+      systemd.user.services.copyq = {
+        Unit = {
+          Description = "CopyQ clipboard management daemon";
+          PartOf = [ "graphical-session.target" ];
+          After = [ "graphical-session.target" ];
+        };
+
+        Service = {
+          ExecStart = executablePath;
+          Restart = "on-failure";
+          Environment = lib.optional cfg.forceXWayland "QT_QPA_PLATFORM=xcb";
+        };
+
+        Install = {
+          WantedBy = [ cfg.systemdTarget ];
+        };
+      };
+
+      home.activation.copyqConfig = lib.mkIf (cfg.settings != { }) (
+        lib.hm.dag.entryAfter [ "writeBoundary" ] (
+          lib.concatLines (
+            lib.mapAttrsToList (
+              k: v:
+              "run --quiet ${
+                lib.escapeShellArgs [
+                  executablePath
+                  "--start-server"
+                  "config"
+                  k
+                  (if lib.isBool v then lib.boolToString v else toString v)
+                ]
+              } 2> >(grep -v '^Warning: CopyQ server is already running' >&2)"
+            ) cfg.settings
+          )
+        )
+      );
+    };
 }

--- a/modules/services/copyq.nix
+++ b/modules/services/copyq.nix
@@ -13,7 +13,7 @@ let
 
 in
 {
-  meta.maintainers = [ lib.maintainers.DamienCassou ];
+  meta.maintainers = [ lib.maintainers.DPDmancul ];
 
   options.services.copyq = {
     enable = lib.mkEnableOption "CopyQ, a clipboard manager with advanced features";

--- a/tests/modules/services/copyq/default.nix
+++ b/tests/modules/services/copyq/default.nix
@@ -3,4 +3,5 @@
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   copyq-basic-configuration = ./basic-configuration.nix;
   copyq-dont-force-x = ./dont-force-x-configuration.nix;
+  copyq-settings = ./settings.nix;
 }

--- a/tests/modules/services/copyq/settings.nix
+++ b/tests/modules/services/copyq/settings.nix
@@ -1,0 +1,23 @@
+{
+  services.copyq = {
+    enable = true;
+    settings = {
+      disable_tray = true;
+      hide_main_window = true;
+      hide_tabs = true;
+      hide_toolbar = true;
+      autostart = false;
+    };
+  };
+
+  nmt.script = ''
+    assertConfig () {
+      assertFileContains activate "copyq --start-server config $@"
+    }
+
+    assertConfig hide_main_window true
+    assertConfig hide_tabs true
+    assertConfig hide_toolbar true
+    assertConfig autostart false
+  '';
+}


### PR DESCRIPTION
### Description

Add settings option to copyq.

### Checklist

- [X] Change is backwards compatible.
- [X] Code formatted with `nix fmt`.
- [X] Code tested through `nix run .#tests -- copyq`.
- [X] Test cases added.
- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```
