### PR TITLE
mblaze: add to labeler mail entry

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -411,6 +411,7 @@
           - modules/programs/getmail/**/*
           - modules/programs/himalaya.nix
           - modules/programs/lieer.nix
+          - modules/programs/mblaze/*
           - modules/programs/mbsync/**/*
           - modules/programs/meli.nix
           - modules/programs/msmtp*
@@ -429,6 +430,7 @@
           - modules/services/protonmail-bridge.nix
           - tests/modules/programs/aerc/*
           - tests/modules/programs/alot/*
+          - tests/modules/programs/mblaze/*
           - tests/modules/programs/himalaya/*
           - tests/modules/programs/mbsync/*
           - tests/modules/programs/mujmap/*


### PR DESCRIPTION
### Description

https://github.com/nix-community/home-manager/pull/9793#issuecomment-5303989618

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

@teto 