### PR TITLE
vscode: add mutable user settings

### DIFF
--- a/modules/misc/news/2026/08/2026-08-31_18-55-53.nix
+++ b/modules/misc/news/2026/08/2026-08-31_18-55-53.nix
@@ -1,0 +1,29 @@
+{ config, ... }:
+{
+  time = "2026-08-31T18:55:53+00:00";
+  condition =
+    config.programs.vscode.enable
+    || config.programs.vscodium.enable
+    || config.programs.cursor.enable
+    || config.programs.windsurf.enable
+    || config.programs.kiro.enable
+    || config.programs.antigravity.enable;
+  message = ''
+    The VS Code modules now support mutable user settings through these
+    per-profile options:
+
+    - `programs.vscode.profiles.<name>.mutableUserSettings`
+    - `programs.vscodium.profiles.<name>.mutableUserSettings`
+    - `programs.cursor.profiles.<name>.mutableUserSettings`
+    - `programs.windsurf.profiles.<name>.mutableUserSettings`
+    - `programs.kiro.profiles.<name>.mutableUserSettings`
+    - `programs.antigravity.profiles.<name>.mutableUserSettings`
+
+    When you enable one of these options, Home Manager merges settings from
+    your configuration into the existing settings file during activation.
+    Values from your configuration take precedence. The merge preserves other
+    settings that you changed through the editor.
+
+    Each option defaults to `false`.
+  '';
+}

--- a/modules/programs/vscode/mkVscodeModule.nix
+++ b/modules/programs/vscode/mkVscodeModule.nix
@@ -30,6 +30,7 @@ let
   vscodeVersion = cfg.package.version or pkgs.vscode.version;
 
   jsonFormat = pkgs.formats.json { };
+  json5 = pkgs.python3Packages.toPythonApplication pkgs.python3Packages.json5;
 
   userDir =
     if pkgs.stdenv.hostPlatform.isDarwin then
@@ -72,6 +73,182 @@ let
         "extensions.autoCheckUpdates" = false;
       };
 
