### PR TITLE
mitmproxy: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -313,6 +313,12 @@
     github = "kayskayskays";
     githubId = 115312476;
   };
+  keshavkrishna = {
+    name = "Keshav Krishna";
+    email = "keshavkrishnadav@gmail.com";
+    github = "keshavkrishna";
+    githubId = 57027202;
+  };
   kmaasrud = {
     name = "Knut Magnus Aasrud";
     email = "km@aasrud.com";

--- a/modules/misc/news/2026/08/2026-08-17_19-52-05.nix
+++ b/modules/misc/news/2026/08/2026-08-17_19-52-05.nix
@@ -1,0 +1,11 @@
+{
+  time = "2026-08-17T19:52:05+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.mitmproxy'.
+
+    Mitmproxy is an interactive, SSL/TLS-capable intercepting proxy. The
+    module installs the mitmproxy tools and writes options to
+    '~/.mitmproxy/config.yaml'.
+  '';
+}

--- a/modules/programs/mitmproxy.nix
+++ b/modules/programs/mitmproxy.nix
@@ -1,0 +1,52 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkIf;
+
+  cfg = config.programs.mitmproxy;
+
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = [ lib.maintainers.keshavkrishna ];
+
+  options.programs.mitmproxy = {
+    enable = lib.mkEnableOption "mitmproxy, an interactive HTTPS proxy";
+
+    package = lib.mkPackageOption pkgs "mitmproxy" { nullable = true; };
+
+    settings = lib.mkOption {
+      inherit (settingsFormat) type;
+      default = { };
+      defaultText = lib.literalExpression "{ }";
+      example = lib.literalExpression ''
+        {
+          listen_port = 8081;
+          ssl_insecure = true;
+          anticache = true;
+        }
+      '';
+      description = ''
+        Options written to {file}`~/.mitmproxy/config.yaml`. This
+        configuration file is shared by all mitmproxy tools (mitmproxy,
+        mitmweb, and mitmdump). See
+        <https://docs.mitmproxy.org/stable/concepts-options/>
+        for the available options. Note that mitmproxy always reads its
+        configuration from `~/.mitmproxy` and does not honor XDG
+        directories.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    home.file.".mitmproxy/config.yaml" = mkIf (cfg.settings != { }) {
+      source = settingsFormat.generate "mitmproxy-config" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/mitmproxy/basic-configuration.nix
+++ b/tests/modules/programs/mitmproxy/basic-configuration.nix
@@ -1,0 +1,16 @@
+{
+  programs.mitmproxy = {
+    enable = true;
+    settings = {
+      listen_port = 8081;
+      ssl_insecure = true;
+      anticache = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.mitmproxy/config.yaml
+    assertFileContent home-files/.mitmproxy/config.yaml \
+      ${./expected-config.yaml}
+  '';
+}

--- a/tests/modules/programs/mitmproxy/default.nix
+++ b/tests/modules/programs/mitmproxy/default.nix
@@ -1,0 +1,4 @@
+{
+  mitmproxy-basic-configuration = ./basic-configuration.nix;
+  mitmproxy-empty-settings = ./empty-settings.nix;
+}

--- a/tests/modules/programs/mitmproxy/empty-settings.nix
+++ b/tests/modules/programs/mitmproxy/empty-settings.nix
@@ -1,0 +1,7 @@
+{
+  programs.mitmproxy.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists home-files/.mitmproxy/config.yaml
+  '';
+}

--- a/tests/modules/programs/mitmproxy/expected-config.yaml
+++ b/tests/modules/programs/mitmproxy/expected-config.yaml
@@ -1,0 +1,3 @@
+anticache: true
+listen_port: 8081
+ssl_insecure: true


### PR DESCRIPTION
## Summary

Adds a `programs.mitmproxy` module for [mitmproxy](https://mitmproxy.org/), the interactive HTTPS/TLS intercepting proxy.

- Installs the mitmproxy tools (`mitmproxy`, `mitmweb`, `mitmdump`) via a nullable `package` option.
- Exposes a `settings` option (freeform YAML, per RFC 42) written to `~/.mitmproxy/config.yaml`, the single config file shared by all three tools.
- mitmproxy hardcodes its config directory to `~/.mitmproxy` and does not support an environment variable override or XDG paths, so the module writes to a fixed path on all platforms rather than exposing a `configDir` option.
- No file is generated when `settings` is empty or `package` is null, per the module guidelines.

## Test plan

- [x] `nix run .#tests -- mitmproxy` — both `mitmproxy-basic-configuration` and `mitmproxy-empty-settings` pass
- [x] `nix fmt` — no formatting changes needed
- [x] `nix-build -A docs.manPages` — builds cleanly, `programs.mitmproxy.*` options render correctly in the generated man page
- [x] Added myself as maintainer in `modules/lib/maintainers.nix`
- [x] Added a news entry under `modules/misc/news/2026/08/`