### PR TITLE
firefox: apply configPath to package wrapper; set configPath to non-default datadir on darwin; {firefox,thunderbird}: add booxter as maintainer

### DIFF
--- a/docs/release-notes/rl-2611.md
+++ b/docs/release-notes/rl-2611.md
@@ -26,6 +26,15 @@ The state version in this release includes the changes below. These
 changes are only active if the `home.stateVersion` option is set to
 "26.11" or later.
 
+- On Darwin, the default value of
+  [](#opt-programs.firefox.configPath) changes from
+  `Library/Application Support/Firefox` to
+  `Library/Application Support/org.nixos.firefox` when
+  `programs.firefox.package` is not `null`. Explicit `configPath` values remain
+  unchanged. Before updating `home.stateVersion`, quit Firefox and move your
+  Firefox data from `~/Library/Application Support/Firefox` to
+  `~/Library/Application Support/org.nixos.firefox`.
+
 - The KDL options under `programs.zellij` will now correctly escape backslashes
   in string values. For example, the Nix string `"\\"` will now correctly
   generate the KDL string `"\\"`. Previously, this would have generated `"\"`,

--- a/modules/misc/news/2026/08/2026-08-27_23-50-03.nix
+++ b/modules/misc/news/2026/08/2026-08-27_23-50-03.nix
@@ -1,0 +1,20 @@
+{ config, pkgs, ... }:
+{
+  time = "2026-08-27T23:50:03+00:00";
+  condition =
+    pkgs.stdenv.hostPlatform.isDarwin
+    && config.programs.firefox.enable
+    && config.programs.firefox.package != null;
+  message = ''
+    On Darwin, the default value of `programs.firefox.configPath` has changed
+    for `home.stateVersion` 26.11 and later from
+    `Library/Application Support/Firefox` to
+    `Library/Application Support/org.nixos.firefox`.
+
+    This is needed on macOS 27 and later, where Firefox builds not signed by
+    Mozilla cannot access the traditional data directory. Before updating
+    `home.stateVersion`, quit Firefox and migrate your Firefox data from
+    `~/Library/Application Support/Firefox` to
+    `~/Library/Application Support/org.nixos.firefox`.
+  '';
+}

--- a/modules/programs/firefox/default.nix
+++ b/modules/programs/firefox/default.nix
@@ -93,6 +93,17 @@ in
   config = lib.mkIf cfg.enable {
     warnings = lib.optional linuxConfigPathStateVersion.shouldWarn linuxConfigPathStateVersion.warning;
 
+    # On macOS 27+, Firefox builds not signed by Mozilla cannot access the
+    # traditional data directory. Use org.nixos.firefox directory instead.
+    # When package is null, we don't know if it's a signed version (e.g.
+    # firefox-bin-unwrapped or from Homebrew) or not, so we leave it up to the
+    # user to adjust as needed.
+    programs.firefox.configPath = lib.mkIf (
+      pkgs.stdenv.hostPlatform.isDarwin
+      && cfg.package != null
+      && lib.versionAtLeast config.home.stateVersion "26.11"
+    ) (lib.mkDefault "Library/Application Support/org.nixos.firefox");
+
     mozilla.firefoxNativeMessagingHosts =
       cfg.nativeMessagingHosts
       # package configured native messaging hosts (entire browser actually)

--- a/modules/programs/firefox/default.nix
+++ b/modules/programs/firefox/default.nix
@@ -50,6 +50,7 @@ let
 in
 {
   meta.maintainers = with lib.maintainers; [
+    booxter
     bricked
     rycee
     lib.hm.maintainers.HPsaucii

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -32,6 +32,8 @@ let
     ;
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
+  defaultConfigPath = with platforms; if isDarwin then darwin.configPath else linux.configPath;
+
   appName = name;
 
   moduleName = concatStringsSep "." modulePath;
@@ -197,12 +199,41 @@ let
 
       # The configuration expected by the Firefox wrapper builder.
       bcfg = setAttrByPath [ browserName ] fcfg;
+
+      configureAppDataDir = cfg.configPath != defaultConfigPath;
+
+      absoluteConfigPath =
+        if lib.hasPrefix "/" cfg.configPath then
+          cfg.configPath
+        else
+          "${config.home.homeDirectory}/${cfg.configPath}";
+
+      callWithAppDataDir =
+        wrapper: args:
+        let
+          wrapperArgs = lib.functionArgs wrapper;
+          supportsAppDataDir = wrapperArgs ? appDataDir;
+          # Gracefully handle wrappers that don't, yet, support appDataDir.
+          appDataDirArgs = lib.optionalAttrs (configureAppDataDir && supportsAppDataDir) {
+            appDataDir = absoluteConfigPath;
+          };
+          argsWithAppDataDir =
+            if lib.isFunction args then
+              # Modern wrapped packages pass an override function.
+              old: args old // appDataDirArgs
+            else
+              # Legacy wrapFirefox passes an attribute set.
+              args // appDataDirArgs;
+        in
+        lib.warnIf (configureAppDataDir && !supportsAppDataDir)
+          "${moduleName}: '${browserName}' does not support the 'appDataDir' wrapper argument; 'configPath' will not be applied to the package wrapper."
+          (wrapper argsWithAppDataDir);
     in
     if package == null then
       null
     else if isWrapped then
       if lib.functionArgs package.override ? cfg then
-        package.override (old: {
+        callWithAppDataDir package.override (old: {
           cfg = old.cfg or { } // fcfg;
           extraPolicies = (old.extraPolicies or { }) // cfg.policies;
           pkcs11Modules = (old.pkcs11Modules or [ ]) ++ cfg.pkcs11Modules;
@@ -210,13 +241,14 @@ let
       else
         let
           droppedPolicies = cfg.policies != { } && (!isDarwin || cfg.darwinDefaultsId == null);
-          droppedOptions = droppedPolicies || cfg.pkcs11Modules != [ ] || cfg.enableGnomeExtensions;
+          droppedOptions =
+            droppedPolicies || cfg.pkcs11Modules != [ ] || cfg.enableGnomeExtensions || configureAppDataDir;
         in
         lib.warnIf droppedOptions
-          "${moduleName}: '${browserName}' cannot be reconfigured; 'policies', 'pkcs11Modules', and 'enableGnomeExtensions' will not be applied."
+          "${moduleName}: '${browserName}' cannot be reconfigured; 'policies', 'pkcs11Modules', 'enableGnomeExtensions', and 'configPath' will not be applied."
           package
     else
-      (pkgs.wrapFirefox.override { config = bcfg; }) package { };
+      callWithAppDataDir ((pkgs.wrapFirefox.override { config = bcfg; }) package) { };
 
   bookmarkTypes = import ./profiles/bookmark-types.nix { inherit lib; };
 in
@@ -377,11 +409,19 @@ in
     };
 
     configPath = mkOption {
-      internal = true;
       type = types.str;
-      default = with platforms; if isDarwin then darwin.configPath else linux.configPath;
+      default = defaultConfigPath;
+      defaultText = literalExpression "platform specific default config path";
       example = ".mozilla/firefox";
-      description = "Directory containing the ${appName} configuration files.";
+      description = ''
+        Directory containing the ${appName} configuration files. A relative
+        path is interpreted relative to the user's home directory.
+
+        Setting this to a non-default path also configures the package wrapper
+        to use it as the application data directory. This can be useful on
+        macOS 27 and later, where wrapped applications may be denied access to
+        the traditional application data directory.
+      '';
     };
 
     nativeMessagingHosts = mkOption {

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -384,9 +384,10 @@ let
 
 in
 {
-  meta.maintainers = [
+  meta.maintainers = with lib.maintainers; [
+    booxter
     lib.hm.maintainers.d-dervishi
-    lib.maintainers.jkarlson
+    jkarlson
   ];
 
   options = {

--- a/tests/modules/programs/firefox/config-path-darwin-default.nix
+++ b/tests/modules/programs/firefox/config-path-darwin-default.nix
@@ -1,0 +1,74 @@
+{
+  expectedDarwinPath,
+  packageIsNull ? false,
+  stateVersion,
+}:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.firefox;
+
+  expectedConfigPath =
+    if pkgs.stdenv.hostPlatform.isDarwin then expectedDarwinPath else ".config/mozilla/firefox";
+
+  expectedAppDataDir =
+    if
+      pkgs.stdenv.hostPlatform.isDarwin && !packageIsNull && lib.versionAtLeast stateVersion "26.11"
+    then
+      "${config.home.homeDirectory}/${expectedDarwinPath}"
+    else
+      null;
+
+  firefoxPackage = lib.makeOverridable (
+    {
+      cfg ? { },
+      extraPolicies ? { },
+      pkcs11Modules ? [ ],
+      appDataDir ? null,
+    }:
+    builtins.deepSeq
+      [
+        cfg
+        extraPolicies
+        pkcs11Modules
+      ]
+      (
+        config.lib.test.mkStubPackage {
+          name = "firefox-config-path-darwin-default-test-stub";
+          extraAttrs = {
+            browserName = "firefox";
+            inherit appDataDir;
+            meta.mainProgram = "firefox";
+          };
+        }
+      )
+  ) { };
+in
+{
+  config = lib.mkIf config.test.enableBig {
+    home.stateVersion = stateVersion;
+
+    programs.firefox = {
+      enable = true;
+      package = if packageIsNull then null else firefoxPackage;
+      profiles.test.settings."general.smoothScroll" = false;
+    };
+
+    assertions = [
+      {
+        assertion = cfg.configPath == expectedConfigPath;
+        message = "Firefox configPath has an unexpected default";
+      }
+      {
+        assertion = cfg.finalPackage == null || cfg.finalPackage.appDataDir == expectedAppDataDir;
+        message = "Firefox wrapper received an unexpected appDataDir";
+      }
+    ];
+
+    mozilla.firefoxNativeMessagingHosts = lib.mkForce [ ];
+  };
+}

--- a/tests/modules/programs/firefox/config-path-wrapper.nix
+++ b/tests/modules/programs/firefox/config-path-wrapper.nix
@@ -1,0 +1,90 @@
+{
+  absolute ? false,
+  configPath,
+  supportsAppDataDir ? true,
+}:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.firefox;
+
+  effectiveConfigPath = if absolute then "${config.home.homeDirectory}/${configPath}" else configPath;
+
+  expectedAppDataDir = "${config.home.homeDirectory}/${configPath}";
+
+  mkPackage =
+    appDataDir:
+    config.lib.test.mkStubPackage {
+      name = "firefox-config-path-test-stub";
+      buildScript = ''
+        mkdir -p "$out/lib/mozilla/native-messaging-hosts"
+      '';
+      extraAttrs = {
+        browserName = "firefox";
+        inherit appDataDir;
+        meta.mainProgram = "firefox";
+      };
+    };
+
+  packageWithAppDataDir = lib.makeOverridable (
+    {
+      cfg ? { },
+      extraPolicies ? { },
+      pkcs11Modules ? [ ],
+      appDataDir ? null,
+    }:
+    builtins.deepSeq [
+      cfg
+      extraPolicies
+      pkcs11Modules
+    ] (mkPackage appDataDir)
+  ) { };
+
+  packageWithoutAppDataDir = lib.makeOverridable (
+    {
+      cfg ? { },
+      extraPolicies ? { },
+      pkcs11Modules ? [ ],
+    }:
+    builtins.deepSeq [
+      cfg
+      extraPolicies
+      pkcs11Modules
+    ] (mkPackage null)
+  ) { };
+in
+{
+  config = lib.mkIf config.test.enableBig {
+    home = {
+      homeDirectory = lib.mkForce (
+        if pkgs.stdenv.hostPlatform.isDarwin then "/Users/hm-user" else "/home/hm-user"
+      );
+      stateVersion = "26.05";
+    };
+
+    programs.firefox = {
+      enable = true;
+      configPath = effectiveConfigPath;
+      package = if supportsAppDataDir then packageWithAppDataDir else packageWithoutAppDataDir;
+      profiles.test.settings."general.smoothScroll" = false;
+    };
+
+    assertions = [
+      {
+        assertion =
+          cfg.finalPackage.appDataDir == (if supportsAppDataDir then expectedAppDataDir else null);
+        message = "Firefox wrapper received an unexpected appDataDir";
+      }
+    ];
+
+    mozilla.firefoxNativeMessagingHosts = lib.mkForce [ ];
+
+    nmt.script = ''
+      assertFileExists "home-files/${configPath}/profiles.ini"
+    '';
+  };
+}

--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -4,6 +4,19 @@
   "firefox-bookmarks-legacy-attrset-warning" = ./bookmarks-legacy-attrset-warning.nix;
   "firefox-config-path-explicit-legacy" = ./config-path-explicit-legacy.nix;
   "firefox-config-path-explicit-xdg" = ./config-path-explicit-xdg.nix;
+  "firefox-config-path-darwin-default-current" = import ./config-path-darwin-default.nix {
+    expectedDarwinPath = "Library/Application Support/org.nixos.firefox";
+    stateVersion = "26.11";
+  };
+  "firefox-config-path-darwin-default-legacy" = import ./config-path-darwin-default.nix {
+    expectedDarwinPath = "Library/Application Support/Firefox";
+    stateVersion = "26.05";
+  };
+  "firefox-config-path-darwin-default-null-package" = import ./config-path-darwin-default.nix {
+    expectedDarwinPath = "Library/Application Support/Firefox";
+    packageIsNull = true;
+    stateVersion = "26.11";
+  };
   "firefox-config-path-wrapper-absolute" = import ./config-path-wrapper.nix {
     absolute = true;
     configPath = "Library/Application Support/org.nixos.firefox";

--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -4,6 +4,17 @@
   "firefox-bookmarks-legacy-attrset-warning" = ./bookmarks-legacy-attrset-warning.nix;
   "firefox-config-path-explicit-legacy" = ./config-path-explicit-legacy.nix;
   "firefox-config-path-explicit-xdg" = ./config-path-explicit-xdg.nix;
+  "firefox-config-path-wrapper-absolute" = import ./config-path-wrapper.nix {
+    absolute = true;
+    configPath = "Library/Application Support/org.nixos.firefox";
+  };
+  "firefox-config-path-wrapper-relative" = import ./config-path-wrapper.nix {
+    configPath = "Library/Application Support/org.nixos.firefox";
+  };
+  "firefox-config-path-wrapper-unsupported" = import ./config-path-wrapper.nix {
+    configPath = "Library/Application Support/org.nixos.firefox";
+    supportsAppDataDir = false;
+  };
   "firefox-config-path-xdg-default" = ./config-path-xdg-default.nix;
   "firefox-config-path-warning" = ./config-path-warning.nix;
   "firefox-multiple-derivatives" = ./multiple-derivatives.nix;


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This is a counterpart for: https://github.com/NixOS/nixpkgs/pull/556611

When configPath is overridden, if wrapper supports the new appDataDir argument, we pass configPath's absolute form to tell the app to look for its datadir in the correct directory.

And we do it automatically for `hm.stateVersion >= 26.11`.

This is necessary on macOS 27+ where Firefox that is not signed by Mozilla has no access to its default datadir.

---

Not sure if besides a news entry we could do anything else to inform users. I was thinking about adding an activation script that would print a warning on MacOS 27+ with default configPath. Or maybe we should issue a eval warning when configPath is "default"?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
