### PR TITLE
home-manager-auto-upgrade: add remote flake support

### DIFF
--- a/modules/services/home-manager-auto-upgrade.nix
+++ b/modules/services/home-manager-auto-upgrade.nix
@@ -57,18 +57,20 @@ let
         ''
           set -euo pipefail
 
-          if [[ ! -f "$FLAKE_DIR/flake.nix" ]]; then
-            echo "No flake.nix found in $FLAKE_DIR." >&2
-            exit 1
-          fi
+          if [[ "$FLAKE_URL" == "." ]]; then
+            if [[ ! -f "$FLAKE_DIR/flake.nix" ]]; then
+              echo "No flake.nix found in $FLAKE_DIR." >&2
+              exit 1
+            fi
 
-          echo "Changing to flake directory $FLAKE_DIR"
-          cd "$FLAKE_DIR"
+            echo "Changing to flake directory $FLAKE_DIR"
+            cd "$FLAKE_DIR"
+          fi
 
           ${preSwitchScript}
 
           echo "Upgrade Home Manager"
-          home-manager switch --flake . ${hmExtraArgs}
+          home-manager switch --flake "$FLAKE_URL" ${hmExtraArgs}
         ''
       else
         ''
@@ -125,6 +127,15 @@ in
         description = ''
           Directory containing flake.nix.
           Also check `services.home-manager.autoUpgrade.useFlake` option.
+        '';
+      };
+
+      flakeUrl = lib.mkOption {
+        type = lib.types.str;
+        default = ".";
+        example = "github:your-user/dotfiles";
+        description = ''
+          git repository for your flake.
         '';
       };
 
@@ -200,6 +211,7 @@ in
 
           Environment = lib.mkIf cfg.useFlake [
             "FLAKE_DIR=${cfg.flakeDir}"
+            "FLAKE_URL=${cfg.flakeUrl}"
           ];
         };
       };

--- a/tests/modules/services/home-manager-auto-upgrade/default.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/default.nix
@@ -6,4 +6,5 @@ lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   home-manager-auto-upgrade-deprecated-flake-configuration = ./deprecated-flake-configuration.nix;
   home-manager-auto-upgrade-flake-configuration = ./flake-configuration.nix;
   home-manager-auto-upgrade-nix-package = ./nix-package.nix;
+  home-manager-auto-upgrade-remote-flake-configuration = ./remote-flake-configuration.nix;
 }

--- a/tests/modules/services/home-manager-auto-upgrade/remote-flake-configuration.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/remote-flake-configuration.nix
@@ -1,0 +1,19 @@
+{
+  home.stateVersion = "26.05";
+
+  services.home-manager.autoUpgrade = {
+    enable = true;
+    frequency = "daily";
+    useFlake = true;
+    flakeUrl = "github:somebody/dotfiles";
+  };
+
+  nmt.script = ''
+    serviceFile="home-files/.config/systemd/user/home-manager-auto-upgrade.service"
+    assertFileExists "$serviceFile"
+    assertFileRegex "$serviceFile" "FLAKE_URL=github:somebody/dotfiles"
+
+    execFile="$(grep ExecStart= "$TESTED/$serviceFile" | cut -d= -f2-)"
+    assertFileRegex "$execFile" "switch --flake \"\$FLAKE_URL\""
+  '';
+}


### PR DESCRIPTION
### Description

Hi,


This allow to configure autoUpgrade on eg. `home-manager switch --flake github:your-user/dotfiles` instead of hardcoding `.`

I believe it is not always convenient to manage a local git clone of the config, when nix can just always grab the latest version from a forge.

To make this PR, I basically followed #8053

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
