### PR TITLE
lib/shell: add idempotent search-variable merge primitives

### DIFF
--- a/modules/lib/session-search-merge.sh
+++ b/modules/lib/session-search-merge.sh
@@ -1,0 +1,74 @@
+# shellcheck shell=sh
+# Merge entries into a separator-delimited search variable.
+#
+#   __hm_merge <prepend|append> <NAME> <SEP> [ENTRY...]
+#
+# The first merge in a process tree removes existing occurrences before placing
+# entries according to mode. Later merges keep existing positions. The exported
+# `__HM_SESS_VARS_MERGED` marker distinguishes those cases independently of
+# `__HM_SESS_VARS_SOURCED`.
+#
+# POSIX sh has no arrays or `${var//pattern/}`. Quoting the `case` and parameter
+# expansion patterns keeps glob metacharacters in entries literal.
+__hm_merge() {
+  __hm_mode=$1
+  __hm_name=$2
+  __hm_sep=$3
+  shift 3
+
+  eval "__hm_cur=\${$__hm_name-}"
+  __hm_add=
+
+  if [ -z "${__HM_SESS_VARS_MERGED-}" ]; then
+    __hm_reposition=1
+  else
+    __hm_reposition=
+  fi
+
+  for __hm_entry in "$@"; do
+    # Empty path elements usually mean the current directory and cannot be
+    # deduplicated reliably. Entries expand only when sourced, so filter them here.
+    [ -n "$__hm_entry" ] || continue
+
+    case "$__hm_sep$__hm_add$__hm_sep" in
+      *"$__hm_sep$__hm_entry$__hm_sep"*) continue ;;
+    esac
+
+    if [ -n "$__hm_reposition" ]; then
+      # Each pass removes one occurrence, so the loop terminates.
+      __hm_work="$__hm_sep$__hm_cur$__hm_sep"
+      while :; do
+        case "$__hm_work" in
+          *"$__hm_sep$__hm_entry$__hm_sep"*) ;;
+          *) break ;;
+        esac
+        __hm_pre="${__hm_work%%"$__hm_sep$__hm_entry$__hm_sep"*}"
+        __hm_post="${__hm_work#*"$__hm_sep$__hm_entry$__hm_sep"}"
+        __hm_work="$__hm_pre$__hm_sep$__hm_post"
+      done
+      __hm_work="${__hm_work#"$__hm_sep"}"
+      __hm_cur="${__hm_work%"$__hm_sep"}"
+    else
+      case "$__hm_sep$__hm_cur$__hm_sep" in
+        *"$__hm_sep$__hm_entry$__hm_sep"*) continue ;;
+      esac
+    fi
+
+    __hm_add="$__hm_add${__hm_add:+$__hm_sep}$__hm_entry"
+  done
+
+  if [ -n "$__hm_add" ]; then
+    if [ "$__hm_mode" = prepend ]; then
+      eval "$__hm_name=\"\$__hm_add\${__hm_cur:+\$__hm_sep}\$__hm_cur\""
+    else
+      eval "$__hm_name=\"\$__hm_cur\${__hm_cur:+\$__hm_sep}\$__hm_add\""
+    fi
+  else
+    # Export the variable even when all configured entries already exist.
+    eval "$__hm_name=\$__hm_cur"
+  fi
+
+  # SC2163: indirect export works in bash, dash, zsh, and BusyBox ash.
+  # shellcheck disable=SC2163
+  export "$__hm_name"
+}

--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -58,9 +58,118 @@ let
       } items;
     in
     foldResult.finishedLines ++ lib.optional (foldResult.currentLine != "") foldResult.currentLine;
