### PR TITLE
podman: fix error removing untagged podman images

### DIFF
--- a/modules/services/podman/linux/activation.nix
+++ b/modules/services/podman/linux/activation.nix
@@ -1,5 +1,14 @@
-{ config, podman-lib, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  podman-lib,
+  ...
+}:
 
+let
+  awk = lib.getExe pkgs.gawk;
+in
 {
   cleanup = ''
     PATH=$PATH:${podman-lib.newuidmapPaths}
@@ -26,20 +35,32 @@
 
       loadManifest "$manifestFile"
 
-      formatString="{{.Name}}"
-      [[ $resourceType = "container" ]] && formatString="{{.Names}}"
-      [[ $resourceType = "image" ]] && formatString="{{.Repository}}"
+      # Print names and IDs of the resources, deliminated by comma
+      # The names are matched against the resource manifest, and the IDs are used for deletion
+      # Exception being the volumes, which use the names as their IDs
+      [[ $resourceType = "container" ]] && formatString="{{.Names}},{{.ID}}"
+      [[ $resourceType = "image" ]] && formatString="{{.Repository}},{{.ID}}"
+      [[ $resourceType = "network" ]] && formatString="{{.Name}},{{.ID}}"
+      [[ $resourceType = "volume" ]] && formatString="{{.Name}},{{.Name}}"
 
       local listOutput=$(${config.services.podman.package}/bin/podman $resourceType ls $extraListCommands --filter 'label=nix.home-manager.managed=true' --format "$formatString")
 
-      IFS=$'\n' read -r -d "" -a podmanResources <<< "$listOutput" || true
+      # If $listOutput is empty, the arrays now do not have one empty string
+      podmanResources=()
+      podmanResourceIds=()
+      if [ -n "$listOutput" ]; then
+        readarray -t podmanResources < <(${awk} -F "," '{print $1}' <<< "$listOutput")
+        readarray -t podmanResourceIds < <(${awk} -F "," '{print $2}' <<< "$listOutput")
+      fi
 
       if [ ''${#podmanResources[@]} -eq 0 ]; then
         VERBOSE_ENABLED && echo "No ''${resourceType}s available to process." || true
       else
-        for resource in "''${podmanResources[@]}"; do
+        for i in "''${!podmanResources[@]}"; do
+          resource="''${podmanResources[$i]}"
+          id="''${podmanResourceIds[$i]}"
           if ! isResourceInManifest "$resource"; then
-            removeResource "$resourceType" "$resource"
+            removeResource "$resourceType" "$resource" "$id"
           else
             VERBOSE_ENABLED && echo "Keeping managed $resourceType: $resource" || true
           fi
@@ -67,22 +88,32 @@
     removeResource() {
       local resourceType="$1"
       local resource="$2"
-      echo "Removing orphaned $resourceType: $resource"
+      local id="$3"
+      echo "Removing orphaned $resourceType: $resource with ID $id"
       commands=()
       case "$resourceType" in
         "container")
-          commands+=("${config.services.podman.package}/bin/podman $resourceType stop $resource")
-          commands+=("${config.services.podman.package}/bin/podman $resourceType rm -f $resource")
+          commands+=("${config.services.podman.package}/bin/podman $resourceType stop $id")
+          commands+=("${config.services.podman.package}/bin/podman $resourceType rm -f $id")
           ;;
-        "image" | "network" | "volume")
-          commands+=("${config.services.podman.package}/bin/podman $resourceType rm $resource")
+        "image")
+          # Only remove an image by its ID if it is untagged. Removes an image by an obsolete tag if possible.
+          # This prevents removing images with the same ID but different tag
+          if [ "$resource" = "<none>" ]; then
+            commands+=("${config.services.podman.package}/bin/podman $resourceType rm $id")
+          else
+            commands+=("${config.services.podman.package}/bin/podman $resourceType rm $resource")
+          fi
+          ;;
+        "network" | "volume")
+          commands+=("${config.services.podman.package}/bin/podman $resourceType rm $id")
           ;;
       esac
       for command in "''${commands[@]}"; do
         command=$(echo $command | tr -d ';&|`')
         DRYRUN_ENABLED && echo "Would run: $command" && continue || true
         VERBOSE_ENABLED && echo "Running: $command" || true
-        if [[ "$(eval "$command")" != *"$resource" ]]; then
+        if ! eval "$command"; then
           echo -e "\tCommand failed: ''${command}"
           [ "$resourceType" == "image" ] && resourceType="ancestor"
           usedByContainers=$(${config.services.podman.package}/bin/podman container ls -a --filter "$resourceType=$resource" --format "{{.Names}}")

--- a/modules/services/podman/linux/install-quadlet.nix
+++ b/modules/services/podman/linux/install-quadlet.nix
@@ -8,7 +8,14 @@ let
   cfg = config.services.podman;
 
   podman-lib = import ./podman-lib.nix { inherit pkgs lib config; };
-  activation = import ./activation.nix { inherit config podman-lib; };
+  activation = import ./activation.nix {
+    inherit
+      pkgs
+      lib
+      config
+      podman-lib
+      ;
+  };
 
   activationCleanupScript = activation.cleanup;
 


### PR DESCRIPTION
Fixes the bug where untagged podman resources are not removed by removing them using their IDs
Resolves #9779

### Description

In the `podmanQuadletCleanup` step, a cleanup script is used to remove resources managed by home-manager (identified by a label) but not listed in the manifests in `$XDG_CONFIG_HOME/containers`. The manifests record the human-readable names, which are also used in `podman rm` commands.

When `services.podman.build` is used and if a new image with the same name is built, the old image's `Repository` property is set to `<none>`, and the command `podman image rm` fails.

This change list both the names and IDs of the podman resources during cleanup. The names are matched against the manifests, and the IDs are used in `podman rm` commands. This ensures backward compatibility and fixes the untagged image issue.

One exception are the volumes--podman volumes do not have IDs, so the volume names are used as IDs.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through a targeted `nix run .#tests -- podman`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  ⚠️ In a separate commit, I asked Claude to write a test for my changes, since I am really not comfortable with testing bash scripts. I am not sure how valuable the test is, since it does weird things like:
  ```nix
  import ../../../../../modules/services/podman/linux/activation.nix
  ```
  writing a stub for `podman ls`, and really performing an imperative test.
  That commit is **not** included in this PR

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
