### PR TITLE
pi-coding-agent: add skills option

### DIFF
--- a/modules/programs/pi-coding-agent.nix
+++ b/modules/programs/pi-coding-agent.nix
@@ -158,6 +158,14 @@ in
       '';
     };
 
+    skills = mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to the skills directory for Pi Coding Agent.
+      '';
+    };
+
     context = mkOption {
       type = lib.types.either lib.types.lines lib.types.path;
       default = "";
@@ -201,6 +209,13 @@ in
         (mkIf (cfg.models != { }) {
           "${cfg.configDir}/models.json".source =
             jsonFormat.generate "pi-coding-agent-models.json" cfg.models;
+        })
+
+        (mkIf (cfg.skills != null) {
+          "${cfg.configDir}/skills" = {
+            source = cfg.skills;
+            recursive = true;
+          };
         })
 
         (

--- a/tests/modules/programs/pi-coding-agent/default.nix
+++ b/tests/modules/programs/pi-coding-agent/default.nix
@@ -7,4 +7,5 @@
   pi-coding-agent-context-empty = ./context-empty.nix;
   pi-coding-agent-custom-config-dir = ./custom-config-dir.nix;
   pi-coding-agent-models = ./models.nix;
+  pi-coding-agent-skills = ./skills.nix;
 }

--- a/tests/modules/programs/pi-coding-agent/skills.nix
+++ b/tests/modules/programs/pi-coding-agent/skills.nix
@@ -1,0 +1,12 @@
+{
+  programs.pi-coding-agent = {
+    enable = true;
+    skills = ./skills;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.pi/agent/skills/my-skill/SKILL.md
+    assertFileContent home-files/.pi/agent/skills/my-skill/SKILL.md \
+      ${./skills/my-skill/SKILL.md}
+  '';
+}

--- a/tests/modules/programs/pi-coding-agent/skills/my-skill/SKILL.md
+++ b/tests/modules/programs/pi-coding-agent/skills/my-skill/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: my-skill
+description: A test skill.
+---
+
+# My Skill
+
+Do test things.


### PR DESCRIPTION
Add an option to link a skills directory into the Pi Coding Agent configuration directory (default ~/.pi/agent/skills), from which Pi auto-discovers skills.

### Description

added `programs.pi-coding-agent.skills`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
