### PR TITLE
zsh: make the package option nullable

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -602,7 +602,11 @@ in
                 fpath+=($profile/share/zsh/site-functions $profile/share/zsh/$ZSH_VERSION/functions $profile/share/zsh/vendor-completions)
               done
             '')
-            (lib.mkIf (cfg.package != null) (mkOrder 520 "HELPDIR=${cfg.package}/share/zsh/$ZSH_VERSION/help"))
+            (lib.mkIf (cfg.package != null) (
+              mkOrder 520 ''
+                HELPDIR="${cfg.package}/share/zsh/$ZSH_VERSION/help"
+              ''
+            ))
 
             (lib.mkIf (cfg.defaultKeymap != null) (
               mkOrder 530 ''

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -127,7 +127,9 @@ in
       programs.zsh = {
         enable = mkEnableOption "Z shell (Zsh)";
 
-        package = lib.mkPackageOption pkgs "zsh" { };
+        package = lib.mkPackageOption pkgs "zsh" {
+          nullable = true;
+        };
 
         autocd = mkOption {
           default = null;
@@ -578,10 +580,9 @@ in
         {
           lib.zsh = zshLib;
 
-          home.packages = [
-            cfg.package
-          ]
-          ++ lib.optional cfg.enableCompletion (lib.lowPrio pkgs.nix-zsh-completions);
+          home.packages = lib.mkIf (cfg.package != null) (
+            [ cfg.package ] ++ lib.optional cfg.enableCompletion (lib.lowPrio pkgs.nix-zsh-completions)
+          );
 
           # NOTE: Always include "main" highlighter with normal priority.
           # Option default priority will cause `main` to get dropped by customization.
@@ -600,9 +601,8 @@ in
               for profile in ''${(z)NIX_PROFILES}; do
                 fpath+=($profile/share/zsh/site-functions $profile/share/zsh/$ZSH_VERSION/functions $profile/share/zsh/vendor-completions)
               done
-
-              HELPDIR="${cfg.package}/share/zsh/$ZSH_VERSION/help"
             '')
+            (lib.mkIf (cfg.package != null) (mkOrder 520 "HELPDIR=${cfg.package}/share/zsh/$ZSH_VERSION/help"))
 
             (lib.mkIf (cfg.defaultKeymap != null) (
               mkOrder 530 ''


### PR DESCRIPTION
### Description

Only configuraiton.nix can set the user login shell, so I make `programs.zsh.package` nullable.
<!--

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
