### PR TITLE
module/cliamp: a retro terminal music player inspired by Winamp

### DIFF
--- a/modules/misc/news/2026/08/2026-08-23_20-22-10.nix
+++ b/modules/misc/news/2026/08/2026-08-23_20-22-10.nix
@@ -1,0 +1,13 @@
+{
+  time = "2026-08-23T14:52:10+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.cliamp'.
+
+    Cliamp is a retro terminal music player inspired by Winamp.
+    Play local files, streams, podcasts, YouTube, YouTube Music, SoundCloud,
+    Bilibili, Spotify, NetEase Cloud Music, Xiaoyuzhou (小宇宙), Navidrome,
+    Plex, Jellyfin, and Audiobookshelf with a spectrum visualizer, parametric
+    EQ, and playlist management.
+  '';
+}

--- a/modules/programs/cliamp.nix
+++ b/modules/programs/cliamp.nix
@@ -1,0 +1,223 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.cliamp;
+  tomlFormat = pkgs.formats.toml { };
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    types
+    ;
+in
+{
+  meta.maintainers = [ lib.maintainers.rachitvrma ];
+
+  options.programs.cliamp = {
+    enable = mkEnableOption "cliamp, a retro terminal music player inspired by Winamp";
+    package = mkPackageOption pkgs "cliamp" { nullable = true; };
+    settings = mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = {
+        eq = [
+          "-2"
+          "0"
+          "0"
+          "0"
+          "0"
+          "0"
+          "0"
+          "0"
+          "0"
+          "0"
+        ];
+        eq_preset = "Custom";
+        theme = "";
+        visualizer = "Bricks";
+        ytmusic = {
+          enabled = true;
+        };
+      };
+
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/cliamp/config.toml`.
+
+        See
+        <https://whiterose.org.contextowl.co/docs/cliamp>
+        for the full list of options.
+      '';
+    };
+    themes = mkOption {
+      type = types.attrsOf (
+        types.oneOf [
+          tomlFormat.type
+        ]
+      );
+      default = { };
+      example = {
+        solarized = {
+          accent = "#268bd2";
+          bright_fg = "#eee8d5";
+          fg = "#839496";
+          green = "#859900";
+          yellow = "#b58900";
+          red = "#dc322f";
+        };
+      };
+      description = ''
+        Each theme is written to {file}`$XDG_CONFIG_HOME/cliamp/themes/NAME.toml`.
+        See <https://whiterose.org.contextowl.co/docs/cliamp/themes> for more information.
+      '';
+    };
+    radios = mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = {
+        station = [
+          {
+            name = "Jazz FR";
+            url = "https://jazz.example.com/stream";
+          }
+          {
+            name = "Ambient Radio";
+            url = "https://ambient.example.com/stream.m3u";
+          }
+        ];
+      };
+      description = ''
+        Add your own stations to {file}`$XDG_CONFIG_HOME/cliamp/radios.toml`.
+        See <https://github.com/bjarneo/cliamp/blob/main/docs/configuration.md#custom-radio-stations>
+      '';
+    };
+
+    systemd = {
+      enable = mkEnableOption "a systemd user service for cliamp";
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [
+          "--auto-play"
+          "--playlist"
+          "Lofi"
+        ];
+        description = ''
+          Extra command-line flags appended after `cliamp --daemon`
+          in the generated systemd user service.
+
+          See <https://whiterose.org.contextowl.co/docs/cliamp/headless-daemon-mode> for
+          more details.
+
+          Note: these are passed directly to `ExecStart`, which is not
+          shell-interpreted — `~` is not expanded. Use an absolute path,
+          or a systemd specifier like `%h` for the user's home directory
+          (e.g. `"%h/Music"`); see systemd.unit(5) § Specifiers.
+        '';
+      };
+    };
+    plugins = mkOption {
+      type =
+        with types;
+        attrsOf (
+          either package (
+            addCheck path (
+              p:
+              (lib.pathIsDirectory p && lib.pathExists (p + "/init.lua"))
+              || (lib.hasSuffix ".lua" (toString p) && lib.pathIsRegularFile p)
+            )
+          )
+        );
+      default = { };
+      example = lib.literalExpression ''
+        {
+          block-burst = pkgs.fetchurl {
+            url = "https://raw.githubusercontent.com/AlexZeitler/cliamp-plugin-block-burst/master/block-burst.lua";
+            hash = "sha256-CK/NlavSzePrOFop6tGLbp5S0aTokb6ZcDNxpvzsxxo=";
+          };
+          cliamp-single-file = ../plugins/visualizer.lua;
+          cliamp-local-dir = ../plugins/lastfm-scrobbler;
+        }
+      '';
+      description = ''
+        Plugins to install in {file}`XDG_CONFIG_HOME/cliamp/plugins`.
+
+        Accepts either a package/derivation (e.g. `pkgs.fetchFromGitHub { ... }`)
+        or a local path. A local path may point at a single `.lua` file, or
+        at a directory containing an `init.lua` entry point — cliamp loads
+        only `init.lua` from a plugin directory, so a directory without one
+        is rejected at evaluation time rather than silently doing nothing.
+
+        Note on trust: cliamp requires every plugin's contents to be
+        approved with `cliamp plugins trust <name>` before it will run
+        them, and re-approval is required whenever the content changes
+        (see cliamp's plugin docs). This module only places files under
+        {file}`plugins/`; it does not and cannot manage
+        {file}`plugins/.trust.json` for you. After a rebuild that adds or
+        changes a plugin here, you will need to re-run
+        `cliamp plugins trust <name>` yourself.
+
+        Package-based plugins (branch above) are not checked for shape at
+        evaluation time, since a derivation's output does not exist on
+        disk until it is built.
+
+        See <https://whiterose.org.contextowl.co/docs/cliamp/lua-plugins>
+        for more details.
+      '';
+    };
+  };
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile = lib.mkMerge [
+      {
+        "cliamp/config.toml" = mkIf (cfg.settings != { }) {
+          source = tomlFormat.generate "cliamp-config" cfg.settings;
+        };
+      }
+      {
+        "cliamp/radios.toml" = mkIf (cfg.radios != { }) {
+          source = tomlFormat.generate "cliamp-radios" cfg.radios;
+        };
+      }
+      (lib.mapAttrs' (
+        name: value:
+        lib.nameValuePair "cliamp/themes/${name}.toml" {
+          source = tomlFormat.generate "cliamp-theme-${name}" value;
+        }
+      ) cfg.themes)
+      (lib.mapAttrs' (
+        name: value:
+        lib.nameValuePair "cliamp/plugins/${name}${lib.optionalString (!lib.pathIsDirectory value) ".lua"}"
+          {
+            source = value;
+          }
+      ) cfg.plugins)
+    ];
+
+    systemd.user.services.cliamp = mkIf cfg.systemd.enable {
+      Unit = {
+        Description = "cliamp headless music player";
+      };
+      Service = {
+        ExecStart = lib.escapeShellArgs (
+          [
+            (lib.getExe cfg.package)
+            "--daemon"
+          ]
+          ++ cfg.systemd.extraFlags
+        );
+        Restart = "on-failure";
+      };
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+    };
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -36,6 +36,7 @@ let
     "cava"
     "chromium"
     "claude-code"
+    "cliamp"
     "clock-rs"
     "cmus"
     "codex"

--- a/tests/modules/programs/cliamp/default.nix
+++ b/tests/modules/programs/cliamp/default.nix
@@ -1,0 +1,6 @@
+{
+  cliamp-empty-config = ./empty-config.nix;
+  cliamp-example-config = ./example-config.nix;
+  cliamp-example-theme = ./example-theme.nix;
+  cliamp-example-radios = ./example-radios.nix;
+}

--- a/tests/modules/programs/cliamp/empty-config.nix
+++ b/tests/modules/programs/cliamp/empty-config.nix
@@ -1,0 +1,7 @@
+{
+  programs.cliamp.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/cliamp"
+  '';
+}

--- a/tests/modules/programs/cliamp/example-config.nix
+++ b/tests/modules/programs/cliamp/example-config.nix
@@ -1,0 +1,29 @@
+{
+  programs.cliamp = {
+    enable = true;
+    settings = {
+      eq = [
+        "-2"
+        "0"
+        "0"
+        "0"
+        "0"
+        "0"
+        "0"
+        "0"
+        "0"
+        "0"
+      ];
+      eq_preset = "Custom";
+      theme = "gruvbox";
+      visualizer = "Bricks";
+      ytmusic = {
+        enabled = true;
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent "home-files/.config/cliamp/config.toml" ${./expected-config.toml}
+  '';
+}

--- a/tests/modules/programs/cliamp/example-radios.nix
+++ b/tests/modules/programs/cliamp/example-radios.nix
@@ -1,0 +1,20 @@
+{
+  programs.cliamp = {
+    enable = true;
+    radios = {
+      station = [
+        {
+          name = "Jazz FM";
+          url = "https://jazz.example.com/stream";
+        }
+        {
+          name = "Ambient Radio";
+          url = "https://ambient.example.com/stream.m3u";
+        }
+      ];
+    };
+  };
+  nmt.script = ''
+    assertFileContent "home-files/.config/cliamp/radios.toml" ${./expected-radios.toml}
+  '';
+}

--- a/tests/modules/programs/cliamp/example-theme.nix
+++ b/tests/modules/programs/cliamp/example-theme.nix
@@ -1,0 +1,20 @@
+{
+  programs.cliamp = {
+    enable = true;
+    themes = {
+      gruvbox-custom = {
+        accent = "#7daea3";
+        bg = "#202020";
+        bright_fg = "#ddc7a1";
+        fg = "#89b482";
+        green = "#a9b665";
+        red = "#ea6962";
+        yellow = "#d8a657";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent "home-files/.config/cliamp/themes/gruvbox-custom.toml" ${./expected-theme.toml}
+  '';
+}

--- a/tests/modules/programs/cliamp/expected-config.toml
+++ b/tests/modules/programs/cliamp/expected-config.toml
@@ -1,0 +1,7 @@
+eq = ["-2", "0", "0", "0", "0", "0", "0", "0", "0", "0"]
+eq_preset = "Custom"
+theme = "gruvbox"
+visualizer = "Bricks"
+
+[ytmusic]
+enabled = true

--- a/tests/modules/programs/cliamp/expected-radios.toml
+++ b/tests/modules/programs/cliamp/expected-radios.toml
@@ -1,0 +1,7 @@
+[[station]]
+name = "Jazz FM"
+url = "https://jazz.example.com/stream"
+
+[[station]]
+name = "Ambient Radio"
+url = "https://ambient.example.com/stream.m3u"

--- a/tests/modules/programs/cliamp/expected-theme.toml
+++ b/tests/modules/programs/cliamp/expected-theme.toml
@@ -1,0 +1,7 @@
+accent = "#7daea3"
+bg = "#202020"
+bright_fg = "#ddc7a1"
+fg = "#89b482"
+green = "#a9b665"
+red = "#ea6962"
+yellow = "#d8a657"

--- a/tests/modules/programs/cliamp/systemd-enabled.nix
+++ b/tests/modules/programs/cliamp/systemd-enabled.nix
@@ -1,0 +1,28 @@
+{ config, ... }:
+{
+  programs.cliamp = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@cliamp@"; };
+    systemd = {
+      enable = true;
+      extraFlags = [
+        "--auto-play"
+        "--playlist"
+        "Lofi"
+      ];
+    };
+  };
+  nmt.script = ''
+    assertFileContent \
+    home-files/.config/systemd/user/cliamp.service \
+    ${builtins.toFile "cliamp.service" ''
+      [Install]
+      WantedBy=default.target
+      [Service]
+      ExecStart=@cliamp@/bin/cliamp --daemon --auto-play --playlist Lofi
+      Restart=on-failure
+      [Unit]
+      Description=cliamp headless music player
+    ''}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Cliamp is a retro terminal music player inspired by Winamp. It can play audio filer of various formats, can be used with YouTube, YouTube Music Player, Spotify, SounCloud, and many more.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
