### PR TITLE
antigravity-cli: emit disabled for disabled MCP servers

### DIFF
--- a/modules/lib/mcp.nix
+++ b/modules/lib/mcp.nix
@@ -157,6 +157,7 @@ in
     mkEnvFilesWrapper
     wrapEnvFilesCommand
     addType
+    resolveEnabled
     ;
 
   /*

--- a/modules/programs/antigravity-cli.nix
+++ b/modules/programs/antigravity-cli.nix
@@ -46,16 +46,27 @@ let
           ]
         else
           server;
+      isDisabled =
+        if server ? disabled && server.disabled != null then
+          server.disabled
+        else if server ? enabled && server.enabled != null then
+          !server.enabled
+        else
+          false;
       transformed =
         removeAttrs cleaned [
           "httpUrl"
           "url"
+          "enabled"
         ]
         // lib.optionalAttrs (server ? httpUrl) {
           serverUrl = server.httpUrl;
         }
         // lib.optionalAttrs (server ? url) {
           serverUrl = server.url;
+        }
+        // lib.optionalAttrs isDisabled {
+          disabled = true;
         };
     in
     lib.filterAttrs (_: v: v != null && v != [ ] && v != { }) transformed;

--- a/modules/programs/antigravity-cli.nix
+++ b/modules/programs/antigravity-cli.nix
@@ -46,13 +46,7 @@ let
           ]
         else
           server;
-      isDisabled =
-        if server ? disabled && server.disabled != null then
-          server.disabled
-        else if server ? enabled && server.enabled != null then
-          !server.enabled
-        else
-          false;
+      isDisabled = lib.hm.mcp.resolveEnabled server == false;
       transformed =
         removeAttrs cleaned [
           "httpUrl"
@@ -166,7 +160,8 @@ in
         {file}`~/.gemini/config/mcp_config.json`.
 
         Remote servers use `serverUrl`; `url` and `httpUrl` are accepted
-        for migration and converted automatically.
+        for migration and converted automatically. `enabled` is accepted
+        and converted to `disabled`.
       '';
     };
 

--- a/tests/modules/programs/antigravity-cli/mcp.nix
+++ b/tests/modules/programs/antigravity-cli/mcp.nix
@@ -54,6 +54,10 @@
             "Authorization" = "Bearer token";
           };
         };
+        disabled-server = {
+          command = "disabled-cmd";
+          enabled = false;
+        };
       };
     };
   };
@@ -69,6 +73,9 @@
     assertFileRegex home-files/.gemini/config/mcp_config.json '"remote-server"'
     assertFileRegex home-files/.gemini/config/mcp_config.json '"serverUrl": "https://remote.example/mcp"'
     assertFileRegex home-files/.gemini/config/mcp_config.json '"type": "http"'
+    assertFileRegex home-files/.gemini/config/mcp_config.json '"disabled-server"'
+    assertFileRegex home-files/.gemini/config/mcp_config.json '"disabled": true'
+    assertFileNotRegex home-files/.gemini/config/mcp_config.json '"enabled": false'
     assertFileNotRegex home-files/.gemini/config/mcp_config.json '"command": null'
     assertFileNotRegex home-files/.gemini/config/mcp_config.json '"env": {}'
   '';

--- a/tests/modules/programs/antigravity-cli/mcp.nix
+++ b/tests/modules/programs/antigravity-cli/mcp.nix
@@ -22,6 +22,14 @@
             "/tmp"
           ];
         };
+        explicit-disabled = {
+          command = "disabled-direct-cmd";
+          disabled = true;
+        };
+        explicit-enabled = {
+          command = "enabled-direct-cmd";
+          enabled = true;
+        };
       };
     };
     mcp = {
@@ -74,8 +82,11 @@
     assertFileRegex home-files/.gemini/config/mcp_config.json '"serverUrl": "https://remote.example/mcp"'
     assertFileRegex home-files/.gemini/config/mcp_config.json '"type": "http"'
     assertFileRegex home-files/.gemini/config/mcp_config.json '"disabled-server"'
+    assertFileRegex home-files/.gemini/config/mcp_config.json '"explicit-disabled"'
+    assertFileRegex home-files/.gemini/config/mcp_config.json '"explicit-enabled"'
     assertFileRegex home-files/.gemini/config/mcp_config.json '"disabled": true'
     assertFileNotRegex home-files/.gemini/config/mcp_config.json '"enabled": false'
+    assertFileNotRegex home-files/.gemini/config/mcp_config.json '"enabled": true'
     assertFileNotRegex home-files/.gemini/config/mcp_config.json '"command": null'
     assertFileNotRegex home-files/.gemini/config/mcp_config.json '"env": {}'
   '';


### PR DESCRIPTION
### Description

Antigravity expects `"disabled": true` in `mcp_config.json` rather than `"enabled": false`.

This PR updates `transformMcpServer` in `modules/programs/antigravity-cli.nix` to map disabled MCP servers to `disabled = true` and strip the unrecognized `enabled` key so Antigravity leaves disabled servers inactive by default.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.