### PR TITLE
nix, xdg/systemDirs: declare search paths as search variables

### DIFF
--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -62,14 +62,14 @@ in
 {
   inherit export wrapLines;
 
-  # Produces a Bourne shell like statement that prepend new values to
-  # an possibly existing variable, using sep(arator).
+  # Produces a Bourne shell-like statement that prepends new values to
+  # a possibly existing variable, using sep(arator).
   # Example:
   #   prependToVar ":" "PATH" [ "$HOME/bin" "$HOME/.local/bin" ]
-  #   => "$HOME/bin:$HOME/.local/bin:${PATH:+:}\$PATH"
+  #   => "$HOME/bin:$HOME/.local/bin:${PATH:+:}${PATH-}"
   prependToVar =
     sep: n: v:
-    "${lib.concatStringsSep sep v}\${${n}:+${sep}}\$${n}";
+    "${lib.concatStringsSep sep v}\${${n}:+${sep}}\${${n}-}";
 
   # Given an attribute set containing shell variable names and their
   # assignment, this function produces a string containing an export

--- a/modules/misc/news/2026/08/2026-08-27_12-00-00.nix
+++ b/modules/misc/news/2026/08/2026-08-27_12-00-00.nix
@@ -1,0 +1,32 @@
+{ config, ... }:
+{
+  time = "2026-08-27T12:00:00+00:00";
+  condition =
+    (config.nix.enable && config.nix.nixPath != [ ] && config.nix.keepOldNixPath)
+    || config.xdg.systemDirs.config != [ ]
+    || config.xdg.systemDirs.data != [ ];
+  message = ''
+    {env}`NIX_PATH`, {env}`XDG_CONFIG_DIRS`, and {env}`XDG_DATA_DIRS` are now
+    declared through {option}`home.sessionSearchVariables` instead of a
+    self-referential {option}`home.sessionVariables` value. The generated shell
+    code expands to the same search path as before, and the
+    {file}`environment.d` values for systemd user services are unchanged.
+
+    One thing does change. A value assigned through
+    {option}`home.sessionVariables.XDG_DATA_DIRS` (or the other two names) no
+    longer conflicts with the module definition. It becomes the trailing value
+    after the configured search entries. Plain list entries assigned through
+    {option}`home.sessionSearchVariables.XDG_DATA_DIRS` stay ahead of the
+    module entries.
+
+    To replace the module's configured search entries while retaining the
+    inherited value, use `lib.mkForce` on
+    {option}`home.sessionSearchVariables.XDG_DATA_DIRS`. To keep the previous
+    exact-value behavior, set the corresponding {option}`nix.nixPath`,
+    {option}`xdg.systemDirs.config`, or {option}`xdg.systemDirs.data` list to
+    empty, using `lib.mkForce [ ]` if other modules contribute values, and
+    continue to use {option}`home.sessionVariables`. For the XDG names, the
+    {file}`environment.d` output remains controlled separately by the
+    corresponding {option}`xdg.systemDirs` list.
+  '';
+}

--- a/modules/misc/nix/default.nix
+++ b/modules/misc/nix/default.nix
@@ -391,7 +391,7 @@ in
       })
 
       (mkIf (cfg.nixPath != [ ] && cfg.keepOldNixPath) {
-        home.sessionVariables.NIX_PATH = "${nixPath}\${NIX_PATH:+:$NIX_PATH}";
+        home.sessionSearchVariables.NIX_PATH = lib.mkAfter cfg.nixPath;
       })
 
       (lib.mkIf (cfg.channels != { }) {

--- a/modules/misc/xdg/system-dirs.nix
+++ b/modules/misc/xdg/system-dirs.nix
@@ -51,13 +51,13 @@ in
     })
 
     (lib.mkIf (cfg.config != [ ]) {
-      home.sessionVariables.XDG_CONFIG_DIRS = "${configDirs}\${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}";
+      home.sessionSearchVariables.XDG_CONFIG_DIRS = lib.mkAfter cfg.config;
 
       systemd.user.sessionVariables.XDG_CONFIG_DIRS = "${configDirs}\${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}";
     })
 
     (lib.mkIf (cfg.data != [ ]) {
-      home.sessionVariables.XDG_DATA_DIRS = "${dataDirs}\${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}";
+      home.sessionSearchVariables.XDG_DATA_DIRS = lib.mkAfter cfg.data;
 
       systemd.user.sessionVariables.XDG_DATA_DIRS = "${dataDirs}\${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}";
     })

