### PR TITLE
targets/generic-linux: source nix.sh once

### DIFF
--- a/modules/misc/news/2026/08/2026-08-28_19-39-36.nix
+++ b/modules/misc/news/2026/08/2026-08-28_19-39-36.nix
@@ -1,0 +1,19 @@
+{ config, ... }:
+{
+  time = "2026-08-28T19:39:36+00:00";
+  condition = config.targets.genericLinux.enable && config.programs.bash.enable;
+  message = ''
+    On generic Linux, Home Manager no longer sources `nix.sh` separately in
+    every interactive Bash shell. The generated session variables file
+    still sources it once per session tree. This prevents repeated Bash
+    startup from adding duplicate `PATH` and `XDG_DATA_DIRS` entries.
+
+    If login initialization resets `PATH` while preserving the session
+    guard, Bash restores the Nix profile's `bin` directory only when it is
+    missing. An existing entry keeps its position in `PATH`.
+
+    Other values set only by `nix.sh` are not restored when a process
+    preserves `__HM_SESS_VARS_SOURCED` but removes those values. If you rely
+    on that behavior, restore the Nix environment at that boundary.
+  '';
+}

--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -73,11 +73,17 @@ in
       export TERM="$TERM"
     '';
 
-    # We need to source both nix.sh and hm-session-vars.sh as noted in
+    # Login initialization can reset PATH while preserving the session guard.
+    # Restore profile commands without repeating nix.sh or changing an existing
+    # profile entry's precedence.
     # https://github.com/nix-community/home-manager/pull/797#issuecomment-544783247
     programs.bash.initExtra = ''
-      . "${nixPkg}/etc/profile.d/nix.sh"
       . "${profileDirectory}/etc/profile.d/hm-session-vars.sh"
+
+      case ":$PATH:" in
+        *":${profileDirectory}/bin:"*) ;;
+        *) export PATH="${profileDirectory}/bin''${PATH:+:}$PATH" ;;
+      esac
     '';
 
     programs.zsh.envExtra = ''

