### PR TITLE
lib/shell: warn on self-referential session variables

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -700,7 +701,15 @@ in
         Manager ignores. Write `.` to include the current directory. If the
         empty entry has tool-specific meaning, set the complete value through
         `home.sessionVariables` instead.
-      '';
+      ''
+      ++ config.lib.shell.selfReferenceWarnings {
+        option = options.home.sessionVariables;
+        optionPath = "home.sessionVariables";
+        rationale = ''
+          Home Manager applies the session variables file once per session
+          today. Applying it again in a new shell could change these values.
+        '';
+      };
 
     home.username = lib.mkIf (lib.versionOlder config.home.stateVersion "20.09") (
       lib.mkDefault (builtins.getEnv "USER")

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -13,6 +13,7 @@ rec {
   gvariant = import ./gvariant.nix { inherit lib; };
   maintainers = import ./maintainers.nix;
   mcp = import ./mcp.nix { inherit lib; };
+  options = import ./options.nix { inherit lib; };
   strings = import ./strings.nix { inherit lib; };
   types = import ./types.nix { inherit gvariant lib; };
 

--- a/modules/lib/options.nix
+++ b/modules/lib/options.nix
@@ -1,0 +1,60 @@
+{ lib }:
+
+{
+  /**
+    Return the files whose surviving definitions contribute to attribute
+    `name` of an `attrsOf` or `lazyAttrsOf` option. The element type's
+    conditions, priorities, ordering, and definition locations are preserved.
+
+    # Type
+
+    ```
+    attrDefinitionFiles :: Option -> String -> [ String ]
+    ```
+  */
+  attrDefinitionFiles =
+    option: name:
+    let
+      pushDownDefinitionProperties =
+        value:
+        let
+          type = value._type or "";
+          push = wrap: lib.map (lib.mapAttrs (_: wrap));
+        in
+        if type == "merge" then
+          lib.concatMap pushDownDefinitionProperties value.contents
+        else if type == "if" then
+          push (lib.mkIf value.condition) (pushDownDefinitionProperties value.content)
+        else if type == "override" then
+          push (lib.mkOverride value.priority) (pushDownDefinitionProperties value.content)
+        else if type == "order" then
+          push (lib.mkOrder value.priority) (pushDownDefinitionProperties value.content)
+        else if type == "definition" then
+          push (attributeValue: value // { value = attributeValue; }) (
+            pushDownDefinitionProperties value.value
+          )
+        else
+          [ value ];
+      definitionsByName = lib.zipAttrs (
+        lib.concatMap (
+          definition:
+          lib.concatMap (
+            value:
+            lib.mapAttrsToList (name: value: {
+              ${name} = definition // {
+                inherit value;
+              };
+            }) value
+          ) (pushDownDefinitionProperties definition.value)
+        ) option.definitionsWithLocations
+      );
+      merged = lib.modules.mergeDefinitions (option.loc ++ [ name ]) option.type.nestedTypes.elemType (
+        definitionsByName.${name} or [ ]
+      );
+    in
+    assert lib.elem option.type.name [
+      "attrsOf"
+      "lazyAttrsOf"
+    ];
+    lib.unique (map (definition: definition.file) merged.defsFinal);
+}

--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -117,9 +117,150 @@ let
         unset ${lib.concatStringsSep " " mergeScratchVariables}
       '';
 
+  isSelfReferential =
+    name: value:
+    lib.isString value
+    && (
+      let
+        dollar = "$";
+        expansionStart = "${dollar}{";
+        escapedName = lib.escapeRegex name;
+        refers =
+          text:
+          let
+            # Escaped characters and `$$` cannot begin a variable reference.
+            plainParts = lib.filter lib.isString (builtins.split ''(\\.|[$][$])'' text);
+            refersInPart =
+              part:
+              builtins.match ".*[$][{]?${escapedName}([^A-Za-z0-9_].*)?" part != null
+              || builtins.match ".*[$][{]#${escapedName}[}].*" part != null;
+          in
+          lib.any refersInPart plainParts;
+        isWholeExpansion =
+          text:
+          let
+            length = lib.stringLength text;
+            # Keep nested parameter expansions inside the outer expression.
+            scan =
+              index: depth:
+              if index >= length then
+                false
+              else if builtins.substring index 2 text == expansionStart then
+                scan (index + 2) (depth + 1)
+              else if builtins.substring index 1 text == "}" then
+                if depth == 1 then index == length - 1 else scan (index + 1) (depth - 1)
+              else if builtins.substring index 1 text == "\\" then
+                scan (index + 2) depth
+              else
+                scan (index + 1) depth;
+          in
+          lib.hasPrefix expansionStart text && scan 2 1;
+        nameExpansionStart = "${expansionStart}${name}";
+        expansionBodyFor =
+          text:
+          if isWholeExpansion text && lib.hasPrefix nameExpansionStart text then
+            builtins.substring (lib.stringLength nameExpansionStart) (
+              lib.stringLength text - lib.stringLength nameExpansionStart - 1
+            ) text
+          else
+            null;
+        operatorFor =
+          body:
+          if body == null then
+            null
+          else
+            lib.findFirst (candidate: lib.hasPrefix candidate body) null [
+              ":-"
+              ":="
+              ":?"
+              ":+"
+              "-"
+              "="
+              "?"
+              "+"
+            ];
+        isStableValue =
+          text:
+          let
+            body = expansionBodyFor text;
+            operator = operatorFor body;
+            word = if operator == null then null else lib.removePrefix operator body;
+          in
+          !refers text
+          || text == "${dollar}${name}"
+          || body == ""
+          || lib.elem operator [
+            ":-"
+            ":="
+            ":?"
+            "-"
+            "="
+            "?"
+          ]
+          || (
+            lib.elem operator [
+              ":+"
+              "+"
+            ]
+            && isStableValue word
+          );
+      in
+      refers value && !isStableValue value
+    );
+
+  /*
+    Build the warning list for self-referential entries of a session-variable
+    option. Shared so every shell that has its own `sessionVariables` reports
+    the same thing.
+
+    # Type
+
+    ```
+    selfReferenceWarnings :: { option, optionPath, rationale, renderValue ? id } -> [ String ]
+    ```
+  */
+  selfReferenceWarnings =
+    {
+      option,
+      optionPath,
+      rationale,
+      renderValue ? lib.id,
+    }:
+    let
+      offenders = lib.attrNames (
+        lib.filterAttrs (name: value: isSelfReferential name (renderValue value)) option.value
+      );
+      formatOffender =
+        name:
+        let
+          files = lib.hm.options.attrDefinitionFiles option name;
+        in
+        "${name}, defined in ${lib.options.showFiles files}";
+    in
+    lib.optional (offenders != [ ]) ''
+      The following ${optionPath} may change when applied again:
+
+        ${lib.concatMapStringsSep "\n  " formatOffender offenders}
+
+      ${lib.removeSuffix "\n" rationale}
+
+      For search paths, use home.sessionPath,
+      home.sessionSearchVariables, or home.sessionSearchVariablesAppend.
+      Those options add only the entries that are missing. For other
+      variables, assign a complete value without referring to its previous
+      contents.
+
+      This check is best-effort and detects only direct parameter references
+      such as $NAME, ''${NAME...}, and ''${#NAME}.
+    '';
+
 in
 {
-  inherit export wrapLines;
+  inherit
+    export
+    wrapLines
+    selfReferenceWarnings
+    ;
 
   /**
     Generate a complete POSIX shell block that merges entries into

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -26,6 +26,15 @@ let
 
   zshLib = import ./lib.nix { inherit config lib; };
   inherit (zshLib) homeDir dotDirAbs dotDirRel;
+  renderSessionVariable =
+    value:
+    if lib.isString value then
+      let
+        rendered = config.lib.zsh.toZshValue value;
+      in
+      lib.removeSuffix ''"'' (lib.removePrefix ''"'' rendered)
+    else
+      value;
 in
 {
   meta.maintainers = [ lib.maintainers.khaneliman ];
@@ -482,20 +491,30 @@ in
           ];
 
           warnings =
-            lib.optionals
-              (cfg.dotDir != homeDir && !lib.hasPrefix "/" cfg.dotDir && !lib.hasInfix "$" cfg.dotDir)
-              [
-                ''
-                  Using relative paths in programs.zsh.dotDir is deprecated and will be removed in a future release.
-                  Current dotDir: ${cfg.dotDir}
-                  Consider using absolute paths or home-manager config options instead.
-                  You can replace relative paths or environment variables with options like:
-                  - config.home.homeDirectory (user's home directory)
-                  - config.xdg.configHome (XDG config directory)
-                  - config.xdg.dataHome (XDG data directory)
-                  - config.xdg.cacheHome (XDG cache directory)
-                ''
-              ]
+            config.lib.shell.selfReferenceWarnings {
+              option = options.programs.zsh.sessionVariables;
+              optionPath = "programs.zsh.sessionVariables";
+              renderValue = renderSessionVariable;
+              rationale = ''
+                Home Manager applies these values once per session today.
+                Applying them in each new Zsh process could change them again.
+              '';
+            }
+            ++
+              lib.optionals
+                (cfg.dotDir != homeDir && !lib.hasPrefix "/" cfg.dotDir && !lib.hasInfix "$" cfg.dotDir)
+                [
+                  ''
+                    Using relative paths in programs.zsh.dotDir is deprecated and will be removed in a future release.
+                    Current dotDir: ${cfg.dotDir}
+                    Consider using absolute paths or home-manager config options instead.
+                    You can replace relative paths or environment variables with options like:
+                    - config.home.homeDirectory (user's home directory)
+                    - config.xdg.configHome (XDG config directory)
+                    - config.xdg.dataHome (XDG data directory)
+                    - config.xdg.cacheHome (XDG cache directory)
+                  ''
+                ]
             ++
               lib.optionals
                 (

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -190,6 +190,7 @@ import nmtSrc {
           ./lib/deprecations
           ./lib/generators
           ./lib/mcp
+          ./lib/options
           ./lib/shell
           ./lib/types
           ./modules/files

--- a/tests/lib/options/attr-definition-files.nix
+++ b/tests/lib/options/attr-definition-files.nix
@@ -1,0 +1,90 @@
+{ lib, ... }:
+
+let
+  eval = lib.evalModules {
+    modules = [
+      {
+        options.demo = lib.mkOption {
+          type = lib.types.lazyAttrsOf lib.types.str;
+          default = { };
+        };
+      }
+      (lib.setDefaultModuleLocation "/fake/plain.nix" { demo.PLAIN = "plain"; })
+      (lib.setDefaultModuleLocation "/fake/merge.nix" {
+        demo = lib.mkMerge [ { MERGED = "merged"; } ];
+      })
+      (lib.setDefaultModuleLocation "/fake/conditional.nix" {
+        demo = lib.mkIf true { CONDITIONAL = "conditional"; };
+      })
+      (lib.setDefaultModuleLocation "/fake/disabled.nix" {
+        demo = {
+          CONDITIONAL = lib.mkIf false "disabled";
+          DISABLED = lib.mkIf false "disabled";
+        };
+      })
+      (lib.setDefaultModuleLocation "/fake/order.nix" {
+        demo.ORDERED = lib.mkBefore "order";
+      })
+      (lib.setDefaultModuleLocation "/fake/default.nix" {
+        demo = {
+          FORCED = lib.mkDefault "default";
+          PRIORITY = lib.mkDefault "default";
+        };
+      })
+      (lib.setDefaultModuleLocation "/fake/user.nix" {
+        demo.PRIORITY = "user";
+      })
+      (lib.setDefaultModuleLocation "/fake/force.nix" {
+        demo.FORCED = lib.mkForce "force";
+      })
+      (lib.setDefaultModuleLocation "/fake/outer.nix" {
+        demo.LOCATED = lib.mkDefinition {
+          file = "/fake/inner.nix";
+          value = "located";
+        };
+      })
+    ];
+  };
+
+  files = lib.hm.options.attrDefinitionFiles eval.options.demo;
+in
+{
+  assertions = [
+    {
+      assertion = files "PLAIN" == [ "/fake/plain.nix" ];
+      message = "plain attribute definition was not attributed";
+    }
+    {
+      assertion = files "MERGED" == [ "/fake/merge.nix" ];
+      message = "mkMerge attribute definition was not attributed";
+    }
+    {
+      assertion = files "CONDITIONAL" == [ "/fake/conditional.nix" ];
+      message = "mkIf attribute definition was attributed incorrectly";
+    }
+    {
+      assertion = files "PRIORITY" == [ "/fake/user.nix" ];
+      message = "losing mkDefault attribute definition was attributed";
+    }
+    {
+      assertion = files "ORDERED" == [ "/fake/order.nix" ];
+      message = "mkOrder attribute definition was not attributed";
+    }
+    {
+      assertion = files "FORCED" == [ "/fake/force.nix" ];
+      message = "losing nested definition was attributed";
+    }
+    {
+      assertion = files "DISABLED" == [ ];
+      message = "false nested mkIf attribute definition was attributed";
+    }
+    {
+      assertion = files "LOCATED" == [ "/fake/inner.nix" ];
+      message = "mkDefinition location was not preserved";
+    }
+  ];
+
+  nmt.script = ''
+    echo "attribute definition locations checked" >/dev/null
+  '';
+}

--- a/tests/lib/options/default.nix
+++ b/tests/lib/options/default.nix
@@ -1,0 +1,3 @@
+{
+  lib-options-attr-definition-files = ./attr-definition-files.nix;
+}

--- a/tests/lib/shell/default.nix
+++ b/tests/lib/shell/default.nix
@@ -1,3 +1,4 @@
 {
+  shell-self-reference-warning = ./self-reference-warning.nix;
   shell-search-variable-merge = ./search-variable-merge.nix;
 }

--- a/tests/lib/shell/self-reference-warning.nix
+++ b/tests/lib/shell/self-reference-warning.nix
@@ -1,0 +1,84 @@
+{ config, lib, ... }:
+
+let
+  eval = lib.evalModules {
+    modules = [
+      {
+        options.demo = lib.mkOption {
+          type = lib.types.attrsOf lib.types.anything;
+          default = { };
+        };
+      }
+      (lib.setDefaultModuleLocation "/fake/session-vars.nix" {
+        demo = {
+          ALTERNATE_COLON = "\${ALTERNATE_COLON:+/prefix:$ALTERNATE_COLON}";
+          ALTERNATE_NO_COLON = "\${ALTERNATE_NO_COLON+/prefix:$ALTERNATE_NO_COLON}";
+          BRACED = "\${BRACED}:/suffix";
+          DOUBLE_ESCAPED = "\\\\$DOUBLE_ESCAPED";
+          DOLLAR = "$DOLLAR:/suffix";
+          LENGTH = "\${#LENGTH}";
+          PATTERN = "\${PATTERN#*:}";
+          PID_THEN_REFERENCE = "$$$PID_THEN_REFERENCE";
+
+          ALTERNATE_CONSTANT = "\${ALTERNATE_CONSTANT:+/prefix}";
+          ALTERNATE_CONSTANT_NO_COLON = "\${ALTERNATE_CONSTANT_NO_COLON+/prefix}";
+          ALTERNATE_IDENTITY = "\${ALTERNATE_IDENTITY:+$ALTERNATE_IDENTITY}";
+          ALTERNATE_IDENTITY_NO_COLON = "\${ALTERNATE_IDENTITY_NO_COLON+$ALTERNATE_IDENTITY_NO_COLON}";
+          BRACED_IDENTITY = "\${BRACED_IDENTITY}";
+          DEFAULT = "\${DEFAULT:-$DEFAULT:/fallback}";
+          DOLLAR_IDENTITY = "$DOLLAR_IDENTITY";
+          ESCAPED = "\\$ESCAPED";
+          NESTED_DEFAULT = "\${NESTED_DEFAULT:-\${HOME}/fallback}";
+          NESTED_DEFAULT_DEEP = "\${NESTED_DEFAULT_DEEP:-\${HOME:-\${USER}}/fallback}";
+          OTHER_NAME = "$UNRELATED";
+          PID = "$$PID";
+          PID_PAIR = "$$$$PID_PAIR";
+          VALUE = 42;
+        };
+      })
+      (lib.setDefaultModuleLocation "/fake/unrelated.nix" { demo.FINE = "/plain/value"; })
+    ];
+  };
+
+  warnings = config.lib.shell.selfReferenceWarnings {
+    option = eval.options.demo;
+    optionPath = "demo";
+    rationale = "Repeated application is unsafe here.";
+  };
+
+  expected = ''
+    The following demo may change when applied again:
+
+      ALTERNATE_COLON, defined in `/fake/session-vars.nix'
+      ALTERNATE_NO_COLON, defined in `/fake/session-vars.nix'
+      BRACED, defined in `/fake/session-vars.nix'
+      DOLLAR, defined in `/fake/session-vars.nix'
+      DOUBLE_ESCAPED, defined in `/fake/session-vars.nix'
+      LENGTH, defined in `/fake/session-vars.nix'
+      PATTERN, defined in `/fake/session-vars.nix'
+      PID_THEN_REFERENCE, defined in `/fake/session-vars.nix'
+
+    Repeated application is unsafe here.
+
+    For search paths, use home.sessionPath,
+    home.sessionSearchVariables, or home.sessionSearchVariablesAppend.
+    Those options add only the entries that are missing. For other
+    variables, assign a complete value without referring to its previous
+    contents.
+
+    This check is best-effort and detects only direct parameter references
+    such as $NAME, ''${NAME...}, and ''${#NAME}.
+  '';
+in
+{
+  assertions = [
+    {
+      assertion = warnings == [ expected ];
+      message = "self-reference warning did not match the expected output";
+    }
+  ];
+
+  nmt.script = ''
+    echo "self-reference warning checked" >/dev/null
+  '';
+}

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -15,6 +15,7 @@ let
     export LOCALE_ARCHIVE_2_27="${config.i18n.glibcLocales}/lib/locale/locale-archive"
     export V1="v1"
     export V2="v2-v1"
+    export WARNING="$WARNING/suffix"
     export XDG_BIN_HOME="/home/hm-user/.local/bin"
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
@@ -32,6 +33,7 @@ let
     export IS_TRUE="true"
     export V1="v1"
     export V2="v2-v1"
+    export WARNING="$WARNING/suffix"
     export XDG_BIN_HOME="/home/hm-user/.local/bin"
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
@@ -55,7 +57,28 @@ in
     IS_NULL = null;
     IS_TRUE = true;
     IS_FALSE = false;
+    WARNING = "$WARNING/suffix";
   };
+
+  test.asserts.warnings.expected = [
+    ''
+      The following home.sessionVariables may change when applied again:
+
+        WARNING, defined in `${toString ./session-variables.nix}'
+
+      Home Manager applies the session variables file once per session
+      today. Applying it again in a new shell could change these values.
+
+      For search paths, use home.sessionPath,
+      home.sessionSearchVariables, or home.sessionSearchVariablesAppend.
+      Those options add only the entries that are missing. For other
+      variables, assign a complete value without referring to its previous
+      contents.
+
+      This check is best-effort and detects only direct parameter references
+      such as $NAME, ''${NAME...}, and ''${#NAME}.
+    ''
+  ];
 
   nmt.script = ''
     assertFileExists home-path/etc/profile.d/hm-session-vars.sh

--- a/tests/modules/programs/zsh/session-variables.nix
+++ b/tests/modules/programs/zsh/session-variables.nix
@@ -5,6 +5,12 @@
     enable = true;
 
     sessionVariables = {
+      ALT_CONSTANT = "\${ALT_CONSTANT:+fixed}";
+      ALT_IDENTITY = "\${ALT_IDENTITY:+$ALT_IDENTITY}";
+      BRACED = "\${BRACED}";
+      DEFAULT = "\${DEFAULT:-fallback}";
+      DIRECT = "$DIRECT";
+      ESCAPED = "\\$ESCAPED";
       PATH = "$HOME/bin:$PATH";
       V1 = "v1";
       V2 = "v2-${config.programs.zsh.sessionVariables.V1}";
@@ -14,6 +20,27 @@
       IS_TRUE = true;
     };
   };
+
+  test.asserts.warnings.expected = [
+    ''
+      The following programs.zsh.sessionVariables may change when applied again:
+
+        ESCAPED, defined in `${toString ./session-variables.nix}'
+        PATH, defined in `${toString ./session-variables.nix}'
+
+      Home Manager applies these values once per session today.
+      Applying them in each new Zsh process could change them again.
+
+      For search paths, use home.sessionPath,
+      home.sessionSearchVariables, or home.sessionSearchVariablesAppend.
+      Those options add only the entries that are missing. For other
+      variables, assign a complete value without referring to its previous
+      contents.
+
+      This check is best-effort and detects only direct parameter references
+      such as $NAME, ''${NAME...}, and ''${#NAME}.
+    ''
+  ];
 
   nmt.script = ''
     assertFileExists home-files/.zshenv

--- a/tests/modules/programs/zsh/session-variables.zprofile
+++ b/tests/modules/programs/zsh/session-variables.zprofile
@@ -4,6 +4,12 @@
 # Only source this once
 if [[ -z "${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
   export __HM_ZSH_SESS_VARS_SOURCED=1
+  export ALT_CONSTANT="${ALT_CONSTANT:+fixed}"
+  export ALT_IDENTITY="${ALT_IDENTITY:+$ALT_IDENTITY}"
+  export BRACED="${BRACED}"
+  export DEFAULT="${DEFAULT:-fallback}"
+  export DIRECT="$DIRECT"
+  export ESCAPED="\\$ESCAPED"
   export IS_EMPTY=""
   export IS_FALSE=false
   export IS_TRUE=true

--- a/tests/modules/programs/zsh/session-variables.zshenv
+++ b/tests/modules/programs/zsh/session-variables.zshenv
@@ -5,6 +5,12 @@ if [[ ! -o login ]]; then
   # Only source this once
   if [[ -z "${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
     export __HM_ZSH_SESS_VARS_SOURCED=1
+    export ALT_CONSTANT="${ALT_CONSTANT:+fixed}"
+    export ALT_IDENTITY="${ALT_IDENTITY:+$ALT_IDENTITY}"
+    export BRACED="${BRACED}"
+    export DEFAULT="${DEFAULT:-fallback}"
+    export DIRECT="$DIRECT"
+    export ESCAPED="\\$ESCAPED"
     export IS_EMPTY=""
     export IS_FALSE=false
     export IS_TRUE=true


### PR DESCRIPTION
### Description

Warns when `home.sessionVariables` or `programs.zsh.sessionVariables` contains a direct self-reference that may change when applied more than once. This PR changes diagnostics only; generated session-variable output is unchanged.

The detector follows each caller's rendering rules, including Zsh backslash escaping. It excludes stable whole-value references, default and assignment expansions, and alternate expansions whose selected value is stable. The check remains best-effort and does not try to parse indirect references.

Each offender is attributed to the surviving definition of that attribute. Attribution respects module conditions, priorities, ordering, and explicit definition locations. The warning recommends the search-variable options for path-like values and complete assignments for other variables.

This gives users advance notice before the next PR allows session-variable configuration to run in each new shell.

Part of splitting #9735 into independently reviewable changes; the stack as a whole supersedes that PR.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt`.
- [x] Code tested through `nix build .#test-all`.
- [x] Test cases updated/added.
- [x] Commit messages follow the `{component}: {description}` format.
