### PR TITLE
home-environment: add sessionSearchVariablesAppend

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -13,7 +13,7 @@ let
   cfg = config.home;
 
   hasEmptySearchVariableEntry = lib.any (lib.any (value: value == "")) (
-    lib.attrValues cfg.sessionSearchVariables
+    lib.attrValues cfg.sessionSearchVariables ++ lib.attrValues cfg.sessionSearchVariablesAppend
   );
 
   # Generated sections normally end in one newline. Remove it before joining
@@ -415,6 +415,48 @@ in
       '';
     };
 
+    home.sessionSearchVariablesAppend = mkOption {
+      default = { };
+      type = with types; attrsOf (listOf str);
+      example = {
+        TERMINFO_DIRS = [ "/usr/share/terminfo" ];
+      };
+      description = ''
+        Extra directories to append to arbitrary PATH-like environment
+        variables. Entries not already present are placed after the inherited
+        value. Use [](#opt-home.sessionSearchVariables) for entries that should
+        precede it.
+
+        This exists because ordering the configured list is not enough.
+        `lib.mkAfter` can place an entry after other configured entries, but
+        it cannot place one after the value inherited at runtime, which is
+        what a fallback needs.
+
+        Only shell sessions consume this. There is no {file}`environment.d`
+        counterpart for either this option or
+        [](#opt-home.sessionSearchVariables), so neither reaches systemd user
+        services; a module that needs that sets
+        {option}`systemd.user.sessionVariables` separately.
+
+        Entries already present in the inherited value are not duplicated. On
+        the first merge in a process tree, configured entries are repositioned
+        according to the prepend or append option. Later merges preserve their
+        existing positions. An entry listed in both options is therefore
+        appended on the first merge, while later merges preserve its inherited
+        position.
+
+        Home Manager warns about entries that are statically empty. All entries
+        that expand to an empty string are ignored; write `.` if you mean the
+        current directory.
+
+        Values are expanded in a double-quoted shell context. Parameter and
+        command expansions are evaluated. Write `\"` for a literal `"`. Plain
+        glob and tilde characters remain literal while the surrounding
+        double-quoted context is intact. `\$` is a literal `$` and `\\` a
+        literal backslash.
+      '';
+    };
+
     home.sessionVariablesExtra = mkOption {
       type = types.lines;
       default = "";
@@ -653,10 +695,11 @@ in
         to your configuration.
       ''
       ++ lib.optional hasEmptySearchVariableEntry ''
-        `home.sessionPath` or `home.sessionSearchVariables` contains an empty
-        entry, which Home Manager ignores. Write `.` to include the current
-        directory. If the empty entry has tool-specific meaning, set the
-        complete value through `home.sessionVariables` instead.
+        `home.sessionPath`, `home.sessionSearchVariables`, or
+        `home.sessionSearchVariablesAppend` contains an empty entry, which Home
+        Manager ignores. Write `.` to include the current directory. If the
+        empty entry has tool-specific meaning, set the complete value through
+        `home.sessionVariables` instead.
       '';
 
     home.username = lib.mkIf (lib.versionOlder config.home.stateVersion "20.09") (
@@ -697,8 +740,11 @@ in
       destination = "/etc/profile.d/hm-session-vars.sh";
       text =
         let
+          # On the first merge, an entry in both options takes append position.
+          # Later merges preserve its inherited position.
           searchSection = config.lib.shell.mergeSearchVariables {
             prepend = cfg.sessionSearchVariables;
+            append = cfg.sessionSearchVariablesAppend;
           };
         in
         mkSections [

--- a/modules/lib/fish-session-variables.nix
+++ b/modules/lib/fish-session-variables.nix
@@ -11,13 +11,20 @@ let
 
   sessionVarsFile = "etc/profile.d/hm-session-vars.fish";
 
-  merges = lib.mapAttrsToList (env: values: {
-    inherit env;
-    candidates = lib.imap0 (index: value: {
-      name = "__hm_candidate_${env}_${toString index}";
-      inherit value;
-    }) (lib.filter (value: value != "") values);
-  }) config.home.sessionSearchVariables;
+  mkMerges =
+    operation: attrs:
+    lib.mapAttrsToList (env: values: {
+      inherit env operation;
+      candidates = lib.imap0 (index: value: {
+        name = "__hm_candidate_${operation}_${env}_${toString index}";
+        inherit value;
+      }) (lib.filter (value: value != "") values);
+    }) attrs;
+
+  # Prepends first, then appends, matching the POSIX generator.
+  merges =
+    mkMerges "prepend" config.home.sessionSearchVariables
+    ++ mkMerges "append" config.home.sessionSearchVariablesAppend;
 
   candidateNames = lib.concatMap (merge: map (candidate: candidate.name) merge.candidates) merges;
 
@@ -41,7 +48,7 @@ let
             candidate: assignDoubleQuoted candidate.name candidate.value
           ) merge.candidates)
           (
-            "__hm_merge prepend ${merge.env} :"
+            "__hm_merge ${merge.operation} ${merge.env} :"
             + lib.optionalString (merge.candidates != [ ]) (
               " " + lib.concatMapStringsSep " " (candidate: "\"\$${candidate.name}\"") merge.candidates
             )

--- a/modules/misc/news/2026/08/2026-08-27_13-00-00.nix
+++ b/modules/misc/news/2026/08/2026-08-27_13-00-00.nix
@@ -1,0 +1,15 @@
+{ config, ... }:
+{
+  time = "2026-08-27T13:00:00+00:00";
+  condition = config.home.sessionSearchVariablesAppend != { };
+  message = ''
+    A new option {option}`home.sessionSearchVariablesAppend` adds entries after
+    the inherited value of a PATH-like environment variable. On the first
+    merge in a process tree, configured entries are repositioned according to
+    the prepend or append option. Later merges preserve existing positions.
+
+    `lib.mkAfter` cannot express this: it orders configured entries relative
+    to each other, but cannot place one after the value inherited at runtime,
+    which is what a fallback needs.
+  '';
+}

--- a/tests/modules/home-environment/default.nix
+++ b/tests/modules/home-environment/default.nix
@@ -1,6 +1,7 @@
 {
   home-session-path = ./session-path.nix;
   home-session-search-variables = ./session-search-variables.nix;
+  home-session-search-variables-append = ./session-search-variables-append.nix;
   home-session-variables = ./session-variables.nix;
   home-nixpkgs-release-check-pkgs = ./nixpkgs-release-check-pkgs.nix;
   home-uid-from-nixos = ./uid-from-nixos.nix;

--- a/tests/modules/home-environment/session-path.nix
+++ b/tests/modules/home-environment/session-path.nix
@@ -8,10 +8,11 @@
 
   test.asserts.warnings.expected = [
     ''
-      `home.sessionPath` or `home.sessionSearchVariables` contains an empty
-      entry, which Home Manager ignores. Write `.` to include the current
-      directory. If the empty entry has tool-specific meaning, set the
-      complete value through `home.sessionVariables` instead.
+      `home.sessionPath`, `home.sessionSearchVariables`, or
+      `home.sessionSearchVariablesAppend` contains an empty entry, which Home
+      Manager ignores. Write `.` to include the current directory. If the
+      empty entry has tool-specific meaning, set the complete value through
+      `home.sessionVariables` instead.
     ''
   ];
 

--- a/tests/modules/home-environment/session-search-variables-append.nix
+++ b/tests/modules/home-environment/session-search-variables-append.nix
@@ -1,0 +1,78 @@
+{ realPkgs, ... }:
+
+{
+  home.sessionSearchVariables = {
+    BOTH = [ "/hm/front" ];
+    SHARED = [ "same" ];
+  };
+  home.sessionSearchVariablesAppend = {
+    BOTH = [ "/hm/back" ];
+    EMPTY = [ "" ];
+    ONLY_APPEND = [
+      "/fallback/one"
+      "/fallback/two"
+    ];
+    SHARED = [ "same" ];
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      `home.sessionPath`, `home.sessionSearchVariables`, or
+      `home.sessionSearchVariablesAppend` contains an empty entry, which Home
+      Manager ignores. Write `.` to include the current directory. If the
+      empty entry has tool-specific meaning, set the complete value through
+      `home.sessionVariables` instead.
+    ''
+  ];
+
+  nmt.script = ''
+    hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
+    assertFileExists $hmSessVars
+
+    for shellBin in \
+      "$BASH" \
+      ${realPkgs.dash}/bin/dash \
+      ${realPkgs.zsh}/bin/zsh; do
+
+      env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+        BOTH=/inherited \
+        ONLY_APPEND=/inherited/append \
+        SHARED=/inherited/shared \
+        "$shellBin" -uc '
+          . "$1"
+
+          # On the first merge, the inherited value remains between them.
+          [ "$BOTH" = "/hm/front:/inherited:/hm/back" ] \
+            || { echo "BOTH: $BOTH"; exit 1; }
+          [ "$ONLY_APPEND" = "/inherited/append:/fallback/one:/fallback/two" ] \
+            || { echo "ONLY_APPEND: $ONLY_APPEND"; exit 1; }
+          [ "$SHARED" = "/inherited/shared:same" ] \
+            || { echo "SHARED: $SHARED"; exit 1; }
+          exit 0
+        ' shell "$TESTED/$hmSessVars" \
+        || fail "$shellBin: append semantics broken"
+
+      # An appended entry already present must not be duplicated or moved,
+      # and a later source must stay idempotent.
+      env -u __HM_SESS_VARS_SOURCED __HM_SESS_VARS_MERGED=1 \
+        BOTH=/hm/back:/inherited \
+        ONLY_APPEND=/fallback/two \
+        SHARED=same:/inherited/shared \
+        "$shellBin" -uc '
+          . "$1"
+          [ "$BOTH" = "/hm/front:/hm/back:/inherited" ] \
+            || { echo "BOTH: $BOTH"; exit 1; }
+          [ "$ONLY_APPEND" = "/fallback/two:/fallback/one" ] \
+            || { echo "ONLY_APPEND: $ONLY_APPEND"; exit 1; }
+          [ "$SHARED" = "same:/inherited/shared" ] \
+            || { echo "SHARED: $SHARED"; exit 1; }
+          before="$BOTH|$ONLY_APPEND|$SHARED"
+          . "$1"
+          [ "$BOTH|$ONLY_APPEND|$SHARED" = "$before" ] \
+            || { echo "not idempotent: $BOTH|$ONLY_APPEND|$SHARED"; exit 1; }
+          exit 0
+        ' shell "$TESTED/$hmSessVars" \
+        || fail "$shellBin: append was not idempotent"
+    done
+  '';
+}

--- a/tests/modules/programs/fish/session-search-variables.nix
+++ b/tests/modules/programs/fish/session-search-variables.nix
@@ -24,6 +24,7 @@ let
     "RUNTIME_EMPTY"
     "RUNTIME_MIXED"
     "SEPARATOR"
+    "SHARED"
     "SUBSTRING"
     "TESTPATH"
     "TEST_DIRS"
@@ -42,6 +43,7 @@ let
         EMPTYPATH = "";
         LATER = "base";
         SEPARATOR = "x:a:b:y";
+        SHARED = "/inherited/shared";
         SUBSTRING = "/usr/share/ubuntu:/usr/share";
         TESTPATH = "/sys/two:/hm/two";
         TEST_DIRS = "/sys/dirs";
@@ -65,9 +67,10 @@ let
         RUNTIME_EMPTY = "";
         RUNTIME_MIXED = "kept";
         SEPARATOR = "a:b:x:y";
+        SHARED = "/inherited/shared:same";
         SUBSTRING = "/usr/share:/usr/share/ubuntu";
-        TESTPATH = "/hm/one:/hm/two:/sys/two";
-        TEST_DIRS = "/hm/dirs:/sys/dirs";
+        TESTPATH = "/hm/one:/hm/two:/sys/two:/hm/fallback";
+        TEST_DIRS = "/hm/dirs:/sys/dirs:/hm/dirs/fallback";
       };
     }
     {
@@ -82,6 +85,7 @@ let
         EMPTYPATH = "configured";
         LATER = "base";
         SEPARATOR = "x:a:b:y";
+        SHARED = "same:/inherited/shared";
         SUBSTRING = "/usr/share/ubuntu:/usr/share";
         TESTPATH = "/sys/two:/hm/two";
         TEST_DIRS = "/sys/dirs:/hm/dirs";
@@ -106,9 +110,10 @@ let
         RUNTIME_EMPTY = "";
         RUNTIME_MIXED = "kept";
         SEPARATOR = "x:a:b:y";
+        SHARED = "same:/inherited/shared";
         SUBSTRING = "/usr/share/ubuntu:/usr/share";
-        TESTPATH = "/hm/one:/sys/two:/hm/two";
-        TEST_DIRS = "/sys/dirs:/hm/dirs";
+        TESTPATH = "/hm/one:/sys/two:/hm/two:/hm/fallback";
+        TEST_DIRS = "/sys/dirs:/hm/dirs:/hm/dirs/fallback";
       };
     }
   ];
@@ -144,9 +149,9 @@ let
   fishProbe = realPkgs.writeText "session-search-variables-fish-probe.fish" ''
     source $argv[1]
 
-    test (count $TESTPATH) -eq 3
+    test (count $TESTPATH) -eq 4
     or begin
-        echo "TESTPATH is not a three-element Fish path list" >&2
+        echo "TESTPATH is not a four-element Fish path list" >&2
         exit 1
     end
     test (count $EMPTYPATH) -eq 1
@@ -227,6 +232,7 @@ in
       "$EMPTY_ENTRY"
     ];
     SEPARATOR = [ "a:b" ];
