### PR TITLE
home-environment: merge search variables idempotently

### DIFF
--- a/docs/release-notes/rl-2611.md
+++ b/docs/release-notes/rl-2611.md
@@ -26,6 +26,27 @@ This release has the following notable changes:
   detect their device. Previously, a daemon that started before the render node
   existed fell back to CPU and never recovered until it was restarted manually.
 
+- Search-path style session variables ([](#opt-home.sessionPath) and
+  [](#opt-home.sessionSearchVariables)) are now merged rather than
+  concatenated. An entry already present in the inherited value is no longer
+  duplicated. Statically empty entries produce a warning, and all entries that
+  expand to an empty string are dropped. Write `.` if you meant the current
+  directory. If you relied on a trailing separator, which tools such as `man`
+  read as "splice the system default in here", set that variable through
+  [](#opt-home.sessionVariables) instead.
+
+- `config.lib.shell.prependToVar` and `lib.hm.shell.prependToVar` were removed.
+  They produced a self-referential value, which is no longer how Home Manager
+  builds search paths. Use `mergeSearchVariables`, which emits the complete
+  helper, merge calls, process marker, and cleanup:
+
+  ```nix
+  config.lib.shell.mergeSearchVariables {
+    prepend.MANPATH = [ "$HOME/share/man" ];
+    append.MANPATH = [ "/usr/share/man" ];
+  }
+  ```
+
 ## State Version Changes {#sec-release-26.11-state-version-changes}
 
 The state version in this release includes the changes below. These

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -12,6 +12,19 @@ let
 
   cfg = config.home;
 
+  hasEmptySearchVariableEntry = lib.any (lib.any (value: value == "")) (
+    lib.attrValues cfg.sessionSearchVariables
+  );
+
+  # Generated sections normally end in one newline. Remove it before joining
+  # so their boundaries do not depend on the preceding section.
+  mkSections =
+    sections:
+    lib.concatStringsSep "\n\n" (
+      map (section: lib.removeSuffix "\n" section) (lib.filter (section: section != "") sections)
+    )
+    + "\n";
+
   languageSubModule = types.submodule {
     options = {
       base = mkOption {
@@ -360,11 +373,16 @@ in
       description = ''
         Extra directories to prepend to {env}`PATH`.
 
-        These directories are added to the {env}`PATH` variable in a
-        double-quoted context, so expressions like `$HOME` are
-        expanded by the shell. However, since expressions like `~` or
-        `*` are escaped, they will end up in the {env}`PATH`
-        verbatim.
+        Entries already present in the inherited value are not duplicated.
+        Home Manager warns about entries that are statically empty. All entries
+        that expand to an empty string are ignored; write `.` if you mean the
+        current directory.
+
+        Values are expanded in a double-quoted shell context. Parameter and
+        command expansions are evaluated. Write `\"` for a literal `"`. Plain
+        glob and tilde characters remain literal while the surrounding
+        double-quoted context is intact. `\$` is a literal `$` and `\\` a
+        literal backslash.
       '';
     };
 
@@ -381,11 +399,19 @@ in
         Extra directories to prepend to arbitrary PATH-like
         environment variables (e.g.: {env}`MANPATH`). The values
         will be concatenated by `:`.
-        These directories are added to the environment variable in a
-        double-quoted context, so expressions like `$HOME` are
-        expanded by the shell. However, since expressions like `~` or
-        `*` are escaped, they will end up in the environment
-        verbatim.
+
+        Entries already present in the inherited value are not duplicated.
+        Home Manager warns about entries that are statically empty. All entries
+        that expand to an empty string are ignored; write `.` if you mean the
+        current directory. To keep a trailing separator, which some tools such
+        as `man` read as "splice in the system default here", set the variable
+        through [](#opt-home.sessionVariables) instead.
+
+        Values are expanded in a double-quoted shell context. Parameter and
+        command expansions are evaluated. Write `\"` for a literal `"`. Plain
+        glob and tilde characters remain literal while the surrounding
+        double-quoted context is intact. `\$` is a literal `$` and `\\` a
+        literal backslash.
       '';
     };
 
@@ -625,6 +651,12 @@ in
           home.enableNixpkgsReleaseCheck = false;
 
         to your configuration.
+      ''
+      ++ lib.optional hasEmptySearchVariableEntry ''
+        `home.sessionPath` or `home.sessionSearchVariables` contains an empty
+        entry, which Home Manager ignores. Write `.` to include the current
+        directory. If the empty entry has tool-specific meaning, set the
+        complete value through `home.sessionVariables` instead.
       '';
 
     home.username = lib.mkIf (lib.versionOlder config.home.stateVersion "20.09") (
@@ -663,20 +695,21 @@ in
     home.sessionVariablesPackage = pkgs.writeTextFile {
       name = "hm-session-vars.sh";
       destination = "/etc/profile.d/hm-session-vars.sh";
-      text = ''
-        # Only source this once.
-        if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
-        export __HM_SESS_VARS_SOURCED=1
-
-        ${config.lib.shell.exportAll cfg.sessionVariables}
-      ''
-      + lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (
-          env: values: config.lib.shell.export env (config.lib.shell.prependToVar ":" env values)
-        ) cfg.sessionSearchVariables
-      )
-      + "\n"
-      + cfg.sessionVariablesExtra;
+      text =
+        let
+          searchSection = config.lib.shell.mergeSearchVariables {
+            prepend = cfg.sessionSearchVariables;
+          };
+        in
+        mkSections [
+          ''
+            # Only source this once.
+            if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
+            export __HM_SESS_VARS_SOURCED=1''
+          (config.lib.shell.exportAll cfg.sessionVariables)
+          searchSection
+          cfg.sessionVariablesExtra
+        ];
     };
 
     home.sessionSearchVariables.PATH = lib.mkIf (cfg.sessionPath != [ ]) cfg.sessionPath;

--- a/modules/lib/fish-session-variables.nix
+++ b/modules/lib/fish-session-variables.nix
@@ -1,0 +1,76 @@
+{
+  config,
+  lib,
+  pkgs,
+}:
+
+let
+  inherit (config.lib) shell;
+
+  inherit (import ./session-search-shell.nix { inherit lib; }) assignDoubleQuoted;
+
+  sessionVarsFile = "etc/profile.d/hm-session-vars.fish";
+
+  merges = lib.mapAttrsToList (env: values: {
+    inherit env;
+    candidates = lib.imap0 (index: value: {
+      name = "__hm_candidate_${env}_${toString index}";
+      inherit value;
+    }) (lib.filter (value: value != "") values);
+  }) config.home.sessionSearchVariables;
+
+  candidateNames = lib.concatMap (merge: map (candidate: candidate.name) merge.candidates) merges;
+
+  prelude = pkgs.writeText "hm-session-vars-fish-prelude.sh" ''
+    if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
+    export __HM_SESS_VARS_SOURCED=1
+
+    ${shell.exportAll config.home.sessionVariables}
+  '';
+
+  extra = pkgs.writeText "hm-session-vars-fish-extra.sh" config.home.sessionVariablesExtra;
+
+  # Translate assignments and calls together so an entry can observe earlier
+  # search-variable merges. The helper itself remains native Fish.
+  mergeScript = pkgs.writeText "hm-session-vars-fish-merges.sh" (
+    lib.concatLines (
+      map (
+        merge:
+        lib.concatLines [
+          (lib.concatMapStringsSep "\n" (
+            candidate: assignDoubleQuoted candidate.name candidate.value
+          ) merge.candidates)
+          (
+            "__hm_merge prepend ${merge.env} :"
+            + lib.optionalString (merge.candidates != [ ]) (
+              " " + lib.concatMapStringsSep " " (candidate: "\"\$${candidate.name}\"") merge.candidates
+            )
+          )
+        ]
+      ) merges
+      ++ [ "export __HM_SESS_VARS_MERGED=1" ]
+    )
+  );
+
+  hasMerges = merges != [ ];
+in
+pkgs.runCommandLocal "hm-session-vars.fish" { } ''
+  mkdir -p "$(dirname "$out/${sessionVarsFile}")"
+  {
+    ${lib.optionalString hasMerges "cat ${./session-search-merge.fish}"}
+
+    echo "function setup_hm_session_vars"
+    ${
+      # One declaration per name: `set -l a b c` declares only `a`, with the
+      # rest as its value.
+      lib.concatMapStringsSep "\n" (name: ''echo "  set -l ${name}"'') candidateNames
+    }
+    ${pkgs.buildPackages.babelfish}/bin/babelfish < ${prelude}
+    ${lib.optionalString hasMerges "${pkgs.buildPackages.babelfish}/bin/babelfish < ${mergeScript}"}
+    ${pkgs.buildPackages.babelfish}/bin/babelfish < ${extra}
+    echo "end"
+
+    echo "setup_hm_session_vars"
+    echo "functions -e setup_hm_session_vars${lib.optionalString hasMerges " __hm_merge"}"
+  } > "$out/${sessionVarsFile}"
+''

--- a/modules/lib/session-search-merge.fish
+++ b/modules/lib/session-search-merge.fish
@@ -1,0 +1,138 @@
+# Native counterpart to session-search-merge.sh. Babelfish cannot translate
+# the POSIX helper's quoted pattern removal. Fish also stores names ending in
+# PATH as lists and colon-joins them on export, so inherited path values must be
+# read in joined form.
+#
+#   __hm_merge <prepend|append> <NAME> <SEP> [ENTRY...]
+#
+# SEP must be `:` when NAME ends in PATH, matching Fish's path-variable rule.
+#
+# Match the joined string, not split elements, so an entry containing the
+# separator remains one unit. `string replace` is literal, so glob and regex
+# characters are compared as written.
+#
+# Keep this in step with session-search-merge.sh: any observable behavior
+# change there must be mirrored here, and both must produce identical results
+# for the same inputs.
+function __hm_merge
+    set -l __hm_mode $argv[1]
+    set -l __hm_name $argv[2]
+    set -l __hm_sep $argv[3]
+    set -l __hm_entries $argv[4..-1]
+
+    set -l __hm_seplen (string length -- $__hm_sep)
+    set -l __hm_values
+    if set -q $__hm_name
+        set __hm_values $$__hm_name
+    end
+
+    # Fish command substitutions trim trailing newlines. Mark the end before a
+    # transformation, then use split0 to recover the exact result.
+    set -l __hm_sentinel __HM_SESS_VARS_END
+    while string match -q -- "*$__hm_sentinel*" "$__hm_sep" $__hm_values $__hm_entries
+        set __hm_sentinel _$__hm_sentinel
+    end
+    set -l __hm_sentinel_pattern "$__hm_sentinel\\z"
+
+    # A trailing PATH in the name is Fish's rule for list-typed variables.
+    set -l __hm_is_path 0
+    if string match -q -- '*PATH' $__hm_name
+        set __hm_is_path 1
+    end
+
+    set -l __hm_cur ""
+    if set -q $__hm_name
+        if test $__hm_is_path -eq 1
+            if test (count $__hm_values) -eq 0
+                set __hm_values $__hm_sentinel
+            else
+                set __hm_values[-1] "$__hm_values[-1]$__hm_sentinel"
+            end
+            set __hm_cur (
+                string join -- $__hm_sep $__hm_values |
+                    string replace -r -- $__hm_sentinel_pattern "\\x00" |
+                    string split0
+            )[1]
+        else
+            set __hm_cur $__hm_values
+        end
+    end
+
+    # The first merge repositions entries; later merges preserve inherited
+    # positions. See session-search-merge.sh for the ordering rationale.
+    set -l __hm_reposition 0
+    # Match the POSIX helper's empty-marker behavior.
+    if test -z "$__HM_SESS_VARS_MERGED"
+        set __hm_reposition 1
+    end
+
+    set -l __hm_add ""
+    for __hm_entry in $__hm_entries
+        # Most search-path consumers interpret an empty entry as current
+        # directory.
+        test -n "$__hm_entry"
+        or continue
+
+        set -l __hm_probe "$__hm_sep$__hm_add$__hm_sep"
+        set -l __hm_deduped (
+            string replace -- "$__hm_sep$__hm_entry$__hm_sep" "$__hm_sep" "$__hm_probe$__hm_sentinel" |
+                string replace -r -- $__hm_sentinel_pattern "\\x00" |
+                string split0
+        )[1]
+        if test "$__hm_deduped" != "$__hm_probe"
+            continue
+        end
+
+        set -l __hm_work "$__hm_sep$__hm_cur$__hm_sep"
+        set -l __hm_stripped $__hm_work
+        while true
+            set -l __hm_next (
+                string replace -- "$__hm_sep$__hm_entry$__hm_sep" "$__hm_sep" "$__hm_stripped$__hm_sentinel" |
+                    string replace -r -- $__hm_sentinel_pattern "\\x00" |
+                    string split0
+            )[1]
+            test "$__hm_next" = "$__hm_stripped"
+            and break
+            set __hm_stripped $__hm_next
+        end
+
+        if test $__hm_reposition -eq 1
+            # Every replacement preserves the wrapper separators.
+            set __hm_stripped (
+                string sub -s (math $__hm_seplen + 1) -- "$__hm_stripped$__hm_sentinel" |
+                    string replace -r -- $__hm_sentinel_pattern "\\x00" |
+                    string split0
+            )[1]
+            set -l __hm_sep_pattern (string escape --style=regex "$__hm_sep")
+            set __hm_stripped (
+                string replace -r -- "$__hm_sep_pattern$__hm_sentinel_pattern" $__hm_sentinel "$__hm_stripped$__hm_sentinel" |
+                    string replace -r -- $__hm_sentinel_pattern "\\x00" |
+                    string split0
+            )[1]
+            set __hm_cur $__hm_stripped
+        else if test "$__hm_stripped" != "$__hm_work"
+            # Already present, and a later merge must not move it.
+            continue
+        end
+
+        if test -n "$__hm_add"
+            set __hm_add "$__hm_add$__hm_sep$__hm_entry"
+        else
+            set __hm_add $__hm_entry
+        end
+    end
+
+    if test -n "$__hm_add"
+        if test -n "$__hm_cur"
+            if test "$__hm_mode" = prepend
+                set __hm_cur "$__hm_add$__hm_sep$__hm_cur"
+            else
+                set __hm_cur "$__hm_cur$__hm_sep$__hm_add"
+            end
+        else
+            set __hm_cur $__hm_add
+        end
+    end
+
+    set -gx $__hm_name $__hm_cur
+end

--- a/modules/lib/session-search-shell.nix
+++ b/modules/lib/session-search-shell.nix
@@ -1,0 +1,36 @@
+{ lib }:
+
+let
+  # Preserve shell expansion inside a double-quoted word while making literal
+  # backslashes safe. Existing shell escapes keep their meaning.
+  escapeDoubleQuoted =
+    let
+      escapeLiteral = lib.replaceStrings [ "\\" ] [ "\\\\" ];
+      handlePart =
+        part:
+        if lib.isString part then
+          escapeLiteral part
+        else
+          let
+            c = lib.head part;
+          in
+          # Only these characters have backslash escapes inside double quotes.
+          if
+            lib.elem c [
+              "$"
+              "\\"
+              "\""
+              "`"
+            ]
+          then
+            "\\${c}"
+          else
+            escapeLiteral "\\${c}";
+    in
+    value: lib.concatMapStrings handlePart (builtins.split ''\\(.)'' value);
+in
+{
+  inherit escapeDoubleQuoted;
+
+  assignDoubleQuoted = name: value: ''${name}="${escapeDoubleQuoted value}"'';
+}

--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -2,6 +2,8 @@
 
 let
 
+  sessionSearchShell = import ./session-search-shell.nix { inherit lib; };
+
   mkShellIntegrationOption =
     name:
     {
@@ -58,26 +60,6 @@ let
       } items;
     in
     foldResult.finishedLines ++ lib.optional (foldResult.currentLine != "") foldResult.currentLine;
-  # Preserve parameter, command, and arithmetic expansion inside a double-quoted
-  # shell word. Existing escapes keep their shell meaning; other backslashes stay
-  # literal.
-  escapeDoubleQuoted =
-    let
-      escapeLiteral = lib.replaceStrings [ "\\" ] [ "\\\\" ];
-      handlePart =
-        part:
-        if lib.isString part then
-          escapeLiteral part
-        else
-          let
-            c = lib.head part;
-          in
-          # These four escapes already have double-quoted shell semantics. Escape
-          # every other backslash, including line continuations, as literal data.
-          if c == "$" || c == "\\" || c == "\"" || c == "`" then "\\${c}" else escapeLiteral "\\${c}";
-    in
-    value: lib.concatMapStrings handlePart (builtins.split ''\\(.)'' value);
-
   # POSIX sh does not define local variables, so remove every scratch name after
   # all calls.
   mergeScratchVariables = [
@@ -101,9 +83,9 @@ let
         "__hm_merge"
         mode
         name
-        ''"${escapeDoubleQuoted sep}"''
+        ''"${sessionSearchShell.escapeDoubleQuoted sep}"''
       ]
-      ++ map (value: ''"${escapeDoubleQuoted value}"'') values
+      ++ map (value: ''"${sessionSearchShell.escapeDoubleQuoted value}"'') values
     );
 
   mergeSearchVariables =
@@ -170,15 +152,6 @@ in
     ```
   */
   inherit mergeSearchVariables;
-
-  # Produces a Bourne shell-like statement that prepends new values to
-  # a possibly existing variable, using sep(arator).
-  # Example:
-  #   prependToVar ":" "PATH" [ "$HOME/bin" "$HOME/.local/bin" ]
-  #   => "$HOME/bin:$HOME/.local/bin:${PATH:+:}${PATH-}"
-  prependToVar =
-    sep: n: v:
-    "${lib.concatStringsSep sep v}\${${n}:+${sep}}\${${n}-}";
 
   # Given an attribute set containing shell variable names and their
   # assignment, this function produces a string containing an export

--- a/modules/misc/news/2026/08/2026-08-27_12-30-00.nix
+++ b/modules/misc/news/2026/08/2026-08-27_12-30-00.nix
@@ -1,0 +1,16 @@
+{ config, ... }:
+{
+  time = "2026-08-27T12:30:00+00:00";
+  condition = config.home.sessionPath != [ ] || config.home.sessionSearchVariables != { };
+  message = ''
+    Search-path style session variables are now merged instead of
+    concatenated. An entry already present in the inherited value is not
+    duplicated. Statically empty entries produce a warning, and all entries
+    that expand to an empty string are dropped.
+
+    If you used an empty entry to mean "the current directory", write `.`
+    instead. If you used a trailing separator so that a tool such as `man`
+    splices in its own system default, set that variable through
+    {option}`home.sessionVariables`, which is still emitted verbatim.
+  '';
+}

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -404,14 +404,10 @@ let
     } "env HOME=$(mktemp -d) fish_indent < $textPath > $out";
 
   sessionVarsFile = "etc/profile.d/hm-session-vars.fish";
-  sessionVarsPkg = pkgs.runCommandLocal "hm-session-vars.fish" { } ''
-    mkdir -p "$(dirname $out/${sessionVarsFile})"
-    (echo "function setup_hm_session_vars;"
-    ${pkgs.buildPackages.babelfish}/bin/babelfish \
-      <${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh
-    echo "end"
-    echo "setup_hm_session_vars") > $out/${sessionVarsFile}
-  '';
+  # Fish gets a generated file rather than babelfish over the POSIX one:
+  # babelfish cannot translate the search-variable merge, and fish needs list
+  # semantics for names ending in PATH. See modules/lib/fish-session-variables.nix.
+  sessionVarsPkg = import ../lib/fish-session-variables.nix { inherit config lib pkgs; };
   sourceHandlersStr =
     let
       handlerAttrs = [

--- a/modules/targets/darwin/terminfo.nix
+++ b/modules/targets/darwin/terminfo.nix
@@ -16,7 +16,10 @@ in
     # we need `/usr/share/terminfo` appended as an explicit fallback: once
     # TERMINFO_DIRS is set, ncurses stops searching the default system path.
     home.sessionVariables = {
-      TERMINFO_DIRS = lib.mkDefault "${profileDirectory}/share/terminfo:$TERMINFO_DIRS\${TERMINFO_DIRS:+:}/usr/share/terminfo";
+      # `${TERMINFO_DIRS-}` rather than `$TERMINFO_DIRS`: the generated
+      # hm-session-vars.sh runs under `set -u` in some shells, where a bare
+      # reference to an unset variable aborts the whole file.
+      TERMINFO_DIRS = lib.mkDefault "${profileDirectory}/share/terminfo:\${TERMINFO_DIRS-}\${TERMINFO_DIRS:+:}/usr/share/terminfo";
     };
 
     home.sessionVariablesExtra = ''

--- a/tests/modules/home-environment/session-path.nix
+++ b/tests/modules/home-environment/session-path.nix
@@ -1,14 +1,32 @@
 {
   home.sessionPath = [
+    ""
     "bar"
     "baz"
     "foo"
   ];
 
+  test.asserts.warnings.expected = [
+    ''
+      `home.sessionPath` or `home.sessionSearchVariables` contains an empty
+      entry, which Home Manager ignores. Write `.` to include the current
+      directory. If the empty entry has tool-specific meaning, set the
+      complete value through `home.sessionVariables` instead.
+    ''
+  ];
+
   nmt.script = ''
     hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
     assertFileExists $hmSessVars
-    assertFileContains $hmSessVars \
-      'export PATH="bar:baz:foo''${PATH:+:}''${PATH-}"'
+
+    # The generated file merges rather than concatenating, so assert the
+    # resulting value instead of the text that produces it.
+    (
+      export PATH=/inherited/bin:baz
+      unset __HM_SESS_VARS_SOURCED __HM_SESS_VARS_MERGED
+      . "$TESTED/$hmSessVars"
+      [ "$PATH" = "bar:baz:foo:/inherited/bin" ] \
+        || { echo "PATH: $PATH"; exit 1; }
+    ) || fail "home.sessionPath entries were not prepended"
   '';
 }

--- a/tests/modules/home-environment/session-search-variables.nix
+++ b/tests/modules/home-environment/session-search-variables.nix
@@ -12,29 +12,36 @@
   nmt.script = ''
     hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
     assertFileExists $hmSessVars
-    testExport=$(grep '^export TEST=' "$TESTED/$hmSessVars")
-    trailingExports=$(grep '^export TRAILING=' "$TESTED/$hmSessVars")
-    unsetExport=$(grep '^export UNSET=' "$TESTED/$hmSessVars")
     (
       set -u
-      unset TEST UNSET
-      eval "$testExport"
-      eval "$unsetExport"
+      unset TEST UNSET __HM_SESS_VARS_SOURCED __HM_SESS_VARS_MERGED
+      . "$TESTED/$hmSessVars"
       [ "$TEST" = "bar:baz:foo" ] \
         || { echo "TEST after unset source: $TEST"; exit 1; }
       [ "$UNSET" = "configured" ] \
         || { echo "UNSET after unset source: $UNSET"; exit 1; }
-    ) || fail "search variables were not safe for unset targets"
-
-    (
-      set -u
-      TEST=/inherited
-      eval "$testExport"
-      eval "$trailingExports"
-      [ "$TEST" = "bar:baz:foo:/inherited" ] \
-        || { echo "TEST after inherited source: $TEST"; exit 1; }
       [ "$TRAILING" = "configured:inherited" ] \
         || { echo "TRAILING after source: $TRAILING"; exit 1; }
-    ) || fail "inherited search variable was not preserved"
+    ) || fail "search variables were not safe for unset targets"
+
+    # First source in a process tree: configured entries take the precedence
+    # they were configured with, so the inherited `baz` moves.
+    (
+      export TEST=/inherited:baz
+      unset __HM_SESS_VARS_SOURCED __HM_SESS_VARS_MERGED
+      . "$TESTED/$hmSessVars"
+      [ "$TEST" = "bar:baz:foo:/inherited" ] \
+        || { echo "TEST after first source: $TEST"; exit 1; }
+    ) || fail "search variable entries were not prepended"
+
+    # A later source must add only what is missing and leave positions alone.
+    (
+      export TEST=/inherited:baz
+      export __HM_SESS_VARS_MERGED=1
+      unset __HM_SESS_VARS_SOURCED
+      . "$TESTED/$hmSessVars"
+      [ "$TEST" = "bar:foo:/inherited:baz" ] \
+        || { echo "TEST after later source: $TEST"; exit 1; }
+    ) || fail "a later source reordered existing entries"
   '';
 }

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -20,7 +20,6 @@ let
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
     export XDG_STATE_HOME="/home/hm-user/.local/state"
-
   '';
 
   darwinExpected = ''
@@ -31,7 +30,7 @@ let
     export IS_EMPTY=""
     export IS_FALSE="false"
     export IS_TRUE="true"
-    export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:$TERMINFO_DIRS''${TERMINFO_DIRS:+:}/usr/share/terminfo"
+    export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:''${TERMINFO_DIRS-}''${TERMINFO_DIRS:+:}/usr/share/terminfo"
     export V1="v1"
     export V2="v2-v1"
     export XDG_BIN_HOME="/home/hm-user/.local/bin"

--- a/tests/modules/misc/debug/default.nix
+++ b/tests/modules/misc/debug/default.nix
@@ -17,12 +17,16 @@
         [ -L $TESTED/home-path/lib/debug/curl ] \
           || fail "Debug-symbols for pkgs.curl should exist in \`/home-path/lib/debug'!"
 
-        #source $TESTED/home-path/etc/profile.d/hm-session-vars.sh
-        #[[ "$NIX_DEBUG_INFO_DIRS" =~ /lib/debug$ ]] \
-          #|| fail "Invalid NIX_DEBUG_INFO_DIRS!"
         assertFileExists home-path/etc/profile.d/hm-session-vars.sh
-        assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
-            'NIX_DEBUG_INFO_DIRS=.*/lib/debug'
+        (
+          export NIX_DEBUG_INFO_DIRS=/inherited/debug
+          unset __HM_SESS_VARS_SOURCED __HM_SESS_VARS_MERGED
+          . "$TESTED/home-path/etc/profile.d/hm-session-vars.sh"
+          case "$NIX_DEBUG_INFO_DIRS" in
+            */lib/debug:/inherited/debug) ;;
+            *) echo "NIX_DEBUG_INFO_DIRS: $NIX_DEBUG_INFO_DIRS"; exit 1 ;;
+          esac
+        ) || fail "Invalid NIX_DEBUG_INFO_DIRS!"
 
         # We need to override NIX_DEBUG_INFO_DIRS here as $HOME evaluates to the home
         # of the user who executes this testcase :/

--- a/tests/modules/misc/nix/example-channels-xdg.nix
+++ b/tests/modules/misc/nix/example-channels-xdg.nix
@@ -24,8 +24,13 @@ in
   };
 
   nmt.script = ''
-    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
-      'export NIX_PATH="/home/hm-user/.local/state/nix/defexpr/50-home-manager''${NIX_PATH:+:}''${NIX_PATH-}"'
+    (
+      export NIX_PATH=/inherited
+      unset __HM_SESS_VARS_SOURCED __HM_SESS_VARS_MERGED
+      . "$TESTED/home-path/etc/profile.d/hm-session-vars.sh"
+      [ "$NIX_PATH" = "/home/hm-user/.local/state/nix/defexpr/50-home-manager:/inherited" ] \
+        || { echo "NIX_PATH: $NIX_PATH"; exit 1; }
+    ) || fail "nix.nixPath was not prepended to NIX_PATH"
     assertFileContent \
       home-files/.local/state/nix/defexpr/50-home-manager/example/default.nix \
       ${exampleChannel}/default.nix

--- a/tests/modules/misc/nix/example-channels.nix
+++ b/tests/modules/misc/nix/example-channels.nix
@@ -16,8 +16,13 @@ in
   };
 
   nmt.script = ''
-    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
-      'export NIX_PATH="/home/hm-user/.nix-defexpr/50-home-manager''${NIX_PATH:+:}''${NIX_PATH-}"'
+    (
+      export NIX_PATH=/inherited
+      unset __HM_SESS_VARS_SOURCED __HM_SESS_VARS_MERGED
+      . "$TESTED/home-path/etc/profile.d/hm-session-vars.sh"
+      [ "$NIX_PATH" = "/home/hm-user/.nix-defexpr/50-home-manager:/inherited" ] \
+        || { echo "NIX_PATH: $NIX_PATH"; exit 1; }
+    ) || fail "nix.nixPath was not prepended to NIX_PATH"
     assertFileContent \
       home-files/.nix-defexpr/50-home-manager/example/default.nix \
       ${exampleChannel}/default.nix

--- a/tests/modules/misc/nix/example-settings.nix
+++ b/tests/modules/misc/nix/example-settings.nix
@@ -42,7 +42,12 @@
       home-files/.config/nix/nix.conf \
       ${./example-settings-expected.conf}
 
-    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
-      'export NIX_PATH="/existing:/a:/b/c''${NIX_PATH:+:}''${NIX_PATH-}"'
+    (
+      export NIX_PATH=/inherited
+      unset __HM_SESS_VARS_SOURCED __HM_SESS_VARS_MERGED
+      . "$TESTED/home-path/etc/profile.d/hm-session-vars.sh"
+      [ "$NIX_PATH" = "/existing:/a:/b/c:/inherited" ] \
+        || { echo "NIX_PATH: $NIX_PATH"; exit 1; }
+    ) || fail "nix.nixPath was not prepended to NIX_PATH"
   '';
 }

--- a/tests/modules/misc/xdg/local-bin-in-path.nix
+++ b/tests/modules/misc/xdg/local-bin-in-path.nix
@@ -3,8 +3,14 @@
   xdg.localBinInPath = true;
 
   nmt.script = ''
-    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
-    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
-      'export PATH="/home/hm-user/.local/bin''${PATH:+:}''${PATH-}"'
+    hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
+    assertFileExists $hmSessVars
+    (
+      export PATH=/inherited/bin
+      unset __HM_SESS_VARS_SOURCED __HM_SESS_VARS_MERGED
+      . "$TESTED/$hmSessVars"
+      [ "$PATH" = "/home/hm-user/.local/bin:/inherited/bin" ] \
+        || { echo "PATH: $PATH"; exit 1; }
+    ) || fail "xdg.localBinInPath did not prepend the local bin directory"
   '';
 }

--- a/tests/modules/misc/xdg/system-dirs.nix
+++ b/tests/modules/misc/xdg/system-dirs.nix
@@ -38,15 +38,11 @@
       assertFileExists $sessionVarsFile
       assertFileContains $sessionVarsFile \
         'export XDG_CONFIG_DIRS="/plain-config"'
-      assertFileContains $sessionVarsFile \
-        'export XDG_CONFIG_DIRS="/existing-config:/etc/xdg:/foo/bar''${XDG_CONFIG_DIRS:+:}''${XDG_CONFIG_DIRS-}"'
-      assertFileContains $sessionVarsFile \
-        'export XDG_DATA_DIRS="/forced-data''${XDG_DATA_DIRS:+:}''${XDG_DATA_DIRS-}"'
 
       (
         XDG_CONFIG_DIRS=/inherited-config
         XDG_DATA_DIRS=/inherited-data
-        unset __HM_SESS_VARS_SOURCED
+        unset __HM_SESS_VARS_SOURCED __HM_SESS_VARS_MERGED
         . "$TESTED/$sessionVarsFile"
         [ "$XDG_CONFIG_DIRS" = "/existing-config:/etc/xdg:/foo/bar:/plain-config" ] \
           || { echo "XDG_CONFIG_DIRS: $XDG_CONFIG_DIRS"; exit 1; }

--- a/tests/modules/programs/fish/default.nix
+++ b/tests/modules/programs/fish/default.nix
@@ -1,4 +1,5 @@
 {
+  fish-session-search-variables = ./session-search-variables.nix;
   fish-abbrs = ./abbrs.nix;
   fish-home-shell-aliases-prefer-abbrs = ./home-shell-aliases-prefer-abbrs.nix;
   fish-format-scripts = ./format-scripts.nix;

--- a/tests/modules/programs/fish/session-search-variables.nix
+++ b/tests/modules/programs/fish/session-search-variables.nix
@@ -1,0 +1,305 @@
+{
+  lib,
+  realPkgs,
+  ...
+}:
+
+let
+  variables = [
+    "ALL_EMPTY"
+    "BACKSLASH"
+    "BACKTICK"
+    "COMMAND"
+    "CONSUMED"
+    "DUPLICATE"
+    "EARLIER"
+    "EMPTY_FIELDS"
+    "EMPTY_FIELDSPATH"
+    "EMPTYPATH"
+    "ESCAPED_QUOTE_GLOB"
+    "EXPANDED"
+    "GLOB"
+    "LITERAL"
+    "LATER"
+    "RUNTIME_EMPTY"
+    "RUNTIME_MIXED"
+    "SEPARATOR"
+    "SUBSTRING"
+    "TESTPATH"
+    "TEST_DIRS"
+  ];
+
+  scenarios = [
+    {
+      name = "first";
+      environment = {
+        CONSUMED = "configured";
+        DUPLICATE = "a:x:a";
+        EARLIER = "old";
+        EMPTY_ENTRY = "";
+        EMPTY_FIELDS = ":middle:";
+        EMPTY_FIELDSPATH = ":middle:";
+        EMPTYPATH = "";
+        LATER = "base";
+        SEPARATOR = "x:a:b:y";
+        SUBSTRING = "/usr/share/ubuntu:/usr/share";
+        TESTPATH = "/sys/two:/hm/two";
+        TEST_DIRS = "/sys/dirs";
+      };
+      expected = {
+        ALL_EMPTY = "";
+        BACKSLASH = "tail\\";
+        BACKTICK = "backtick";
+        COMMAND = "command with space";
+        CONSUMED = "configured";
+        DUPLICATE = "a:x";
+        EARLIER = "configured:old";
+        EMPTY_FIELDS = "added::middle:";
+        EMPTY_FIELDSPATH = "added::middle:";
+        EMPTYPATH = "configured";
+        ESCAPED_QUOTE_GLOB = "\"*";
+        EXPANDED = "/runtime/home/tools";
+        GLOB = "[a-z]";
+        LITERAL = "$NOT_EXPANDED/entry";
+        LATER = "configured:old:base";
+        RUNTIME_EMPTY = "";
+        RUNTIME_MIXED = "kept";
+        SEPARATOR = "a:b:x:y";
+        SUBSTRING = "/usr/share:/usr/share/ubuntu";
+        TESTPATH = "/hm/one:/hm/two:/sys/two";
+        TEST_DIRS = "/hm/dirs:/sys/dirs";
+      };
+    }
+    {
+      name = "later";
+      environment = {
+        CONSUMED = "configured";
+        DUPLICATE = "x:a";
+        EARLIER = "old:configured";
+        EMPTY_ENTRY = "";
+        EMPTY_FIELDS = ":middle:added:";
+        EMPTY_FIELDSPATH = ":middle:added:";
+        EMPTYPATH = "configured";
+        LATER = "base";
+        SEPARATOR = "x:a:b:y";
+        SUBSTRING = "/usr/share/ubuntu:/usr/share";
+        TESTPATH = "/sys/two:/hm/two";
+        TEST_DIRS = "/sys/dirs:/hm/dirs";
+        __HM_SESS_VARS_MERGED = "1";
+      };
+      expected = {
+        ALL_EMPTY = "";
+        BACKSLASH = "tail\\";
+        BACKTICK = "backtick";
+        COMMAND = "command with space";
+        CONSUMED = "configured";
+        DUPLICATE = "x:a";
+        EARLIER = "old:configured";
+        EMPTY_FIELDS = ":middle:added:";
+        EMPTY_FIELDSPATH = ":middle:added:";
+        EMPTYPATH = "configured";
+        ESCAPED_QUOTE_GLOB = "\"*";
+        EXPANDED = "/runtime/home/tools";
+        GLOB = "[a-z]";
+        LITERAL = "$NOT_EXPANDED/entry";
+        LATER = "old:configured:base";
+        RUNTIME_EMPTY = "";
+        RUNTIME_MIXED = "kept";
+        SEPARATOR = "x:a:b:y";
+        SUBSTRING = "/usr/share/ubuntu:/usr/share";
+        TESTPATH = "/hm/one:/sys/two:/hm/two";
+        TEST_DIRS = "/sys/dirs:/hm/dirs";
+      };
+    }
+  ];
+
+  newlineValue = "\nlead\n__HM_SESS_VARS_END\ntrail\n";
+
+  renderExpected =
+    expected: lib.concatMapStrings (name: "${name}=set:${expected.${name}}\n") variables;
+
+  environmentArguments =
+    environment:
+    lib.escapeShellArgs (
+      [ "HOME=/runtime/home" ] ++ lib.mapAttrsToList (name: value: "${name}=${value}") environment
+    );
+
+  posixProbe = realPkgs.writeShellScript "session-search-variables-posix-probe" ''
+    set -eu
+    . "$1"
+
+    for name in ${lib.escapeShellArgs variables}; do
+      eval "state=\''${$name+x}"
+      if [ "$state" = x ]; then
+        state=set
+        eval "value=\''${$name-}"
+      else
+        state=unset
+        value=
+      fi
+      printf '%s=%s:%s\n' "$name" "$state" "$value"
+    done
+  '';
+
+  fishProbe = realPkgs.writeText "session-search-variables-fish-probe.fish" ''
+    source $argv[1]
+
+    test (count $TESTPATH) -eq 3
+    or begin
+        echo "TESTPATH is not a three-element Fish path list" >&2
+        exit 1
+    end
+    test (count $EMPTYPATH) -eq 1
+    or begin
+        echo "EMPTYPATH did not retain one configured element" >&2
+        exit 1
+    end
+    test (count $EMPTY_FIELDSPATH) -eq 4
+    or begin
+        echo "EMPTY_FIELDSPATH did not retain its empty field" >&2
+        exit 1
+    end
+    test (count $TEST_DIRS) -eq 1
+    or begin
+        echo "TEST_DIRS should remain one scalar value" >&2
+        exit 1
+    end
+
+    for name in ${lib.escapeShellArgs variables}
+        if set -q $name
+            set state set
+            set value (string join : $$name)
+        else
+            set state unset
+            set value ""
+        end
+        printf '%s=%s:%s\n' $name $state $value
+    end
+
+    if functions -q __hm_merge
+        echo "__hm_merge was not removed" >&2
+        exit 1
+    end
+
+    exit 0
+  '';
+
+  posixNewlineProbe = realPkgs.writeShellScript "session-search-variables-posix-newline-probe" ''
+    set -eu
+    . "$1"
+    printf '%s\0%s\0' "$NEWLINE_SCALAR" "$NEWLINEPATH"
+  '';
+
+  fishNewlineProbe = realPkgs.writeText "session-search-variables-fish-newline-probe.fish" ''
+    source $argv[1]
+    test (count $NEWLINEPATH) -eq 1
+    or exit 1
+    printf '%s\0%s\0' "$NEWLINE_SCALAR" "$NEWLINEPATH[1]"
+  '';
+in
+{
+  programs.fish.enable = true;
+
+  home.sessionSearchVariables = {
+    ALL_EMPTY = [ "" ];
+    BACKSLASH = [ "tail\\" ];
+    BACKTICK = [ "`printf backtick`" ];
+    COMMAND = [ "$(printf \"%s\" \"command with space\")" ];
+    CONSUMED = [ "configured" ];
+    DUPLICATE = [
+      "a"
+      "a"
+    ];
+    EARLIER = [ "configured" ];
+    EMPTY_FIELDS = [ "added" ];
+    EMPTY_FIELDSPATH = [ "added" ];
+    EMPTYPATH = [ "configured" ];
+    ESCAPED_QUOTE_GLOB = [ "\\\"*" ];
+    EXPANDED = [ "$HOME/tools" ];
+    GLOB = [ "[a-z]" ];
+    LITERAL = [ "\\$NOT_EXPANDED/entry" ];
+    LATER = [ "$EARLIER" ];
+    NEWLINEPATH = [ newlineValue ];
+    NEWLINE_SCALAR = [ newlineValue ];
+    RUNTIME_EMPTY = [ "$EMPTY_ENTRY" ];
+    RUNTIME_MIXED = [
+      "kept"
+      "$EMPTY_ENTRY"
+    ];
+    SEPARATOR = [ "a:b" ];
+    SUBSTRING = [ "/usr/share" ];
+    TESTPATH = [
+      "/hm/one"
+      "/hm/two"
+    ];
+    TEST_DIRS = [ "/hm/dirs" ];
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      `home.sessionPath` or `home.sessionSearchVariables` contains an empty
+      entry, which Home Manager ignores. Write `.` to include the current
+      directory. If the empty entry has tool-specific meaning, set the
+      complete value through `home.sessionVariables` instead.
+    ''
+  ];
+
+  nmt.script = ''
+    posixSessionVars=home-path/etc/profile.d/hm-session-vars.sh
+    fishSessionVars=home-path/etc/profile.d/hm-session-vars.fish
+    assertFileExists $posixSessionVars
+    assertFileExists $fishSessionVars
+
+    ${lib.concatMapStringsSep "\n" (
+      scenario:
+      let
+        expected = realPkgs.writeText "session-search-variables-${scenario.name}.expected" (
+          renderExpected scenario.expected
+        );
+      in
+      ''
+        ${realPkgs.coreutils}/bin/env -i ${environmentArguments scenario.environment} \
+          ${posixProbe} "$TESTED/$posixSessionVars" > posix-${scenario.name} \
+          || fail "POSIX ${scenario.name} probe failed"
+        ${realPkgs.coreutils}/bin/env -i ${environmentArguments scenario.environment} \
+          ${realPkgs.fish}/bin/fish --no-config ${fishProbe} \
+          "$TESTED/$fishSessionVars" > fish-${scenario.name} \
+          || fail "Fish ${scenario.name} probe failed"
+
+        ${realPkgs.diffutils}/bin/diff -u ${expected} posix-${scenario.name} \
+          || fail "POSIX ${scenario.name}-merge output was incorrect"
+        ${realPkgs.diffutils}/bin/diff -u posix-${scenario.name} fish-${scenario.name} \
+          || fail "POSIX and Fish ${scenario.name}-merge output differed"
+      ''
+    ) scenarios}
+
+    printf '%s\0%s\0' ${lib.escapeShellArg newlineValue} ${lib.escapeShellArg newlineValue} \
+      > newline.expected
+
+    for marker in first later; do
+      markerArgs=()
+      if [[ $marker == later ]]; then
+        markerArgs+=(__HM_SESS_VARS_MERGED=1)
+      fi
+
+      ${realPkgs.coreutils}/bin/env -i HOME=/runtime/home EMPTY_ENTRY= EARLIER=old \
+        "''${markerArgs[@]}" \
+        ${lib.escapeShellArg "NEWLINE_SCALAR=${newlineValue}"} \
+        ${lib.escapeShellArg "NEWLINEPATH=${newlineValue}"} \
+        ${posixNewlineProbe} "$TESTED/$posixSessionVars" > newline-posix-$marker \
+        || fail "POSIX $marker newline probe failed"
+      ${realPkgs.coreutils}/bin/env -i HOME=/runtime/home EMPTY_ENTRY= EARLIER=old \
+        "''${markerArgs[@]}" \
+        ${lib.escapeShellArg "NEWLINE_SCALAR=${newlineValue}"} \
+        ${lib.escapeShellArg "NEWLINEPATH=${newlineValue}"} \
+        ${realPkgs.fish}/bin/fish --no-config ${fishNewlineProbe} \
+        "$TESTED/$fishSessionVars" > newline-fish-$marker \
+        || fail "Fish $marker newline probe failed"
+
+      ${realPkgs.diffutils}/bin/cmp newline.expected newline-posix-$marker \
+        || fail "POSIX $marker merge changed newline-bearing entries"
+      ${realPkgs.diffutils}/bin/cmp newline-posix-$marker newline-fish-$marker \
+        || fail "POSIX and Fish $marker newline output differed"
+    done
+  '';
+}

--- a/tests/modules/programs/man/mandoc.nix
+++ b/tests/modules/programs/man/mandoc.nix
@@ -24,8 +24,13 @@
       assertLinkExists home-files/.local/share/mandoc/man
 
       assertFileExists $hmSessVars
-      assertFileContains $hmSessVars \
-        'export MANPATH="/home/hm-user/.local/share/mandoc/man''${MANPATH:+:}''${MANPATH-}"'
+      (
+        export MANPATH=/inherited/man
+        unset __HM_SESS_VARS_SOURCED __HM_SESS_VARS_MERGED
+        . "$TESTED/$hmSessVars"
+        [ "$MANPATH" = "/home/hm-user/.local/share/mandoc/man:/inherited/man" ] \
+          || { echo "MANPATH: $MANPATH"; exit 1; }
+      ) || fail "mandoc man directory was not prepended to MANPATH"
     '';
   };
 }

--- a/tests/modules/targets-darwin/terminfo.nix
+++ b/tests/modules/targets-darwin/terminfo.nix
@@ -4,7 +4,7 @@
       sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
       assertFileExists $sessionVarsFile
       assertFileContains $sessionVarsFile \
-        'export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:$TERMINFO_DIRS''${TERMINFO_DIRS:+:}/usr/share/terminfo"'
+        'export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:''${TERMINFO_DIRS-}''${TERMINFO_DIRS:+:}/usr/share/terminfo"'
       assertFileContains $sessionVarsFile \
         'export TERM="$TERM"'
     '';


### PR DESCRIPTION
### Description

Switches `home.sessionPath` and `home.sessionSearchVariables` from string
concatenation to `config.lib.shell.mergeSearchVariables` from the previous PR.
Search order is unchanged on the first source. An already-present entry is no
longer duplicated, and later sources preserve its inherited position. Statically
empty configured entries produce an evaluation warning. All entries that expand
to empty at runtime are ignored.

Fish gets its own generator (`modules/lib/fish-session-variables.nix`) instead
of running the complete POSIX file through babelfish: babelfish rejects the
`${var%%"pattern"*}` expansion used by the merge helper, and Fish's list
semantics for `*PATH` names require explicit handling at the scalar boundary. A
shared fixture checks that the POSIX and Fish generators produce the same
observable values for first and later sources, cross-variable expansion,
escaping boundaries, empty values, duplicates, separator-bearing entries, and
values with leading, embedded, or trailing newlines.

Removes `prependToVar`, which has no consumers left and produced the
self-referential form this replaces. It was public API through `lib.hm.shell`,
so the release note covers the removal and shows how module authors can migrate
to the complete `mergeSearchVariables` generator.

Part of splitting #9735 into independently reviewable changes; the stack as a
whole supersedes that PR.

### Checklist

- [ ] Change is backwards compatible. (Removes `lib.hm.shell.prependToVar`; release note included.)
- [x] Code formatted with `nix fmt`.
- [x] Code tested through `nix build .#test-all`.
- [x] Test cases updated/added.
- [x] Commit messages follow the `{component}: {description}` format.
