### PR TITLE
stylua: init module

### DIFF
--- a/modules/misc/news/2026/08/2026-08-24_17-55-03.nix
+++ b/modules/misc/news/2026/08/2026-08-24_17-55-03.nix
@@ -1,0 +1,13 @@
+{
+  time = "2026-08-24T12:25:03+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.stylua`
+
+    Stylua is a formatter for lua files. It parses your Lua codebase, and prints
+    it back from scratch, enforcing a consistent code style. It's inspired by
+    the likes of prettier.
+
+    See <https://github.com/JohnnyMorganz/StyLua> for more details.
+  '';
+}

--- a/modules/programs/stylua.nix
+++ b/modules/programs/stylua.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.programs.stylua;
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    mkIf
+    types
+    ;
+  tomlFormat = pkgs.formats.toml { };
+
+  styluaPackage =
+    if cfg.settings != { } then
+      pkgs.symlinkJoin {
+        name = "stylua-wrapped";
+        paths = [ cfg.package ];
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        postBuild = ''
+          wrapProgram $out/bin/stylua --add-flags '--search-parent-directories'
+        '';
+      }
+    else
+      cfg.package;
+in
+{
+  meta.maintainers = [ lib.maintainers.rachitvrma ];
+
+  options.programs.stylua = {
+    enable = mkEnableOption "stylua, a formatter for lua";
+    package = mkPackageOption pkgs "stylua" { };
+    finalPackage = mkOption {
+      readOnly = true;
+      visible = false;
+      type = types.package;
+      description = "Resulting stylua package";
+    };
+    settings = mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = {
+        call_parentheses = "Always";
+        collapse_simple_statement = "Always";
+        column_width = 85;
+        indent_type = "Spaces";
+        indent_width = 2;
+        line_endings = "Unix";
+        quote_style = "AutoPreferSingle";
+      };
+      description = ''
+        Configuration options that are written to {file}`XDG_CONFIG_HOME/stylua/stylua.toml`
+
+        See <https://github.com/JohnnyMorganz/StyLua#options> for more options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.finalPackage ];
+
+    programs.stylua.finalPackage = styluaPackage;
+
+    xdg.configFile."stylua/stylua.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "hm_stylua.toml" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/stylua/default.nix
+++ b/tests/modules/programs/stylua/default.nix
@@ -1,0 +1,4 @@
+{
+  stylua-empty-config = ./empty-config.nix;
+  stylua-example-config = ./example-config.nix;
+}

--- a/tests/modules/programs/stylua/empty-config.nix
+++ b/tests/modules/programs/stylua/empty-config.nix
@@ -1,0 +1,6 @@
+{
+  programs.stylua.enable = true;
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/stylua"
+  '';
+}

--- a/tests/modules/programs/stylua/example-config.nix
+++ b/tests/modules/programs/stylua/example-config.nix
@@ -1,0 +1,20 @@
+{ realPkgs, ... }: {
+  programs.stylua = {
+    enable = true;
+    settings = {
+      call_parentheses = "Always";
+      collapse_simple_statement = "Always";
+      column_width = 85;
+      indent_type = "Spaces";
+      indent_width = 2;
+      line_endings = "Unix";
+      quote_style = "AutoPreferSingle";
+    };
+  };
+  test.unstubs = [ (_self: _super: { inherit (realPkgs) stylua; }) ];
+
+  nmt.script = ''
+    assertFileContent "home-files/.config/stylua/stylua.toml" ${./expected-config.toml}
+    assertFileRegex "home-path/bin/stylua" "search-parent-directories"
+  '';
+}

--- a/tests/modules/programs/stylua/expected-config.toml
+++ b/tests/modules/programs/stylua/expected-config.toml
@@ -1,0 +1,7 @@
+call_parentheses = "Always"
+collapse_simple_statement = "Always"
+column_width = 85
+indent_type = "Spaces"
+indent_width = 2
+line_endings = "Unix"
+quote_style = "AutoPreferSingle"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Stylua is deterministic formatter for Lua 5.1, 5.2, 5.3, 5.4, LuaJIT, Luau and CfxLua/FiveM Lua, built using full-moon. StyLua is inspired by the likes of prettier, it parses your Lua codebase, and prints it back out from scratch, enforcing a consistent code style.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
