### PR TITLE
fnox: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -451,6 +451,12 @@
     github = "NitroSniper";
     githubId = 44097331;
   };
+  o-az = {
+    name = "Omar Aziz";
+    email = "23618431+o-az@users.noreply.github.com";
+    github = "o-az";
+    githubId = 23618431;
+  };
   olmokramer = {
     name = "Olmo Kramer";
     email = "olmokramer@users.noreply.github.com";

--- a/modules/misc/news/2026/08/2026-08-17_19-14-24.nix
+++ b/modules/misc/news/2026/08/2026-08-17_19-14-24.nix
@@ -1,0 +1,11 @@
+{
+  time = "2026-08-17T19:14:24+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.fnox'.
+
+    fnox manages secrets from encrypted files and external providers. The
+    module can install fnox, generate its global configuration, and enable
+    Bash, Fish, Nushell, and Zsh integration.
+  '';
+}

--- a/modules/programs/fnox.nix
+++ b/modules/programs/fnox.nix
@@ -1,0 +1,104 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.fnox;
+  tomlFormat = pkgs.formats.toml { };
+  fnox = lib.getExe' cfg.package "fnox";
+
+  shellIntegrationDescription = ''
+    The integration automatically resolves and exports secrets when changing
+    directories and before displaying a prompt.
+  '';
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.o-az ];
+
+  options.programs.fnox = {
+    enable = lib.mkEnableOption "fnox, a flexible secret management tool";
+
+    package = lib.mkPackageOption pkgs "fnox" { };
+
+    settings = lib.mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          env = "exec";
+          if_missing = "warn";
+          prompt_auth = false;
+          daemon.enabled = false;
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/fnox/config.toml`.
+
+        All values configured here are copied to the Nix store. Do not include
+        plaintext secrets, private keys, authentication tokens, or other
+        credentials. Use encrypted values or references to external secret
+        providers instead.
+
+        The generated file is immutable. Commands that modify fnox's global
+        configuration cannot update it.
+
+        See <https://github.com/jdx/fnox/blob/main/docs/reference/configuration.md>
+        for available settings.
+      '';
+    };
+
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption {
+      inherit config;
+      extraDescription = shellIntegrationDescription;
+    };
+
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption {
+      inherit config;
+      extraDescription = shellIntegrationDescription;
+    };
+
+    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption {
+      inherit config;
+      extraDescription = shellIntegrationDescription;
+    };
+
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption {
+      inherit config;
+      extraDescription = shellIntegrationDescription;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."fnox/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "fnox-config.toml" cfg.settings;
+    };
+
+    programs = {
+      bash.initExtra = lib.mkIf cfg.enableBashIntegration ''
+        eval "$(${fnox} activate bash)"
+      '';
+
+      fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+        ${fnox} activate fish | source
+      '';
+
+      nushell.extraConfig = lib.mkIf cfg.enableNushellIntegration ''
+        source ${
+          pkgs.runCommand "fnox-nushell-integration.nu" { } ''
+            ${fnox} activate nu > "$out"
+          ''
+        }
+      '';
+
+      zsh.initContent = lib.mkIf cfg.enableZshIntegration ''
+        eval "$(${fnox} activate zsh)"
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/fnox/default-package.nix
+++ b/tests/modules/programs/fnox/default-package.nix
@@ -1,0 +1,35 @@
+{
+  programs = {
+    fnox = {
+      enable = true;
+      enableBashIntegration = false;
+      enableFishIntegration = false;
+      enableNushellIntegration = false;
+      enableZshIntegration = false;
+      settings = { };
+    };
+
+    bash.enable = true;
+    fish.enable = true;
+    nushell.enable = true;
+    zsh.enable = true;
+  };
+
+  test.stubs.fnox = {
+    outPath = null;
+    buildScript = ''
+      mkdir -p "$out/bin"
+      touch "$out/bin/fnox"
+    '';
+  };
+
+  nmt.script = ''
+    assertFileExists home-path/bin/fnox
+    assertPathNotExists home-files/.config/fnox/config.toml
+
+    assertFileNotRegex home-files/.bashrc 'fnox activate'
+    assertFileNotRegex home-files/.config/fish/config.fish 'fnox activate'
+    assertFileNotRegex home-files/.config/nushell/config.nu 'fnox activate'
+    assertFileNotRegex home-files/.zshrc 'fnox activate'
+  '';
+}

--- a/tests/modules/programs/fnox/default.nix
+++ b/tests/modules/programs/fnox/default.nix
@@ -1,0 +1,6 @@
+{
+  fnox-default-package = ./default-package.nix;
+  fnox-disabled = ./disabled.nix;
+  fnox-package-override = ./package-override.nix;
+  fnox-settings-and-shell-integrations = ./settings-and-shell-integrations.nix;
+}

--- a/tests/modules/programs/fnox/disabled.nix
+++ b/tests/modules/programs/fnox/disabled.nix
@@ -1,0 +1,35 @@
+{
+  programs = {
+    fnox = {
+      enable = false;
+      settings.env = "exec";
+    };
+
+    bash = {
+      enable = true;
+      initExtra = "# Bash marker";
+    };
+    fish = {
+      enable = true;
+      interactiveShellInit = "# Fish marker";
+    };
+    nushell = {
+      enable = true;
+      extraConfig = "# Nushell marker";
+    };
+    zsh = {
+      enable = true;
+      initContent = "# Zsh marker";
+    };
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/fnox/config.toml
+    assertPathNotExists home-path/bin/fnox
+
+    assertFileNotRegex home-files/.bashrc 'fnox activate'
+    assertFileNotRegex home-files/.config/fish/config.fish 'fnox activate'
+    assertFileNotRegex home-files/.config/nushell/config.nu 'fnox activate'
+    assertFileNotRegex home-files/.zshrc 'fnox activate'
+  '';
+}

--- a/tests/modules/programs/fnox/expected.toml
+++ b/tests/modules/programs/fnox/expected.toml
@@ -1,0 +1,6 @@
+env = "exec"
+if_missing = "warn"
+prompt_auth = false
+
+[daemon]
+enabled = false

--- a/tests/modules/programs/fnox/package-override.nix
+++ b/tests/modules/programs/fnox/package-override.nix
@@ -1,0 +1,25 @@
+{ config, ... }:
+
+{
+  programs.fnox = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "fnox";
+      buildScript = ''
+        mkdir -p "$out/bin"
+        cat > "$out/bin/fnox" <<'EOF'
+        #!/bin/sh
+        # fnox package override
+        EOF
+        chmod +x "$out/bin/fnox"
+      '';
+    };
+  };
+
+  home.shell.enableShellIntegration = false;
+
+  nmt.script = ''
+    assertFileExists home-path/bin/fnox
+    assertFileContains home-path/bin/fnox '# fnox package override'
+  '';
+}

--- a/tests/modules/programs/fnox/settings-and-shell-integrations.nix
+++ b/tests/modules/programs/fnox/settings-and-shell-integrations.nix
@@ -1,0 +1,53 @@
+{ config, ... }:
+
+{
+  programs = {
+    fnox = {
+      enable = true;
+      package = config.lib.test.mkStubPackage {
+        name = "custom-fnox";
+        buildScript = ''
+          mkdir -p "$out/bin"
+          cat > "$out/bin/fnox" <<'EOF'
+          #!/bin/sh
+          if [ "$1" = activate ] && [ "$2" = nu ]; then
+            echo "# $0 $1 $2"
+          fi
+          EOF
+          chmod +x "$out/bin/fnox"
+        '';
+      };
+      settings = {
+        env = "exec";
+        if_missing = "warn";
+        prompt_auth = false;
+        daemon.enabled = false;
+      };
+    };
+
+    bash.enable = true;
+    fish.enable = true;
+    nushell.enable = true;
+    zsh.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/fnox/config.toml
+    assertFileContent home-files/.config/fnox/config.toml ${./expected.toml}
+
+    assertFileRegex home-files/.bashrc \
+      '/nix/store/[^/]*-custom-fnox/bin/fnox activate bash'
+    assertFileRegex home-files/.config/fish/config.fish \
+      '/nix/store/[^/]*-custom-fnox/bin/fnox activate fish \| source'
+    assertFileRegex home-files/.zshrc \
+      '/nix/store/[^/]*-custom-fnox/bin/fnox activate zsh'
+
+    assertFileRegex home-files/.config/nushell/config.nu \
+      'source /nix/store/[^/]*-fnox-nushell-integration.nu'
+    nushellIntegration=$(sed -n \
+      's|^source \(/nix/store/[^/]*-fnox-nushell-integration.nu\)$|\1|p' \
+      "$(_abs home-files/.config/nushell/config.nu)")
+    assertFileRegex "$nushellIntegration" \
+      '^# /nix/store/[^/]*-custom-fnox/bin/fnox activate nu$'
+  '';
+}


### PR DESCRIPTION
### Description

Adds a new `programs.fnox` module for [fnox](https://fnox.jdx.dev).

It installs the configured package, writes non-empty settings to `$XDG_CONFIG_HOME/fnox/config.toml`, and supports Bash, Zsh, Fish, & Nushell integration. All shell activation commands use the configured package.

Although it is self-explanatory in `fnox` docs and usage, I still made the settings documentation warn that generated values enter the Nix store and must not contain plaintext secrets or credentials.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)