### PR TITLE
herdr: add plugins option with idempotent registration

### DIFF
--- a/modules/programs/herdr.nix
+++ b/modules/programs/herdr.nix
@@ -11,6 +11,28 @@ let
   cfg = config.programs.herdr;
 
   tomlFormat = pkgs.formats.toml { };
+
+  binPath = if cfg.package == null then "herdr" else "${lib.getExe cfg.package}";
+
+  # Plugin manifests this module wants to have registered. herdr resolves a
+  # linked path to its canonical form, so the desired set is keyed on the
+  # canonical store path of each configured package.
+  desiredPluginManifests = lib.toJSON (
+    lib.mapAttrsToList (_id: plugin: "${toString plugin.package}/herdr-plugin.toml") cfg.plugins
+  );
+
+  # Plugin ids registered from the nix store that are no longer configured.
+  stalePluginIds = ''
+    .result.plugins[]?
+    | select((.manifest_path // "") | startswith($store))
+    | select((.manifest_path as $p | $desired | index($p)) | not)
+    | .plugin_id
+  '';
+
+  # Configured plugin manifests that are not registered yet.
+  missingPluginManifests = ''
+    ($desired - [.result.plugins[]?.manifest_path?])[]
+  '';
 in
 {
   meta.maintainers = [ lib.maintainers.amadejkastelic ];
@@ -57,18 +79,92 @@ in
         See <https://herdr.dev/docs/configuration/> for the full list of options.
       '';
     };
+
+    plugins = mkOption {
+      type =
+        with lib.types;
+        attrsOf (submodule {
+          options = {
+            package = mkOption {
+              type = either package path;
+              description = ''
+                The plugin package or a path to the plugin directory. Its top
+                level must contain a {file}`herdr-plugin.toml` manifest; herdr
+                reads the plugin id from that manifest when linking.
+              '';
+            };
+          };
+        });
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "chmarax.herdr-nvim" = {
+            package = let
+              src = pkgs.fetchFromGitHub {
+                owner = "ChmaraX";
+                repo = "herdr-nvim";
+                rev = "9ce76bba554ba022ee622bcf7b04793011728aa2";
+                hash = "sha256-szXayf81beA0ti9kx0uQja49+G59Og2bYOze8v+pbik=";
+              };
+            in
+              pkgs.rustPlatform.buildRustPackage {
+                pname = "herdr-nvim";
+                version = "0.1.1";
+                inherit src;
+                cargoLock.lockFile = "''${src}/Cargo.lock";
+                postInstall = '''
+                  cp -r $src/lua $out/lua
+                  cp $src/herdr-plugin.toml $out/
+                  mkdir -p $out/herdr
+                  cp $src/herdr/run.sh $out/herdr/
+                  chmod +x $out/herdr/run.sh
+                ''';
+              };
+          };
+        }
+      '';
+      description = ''
+        Plugins to register with herdr. Each value is a plugin package or a
+        path to a plugin directory; its top level must contain a
+        {file}`herdr-plugin.toml` manifest, from which herdr reads the plugin
+        id.
+
+        Plugins registered outside this option, for example with
+        {command}`herdr plugin install`, are left untouched.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-    xdg.configFile."herdr/config.toml" = mkIf (cfg.settings != { }) {
-      source = tomlFormat.generate "herdr-config.toml" cfg.settings;
-      onChange =
-        let
-          binPath = if cfg.package == null then "herdr" else "${lib.getExe cfg.package}";
-        in
-        "${binPath} server reload-config || true";
+    xdg.configFile = mkIf (cfg.settings != { }) {
+      "herdr/config.toml" = {
+        source = tomlFormat.generate "herdr-config.toml" cfg.settings;
+        onChange = "${binPath} server reload-config || true";
+      };
     };
+
+    home.activation.herdrPlugins = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      registered="$(${binPath} plugin list --json 2>/dev/null || true)"
+
+      # `plugin list` falls back to the on-disk registry when no server is
+      # running, so the diff below still converges. `plugin unlink` needs a
+      # reachable server and is therefore deferred (best effort) until the
+      # next activation, while `plugin link` persists offline.
+      printf '%s' "$registered" \
+        | ${lib.getExe pkgs.jq} -r \
+          --arg store "/nix/store/" \
+          --argjson desired ${lib.escapeShellArg desiredPluginManifests} '${stalePluginIds}' \
+        | while read -r id; do
+            [ -n "$id" ] && ${binPath} plugin unlink "$id" >/dev/null 2>&1 || true
+          done
+
+      printf '%s' "$registered" \
+        | ${lib.getExe pkgs.jq} -r --argjson desired ${lib.escapeShellArg desiredPluginManifests} '${missingPluginManifests}' \
+        | while read -r manifest; do
+            [ -n "$manifest" ] && ${binPath} plugin link "$manifest" >/dev/null 2>&1 || true
+          done
+    '';
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -57,6 +57,7 @@ let
         inherit (pkgs)
           coreutils
           crudini
+          herdr
           jq
           desktop-file-utils
           diffutils

--- a/tests/modules/programs/herdr/default.nix
+++ b/tests/modules/programs/herdr/default.nix
@@ -1,4 +1,5 @@
 {
   herdr-enable = ./herdr-enable.nix;
+  herdr-plugins = ./herdr-plugins.nix;
   herdr-settings = ./herdr-settings.nix;
 }

--- a/tests/modules/programs/herdr/herdr-plugin.toml
+++ b/tests/modules/programs/herdr/herdr-plugin.toml
@@ -1,0 +1,24 @@
+# herdr plugin smoke fixture, vendored from herdrdev/herdr
+# (tests/fixtures/plugin-smoke/herdr-plugin.toml, Apache-2.0).
+id = "example.smoke"
+name = "Smoke Plugin"
+version = "0.1.0"
+min_herdr_version = "0.6.10"
+description = "Portable plugin smoke fixture"
+platforms = ["linux", "macos", "windows"]
+
+[[actions]]
+id = "workspace-list"
+title = "List workspaces"
+contexts = ["workspace"]
+command = ["herdr", "workspace", "list"]
+
+[[events]]
+on = "worktree.created"
+command = ["herdr", "plugin", "log", "list", "--plugin", "example.smoke"]
+
+[[panes]]
+id = "board"
+title = "Board"
+placement = "overlay"
+command = ["herdr", "workspace", "list"]

--- a/tests/modules/programs/herdr/herdr-plugins.nix
+++ b/tests/modules/programs/herdr/herdr-plugins.nix
@@ -1,0 +1,172 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  # herdr's own plugin smoke fixture, packaged so `plugin link` sees a
+  # canonical nix-store manifest path.
+  packagePlugin = pkgs.runCommand "herdr-smoke-plugin" { } ''
+    mkdir -p $out
+    cp ${./herdr-plugin.toml} $out/herdr-plugin.toml
+  '';
+  herdrBin = lib.getExe pkgs.herdr;
+  jqBin = lib.getExe pkgs.jq;
+  activationScript = pkgs.writeScript "activation" config.home.activation.herdrPlugins.data;
+
+  # Registry seeds. herdr stores registrations in plugins.json; the server
+  # reloads the file on every `plugin list`, so seeding is enough to exercise
+  # the module against a live server.
+  staleOld = {
+    plugin_id = "stale.old";
+    name = "Stale Old";
+    version = "0.1.0";
+    min_herdr_version = "0.6.10";
+    manifest_path = "/nix/store/00000000000000000000000000000000-stale/herdr-plugin.toml";
+    plugin_root = "/nix/store/00000000000000000000000000000000-stale";
+    enabled = true;
+  };
+  githubTool = {
+    plugin_id = "github.tool";
+    name = "Github Tool";
+    version = "0.1.0";
+    min_herdr_version = "0.6.10";
+    manifest_path = "/home/hm-user/.config/herdr/plugins/github/owner-repo-abcdef/github-tool/herdr-plugin.toml";
+    plugin_root = "/home/hm-user/.config/herdr/plugins/github/owner-repo-abcdef/github-tool";
+    enabled = true;
+    source = {
+      kind = "github";
+      owner = "owner";
+      repo = "repo";
+      subdir = "github-tool";
+      managed_path = "/home/hm-user/.config/herdr/plugins/github/owner-repo-abcdef/github-tool";
+    };
+  };
+  smokeAt = enabled: manifest_path: plugin_root: {
+    plugin_id = "example.smoke";
+    name = "Smoke Plugin";
+    version = "0.1.0";
+    min_herdr_version = "0.6.10";
+    inherit manifest_path plugin_root enabled;
+  };
+  seedRegistry = seed: ''
+    cat >"$XDG_CONFIG_HOME/herdr/plugins.json" <<EOF
+    ${builtins.toJSON seed}
+    EOF
+  '';
+in
+{
+  programs.herdr = {
+    enable = true;
+    package = pkgs.herdr;
+
+    plugins = {
+      "example.smoke" = {
+        package = packagePlugin;
+      };
+    };
+  };
+
+  test.asserts.warnings.expected = [ ];
+
+  nmt.script = ''
+    export HOME=$TMPDIR/hm-user
+    export XDG_CONFIG_HOME=$TMPDIR/xdg-config
+    export XDG_STATE_HOME=$TMPDIR/xdg-state
+    export XDG_CACHE_HOME=$TMPDIR/xdg-cache
+    export HERDR_SOCKET_PATH=$TMPDIR/herdr.sock
+    mkdir -p "$HOME" "$XDG_CONFIG_HOME/herdr"
+
+    # The generated activation script must diff canonical nix-store manifests
+    # and drive the real herdr binary (the whitelisted pkgs.herdr).
+    assertFileContains ${activationScript} "${herdrBin} plugin list --json"
+    assertFileContains ${activationScript} ".result.plugins[]?"
+    assertFileContains ${activationScript} 'store "/nix/store/"'
+    assertFileContains ${activationScript} "startswith(\$store)"
+    assertFileContains ${activationScript} 'plugin unlink "$id" >/dev/null 2>&1 || true'
+    assertFileContains ${activationScript} 'plugin link "$manifest" >/dev/null 2>&1 || true'
+    assertFileContains ${activationScript} '($desired - [.result.plugins[]?.manifest_path?])[]'
+    assertFileContains ${activationScript} '"${packagePlugin}/herdr-plugin.toml"'
+
+    # Scenario A: first activation against a live headless herdr server. The
+    # seed holds a stale store plugin, a plugin herdr installed itself under
+    # its managed `github` directory, and the configured plugin registered at
+    # an old store path (as if its package was updated).
+    ${seedRegistry [
+      staleOld
+      githubTool
+      (smokeAt true "/nix/store/00000000000000000000000000000000-herdr-smoke-plugin-old/herdr-plugin.toml"
+        "/nix/store/00000000000000000000000000000000-herdr-smoke-plugin-old"
+      )
+    ]}
+
+    "${herdrBin}" server >"$TMPDIR/herdr-server.log" 2>&1 &
+    SRV=$!
+    for _ in $(seq 1 100); do [ -S "$HERDR_SOCKET_PATH" ] && break; sleep 0.1; done
+    [ -S "$HERDR_SOCKET_PATH" ] \
+      || {
+        cat "$TMPDIR/herdr-server.log" 2>/dev/null || true
+        kill "$SRV" 2>/dev/null || true
+        fail "herdr server did not start"
+      }
+
+    source ${activationScript}
+
+    "${herdrBin}" plugin list --json 2>/dev/null \
+      | ${jqBin} -r '.result.plugins[]?.plugin_id' >"$TMPDIR/plugins-after-a"
+    grep -q '^example.smoke$' "$TMPDIR/plugins-after-a" \
+      || fail "expected example.smoke to be registered after activation"
+    grep -q '^github.tool$' "$TMPDIR/plugins-after-a" \
+      || fail "expected github.tool to remain registered"
+    grep -q '^stale.old$' "$TMPDIR/plugins-after-a" \
+      && fail "expected stale.old to be unlinked"
+    "${herdrBin}" plugin list --json 2>/dev/null \
+      | ${jqBin} -r --arg p "${packagePlugin}/herdr-plugin.toml" \
+        '.result.plugins[]? | select(.plugin_id == "example.smoke") | .manifest_path' \
+      | grep -Fqx "${packagePlugin}/herdr-plugin.toml" \
+      || fail "expected example.smoke to be linked at its canonical manifest"
+
+    # Scenario B: a second activation must be a true no-op.
+    BEFORE="$("${herdrBin}" plugin list --json 2>/dev/null)"
+    source ${activationScript}
+    AFTER="$("${herdrBin}" plugin list --json 2>/dev/null)"
+    [ "$BEFORE" = "$AFTER" ] \
+      || fail "expected the second activation to leave the registry unchanged"
+
+    # Scenario C: a desired plugin the user disabled stays disabled.
+    ${seedRegistry [
+      githubTool
+      (smokeAt false "${packagePlugin}/herdr-plugin.toml" "${packagePlugin}")
+    ]}
+    source ${activationScript}
+    "${herdrBin}" plugin list --json 2>/dev/null \
+      | ${jqBin} -r --arg p "${packagePlugin}/herdr-plugin.toml" \
+        '.result.plugins[]? | select(.plugin_id == "example.smoke") | [.manifest_path == $p, (.enabled | not)] | all' \
+      | grep -qx true \
+      || fail "expected the disabled plugin to stay disabled at its canonical manifest"
+
+    # Scenario D: with the server unreachable, `plugin link` still persists
+    # offline while `plugin unlink` is deferred to the next activation.
+    kill "$SRV" 2>/dev/null || true
+    wait "$SRV" 2>/dev/null || true
+    rm -f "$HERDR_SOCKET_PATH"
+
+    ${seedRegistry [
+      staleOld
+      githubTool
+    ]}
+    source ${activationScript}
+
+    "${herdrBin}" plugin list --json 2>/dev/null \
+      | ${jqBin} -r '.result.plugins[]?.plugin_id' >"$TMPDIR/plugins-after-d"
+    grep -q '^example.smoke$' "$TMPDIR/plugins-after-d" \
+      || fail "expected example.smoke to be registered even without a running server"
+    grep -q '^stale.old$' "$TMPDIR/plugins-after-d" \
+      || fail "expected stale.old to stay registered while the server is unreachable"
+    grep -Fq "${packagePlugin}/herdr-plugin.toml" "$XDG_CONFIG_HOME/herdr/plugins.json" \
+      || fail "expected the offline link to be persisted to the registry"
+    grep -Fq '"plugin_id": "stale.old"' "$XDG_CONFIG_HOME/herdr/plugins.json" \
+      || fail "expected the deferred unlink to leave stale.old in the registry"
+  '';
+}


### PR DESCRIPTION
## Description

Adds a `programs.herdr.plugins` option that registers plugins with herdr during activation, keyed on each plugin's canonical nix-store manifest path. Registration is idempotent:

- Plugins configured in home-manager are linked with `herdr plugin link` when not yet registered.
- Plugins registered from the nix store that are no longer configured are unlinked with `herdr plugin unlink`.
- Registrations outside the nix store (e.g. herdr-managed installs under `github/` or manually linked local plugins) are left untouched.

Both operations are best-effort and never break activation: `herdr plugin link` writes the registration to herdr's on-disk registry even without a running server, while `herdr plugin unlink` is deferred until a server is reachable and retried on the next activation.

Example:

```nix
{
  "chmarax.herdr-nvim" = {
    package = let
      src = pkgs.fetchFromGitHub {
        owner = "ChmaraX";
        repo = "herdr-nvim";
        rev = "9ce76bba554ba022ee622bcf7b04793011728aa2";
        hash = "sha256-szXayf81beA0ti9kx0uQja49+G59Og2bYOze8v+pbik=";
      };
    in
      pkgs.rustPlatform.buildRustPackage {
        pname = "herdr-nvim";
        version = "0.1.1";
        inherit src;
        cargoLock.lockFile = "${src}/Cargo.lock";
        postInstall = ''
          cp -r $src/lua $out/lua
          cp $src/herdr-plugin.toml $out/
          mkdir -p $out/herdr
          cp $src/herdr/run.sh $out/herdr/
          chmod +x $out/herdr/run.sh
        '';
      };
  };
}
```

No files are placed on disk; registration is keyed on the canonical manifest path so nix-store plugin packages stay in the store.

## Tests

Single nmt test `tests/modules/programs/herdr/herdr-plugins.nix` covering:

- static assertion of the activation script's `plugin list`/`link`/`unlink` invocations
- behavioral runs against a live headless `herdr server` (the real `pkgs.herdr` binary, whitelisted in `tests/default.nix`, with the registry seeded via `plugins.json`):
  - first activation links the new plugin at its canonical manifest and unlinks stale/old store registrations
  - second activation is a no-op (idempotency)
  - a plugin the user disabled stays disabled
  - offline (server stopped): `plugin link` still persists to the registry while `plugin unlink` is deferred to the next activation

Uses herdr's own smoke plugin fixture (`example.smoke`, Apache-2.0, vendored from herdrdev/herdr) as the test plugin.

All herdr tests pass, plus `nixfmt`, `statix`, and `deadnix` are clean.

Co-Authored-By: OpenCode