--- a/tests/modules/home-environment/session-path.nix
+++ b/tests/modules/home-environment/session-path.nix
@@ -9,6 +9,6 @@
     hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
     assertFileExists $hmSessVars
     assertFileContains $hmSessVars \
-      'export PATH="bar:baz:foo''${PATH:+:}$PATH"'
+      'export PATH="bar:baz:foo''${PATH:+:}''${PATH-}"'
   '';
 }

--- a/tests/modules/home-environment/session-search-variables.nix
+++ b/tests/modules/home-environment/session-search-variables.nix
@@ -1,14 +1,40 @@
 {
+  home.sessionVariables.TRAILING = "inherited";
+
   home.sessionSearchVariables.TEST = [
     "bar"
     "baz"
     "foo"
   ];
+  home.sessionSearchVariables.UNSET = [ "configured" ];
+  home.sessionSearchVariables.TRAILING = [ "configured" ];
 
   nmt.script = ''
     hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
     assertFileExists $hmSessVars
-    assertFileContains $hmSessVars \
-      'export TEST="bar:baz:foo''${TEST:+:}$TEST"'
+    testExport=$(grep '^export TEST=' "$TESTED/$hmSessVars")
+    trailingExports=$(grep '^export TRAILING=' "$TESTED/$hmSessVars")
+    unsetExport=$(grep '^export UNSET=' "$TESTED/$hmSessVars")
+    (
+      set -u
+      unset TEST UNSET
+      eval "$testExport"
+      eval "$unsetExport"
+      [ "$TEST" = "bar:baz:foo" ] \
+        || { echo "TEST after unset source: $TEST"; exit 1; }
+      [ "$UNSET" = "configured" ] \
+        || { echo "UNSET after unset source: $UNSET"; exit 1; }
+    ) || fail "search variables were not safe for unset targets"
+
+    (
+      set -u
+      TEST=/inherited
+      eval "$testExport"
+      eval "$trailingExports"
+      [ "$TEST" = "bar:baz:foo:/inherited" ] \
+        || { echo "TEST after inherited source: $TEST"; exit 1; }
+      [ "$TRAILING" = "configured:inherited" ] \
+        || { echo "TRAILING after source: $TRAILING"; exit 1; }
+    ) || fail "inherited search variable was not preserved"
   '';
 }

--- a/tests/modules/misc/nix/example-channels-xdg.nix
+++ b/tests/modules/misc/nix/example-channels-xdg.nix
@@ -25,7 +25,7 @@ in
 
   nmt.script = ''
     assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
-      'export NIX_PATH="/home/hm-user/.local/state/nix/defexpr/50-home-manager''${NIX_PATH:+:$NIX_PATH}"'
+      'export NIX_PATH="/home/hm-user/.local/state/nix/defexpr/50-home-manager''${NIX_PATH:+:}''${NIX_PATH-}"'
     assertFileContent \
       home-files/.local/state/nix/defexpr/50-home-manager/example/default.nix \
       ${exampleChannel}/default.nix

--- a/tests/modules/misc/nix/example-channels.nix
+++ b/tests/modules/misc/nix/example-channels.nix
@@ -17,7 +17,7 @@ in
 
   nmt.script = ''
     assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
-      'export NIX_PATH="/home/hm-user/.nix-defexpr/50-home-manager''${NIX_PATH:+:$NIX_PATH}"'
+      'export NIX_PATH="/home/hm-user/.nix-defexpr/50-home-manager''${NIX_PATH:+:}''${NIX_PATH-}"'
     assertFileContent \
       home-files/.nix-defexpr/50-home-manager/example/default.nix \
       ${exampleChannel}/default.nix

--- a/tests/modules/misc/nix/example-settings.nix
+++ b/tests/modules/misc/nix/example-settings.nix
@@ -35,12 +35,14 @@
     };
   };
 
+  home.sessionSearchVariables.NIX_PATH = [ "/existing" ];
+
   nmt.script = ''
     assertFileContent \
       home-files/.config/nix/nix.conf \
       ${./example-settings-expected.conf}
 
     assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
-      'export NIX_PATH="/a:/b/c''${NIX_PATH:+:$NIX_PATH}"'
+      'export NIX_PATH="/existing:/a:/b/c''${NIX_PATH:+:}''${NIX_PATH-}"'
   '';
 }

--- a/tests/modules/misc/xdg/local-bin-in-path.nix
+++ b/tests/modules/misc/xdg/local-bin-in-path.nix
@@ -5,6 +5,6 @@
   nmt.script = ''
     assertFileExists home-path/etc/profile.d/hm-session-vars.sh
     assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