--- a/tests/modules/targets-linux/generic-linux-runtime.nix
+++ b/tests/modules/targets-linux/generic-linux-runtime.nix
@@ -1,0 +1,64 @@
+{ pkgs, profileDirectory }:
+
+''
+  set -eu
+
+  testHome="$TMPDIR/generic-linux-bash-home"
+  ${pkgs.coreutils}/bin/rm -rf "$testHome"
+  ${pkgs.coreutils}/bin/mkdir -p "$testHome"
+  ${pkgs.coreutils}/bin/cp "$TESTED/home-files/.bash_profile" "$testHome/.bash_profile"
+  ${pkgs.coreutils}/bin/cp "$TESTED/home-files/.bashrc" "$testHome/.bashrc"
+  ${pkgs.coreutils}/bin/cp "$TESTED/home-files/.profile" "$testHome/.profile"
+  ${pkgs.gnused}/bin/sed -i "s|${profileDirectory}|$testHome/profile|g" \
+    "$testHome/.bash_profile" "$testHome/.bashrc" "$testHome/.profile"
+  ${pkgs.coreutils}/bin/ln -s "$TESTED/home-path" "$testHome/profile"
+
+  initialPath="/usr/bin:/bin"
+  initialXdgDataDirs="/fixture/xdg-data"
+  bashPath="$BASH"
+  ${pkgs.coreutils}/bin/env -i \
+    HOME="$testHome" \
+    PATH="$initialPath" \
+    TMPDIR="$TMPDIR" \
+    XDG_DATA_DIRS="$initialXdgDataDirs" \
+    ORIGINAL_XDG_DATA_DIRS="$initialXdgDataDirs" \
+    __HM_SESS_VARS_SOURCED=1 \
+    "$bashPath" --noprofile --norc -i -c '
+        . "$HOME/.bash_profile" || exit 1
+        firstPath="$PATH"
+        firstXdgDataDirs="$XDG_DATA_DIRS"
+        [ "$XDG_DATA_DIRS" = "$ORIGINAL_XDG_DATA_DIRS" ] \
+          || { echo "XDG_DATA_DIRS changed on startup"; exit 1; }
+        . "$HOME/.bash_profile" || exit 1
+        [ "$(command -v hm-profile-command)" = "$HOME/profile/bin/hm-profile-command" ] \
+          || { echo "profile command was not found through PATH"; exit 1; }
+        [ "$PATH" = "$firstPath" ] \
+          || { echo "PATH changed on repeated startup"; exit 1; }
+        [ "$XDG_DATA_DIRS" = "$firstXdgDataDirs" ] \
+          || { echo "XDG_DATA_DIRS changed on repeated startup"; exit 1; }
+        profileBinCount=$(
+          printf "%s" ":$PATH:" | ${pkgs.coreutils}/bin/tr : "\n" |
+            ${pkgs.gnugrep}/bin/grep -cFx "$HOME/profile/bin"
+        )
+        [ "$profileBinCount" = 1 ] \
+          || { echo "profile bin appeared $profileBinCount times"; exit 1; }
+      ' \
+    || fail "Bash startup did not preserve profile command lookup or session variables"
+
+  ${pkgs.coreutils}/bin/mkdir -p "$testHome/precedence"
+  ${pkgs.coreutils}/bin/ln -s "$testHome/profile/bin/hm-profile-command" \
+    "$testHome/precedence/hm-profile-command"
+  ${pkgs.coreutils}/bin/env -i \
+    HOME="$testHome" \
+    PATH="$testHome/precedence:$testHome/profile/bin:$initialPath" \
+    TMPDIR="$TMPDIR" \
+    XDG_DATA_DIRS="$initialXdgDataDirs" \
+    ORIGINAL_XDG_DATA_DIRS="$initialXdgDataDirs" \
+    __HM_SESS_VARS_SOURCED=1 \
+    "$bashPath" --noprofile --norc -i -c '
+        . "$HOME/.bash_profile" || exit 1
+        [ "$(command -v hm-profile-command)" = "$HOME/precedence/hm-profile-command" ] \
+          || { echo "existing profile command lost precedence"; exit 1; }
+      ' \
+    || fail "Bash startup changed precedence of an existing profile command"
+''

