### PR TITLE
nushell: Improve error message on outdated plugin

### DIFF
--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -296,6 +296,7 @@ in
         let
           msgPackz = pkgs.runCommand "nushellMsgPackz" { } ''
             mkdir -p "$out"
+            touch "$out/plugin.msgpackz"
             ${lib.getExe cfg.package} \
               --plugin-config "$out/plugin.msgpackz" \
               --commands '${


### PR DESCRIPTION
With this change the derivation log calls out the outdated plugin instead of just complaining about a broken pipe.

### Description

Nushell requires plugins to match protocol versions exactly.
If any plugin configured through home manager has a version mismatch the derivation currently fails with this rather cryptic error message
```
Error: nu::shell::io::broken_pipe

  × I/O error
  ╰─▶   × PluginWrite could not flush
      
   ╭────
 1 │ crates/nu-plugin-core/src/interface/mod.rs:110:28
   · ────────────────────────┬────────────────────────
   ·                         ╰── Broken pipe
   ╰────
```

This change improves this error message to something like this.

```
Error: nu::shell::error

  × Failed to send plugin call to `dbus`
   ╭────
 1 │ crates/nu-plugin-engine/src/interface/mod.rs:950:17
   · ─────────────────────────┬─────────────────────────
   ·                          ╰── the plugin encountered an error before this operation could be attempted
   ╰────
  help: try loading the plugin again with `plugin use 'dbus'`

Error: nu::shell::plugin_failed_to_load

  × Plugin failed to load: Plugin `dbus` is compiled for nushell version 0.114.1, which is not compatible with version 0.115.0
```

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