-      'export PATH="/home/hm-user/.local/bin''${PATH:+:}$PATH"'
+      'export PATH="/home/hm-user/.local/bin''${PATH:+:}''${PATH-}"'
   '';
 }

--- a/tests/modules/misc/xdg/system-dirs.nix
+++ b/tests/modules/misc/xdg/system-dirs.nix
@@ -1,5 +1,6 @@
 {
   config,
+  lib,
   pkgs,
   ...
 }:
@@ -15,6 +16,9 @@
       "/usr/share"
       "/baz/quux"
     ];
+    home.sessionVariables.XDG_CONFIG_DIRS = "/plain-config";
+    home.sessionSearchVariables.XDG_CONFIG_DIRS = [ "/existing-config" ];
+    home.sessionSearchVariables.XDG_DATA_DIRS = lib.mkForce [ "/forced-data" ];
 
     nmt.script = ''
       envFile=home-files/.config/environment.d/10-home-manager.conf
@@ -33,9 +37,22 @@
       sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
       assertFileExists $sessionVarsFile
       assertFileContains $sessionVarsFile \
-        'export XDG_CONFIG_DIRS="/etc/xdg:/foo/bar''${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}"'
+        'export XDG_CONFIG_DIRS="/plain-config"'
       assertFileContains $sessionVarsFile \
-        'export XDG_DATA_DIRS="/usr/local/share:/usr/share:/baz/quux''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"'
+        'export XDG_CONFIG_DIRS="/existing-config:/etc/xdg:/foo/bar''${XDG_CONFIG_DIRS:+:}''${XDG_CONFIG_DIRS-}"'
+      assertFileContains $sessionVarsFile \
+        'export XDG_DATA_DIRS="/forced-data''${XDG_DATA_DIRS:+:}''${XDG_DATA_DIRS-}"'
+
+      (
+        XDG_CONFIG_DIRS=/inherited-config
+        XDG_DATA_DIRS=/inherited-data
+        unset __HM_SESS_VARS_SOURCED
+        . "$TESTED/$sessionVarsFile"
+        [ "$XDG_CONFIG_DIRS" = "/existing-config:/etc/xdg:/foo/bar:/plain-config" ] \
+          || { echo "XDG_CONFIG_DIRS: $XDG_CONFIG_DIRS"; exit 1; }
+        [ "$XDG_DATA_DIRS" = "/forced-data:/inherited-data" ] \
+          || { echo "XDG_DATA_DIRS: $XDG_DATA_DIRS"; exit 1; }
+      ) || fail "XDG search variable precedence was not preserved"
     '';
   };
 }

--- a/tests/modules/programs/man/mandoc.nix
+++ b/tests/modules/programs/man/mandoc.nix
@@ -25,7 +25,7 @@
 
       assertFileExists $hmSessVars
       assertFileContains $hmSessVars \
-        'export MANPATH="/home/hm-user/.local/share/mandoc/man''${MANPATH:+:}$MANPATH"'
+        'export MANPATH="/home/hm-user/.local/share/mandoc/man''${MANPATH:+:}''${MANPATH-}"'
     '';
   };
 }


### PR DESCRIPTION
### Description

`NIX_PATH` (under `nix.nixPath` with `keepOldNixPath`),
`XDG_CONFIG_DIRS`, and `XDG_DATA_DIRS` were defined as self-referential
`home.sessionVariables` values. This declares them through
`home.sessionSearchVariables` instead, without depending on the variable being
defined.

The shared search-variable generator now reads inherited values through a
default-safe expansion. Unset variables behave as empty under `set -u`, so this
PR does not depend on a later stack layer for safe shell startup. Existing
plain `home.sessionSearchVariables` entries retain their precedence over the
migrated module entries.

`systemd.user.sessionVariables` is untouched, so `environment.d` output is
byte-identical. One intentional compatibility change remains: a value set
through `home.sessionVariables` no longer collides with these module
definitions and instead becomes the trailing value. The news entry documents
list merging, `lib.mkForce`, exact-value migration, and the separate
`environment.d` behavior.

Part of splitting #9735 into independently reviewable changes; the stack as a
whole supersedes that PR.

### Checklist

- [ ] Change is backwards compatible. (User-defined values for these three
  names now compose with the module entries; a news entry is included.)
- [x] Code formatted with `nix fmt`.
- [x] Code tested through focused NMT suites.
- [x] Test cases updated and added.
- [x] Commit messages follow the `{component}: {description}` format.