+  # Preserve parameter, command, and arithmetic expansion inside a double-quoted
+  # shell word. Existing escapes keep their shell meaning; other backslashes stay
+  # literal.
+  escapeDoubleQuoted =
+    let
+      escapeLiteral = lib.replaceStrings [ "\\" ] [ "\\\\" ];
+      handlePart =
+        part:
+        if lib.isString part then
+          escapeLiteral part
+        else
+          let
+            c = lib.head part;
+          in
+          # These four escapes already have double-quoted shell semantics. Escape
+          # every other backslash, including line continuations, as literal data.
+          if c == "$" || c == "\\" || c == "\"" || c == "`" then "\\${c}" else escapeLiteral "\\${c}";
+    in
+    value: lib.concatMapStrings handlePart (builtins.split ''\\(.)'' value);
+
+  # POSIX sh does not define local variables, so remove every scratch name after
+  # all calls.
+  mergeScratchVariables = [
+    "__hm_mode"
+    "__hm_name"
+    "__hm_sep"
+    "__hm_cur"
+    "__hm_add"
+    "__hm_entry"
+    "__hm_reposition"
+    "__hm_work"
+    "__hm_pre"
+    "__hm_post"
+  ];
+
+  # Double-quote entry values so expansions run when the block is sourced.
+  mkMergeCall =
+    mode: sep: name: values:
+    lib.concatStringsSep " " (
+      [
+        "__hm_merge"
+        mode
+        name
+        ''"${escapeDoubleQuoted sep}"''
+      ]
+      ++ map (value: ''"${escapeDoubleQuoted value}"'') values
+    );
+
+  mergeSearchVariables =
+    {
+      prepend ? { },
+      append ? { },
+    }:
+    let
+      mkCalls =
+        mode: variables:
+        lib.concatStringsSep "\n" (
+          map (name: mkMergeCall mode ":" name variables.${name}) (lib.attrNames variables)
+        );
+      calls = lib.concatStringsSep "\n" (
+        lib.filter (value: value != "") [
+          (mkCalls "prepend" prepend)
+          (mkCalls "append" append)
+        ]
+      );
+    in
+    if prepend == { } && append == { } then
+      ""
+    else
+      ''
+        ${builtins.readFile ./session-search-merge.sh}
+        ${calls}
+        export __HM_SESS_VARS_MERGED=1
+        unset -f __hm_merge
+        unset ${lib.concatStringsSep " " mergeScratchVariables}
+      '';
+
 in
 {
   inherit export wrapLines;
+
+  /**
+    Generate a complete POSIX shell block that merges entries into
+    colon-delimited search variables.
+
+    Prepends run before appends. The generated block exports a process marker
+    so later blocks preserve inherited entry positions.
+
+    Entries are evaluated in a double-quoted shell context. Parameter and
+    arithmetic expansions and both command-substitution forms stay active.
+    Write `\"` for a literal `"`. Plain glob and tilde characters remain
+    literal while the surrounding double-quoted context is intact.
+
+    Returns an empty string when both attribute sets are empty.
+
+    # Inputs
+
+    `prepend`
+
+    : Attribute set that maps variable names to entries added at the front
+
+    `append`
+
+    : Attribute set that maps variable names to entries added at the end
+
+    # Type
+
+    ```
+    mergeSearchVariables :: { prepend ? AttrSet [ String ], append ? AttrSet [ String ] } -> String
+    ```
+  */
+  inherit mergeSearchVariables;
 
   # Produces a Bourne shell-like statement that prepends new values to
   # a possibly existing variable, using sep(arator).

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -190,6 +190,7 @@ import nmtSrc {
           ./lib/deprecations
           ./lib/generators
           ./lib/mcp
+          ./lib/shell
           ./lib/types
           ./modules/files
           ./modules/home-environment

--- a/tests/lib/shell/default.nix
+++ b/tests/lib/shell/default.nix
@@ -1,0 +1,3 @@
+{
+  shell-search-variable-merge = ./search-variable-merge.nix;
+}

--- a/tests/lib/shell/search-variable-merge.nix
+++ b/tests/lib/shell/search-variable-merge.nix
@@ -1,0 +1,139 @@
+{
+  config,
+  realPkgs,
+  ...
+}:
+
+let
+  inherit (config.lib) shell;
+in
+{
+  # Put the helper in the test home so nmt.script can source it through $TESTED
+  # instead of embedding a store path.
+  home.file.".config/hm-search-merge-test.sh".text = ''
+    ${shell.mergeSearchVariables {
+      prepend = {
+        SUBSTRING = [ "/usr/share" ];
+        DEDUP = [
+          "bar"
+          "baz"
+          "bar"
+          ""
+          "$EMPTY_ENTRY"
+          "foo"
+        ];
+        EXPANDED = [ "$HOME/tools" ];
+        COMMAND = [ "$(printf \"%s\" \"command with space\")" ];
+        ARITHMETIC = [ "$((6 * 7))" ];
+        BACKTICK = [ "`printf backtick`" ];
+        LITERAL = [ "\\$NOT_EXPANDED/entry" ];
+        ESCAPED_QUOTE_GLOB = [ "\\\"*" ];
+        GLOB = [ "[a-z]" ];
+        SEPARATOR = [ "a:b" ];
+        COMPLETE = [ "qux" ];
+        BOTH = [ "front" ];
+      };
+      append = {
+        BOTH = [ "fallback" ];
+        TRAILING = [ "/first" ];
+      };
+    }}
+  '';
+
+  nmt.script = ''
+    script="$TESTED/home-files/.config/hm-search-merge-test.sh"
+    assertFileExists home-files/.config/hm-search-merge-test.sh
+
+    # NMT supplies Bash. dash and zsh must come from realPkgs because the
+    # ordinary test package set is scrubbed to non-runnable paths.
+    for shellBin in \
+      "$BASH" \
+      ${realPkgs.dash}/bin/dash \
+      ${realPkgs.zsh}/bin/zsh; do
+
+      # On the first merge, configured precedence repositions inherited duplicates.
+      env -u __HM_SESS_VARS_MERGED \
+        HOME=/runtime/home \
+        EMPTY_ENTRY="" \
+        SUBSTRING="/usr/share/ubuntu:/usr/share" \
+        DEDUP="baz" \
+        BOTH="fallback:middle:front" \
+        COMPLETE="qux" \
+        TRAILING="/first:/last" \
+        "$shellBin" -uc '
+          unset EXPANDED LITERAL GLOB SEPARATOR NOT_EXPANDED
+          . "$1"
+
+          [ "$SUBSTRING" = "/usr/share:/usr/share/ubuntu" ] \
+            || { echo "SUBSTRING: $SUBSTRING"; exit 1; }
+          [ "$DEDUP" = "bar:baz:foo" ] \
+            || { echo "DEDUP: $DEDUP"; exit 1; }
+          [ "$EXPANDED" = "/runtime/home/tools" ] \
+            || { echo "EXPANDED: $EXPANDED"; exit 1; }
+          [ "$COMMAND" = "command with space" ] \
+            || { echo "COMMAND: $COMMAND"; exit 1; }
+          [ "$ARITHMETIC" = "42" ] \
+            || { echo "ARITHMETIC: $ARITHMETIC"; exit 1; }
+          [ "$BACKTICK" = "backtick" ] \
+            || { echo "BACKTICK: $BACKTICK"; exit 1; }
+          [ "$LITERAL" = "\$NOT_EXPANDED/entry" ] \
+            || { echo "LITERAL: $LITERAL"; exit 1; }
+          [ "$ESCAPED_QUOTE_GLOB" = "\"*" ] \
+            || { echo "ESCAPED_QUOTE_GLOB: $ESCAPED_QUOTE_GLOB"; exit 1; }
+          [ "$GLOB" = "[a-z]" ] \
+            || { echo "GLOB: $GLOB"; exit 1; }
+          [ "$SEPARATOR" = "a:b" ] \
+            || { echo "SEPARATOR: $SEPARATOR"; exit 1; }
+          [ "$BOTH" = "front:middle:fallback" ] \
+            || { echo "BOTH: $BOTH"; exit 1; }
+          [ "$TRAILING" = "/last:/first" ] \
+            || { echo "TRAILING: $TRAILING"; exit 1; }
+
+          # Export the target even when every configured entry already exists.
+          env | grep -qx "COMPLETE=qux" \
+            || { echo "COMPLETE was not exported"; exit 1; }
+          env | grep -qx "__HM_SESS_VARS_MERGED=1" \
+            || { echo "merge marker was not exported"; exit 1; }
+
+          for scratch in __hm_mode __hm_name __hm_sep __hm_cur __hm_add \
+                         __hm_entry __hm_reposition __hm_work __hm_pre __hm_post; do
+            eval "value=\''${$scratch-unset}"
+            [ "$value" = unset ] || { echo "$scratch leaked: $value"; exit 1; }
+          done
+          command -v __hm_merge >/dev/null \
+            && { echo "__hm_merge was not removed"; exit 1; }
+
+          exit 0
+        ' shell "$script" \
+        || fail "$shellBin: first-merge search variable semantics broken"
+
+      # Later merges preserve existing positions and remain idempotent.
+      env __HM_SESS_VARS_MERGED=1 \
+        HOME=/runtime/home \
+        EMPTY_ENTRY="" \
+        SUBSTRING="/usr/share/ubuntu:/usr/share" \
+        DEDUP="baz" \
+        BOTH="fallback:middle:front" \
+        COMPLETE="qux" \
+        TRAILING="/first:/last" \
+        "$shellBin" -uc '
+          unset EXPANDED LITERAL GLOB SEPARATOR NOT_EXPANDED
+          . "$1"
+          [ "$SUBSTRING" = "/usr/share/ubuntu:/usr/share" ] \
+            || { echo "SUBSTRING moved on a later merge: $SUBSTRING"; exit 1; }
+          [ "$DEDUP" = "bar:foo:baz" ] \
+            || { echo "DEDUP: $DEDUP"; exit 1; }
+          [ "$BOTH" = "fallback:middle:front" ] \
+            || { echo "BOTH moved on a later merge: $BOTH"; exit 1; }
+          [ "$TRAILING" = "/first:/last" ] \
+            || { echo "TRAILING moved on a later merge: $TRAILING"; exit 1; }
+          first="$SUBSTRING:$DEDUP:$BOTH:$TRAILING"
+          . "$1"
+          [ "$SUBSTRING:$DEDUP:$BOTH:$TRAILING" = "$first" ] \
+            || { echo "not idempotent: $SUBSTRING:$DEDUP:$BOTH:$TRAILING"; exit 1; }
+          exit 0
+        ' shell "$script" \
+        || fail "$shellBin: later-merge search variable semantics broken"
+    done
+  '';
+}


### PR DESCRIPTION
### Description

Adds the POSIX `__hm_merge` helper and one public
`mergeSearchVariables { prepend, append }` generator. The generator emits the
complete sourceable block: helper definition, merge calls, process marker, and
cleanup. Keeping those stages private prevents callers from omitting or
misordering them. Nothing consumes the generator yet; `prependToVar` is
untouched, so this PR changes no generated output.

Adding an already-present entry never duplicates it. On the first merge in a
process tree, detected through `__HM_SESS_VARS_MERGED`, configured entries take
configured precedence and may be repositioned. On later merges, existing
entries keep their position, so re-sourcing cannot reorder a path that
`nix develop`, direnv, or a wrapper put in front. Removal is join-based rather
than token-splitting so entries containing the separator stay idempotent.

The in-tree test suite (`tests/lib/shell/search-variable-merge.nix`) exercises
the complete generator across Bash, dash, and Zsh. It covers expansion,
prepend and append ordering, marker export, cleanup, and repeated sourcing.

Part of splitting #9735 into independently reviewable changes; the stack as a
whole supersedes that PR.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt`.
- [x] Code tested through `nix build .#test-all`.
- [x] Test cases updated/added.
- [x] Commit messages follow the `{component}: {description}` format.