--- a/tests/modules/targets-linux/generic-linux-xdg.nix
+++ b/tests/modules/targets-linux/generic-linux-xdg.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   expectedXdgDataDirs = lib.concatStringsSep ":" [
     "\${NIX_STATE_DIR:-/nix/var/nix}/profiles/default/share"
@@ -13,6 +18,13 @@ in
 {
   config = {
     targets.genericLinux.enable = true;
+
+    programs.bash = {
+      enable = true;
+      enableCompletion = false;
+    };
+
+    home.packages = [ (pkgs.writeShellScriptBin "hm-profile-command" "exit 0") ];
 
     xdg.systemDirs.data = [ "/foo" ];
 
@@ -34,6 +46,11 @@ in
       assertFileContains \
         home-path/etc/profile.d/hm-session-vars.sh \
         'export TERM="$TERM"'
+
+      ${(import ./generic-linux-runtime.nix) {
+        inherit pkgs;
+        profileDirectory = config.home.profileDirectory;
+      }}
     '';
   };
 }

--- a/tests/modules/targets-linux/generic-linux.nix
+++ b/tests/modules/targets-linux/generic-linux.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   expectedXdgDataDirs = lib.concatStringsSep ":" [
     "\${NIX_STATE_DIR:-/nix/var/nix}/profiles/default/share"
@@ -13,6 +18,13 @@ in
 {
   config = {
     targets.genericLinux.enable = true;
+
+    programs.bash = {
+      enable = true;
+      enableCompletion = false;
+    };
+
+    home.packages = [ (pkgs.writeShellScriptBin "hm-profile-command" "exit 0") ];
 
     xdg.systemDirs.data = [ "/foo" ];
 
@@ -32,6 +44,42 @@ in
       assertFileContains \
         home-path/etc/profile.d/hm-session-vars.sh \
         'export TERM="$TERM"'
+
+      # nix.sh is not idempotent, so it must appear exactly once and must not
+      # be repeated in .bashrc, which now re-sources the session variables
+      # file on every interactive shell.
+      assertFileExists home-files/.bashrc
+      assertFileNotRegex home-files/.bashrc 'profile\.d/nix\.sh'
+      nixShCount=$(grep -c 'profile\.d/nix\.sh' \
+        "$TESTED/home-path/etc/profile.d/hm-session-vars.sh")
+      [ "$nixShCount" = 1 ] \
+        || fail "nix.sh referenced $nixShCount times in hm-session-vars.sh"
+
+      # Behavioural: applying the file twice must still run nix.sh once,
+      # because it lives in the guarded section.
+      printf '%s\n' \
+        'NIX_SH_RUNS=$(( ''${NIX_SH_RUNS:-0} + 1 ))' \
+        'export NIX_SH_RUNS' \
+        > "$TMPDIR/fake-nix.sh"
+      sed "s|\. \"${pkgs.nix}/etc/profile.d/nix.sh\"|. \"$TMPDIR/fake-nix.sh\"|" \
+        "$TESTED/home-path/etc/profile.d/hm-session-vars.sh" > "$TMPDIR/sessvars.sh"
+      grep -q 'fake-nix.sh' "$TMPDIR/sessvars.sh" \
+        || fail "could not substitute the nix.sh stand-in"
+
+      env -u __HM_SESS_VARS_SOURCED -u NIX_SH_RUNS \
+        TERM=dumb "$BASH" --noprofile --norc -c '
+          . "$1"
+          . "$1"
+          [ "$NIX_SH_RUNS" = 1 ] \
+            || { echo "nix.sh ran $NIX_SH_RUNS times"; exit 1; }
+          exit 0
+        ' shell "$TMPDIR/sessvars.sh" \
+        || fail "nix.sh was not sourced exactly once"
+
+      ${(import ./generic-linux-runtime.nix) {
+        inherit pkgs;
+        profileDirectory = config.home.profileDirectory;
+      }}
     '';
   };
 }


### PR DESCRIPTION
### Description

On generic Linux, Home Manager sources `nix.sh` through the guarded session variables file and directly from Bash `initExtra`. The direct call runs in interactive login and non-login shells. Since `nix.sh` is not idempotent, repeated Bash startup adds duplicate `PATH` and `XDG_DATA_DIRS` entries.

Remove the direct call, but retain PATH recovery. Login initialization can reset `PATH` while preserving `__HM_SESS_VARS_SOURCED`, so the guard does not guarantee that profile commands remain available. Bash now prepends the configured profile's `bin` directory only when it is missing. An existing entry keeps its position, preserving development-environment precedence.

This does not replay `nix.sh` to recover other removed environment values. The news entry documents that remaining boundary; #9925 at the top of the stack removes it.

Tests execute generated Bash startup files with an inherited guard and a reset PATH. They cover command lookup, repeated startup, and existing PATH precedence for traditional and XDG profiles. The existing counting test also checks that the guarded session file sources `nix.sh` only once.

This is a standalone bugfix at the bottom of the session-variable stack. Part of splitting #9735 into independently reviewable changes; the stack as a whole supersedes that PR.

### Checklist

- [ ] Change is backwards compatible. (Recovery of other removed `nix.sh` values changes; news entry included.)
- [x] Code formatted with `nix fmt`.
- [x] Focused Generic Linux tests pass.
- [x] Test cases updated/added.
- [x] Commit messages follow the `{component}: {description}` format.

