### PR TITLE
targets/darwin/terminfo: compose TERMINFO_DIRS

### DIFF
--- a/modules/misc/news/2026/08/2026-08-27_13-30-00.nix
+++ b/modules/misc/news/2026/08/2026-08-27_13-30-00.nix
@@ -1,0 +1,25 @@
+{ pkgs, ... }:
+{
+  time = "2026-08-27T13:30:00+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin;
+  message = ''
+    On Darwin, {env}`TERMINFO_DIRS` is now built from
+    {option}`home.sessionSearchVariables` and
+    {option}`home.sessionSearchVariablesAppend` instead of a single
+    self-referential {option}`home.sessionVariables` value. On the first merge,
+    Home Manager's directory comes first and {file}`/usr/share/terminfo` comes
+    last, with inherited directories kept between them and without duplicating
+    configured entries. Later merges preserve the positions of configured
+    entries already present in {env}`TERMINFO_DIRS`.
+
+    This retires the opt-out described in the 2026-04-20 news entry. Overriding
+    {option}`home.sessionVariables.TERMINFO_DIRS` no longer replaces Home
+    Manager's value, and it does so quietly rather than failing, because the
+    module no longer defines that name.
+
+    Use {option}`targets.darwin.terminfo.enable` `= false` to manage the
+    variable yourself, or add your own entries to
+    {option}`home.sessionSearchVariables.TERMINFO_DIRS`, which compose with
+    Home Manager's.
+  '';
+}

--- a/modules/targets/darwin/terminfo.nix
+++ b/modules/targets/darwin/terminfo.nix
@@ -7,20 +7,38 @@
 
 let
   inherit (config.home) profileDirectory;