+    SHARED = [ "same" ];
     SUBSTRING = [ "/usr/share" ];
     TESTPATH = [
       "/hm/one"
@@ -237,12 +243,19 @@ in
 
   test.asserts.warnings.expected = [
     ''
-      `home.sessionPath` or `home.sessionSearchVariables` contains an empty
-      entry, which Home Manager ignores. Write `.` to include the current
-      directory. If the empty entry has tool-specific meaning, set the
-      complete value through `home.sessionVariables` instead.
+      `home.sessionPath`, `home.sessionSearchVariables`, or
+      `home.sessionSearchVariablesAppend` contains an empty entry, which Home
+      Manager ignores. Write `.` to include the current directory. If the
+      empty entry has tool-specific meaning, set the complete value through
+      `home.sessionVariables` instead.
     ''
   ];
+
+  home.sessionSearchVariablesAppend = {
+    SHARED = [ "same" ];
+    TESTPATH = [ "/hm/fallback" ];
+    TEST_DIRS = [ "/hm/dirs/fallback" ];
+  };
 
   nmt.script = ''
     posixSessionVars=home-path/etc/profile.d/hm-session-vars.sh


### PR DESCRIPTION
### Description

Adds `home.sessionSearchVariablesAppend` for PATH-like entries that should
follow the runtime-inherited value. `lib.mkAfter` cannot express this: it
orders configured entries relative to each other but cannot place one after a
value inherited at runtime.

On the first merge in a process tree, configured entries are repositioned
according to prepend or append mode. Later merges preserve existing positions
so intervening environment changes are not reordered. An entry listed in both
options therefore takes append position on the first merge and retains its
inherited position later.

Statically empty append entries produce the same warning as empty prepend
entries. Entries that expand to an empty string at source time are ignored.

Neither this option nor `home.sessionSearchVariables` reaches systemd user
services; the option docs say so explicitly.

Part of splitting #9735 into independently reviewable changes; the stack as a
whole supersedes that PR.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt`.
- [x] Code tested through `nix build .#test-all`.
- [x] Test cases updated/added.
- [x] Commit messages follow the `{component}: {description}` format.
