### PR TITLE
claude-code: disable automatic updates for managed marketplaces

### DIFF
--- a/modules/programs/claude-code/lib.nix
+++ b/modules/programs/claude-code/lib.nix
@@ -32,6 +32,7 @@ in
         // {
           installLocation = content;
           lastUpdated = "1970-01-01T00:00:00Z";
+          autoUpdate = false;
         };
 
       mkMarkdownEntries =

--- a/tests/modules/programs/claude-code/expected-known-marketplaces.json
+++ b/tests/modules/programs/claude-code/expected-known-marketplaces.json
@@ -1,5 +1,6 @@
 {
   "test-duplicate": {
+    "autoUpdate": false,
     "installLocation": "/nix/store/00000000000000000000000000000000-test-marketplace",
     "lastUpdated": "1970-01-01T00:00:00Z",
     "source": {
@@ -8,6 +9,7 @@
     }
   },
   "test-market": {
+    "autoUpdate": false,
     "installLocation": "/nix/store/00000000000000000000000000000000-test-marketplace",
     "lastUpdated": "1970-01-01T00:00:00Z",
     "source": {


### PR DESCRIPTION
### Description

The "claude-plugins-official" marketplace will be automatically updated when starting up `claude`; this poses a problem when using the `programs.claude-code.marketplaces` option, as both `claude` and Home Manager are making edits to ~/.claude/plugins/known_marketplaces.json`:
```
$ home-manager switch
...
Existing file '~/.claude/plugins/known_marketplaces.json' would be clobbered
```

This undesirable behavior can be disabled in `claude` by setting the `autoUpdate` key of a marketplace to false, which is what this PR allows.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