+
+  cfg = config.targets.darwin.terminfo;
 in
 {
-  # macOS has no systemd/environment.d equivalent, so expose Home Manager's
-  # terminfo via the shell session file sourced by bash/zsh.
-  config = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
-    # Not using `home.sessionSearchVariables` because it only prepends, whereas
-    # we need `/usr/share/terminfo` appended as an explicit fallback: once
-    # TERMINFO_DIRS is set, ncurses stops searching the default system path.
-    home.sessionVariables = {
-      # `${TERMINFO_DIRS-}` rather than `$TERMINFO_DIRS`: the generated
-      # hm-session-vars.sh runs under `set -u` in some shells, where a bare
-      # reference to an unset variable aborts the whole file.
-      TERMINFO_DIRS = lib.mkDefault "${profileDirectory}/share/terminfo:\${TERMINFO_DIRS-}\${TERMINFO_DIRS:+:}/usr/share/terminfo";
-    };
+  options.targets.darwin.terminfo.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = true;
+    example = false;
+    description = ''
+      Whether to expose Home Manager's terminfo database through
+      {env}`TERMINFO_DIRS`.
+
+      macOS has no {file}`environment.d` equivalent, so this goes through the
+      shell session file that bash, zsh, and fish source.
+
+      On the first merge, Home Manager prepends its own terminfo directory and
+      appends {file}`/usr/share/terminfo`, keeping any inherited directories
+      between the two. Later merges preserve the positions of configured
+      entries already present in {env}`TERMINFO_DIRS`. The system path has to
+      be appended explicitly because once {env}`TERMINFO_DIRS` is set at all,
+      ncurses stops searching its built-in default.
+
+      Set this to `false` to manage {env}`TERMINFO_DIRS` yourself. That also
+      skips the {env}`TERM` re-export.
+    '';
+  };
+
+  config = lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && cfg.enable) {
+    home.sessionSearchVariables.TERMINFO_DIRS = [ "${profileDirectory}/share/terminfo" ];
+
+    # Place the system fallback after ordinary user-configured append entries.
+    home.sessionSearchVariablesAppend.TERMINFO_DIRS = lib.mkAfter [ "/usr/share/terminfo" ];
 
     home.sessionVariablesExtra = ''
       # reset TERM with new TERMINFO available (if any)

--- a/tests/lib/shell/search-variable-merge.nix
+++ b/tests/lib/shell/search-variable-merge.nix
@@ -49,7 +49,7 @@ in
     for shellBin in \
       "$BASH" \
       ${realPkgs.dash}/bin/dash \
-      ${realPkgs.zsh}/bin/zsh; do
+      "${realPkgs.zsh}/bin/zsh -f"; do
 
       # On the first merge, configured precedence repositions inherited duplicates.
       env -u __HM_SESS_VARS_MERGED \
@@ -60,7 +60,7 @@ in
         BOTH="fallback:middle:front" \
         COMPLETE="qux" \
         TRAILING="/first:/last" \
-        "$shellBin" -uc '
+        $shellBin -uc '
           unset EXPANDED LITERAL GLOB SEPARATOR NOT_EXPANDED
           . "$1"
 
@@ -116,7 +116,7 @@ in
         BOTH="fallback:middle:front" \
         COMPLETE="qux" \
         TRAILING="/first:/last" \
-        "$shellBin" -uc '
+        $shellBin -uc '
           unset EXPANDED LITERAL GLOB SEPARATOR NOT_EXPANDED
           . "$1"
           [ "$SUBSTRING" = "/usr/share/ubuntu:/usr/share" ] \

--- a/tests/modules/home-environment/session-search-variables-append.nix
+++ b/tests/modules/home-environment/session-search-variables-append.nix
@@ -32,13 +32,13 @@
     for shellBin in \
       "$BASH" \
       ${realPkgs.dash}/bin/dash \
-      ${realPkgs.zsh}/bin/zsh; do
+      "${realPkgs.zsh}/bin/zsh -f"; do
 
       env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
         BOTH=/inherited \
         ONLY_APPEND=/inherited/append \
         SHARED=/inherited/shared \
-        "$shellBin" -uc '
+        $shellBin -uc '
           . "$1"
 
           # On the first merge, the inherited value remains between them.
@@ -58,7 +58,7 @@
         BOTH=/hm/back:/inherited \
         ONLY_APPEND=/fallback/two \
         SHARED=same:/inherited/shared \
-        "$shellBin" -uc '
+        $shellBin -uc '
           . "$1"
           [ "$BOTH" = "/hm/front:/hm/back:/inherited" ] \
             || { echo "BOTH: $BOTH"; exit 1; }

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -30,7 +30,6 @@ let
     export IS_EMPTY=""
     export IS_FALSE="false"
     export IS_TRUE="true"
-    export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:''${TERMINFO_DIRS-}''${TERMINFO_DIRS:+:}/usr/share/terminfo"
     export V1="v1"
     export V2="v2-v1"
     export XDG_BIN_HOME="/home/hm-user/.local/bin"
@@ -38,15 +37,17 @@ let
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
     export XDG_STATE_HOME="/home/hm-user/.local/state"
-
-    # reset TERM with new TERMINFO available (if any)
-    export TERM="$TERM"
   '';
 
   expected = pkgs.writeText "expected" (if isDarwin then darwinExpected else linuxExpected);
 
 in
 {
+  # Keep this test to plain session variables. On Darwin the terminfo module
+  # would otherwise add its TERMINFO_DIRS merge and TERM re-export here; both
+  # are covered by tests/modules/targets-darwin/terminfo.nix.
+  targets.darwin.terminfo.enable = false;
+
   home.sessionVariables = {
     V1 = "v1";
     V2 = "v2-${config.home.sessionVariables.V1}";

--- a/tests/modules/targets-darwin/default.nix
+++ b/tests/modules/targets-darwin/default.nix
@@ -1,7 +1,11 @@
-{
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
   # Disabled for now due to conflicting behavior with nix-darwin. See
   # https://github.com/nix-community/home-manager/issues/1341#issuecomment-687286866
   #targets-darwin = ./darwin.nix;
   terminfo = ./terminfo.nix;
+  terminfo-disabled = ./terminfo-disabled.nix;
+  terminfo-override = ./terminfo-override.nix;
   user-defaults = ./user-defaults.nix;
 }

--- a/tests/modules/targets-darwin/terminfo-disabled.nix
+++ b/tests/modules/targets-darwin/terminfo-disabled.nix
@@ -1,0 +1,12 @@
+{
+  config = {
+    targets.darwin.terminfo.enable = false;
+
+    nmt.script = ''
+      sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
+      assertFileExists $sessionVarsFile
+      assertFileNotRegex $sessionVarsFile 'TERMINFO_DIRS'
+      assertFileNotRegex $sessionVarsFile 'export TERM='
+    '';
+  };
+}

--- a/tests/modules/targets-darwin/terminfo-override.nix
+++ b/tests/modules/targets-darwin/terminfo-override.nix
@@ -1,0 +1,22 @@
+_:
+
+{
+  config = {
+    home.sessionSearchVariables.TERMINFO_DIRS = [ "/my/terminfo" ];
+
+    nmt.script = ''
+      sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
+      assertFileExists $sessionVarsFile
+
+      env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+        TERM=dumb TERMINFO_DIRS=/inherited \
+        "$BASH" -uc '
+          . "$1"
+          [ "$TERMINFO_DIRS" = "/home/hm-user/.nix-profile/share/terminfo:/my/terminfo:/inherited:/usr/share/terminfo" ] \
+            || { echo "TERMINFO_DIRS: $TERMINFO_DIRS"; exit 1; }
+          exit 0
+        ' shell "$TESTED/$sessionVarsFile" \
+        || fail "user TERMINFO_DIRS entries did not compose"
+    '';
+  };
+}

--- a/tests/modules/targets-darwin/terminfo.nix
+++ b/tests/modules/targets-darwin/terminfo.nix
@@ -1,12 +1,66 @@
+{ realPkgs, ... }:
+
 {
   config = {
     nmt.script = ''
       sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
       assertFileExists $sessionVarsFile
       assertFileContains $sessionVarsFile \
-        'export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:''${TERMINFO_DIRS-}''${TERMINFO_DIRS:+:}/usr/share/terminfo"'
-      assertFileContains $sessionVarsFile \
         'export TERM="$TERM"'
+
+      for shellBin in \
+        "$BASH" \
+        ${realPkgs.dash}/bin/dash \
+        "${realPkgs.zsh}/bin/zsh -f"; do
+
+        # Home Manager's directory wins, the system path stays last, and an
+        # inherited directory keeps its place between the two.
+        env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+          TERM=dumb TERMINFO_DIRS=/inherited/terminfo \
+          $shellBin -uc '
+            . "$1"
+            [ "$TERMINFO_DIRS" = "/home/hm-user/.nix-profile/share/terminfo:/inherited/terminfo:/usr/share/terminfo" ] \
+              || { echo "TERMINFO_DIRS: $TERMINFO_DIRS"; exit 1; }
+            exit 0
+          ' shell "$TESTED/$sessionVarsFile" \
+          || fail "$shellBin: TERMINFO_DIRS did not compose"
+
+        # Safe when TERMINFO_DIRS is unset, which is the usual macOS case.
+        env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+          TERM=dumb \
+          $shellBin -uc '
+            unset TERMINFO_DIRS
+            . "$1"
+            [ "$TERMINFO_DIRS" = "/home/hm-user/.nix-profile/share/terminfo:/usr/share/terminfo" ] \
+              || { echo "TERMINFO_DIRS: $TERMINFO_DIRS"; exit 1; }
+            exit 0
+          ' shell "$TESTED/$sessionVarsFile" \
+          || fail "$shellBin: TERMINFO_DIRS broken when unset"
+
+        # No duplicate system fallback when it is already inherited.
+        env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+          TERM=dumb TERMINFO_DIRS=/usr/share/terminfo \
+          $shellBin -uc '
+            . "$1"
+            [ "$TERMINFO_DIRS" = "/home/hm-user/.nix-profile/share/terminfo:/usr/share/terminfo" ] \
+              || { echo "TERMINFO_DIRS: $TERMINFO_DIRS"; exit 1; }
+            exit 0
+          ' shell "$TESTED/$sessionVarsFile" \
+          || fail "$shellBin: duplicated the system terminfo path"
+
+        # Later merges preserve existing configured-entry positions.
+        env -u __HM_SESS_VARS_SOURCED \
+          __HM_SESS_VARS_MERGED=1 \
+          TERM=dumb \
+          TERMINFO_DIRS=/usr/share/terminfo:/inherited/terminfo:/home/hm-user/.nix-profile/share/terminfo \
+          $shellBin -uc '
+            . "$1"
+            [ "$TERMINFO_DIRS" = "/usr/share/terminfo:/inherited/terminfo:/home/hm-user/.nix-profile/share/terminfo" ] \
+              || { echo "TERMINFO_DIRS: $TERMINFO_DIRS"; exit 1; }
+            exit 0
+          ' shell "$TESTED/$sessionVarsFile" \
+          || fail "$shellBin: later merge repositioned TERMINFO_DIRS entries"
+      done
     '';
   };
 }


### PR DESCRIPTION
### Description

Builds Darwin's `TERMINFO_DIRS` from `home.sessionSearchVariables` plus the new append option instead of one self-referential `home.sessionVariables` value.

On the first merge, Home Manager's terminfo directory comes first and `/usr/share/terminfo` comes last. Inherited directories remain between them, and configured entries are not duplicated. Later merges preserve the positions of configured entries already present in `TERMINFO_DIRS`.

Adds `targets.darwin.terminfo.enable`. The 2026-04-20 news entry told users to opt out by overriding `home.sessionVariables.TERMINFO_DIRS`. That value now composes with the module's paths instead of disabling them, so the new news entry points to the explicit option.

Part of splitting #9735 into independently reviewable changes. The stack as a whole supersedes that PR.

### Verification

- `nix build path:.#test-all`
- focused session-variable and news tests
- `nix fmt -- --ci`
- HTML manual and manpages
- aarch64-darwin evaluation for the default, disabled, and user-composed cases

### Checklist

- [ ] Change is backwards compatible. (The old `home.sessionVariables.TERMINFO_DIRS` opt-out now composes with the module paths; news entry included.)
- [x] Code formatted with `nix fmt`.
- [x] Code tested through `nix build .#test-all`.
- [x] Test cases updated/added.
- [x] Commit messages follow the `{component}: {description}` format.
