### PR TITLE
eilmeldung: init module

### DIFF
--- a/modules/misc/news/2026/08/2026-08-18_23-56-12.nix
+++ b/modules/misc/news/2026/08/2026-08-18_23-56-12.nix
@@ -1,0 +1,18 @@
+{
+  time = "2026-08-18T18:26:12+00:00";
+  condition = true;
+  message = ''
+    A new module is available: programs.eilmeldung.
+
+    eilmeldung is a fast TUI RSS reader built on the news-flash library which
+    supports many RSS providers. It provides Vim-inspired keybindings, a
+    non-blocking interface and instant startup, while keeping the interface
+    uncluttered. Articles can be searched and filtered using a powerful query
+    language, tagged for later reference, and read in a distraction-free "zen mode".
+
+    eilmeldung comes with sensible defaults but is extensively configurable,
+    including keybindings, colors, displayed content and RSS providers. It
+    also supports smart folders through article queries, allowing feeds and
+    articles to be organized without leaving the reader.
+  '';
+}

--- a/modules/programs/eilmeldung.nix
+++ b/modules/programs/eilmeldung.nix
@@ -1,0 +1,85 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    mkIf
+    ;
+  cfg = config.programs.eilmeldung;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = [
+    lib.maintainers.christo-auer
+    lib.maintainers.rachitvrma
+  ];
+
+  options.programs.eilmeldung = {
+    enable = mkEnableOption "eilmeldung, a TUI news feed reader";
+
+    package = mkPackageOption pkgs "eilmeldung" { nullable = true; };
+
+    settings = mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = {
+        mouse_support = true;
+
+        feed_list = [
+          "query: \"Marked\" marked"
+          "query: \"Reviews\" #reviews"
+          "feeds"
+          "* categories"
+          "tags"
+        ];
+
+        startup_commands = [ "sync" ];
+
+        after_sync_commands = [
+          "query lastsync"
+          "tag rust title:\"rust\""
+          "read title:/^Advertisement/"
+          "refresh"
+        ];
+
+        video_enclosure_command = "mpv {url}";
+        audio_enclosure_command = "mpv --no-audio {url}";
+
+        share_targets = [
+          "clipboard"
+          "feh feh \"{url}\""
+        ];
+
+        input_config.mappings = {
+          "; i" = [ "cmd hintshare feh" ];
+          "y" = [
+            "confirm in articles read all"
+            "nextunread"
+          ];
+        };
+      };
+
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/eilmeldung/config.toml`.
+
+        See
+        <https://github.com/christo-auer/eilmeldung/blob/main/docs/configuration.md>
+        for the full list of options.
+      '';
+    };
+  };
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."eilmeldung/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "eilmeldung-config.toml" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/eilmeldung/default.nix
+++ b/tests/modules/programs/eilmeldung/default.nix
@@ -1,0 +1,4 @@
+{
+  eilmeldung-empty-config = ./empty-config.nix;
+  eilmeldung-example-config = ./example-config.nix;
+}

--- a/tests/modules/programs/eilmeldung/empty-config.nix
+++ b/tests/modules/programs/eilmeldung/empty-config.nix
@@ -1,0 +1,7 @@
+{
+  programs.eilmeldung.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/eilmeldung"
+  '';
+}

--- a/tests/modules/programs/eilmeldung/example-config.nix
+++ b/tests/modules/programs/eilmeldung/example-config.nix
@@ -1,0 +1,47 @@
+{
+  programs.eilmeldung = {
+    enable = true;
+
+    settings = {
+      mouse_support = true;
+
+      feed_list = [
+        "query: \"Marked\" marked"
+        "query: \"Reviews\" #reviews"
+        "feeds"
+        "* categories"
+        "tags"
+      ];
+
+      startup_commands = [ "sync" ];
+
+      after_sync_commands = [
+        "query lastsync"
+        "tag rust title:\"rust\""
+        "read title:/^Advertisement/"
+        "refresh"
+      ];
+
+      video_enclosure_command = "mpv {url}";
+      audio_enclosure_command = "vlc {url}";
+
+      share_targets = [
+        "clipboard"
+        "feh feh \"{url}\""
+      ];
+
+      input_config.mappings = {
+        "; i" = [ "cmd hintshare feh" ];
+        "y" = [
+          "confirm in articles read all"
+          "nextunread"
+        ];
+      };
+    };
+  };
+
+  nmt.script = ''
+    local configFile="home-files/.config/eilmeldung/config.toml"
+    assertFileContent "$configFile" ${./expected-config.toml}
+  '';
+}

--- a/tests/modules/programs/eilmeldung/expected-config.toml
+++ b/tests/modules/programs/eilmeldung/expected-config.toml
@@ -1,0 +1,11 @@
+after_sync_commands = ["query lastsync", 'tag rust title:"rust"', "read title:/^Advertisement/", "refresh"]
+audio_enclosure_command = "vlc {url}"
+feed_list = ['query: "Marked" marked', 'query: "Reviews" #reviews', "feeds", "* categories", "tags"]
+mouse_support = true
+share_targets = ["clipboard", 'feh feh "{url}"']
+startup_commands = ["sync"]
+video_enclosure_command = "mpv {url}"
+
+[input_config.mappings]
+"; i" = ["cmd hintshare feh"]
+y = ["confirm in articles read all", "nextunread"]


### PR DESCRIPTION
### Description

eilmeldung is a fast TUI RSS reader built on the news-flash library which supports many RSS providers. It provides Vim-inspired keybindings, a non-blocking interface and instant startup, while keeping the interface uncluttered. Articles can be searched and filtered using a powerful query language, tagged for later reference, and read in a distraction-free "zen mode".



<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