+  effectiveUserSettings =
+    profile:
+    mergedUserSettings profile.userSettings profile.enableUpdateCheck
+      profile.enableExtensionUpdateCheck;
+
+  declaredUserSettingsSource =
+    profile:
+    let
+      settings = effectiveUserSettings profile;
+    in
+    if isPathLike settings then
+      let
+        settingsPath = toString settings;
+      in
+      if builtins.hasContext settingsPath then
+        settings
+      else
+        builtins.path {
+          path = settings;
+          name = "vscode-user-settings-json5";
+        }
+    else
+      jsonFormat.generate "vscode-user-settings" settings;
+
+  mutableUserSettingsProfiles = lib.filterAttrs (
+    _name: profile: profile.mutableUserSettings && effectiveUserSettings profile != { }
+  ) cfg.profiles;
+
+  immutableUserSettingsProfiles = lib.filterAttrs (
+    profileName: profile:
+    !profile.mutableUserSettings
+    && effectiveUserSettings profile != { }
+    && config.home.file.${configFilePath profileName}.enable
+  ) cfg.profiles;
+
+  mutableUserSettingsOperation =
+    profileName: profile:
+    let
+      settingsPath = configFilePath profileName;
+      staticSettingsFile = declaredUserSettingsSource profile;
+    in
+    ''
+      (
+        display_path=${lib.escapeShellArg settingsPath}
+        settings_path="$display_path"
+        settings_was_symlink=
+        if [[ -L "$display_path" ]]; then
+          settings_was_symlink=1
+          if ! settings_path="$(${lib.getExe' pkgs.coreutils "readlink"} -e -- "$display_path")"; then
+            errorEcho "Cannot resolve ${name} settings at '$display_path'; leaving the symlink unchanged."
+            exit 1
+          fi
+        fi
+        settings_directory="$(dirname "$settings_path")"
+        target_existed=
+        if [[ -e "$settings_path" ]]; then
+          target_existed=1
+        fi
+
+        snapshot_path=
+        candidate_path=
+        trap '
+          [[ -z "$snapshot_path" ]] || rm -f -- "$snapshot_path"
+          [[ -z "$candidate_path" ]] || rm -f -- "$candidate_path"
+        ' EXIT
+
+        dynamic='{}'
+        if [[ -n "$target_existed" ]]; then
+          if [[ -v DRY_RUN ]]; then
+            input_path="$settings_path"
+          else
+            if ! snapshot_path="$(mktemp "$settings_path.snapshot.XXXXXX")"; then
+              errorEcho "Creating a snapshot for ${name} settings at '$display_path' failed."
+              exit 1
+            fi
+            if ! cp --preserve=mode -- "$settings_path" "$snapshot_path"; then
+              errorEcho "Snapshotting ${name} settings at '$display_path' failed."
+              exit 1
+            fi
+            input_path="$snapshot_path"
+          fi
+
+          if dynamic="$(${lib.getExe json5} --as-json "$input_path" 2>/dev/null)"; then
+            :
+          elif ${lib.getExe pkgs.gnugrep} -q '[^[:space:]]' "$input_path"; then
+            errorEcho "Cannot parse ${name} settings at '$display_path' as JSON5; leaving the file unchanged."
+            exit 1
+          else
+            grep_status=$?
+            if (( grep_status > 1 )); then
+              errorEcho "Cannot read ${name} settings at '$display_path'; leaving the file unchanged."
+              exit 1
+            fi
+            dynamic='{}'
+          fi
+        fi
+
+        if ! static="$(${lib.getExe json5} --as-json ${lib.escapeShellArg staticSettingsFile})"; then
+          errorEcho "Cannot parse the declared ${name} settings for '$display_path' as JSON5."
+          exit 1
+        fi
+        if ! settings="$(${lib.getExe pkgs.jq} -n '$dynamic * $static' --argjson dynamic "$dynamic" --argjson static "$static")"; then
+          errorEcho "Merging ${name} settings for '$display_path' failed."
+          exit 1
+        fi
+
+        verboseEcho "Merging declared ${name} settings into '$display_path'"
+        if ! run mkdir -p "$settings_directory"; then
+          errorEcho "Creating the directory '$settings_directory' failed."
+          exit 1
+        fi
+        if [[ -v DRY_RUN ]]; then
+          echo "Would update ${name} settings at '$display_path'"
+          exit 0
+        fi
+
+        if ! candidate_path="$(mktemp "$settings_path.candidate.XXXXXX")"; then
+          errorEcho "Creating a candidate for ${name} settings at '$display_path' failed."
+          exit 1
+        fi
+
+        if ! printf '%s\n' "$settings" > "$candidate_path"; then
+          errorEcho "Writing merged ${name} settings for '$display_path' failed."
+          exit 1
+        fi
+        if [[ -n "$target_existed" ]] && ! chmod --reference="$snapshot_path" -- "$candidate_path"; then
+          errorEcho "Copying permissions from '$display_path' failed."
+          exit 1
+        fi
+
+        conflict=
+        if [[ -n "$target_existed" ]]; then
+          if [[ -n "$settings_was_symlink" ]]; then
+            current_settings_path=
+            if [[ ! -L "$display_path" ]] \
+              || ! current_settings_path="$(${lib.getExe' pkgs.coreutils "readlink"} -e -- "$display_path")" \
+              || [[ "$current_settings_path" != "$settings_path" ]]; then
+              conflict=1
+            fi
+          elif [[ -L "$display_path" ]]; then
+            conflict=1
+          fi
+
+          if ! cmp -s -- "$snapshot_path" "$settings_path"; then
+            conflict=1
+          fi
+        elif [[ -e "$display_path" || -L "$display_path" ]]; then
+          conflict=1
+        fi
+
+        if [[ -n "$conflict" ]]; then
+          errorEcho "${name} settings at '$display_path' changed during activation; keeping the newer file."
+          exit 1
+        fi
+
+        if ! mv -f -- "$candidate_path" "$settings_path"; then
+          errorEcho "Replacing ${name} settings at '$display_path' failed."
+          exit 1
+        fi
+        candidate_path=
+      ) || exit 1
+    '';
+
+  immutableUserSettingsOperation =
+    profileName: profile:
+    let
+      settingsPath = configFilePath profileName;
+      settingsSource = declaredUserSettingsSource profile;
+    in
+    ''
+      if [[ -f ${lib.escapeShellArg settingsPath} && ! -L ${lib.escapeShellArg settingsPath} ]] \
+        && cmp -s -- ${lib.escapeShellArg settingsSource} ${lib.escapeShellArg settingsPath}; then
+        run rm -- ${lib.escapeShellArg settingsPath}
+      fi
+    '';
+
   transformMcpServerForVscode = name: server: {
     inherit name;
     value = lib.hm.mcp.transformMcpServer {
@@ -85,6 +262,8 @@ let
 
   profileType = types.submodule {
     options = {
+      mutableUserSettings = lib.mkEnableOption "mutable user settings for ${name}";
+
       userSettings = mkOption {
         type = types.either types.path jsonFormat.type;
         default = { };
@@ -361,6 +540,22 @@ in
         in
         modifyGlobalStorage.outPath
       );
+    }
+    // lib.optionalAttrs (mutableUserSettingsProfiles != { }) {
+      "${lib.last modulePath}MutableUserSettings" = lib.hm.dag.entryAfter [ "linkGeneration" ] (
+        lib.concatStrings (lib.mapAttrsToList mutableUserSettingsOperation mutableUserSettingsProfiles)
+      );
+    }
+    // lib.optionalAttrs (immutableUserSettingsProfiles != { }) {
+      "${lib.last modulePath}ImmutableUserSettings" =
+        lib.hm.dag.entryBetween
+          [ "linkGeneration" ]
+          [
+            "writeBoundary"
+          ]
+          (
+            lib.concatStrings (lib.mapAttrsToList immutableUserSettingsOperation immutableUserSettingsProfiles)
+          );
     };
 
     home.file = lib.mkMerge (flatten [
@@ -375,11 +570,10 @@ in
       (mapAttrsToList (n: v: [
         (
           let
-            merged = mergedUserSettings v.userSettings v.enableUpdateCheck v.enableExtensionUpdateCheck;
+            merged = effectiveUserSettings v;
           in
-          mkIf (merged != { }) {
-            "${configFilePath n}".source =
-              if isPathLike merged then merged else jsonFormat.generate "vscode-user-settings" merged;
+          mkIf (!v.mutableUserSettings && merged != { }) {
+            "${configFilePath n}".source = declaredUserSettingsSource v;
           }
         )
 

--- a/tests/modules/programs/vscode/default.nix
+++ b/tests/modules/programs/vscode/default.nix
@@ -14,6 +14,8 @@ let
     mcp-integration = import ./mcp-integration.nix;
     mcp-integration-with-override = import ./mcp-integration-with-override.nix;
     update-checks = import ./update-checks.nix;
+    mutable-settings = import ./mutable-settings.nix;
+    immutable-transition = import ./immutable-transition.nix;
     path-literal = import ./path-literal.nix;
     snippets = import ./snippets.nix;
     null-package = import ./null-package.nix;

--- a/tests/modules/programs/vscode/immutable-transition.nix
+++ b/tests/modules/programs/vscode/immutable-transition.nix
@@ -1,0 +1,121 @@
+package:
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  userPath =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/Code/User"
+    else
+      ".config/Code/User";
+  settingsPath = "${userPath}/settings.json";
+  disabledSettingsPath = "${userPath}/profiles/disabled/settings.json";
+  activationTemplate = pkgs.writeShellScript "activation" ''
+    set -eu
+    set -o pipefail
+    PATH="$(dirname "$BASH"):${
+      lib.makeBinPath [
+        pkgs.coreutils
+        pkgs.diffutils
+        pkgs.findutils
+      ]
+    }:$PATH"
+    ${config.lib.bash.initHomeManagerLib}
+
+    newGenPath="$TESTED"
+    ${config.home.activation.checkLinkTargets.data}
+    ${config.home.activation.vscodeImmutableUserSettings.data}
+    ${config.home.activation.linkGeneration.data}
+  '';
+  sed = lib.getExe pkgs.gnused;
+in
+{
+  programs.vscode = {
+    enable = true;
+    inherit package;
+    mutableExtensionsDir = false;
+    profiles.default = {
+      mutableUserSettings = false;
+      userSettings.transition = "immutable";
+    };
+    profiles.disabled = {
+      mutableUserSettings = false;
+      userSettings.transition = "immutable";
+    };
+  };
+
+  home.homeDirectory = lib.mkForce "/@HOME@";
+  home.file."${config.home.homeDirectory}/${disabledSettingsPath}".enable = false;
+
+  nmt.script = ''
+    set -eu
+    set -o pipefail
+
+    export TESTED
+    generated_settings="$TESTED/home-files/${settingsPath}"
+    assertPathNotExists "home-files/${disabledSettingsPath}"
+
+    identical_home="$TMPDIR/identical-home"
+    mkdir -p "$identical_home/${userPath}/profiles/disabled"
+    cp --dereference "$generated_settings" "$identical_home/${settingsPath}"
+    cp --dereference "$generated_settings" "$identical_home/${disabledSettingsPath}"
+    ${sed} "s|/@HOME@|$identical_home|g" ${activationTemplate} > $TMPDIR/activate-identical
+    chmod +x $TMPDIR/activate-identical
+
+    HOME="$identical_home" \
+      HOME_MANAGER_BACKUP_COMMAND= \
+      HOME_MANAGER_BACKUP_EXT= \
+      HOME_MANAGER_BACKUP_OVERWRITE= \
+      $TMPDIR/activate-identical
+
+    test -L "$identical_home/${settingsPath}"
+    test "$(readlink -e "$identical_home/${settingsPath}")" = "$(readlink -e "$generated_settings")"
+    if [[ ! -f "$identical_home/${disabledSettingsPath}" ]]; then
+      echo "Activation removed disabled settings" >&2
+      exit 1
+    fi
+    test ! -L "$identical_home/${disabledSettingsPath}"
+    cmp "$generated_settings" "$identical_home/${disabledSettingsPath}"
+
+    differing_home="$TMPDIR/differing-home"
+    mkdir -p "$differing_home/${userPath}"
+    printf '{"user": "newer"}\n' > "$differing_home/${settingsPath}"
+    ${sed} "s|/@HOME@|$differing_home|g" ${activationTemplate} > $TMPDIR/activate-differing
+    chmod +x $TMPDIR/activate-differing
+
+    if HOME="$differing_home" \
+      HOME_MANAGER_BACKUP_COMMAND= \
+      HOME_MANAGER_BACKUP_EXT= \
+      HOME_MANAGER_BACKUP_OVERWRITE= \
+      $TMPDIR/activate-differing > $TMPDIR/differing-output 2>&1; then
+      echo "Activation unexpectedly replaced differing mutable settings" >&2
+      exit 1
+    fi
+
+    grep -F "Existing file '$differing_home/${settingsPath}' would be clobbered" \
+      $TMPDIR/differing-output
+    test ! -L "$differing_home/${settingsPath}"
+    grep -Fx '{"user": "newer"}' "$differing_home/${settingsPath}"
+
+    backup_home="$TMPDIR/backup-home"
+    mkdir -p "$backup_home/${userPath}"
+    printf '{"user": "backed-up"}\n' > "$backup_home/${settingsPath}"
+    ${sed} "s|/@HOME@|$backup_home|g" ${activationTemplate} > $TMPDIR/activate-backup
+    chmod +x $TMPDIR/activate-backup
+
+    HOME="$backup_home" \
+      HOME_MANAGER_BACKUP_COMMAND= \
+      HOME_MANAGER_BACKUP_EXT=backup \
+      HOME_MANAGER_BACKUP_OVERWRITE= \
+      $TMPDIR/activate-backup
+
+    test -L "$backup_home/${settingsPath}"
+    test "$(readlink -e "$backup_home/${settingsPath}")" = "$(readlink -e "$generated_settings")"
+    grep -Fx '{"user": "backed-up"}' "$backup_home/${settingsPath}.backup"
+  '';
+}

--- a/tests/modules/programs/vscode/mutable-settings-live.json5
+++ b/tests/modules/programs/vscode/mutable-settings-live.json5
@@ -1,0 +1,14 @@
+{
+  // Interactive settings use JSON5.
+  "editor.fontSize": 12,
+  "arraySetting": ["live",],
+  "nested": {
+    "declared": "live",
+    "keep": true,
+    "deeper": {
+      "declared": "live",
+      "keep": "nested-live",
+    },
+  },
+  "unrelated": "survives",
+}

--- a/tests/modules/programs/vscode/mutable-settings-malformed.json5
+++ b/tests/modules/programs/vscode/mutable-settings-malformed.json5
@@ -1,0 +1,1 @@
+{ definitely not JSON5

--- a/tests/modules/programs/vscode/mutable-settings-path.jsonc
+++ b/tests/modules/programs/vscode/mutable-settings-path.jsonc
@@ -1,0 +1,8 @@
+{
+  // A path-based settings file may use JSON with comments.
+  "editor.wordWrap": "on",
+  "nested": {
+    "declared": "from-path",
+    "pathOnly": true,
+  },
+}

--- a/tests/modules/programs/vscode/mutable-settings-work-live.json5
+++ b/tests/modules/programs/vscode/mutable-settings-work-live.json5
@@ -1,0 +1,9 @@
+{
+  /* The declared path overrides one nested key. */
+  "editor.wordWrap": "off",
+  "nested": {
+    "declared": "live",
+    "liveOnly": true,
+  },
+  "workbench.colorTheme": "Interactive",
+}

--- a/tests/modules/programs/vscode/mutable-settings.nix
+++ b/tests/modules/programs/vscode/mutable-settings.nix
@@ -1,0 +1,261 @@
+package:
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  userPath =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/Code/User"
+    else
+      ".config/Code/User";
+  settingsPath = "${userPath}/settings.json";
+  workSettingsPath = "${userPath}/profiles/work/settings.json";
+  missingSettingsPath = "${userPath}/profiles/missing/settings.json";
+  malformedSettingsPath = "${userPath}/profiles/malformed/settings.json";
+  relativeSettingsPath = "${userPath}/profiles/relative/settings.json";
+  relativeSettingsTarget = "${userPath}/relative-settings.json";
+  appearingSettingsPath = "${userPath}/profiles/appearing/settings.json";
+  danglingSettingsPath = "${userPath}/profiles/z-dangling/settings.json";
+  emptySettingsPath = "${userPath}/profiles/empty/settings.json";
+  activationScript = pkgs.writeShellScript "activation" ''
+    set -eu
+    set -o pipefail
+    ${config.lib.bash.initHomeManagerLib}
+    ${config.home.activation.vscodeMutableUserSettings.data}
+  '';
+  jq = lib.getExe pkgs.jq;
+  sed = lib.getExe pkgs.gnused;
+  stat = lib.getExe' pkgs.coreutils "stat";
+in
+{
+  programs.vscode = {
+    enable = true;
+    inherit package;
+    mutableExtensionsDir = false;
+    profiles = {
+      default = {
+        mutableUserSettings = true;
+        enableUpdateCheck = false;
+        enableExtensionUpdateCheck = false;
+        userSettings = {
+          "editor.fontSize" = 14;
+          arraySetting = [ "declared" ];
+          nested = {
+            declared = "from-nix";
+            added = true;
+            deeper.declared = "from-nix";
+          };
+        };
+      };
+
+      work = {
+        mutableUserSettings = true;
+        userSettings = ./mutable-settings-path.jsonc;
+      };
+
+      missing = {
+        mutableUserSettings = true;
+        userSettings.created = true;
+      };
+
+      malformed = {
+        mutableUserSettings = true;
+        userSettings.recovered = true;
+      };
+
+      relative = {
+        mutableUserSettings = true;
+        userSettings.declared = "through-link";
+      };
+
+      appearing = {
+        mutableUserSettings = true;
+        userSettings.declared = "from-nix";
+      };
+
+      z-dangling = {
+        mutableUserSettings = true;
+        userSettings.declared = "from-nix";
+      };
+
+      empty.mutableUserSettings = true;
+    };
+  };
+
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+  nmt.script = ''
+    set -eu
+    set -o pipefail
+
+    export HOME=$TMPDIR/hm-user
+
+    mkdir -p "$HOME/${userPath}/profiles/work"
+    mkdir -p "$HOME/${userPath}/profiles/malformed"
+    mkdir -p "$HOME/${userPath}/profiles/relative"
+    cp ${./mutable-settings-live.json5} "$HOME/${settingsPath}"
+    cp ${./mutable-settings-work-live.json5} "$HOME/${workSettingsPath}"
+    printf '{ live: "through-relative-link" }\n' > "$HOME/${relativeSettingsTarget}"
+    ln -s ../../relative-settings.json "$HOME/${relativeSettingsPath}"
+    printf ' \n\t\n' > "$HOME/${malformedSettingsPath}"
+    chmod 0640 "$HOME/${settingsPath}"
+    chmod 0604 "$HOME/${workSettingsPath}"
+    chmod 0644 "$HOME/${malformedSettingsPath}"
+
+    ${sed} "s|/@TMPDIR@|$TMPDIR|g" ${activationScript} > $TMPDIR/activate
+    chmod +x $TMPDIR/activate
+
+    cp "$HOME/${settingsPath}" $TMPDIR/default-settings-before-dry-run
+    cp "$HOME/${workSettingsPath}" $TMPDIR/work-settings-before-dry-run
+    cp "$HOME/${malformedSettingsPath}" $TMPDIR/malformed-settings-before-dry-run
+    relative_link_before_dry_run="$(readlink "$HOME/${relativeSettingsPath}")"
+
+    DRY_RUN=1 $TMPDIR/activate > $TMPDIR/dry-run-output
+
+    cmp $TMPDIR/default-settings-before-dry-run "$HOME/${settingsPath}"
+    cmp $TMPDIR/work-settings-before-dry-run "$HOME/${workSettingsPath}"
+    cmp $TMPDIR/malformed-settings-before-dry-run "$HOME/${malformedSettingsPath}"
+    test "$(readlink "$HOME/${relativeSettingsPath}")" = "$relative_link_before_dry_run"
+    assertPathNotExists "$HOME/${userPath}/profiles/missing"
+    grep -F "mkdir -p $HOME/${userPath}/profiles/missing" $TMPDIR/dry-run-output
+    grep -F "Would update Visual Studio Code settings at '$HOME/${missingSettingsPath}'" $TMPDIR/dry-run-output
+    test -z "$(find "$HOME/${userPath}" \
+      \( -name 'settings.json.snapshot.*' -o -name 'settings.json.candidate.*' \) \
+      -print -quit)"
+
+    VERBOSE=1 $TMPDIR/activate > $TMPDIR/verbose-output
+
+    grep -F "Merging declared Visual Studio Code settings into '$HOME/${settingsPath}'" \
+      $TMPDIR/verbose-output
+
+    assertPathNotExists "home-files/${settingsPath}"
+    assertPathNotExists "home-files/${workSettingsPath}"
+    test ! -L "$HOME/${settingsPath}"
+    test ! -L "$HOME/${workSettingsPath}"
+    test -L "$HOME/${relativeSettingsPath}"
+    test "$(readlink "$HOME/${relativeSettingsPath}")" = ../../relative-settings.json
+    test -w "$HOME/${settingsPath}"
+    test -w "$HOME/${workSettingsPath}"
+    test "$(${stat} -c %a "$HOME/${settingsPath}")" = 640
+    test "$(${stat} -c %a "$HOME/${workSettingsPath}")" = 604
+
+    ${jq} -e '
+      .["editor.fontSize"] == 14 and
+      .arraySetting == ["declared"] and
+      .nested.declared == "from-nix" and
+      .nested.added == true and
+      .nested.keep == true and
+      .nested.deeper.declared == "from-nix" and
+      .nested.deeper.keep == "nested-live" and
+      .unrelated == "survives" and
+      .["update.mode"] == "none" and
+      .["extensions.autoCheckUpdates"] == false
+    ' "$HOME/${settingsPath}"
+
+    ${jq} -e '
+      .["editor.wordWrap"] == "on" and
+      .nested.declared == "from-path" and
+      .nested.pathOnly == true and
+      .nested.liveOnly == true and
+      .["workbench.colorTheme"] == "Interactive"
+    ' "$HOME/${workSettingsPath}"
+
+    ${jq} -e '. == {"created": true}' "$HOME/${missingSettingsPath}"
+    ${jq} -e '. == {"recovered": true}' "$HOME/${malformedSettingsPath}"
+    ${jq} -e '. == {"live": "through-relative-link", "declared": "through-link"}' \
+      "$HOME/${relativeSettingsTarget}"
+    assertPathNotExists "$HOME/${emptySettingsPath}"
+    test -z "$(find "$HOME/${userPath}" \
+      \( -name 'settings.json.snapshot.*' -o -name 'settings.json.candidate.*' \) \
+      -print -quit)"
+
+    cp "$HOME/${settingsPath}" $TMPDIR/default-settings-before
+    cp "$HOME/${workSettingsPath}" $TMPDIR/work-settings-before
+    cp "$HOME/${missingSettingsPath}" $TMPDIR/missing-settings-before
+    cp "$HOME/${malformedSettingsPath}" $TMPDIR/malformed-settings-before
+
+    $TMPDIR/activate
+
+    cmp $TMPDIR/default-settings-before "$HOME/${settingsPath}"
+    cmp $TMPDIR/work-settings-before "$HOME/${workSettingsPath}"
+    cmp $TMPDIR/missing-settings-before "$HOME/${missingSettingsPath}"
+    cmp $TMPDIR/malformed-settings-before "$HOME/${malformedSettingsPath}"
+
+    cp ${./mutable-settings-malformed.json5} "$HOME/${malformedSettingsPath}"
+    cp "$HOME/${malformedSettingsPath}" $TMPDIR/malformed-settings-before-failure
+
+    if $TMPDIR/activate > $TMPDIR/malformed-output 2>&1; then
+      echo "Activation unexpectedly accepted malformed JSON5" >&2
+      exit 1
+    fi
+
+    grep -F "Cannot parse Visual Studio Code settings at '$HOME/${malformedSettingsPath}' as JSON5" $TMPDIR/malformed-output
+    cmp $TMPDIR/malformed-settings-before-failure "$HOME/${malformedSettingsPath}"
+
+    printf ' \n\t\n' > "$HOME/${malformedSettingsPath}"
+    cp ${./mutable-settings-live.json5} "$HOME/${settingsPath}"
+
+    if (
+      CONCURRENT_WRITE_PATH="$HOME/${settingsPath}"
+      chmod() {
+        candidate_argument="''${!#}"
+        if [[ $1 == --reference=* \
+          && $candidate_argument == "$CONCURRENT_WRITE_PATH.candidate."* ]]; then
+          command printf '{"concurrent": true}\n' > "$CONCURRENT_WRITE_PATH"
+        fi
+        command chmod "$@"
+      }
+      source $TMPDIR/activate
+    ) > $TMPDIR/concurrent-output 2>&1; then
+      echo "Activation unexpectedly replaced a concurrent settings update" >&2
+      exit 1
+    fi
+
+    grep -F "Visual Studio Code settings at '$HOME/${settingsPath}' changed during activation" \
+      $TMPDIR/concurrent-output
+    ${jq} -e '. == {"concurrent": true}' "$HOME/${settingsPath}"
+
+    rm -f "$HOME/${appearingSettingsPath}"
+
+    if (
+      APPEARING_PATH="$HOME/${appearingSettingsPath}"
+      printf() {
+        builtin printf "$@"
+        if [[ -n ''${candidate_path-} \
+          && $candidate_path == "$APPEARING_PATH.candidate."* ]]; then
+          command printf '{"appeared": true}\n' > "$APPEARING_PATH"
+        fi
+      }
+      source $TMPDIR/activate
+    ) > $TMPDIR/appearing-output 2>&1; then
+      echo "Activation unexpectedly replaced a settings file that appeared during activation" >&2
+      exit 1
+    fi
+
+    grep -F "Visual Studio Code settings at '$HOME/${appearingSettingsPath}' changed during activation" \
+      $TMPDIR/appearing-output
+    ${jq} -e '. == {"appeared": true}' "$HOME/${appearingSettingsPath}"
+
+    rm -f "$HOME/${danglingSettingsPath}"
+    ln -s missing-target.json "$HOME/${danglingSettingsPath}"
+
+    if $TMPDIR/activate > $TMPDIR/dangling-output 2>&1; then
+      echo "Activation unexpectedly replaced a dangling settings symlink" >&2
+      exit 1
+    fi
+
+    grep -F "Cannot resolve Visual Studio Code settings at '$HOME/${danglingSettingsPath}'" \
+      $TMPDIR/dangling-output
+    test -L "$HOME/${danglingSettingsPath}"
+    test "$(readlink "$HOME/${danglingSettingsPath}")" = missing-target.json
+    test ! -e "$HOME/${danglingSettingsPath}"
+    test -z "$(find "$HOME/${userPath}" \
+      \( -name 'settings.json.snapshot.*' -o -name 'settings.json.candidate.*' \) \
+      -print -quit)"
+  '';
+}


### PR DESCRIPTION
### Description

This PR adds a per-profile `mutableUserSettings` option to the shared VS Code module. Without it, Home Manager manages `settings.json` as a read-only symlink to the Nix store, so settings changed through the editor cannot be saved. Users may also encounter error messages when VS Code and its forks expect a writable settings file.

When enabled, activation merges the declared settings into the existing JSON5 or JSONC file. Declared values win, while unrelated settings changed through the editor are kept.

The new files are written atomically, malformed files are left unchanged, and the option defaults to false so as to not lead to unexpected behavior for existing users. 

This PR is conceptually similar to #6993, which has been merged for Zed.

Since this change lives in the shared module, it also covers VSCodium, Cursor, Windsurf, Kiro, and Antigravity.

Fixes #1800 #7617 #8573 and perhaps others.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
