### PR TITLE
thunderbird: support contact settings

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -323,6 +323,7 @@ let
         "ldap_2.servers.contact_${id}.carddav.username" = contact.remote.userName;
         "ldap_2.servers.contact_${id}.carddav.token" = contact.thunderbird.token;
       }
+      // contact.thunderbird.settings id
     );
 
   toThunderbirdFeed =
@@ -968,6 +969,30 @@ in
               example = "secret_token";
               description = ''
                 A token is generated when adding an address book manually to Thunderbird, this can be entered here.
+              '';
+            };
+
+            settings = mkOption {
+              type =
+                with types;
+                functionTo (
+                  attrsOf (oneOf [
+                    bool
+                    int
+                    str
+                  ])
+                );
+              default = _: { };
+              defaultText = literalExpression "_: { }";
+              example = literalExpression ''
+                id: {
+                  "ldap_2.servers.contact_''${id}.carddav.url" =
+                    "https://example.com/addressbook/";
+                };
+              '';
+              description = ''
+                Extra settings to add to this Thunderbird address book configuration.
+                The {var}`id` given as argument is an automatically generated account identifier.
               '';
             };
           };


### PR DESCRIPTION
### Description

Adds a `settings` option to Thunderbird contact account configurations. This is new functionality: contact accounts previously had neither a `thunderbird.settings` option nor a corresponding merge step.

The new option makes contact configuration consistent with the existing `calendar.thunderbird.settings` interface. Like the calendar option, it is a function receiving the automatically generated account identifier and returning extra Thunderbird preferences. This allows configuring address-book properties that are not exposed as dedicated Home Manager options while still referencing the generated identifier.

For example:

```nix
settings = id: {
  "ldap_2.servers.contact_${id}.carddav.url" =
    "https://example.com/addressbook/";
};
```

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt` or `nix-shell -A dev --run treefmt`.
- [ ] Code tested through `nix build .#test-all` or a targeted `nix run .#tests -- <pattern>`.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted

See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
