### PR TITLE
readest: add module

### DIFF
--- a/modules/programs/readest.nix
+++ b/modules/programs/readest.nix
@@ -1,0 +1,56 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    mkIf
+    types
+    ;
+in
+{
+  meta.maintainers = [ lib.maintainers.nyxar77 ];
+  options.programs.readest = {
+    enable = mkEnableOption "Readest";
+    package = mkPackageOption pkgs "readest" { nullable = true; };
+
+    settings = mkOption {
+      type = types.nullOr (types.either types.path types.lines);
+      default = null;
+      example = lib.literalExpression ''
+                {
+          "telemetryEnabled": false,
+          "libraryViewMode": "grid",
+          "globalViewSettings": {
+            "theme": "dark",
+            "defaultFontSize": 18,
+            "lineHeight": 1.5
+          }
+        }
+        '''
+      '';
+      description = ''
+          Readest configuration as either a path to a JSON file or literal JSON
+        content. The configuration is written to
+        {file}`$XDG_CONFIG_HOME/com.bilingify.readest/settings.json`.
+      '';
+    };
+  };
+
+  config =
+    let
+      cfg = config.programs.readest;
+    in
+    mkIf cfg.enable {
+      home.packages = mkIf (cfg.package != null) [ cfg.package ];
+      xdg.configFile."com.bilingify.readest/settings.json" = mkIf (cfg.settings != null) {
+        source =
+          if builtins.isPath cfg.settings then cfg.settings else pkgs.writeText "settings.json" cfg.settings;
+      };
+    };
+}


### PR DESCRIPTION
### Description

adds `programs.readest` for installing and configuring `readest`

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
