### PR TITLE
home-environment: refresh session vars in shells

### DIFF
--- a/docs/release-notes/rl-2611.md
+++ b/docs/release-notes/rl-2611.md
@@ -47,6 +47,21 @@ This release has the following notable changes:
   }
   ```
 
+- {file}`hm-session-vars.sh` now refreshes plain and search variables whenever
+  a shell applies it. Zsh, Fish, and `targets.genericLinux.enable` startup
+  paths pick up values changed by `home-manager switch` without requiring a
+  logout.
+  Plain variables are re-evaluated and re-exported. Search variables add only
+  the entries that are missing. Module-provided extra setup keeps its
+  once-per-session guard because it may run arbitrary code.
+
+  Shell expansions in plain variable values now run each time the file is
+  applied, including command substitutions. Self-referential values can change
+  repeatedly, and append or prepend forms can accumulate copies. Home Manager
+  warns about the cases it can detect; use the search-path options instead.
+  Removing a variable still requires a new session because Home Manager does
+  not record what a previous generation exported.
+
 ## State Version Changes {#sec-release-26.11-state-version-changes}
 
 The state version in this release includes the changes below. These

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -329,6 +329,9 @@ in
         value `bar` can be given as per
         `''${parameter:+bar}`.
 
+        Shell expansions, including command substitutions, run each time the
+        generated session variables file is applied.
+
         Note, these variables may be set in any order so no session
         variable may have a runtime dependency on another session
         variable. In particular code like
@@ -360,6 +363,12 @@ in
       description = ''
         The package containing the
         {file}`hm-session-vars.sh` file.
+
+        Shells can apply the file more than once. Plain variables are
+        re-evaluated and re-exported, and search variables add only missing
+        entries. Shell expansions in plain variable values run each time.
+        [](#opt-home.sessionVariablesExtra) is guarded to run once per
+        session.
       '';
     };
 
@@ -706,8 +715,8 @@ in
         option = options.home.sessionVariables;
         optionPath = "home.sessionVariables";
         rationale = ''
-          Home Manager applies the session variables file once per session
-          today. Applying it again in a new shell could change these values.
+          Home Manager applies the session variables file in each new shell,
+          so these values can change repeatedly.
         '';
       };
 
@@ -757,12 +766,14 @@ in
           };
         in
         mkSections [
-          ''
-            # Only source this once.
-            if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
-            export __HM_SESS_VARS_SOURCED=1''
           (config.lib.shell.exportAll cfg.sessionVariables)
           searchSection
+          # Keep arbitrary extra code at top level. A compound wrapper would
+          # change when aliases and parser options take effect.
+          ''
+            if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
+            export __HM_SESS_VARS_SOURCED=1
+          ''
           cfg.sessionVariablesExtra
         ];
     };

--- a/modules/lib/fish-session-variables.nix
+++ b/modules/lib/fish-session-variables.nix
@@ -29,13 +29,15 @@ let
   candidateNames = lib.concatMap (merge: map (candidate: candidate.name) merge.candidates) merges;
 
   prelude = pkgs.writeText "hm-session-vars-fish-prelude.sh" ''
-    if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
-    export __HM_SESS_VARS_SOURCED=1
-
     ${shell.exportAll config.home.sessionVariables}
   '';
 
-  extra = pkgs.writeText "hm-session-vars-fish-extra.sh" config.home.sessionVariablesExtra;
+  extra = pkgs.writeText "hm-session-vars-fish-extra.sh" ''
+    if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
+    export __HM_SESS_VARS_SOURCED=1
+
+    ${config.home.sessionVariablesExtra}
+  '';
 
   # Translate assignments and calls together so an entry can observe earlier
   # search-variable merges. The helper itself remains native Fish.

--- a/modules/misc/news/2026/08/2026-08-27_14-00-00.nix
+++ b/modules/misc/news/2026/08/2026-08-27_14-00-00.nix
@@ -1,0 +1,19 @@
+{
+  time = "2026-08-27T14:00:00+00:00";
+  condition = true;
+  message = ''
+    {file}`hm-session-vars.sh` now refreshes plain and search variables whenever
+    a shell applies it. Zsh, Fish, and `targets.genericLinux.enable` startup
+    paths pick up values changed by `home-manager switch` without logging out.
+    Plain variables are re-evaluated and re-exported, while search variables
+    add only missing entries. Shell expansions, including command
+    substitutions, run again when the file is applied.
+
+    Module-provided extra setup still runs once per session because it may
+    contain arbitrary code.
+
+    Self-referential values can change repeatedly. Removing a variable still
+    requires a new session because Home Manager does not record what a previous
+    generation exported.
+  '';
+}

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -429,14 +429,14 @@ in
   config =
     let
       envVarsStr = config.lib.zsh.exportAll cfg.sessionVariables { indent = "  "; };
+      sessionVarsToken = "${config.home.sessionVariablesPackage}:${builtins.hashString "sha256" envVarsStr}";
       localVarsStr = config.lib.zsh.defineAll cfg.localVariables;
       sessionVarsStr = lib.removeSuffix "\n" ''
-        # Environment variables
-        . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
-
-        # Only source this once
-        if [[ -z "''${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
-          export __HM_ZSH_SESS_VARS_SOURCED=1
+        # Apply one generated version per process tree. The token changes when
+        # either the generic or Zsh-specific variables change.
+        if [[ "''${__HM_ZSH_SESS_VARS_SOURCED-}" != "${sessionVarsToken}" ]]; then
+          export __HM_ZSH_SESS_VARS_SOURCED="${sessionVarsToken}"
+          . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
           ${envVarsStr}
         fi
       '';
@@ -496,8 +496,8 @@ in
               optionPath = "programs.zsh.sessionVariables";
               renderValue = renderSessionVariable;
               rationale = ''
-                Home Manager applies these values once per session today.
-                Applying them in each new Zsh process could change them again.
+                Home Manager reapplies these values after the generated session
+                variables change, so self-referential values can change again.
               '';
             }
             ++

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -1,49 +1,5 @@
-{ config, pkgs, ... }:
+{ config, realPkgs, ... }:
 
-let
-
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
-
-  linuxExpected = ''
-    # Only source this once.
-    if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
-    export __HM_SESS_VARS_SOURCED=1
-
-    export IS_EMPTY=""
-    export IS_FALSE="false"
-    export IS_TRUE="true"
-    export LOCALE_ARCHIVE_2_27="${config.i18n.glibcLocales}/lib/locale/locale-archive"
-    export V1="v1"
-    export V2="v2-v1"
-    export WARNING="$WARNING/suffix"
-    export XDG_BIN_HOME="/home/hm-user/.local/bin"
-    export XDG_CACHE_HOME="/home/hm-user/.cache"
-    export XDG_CONFIG_HOME="/home/hm-user/.config"
-    export XDG_DATA_HOME="/home/hm-user/.local/share"
-    export XDG_STATE_HOME="/home/hm-user/.local/state"
-  '';
-
-  darwinExpected = ''
-    # Only source this once.
-    if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
-    export __HM_SESS_VARS_SOURCED=1
-
-    export IS_EMPTY=""
-    export IS_FALSE="false"
-    export IS_TRUE="true"
-    export V1="v1"
-    export V2="v2-v1"
-    export WARNING="$WARNING/suffix"
-    export XDG_BIN_HOME="/home/hm-user/.local/bin"
-    export XDG_CACHE_HOME="/home/hm-user/.cache"
-    export XDG_CONFIG_HOME="/home/hm-user/.config"
-    export XDG_DATA_HOME="/home/hm-user/.local/share"
-    export XDG_STATE_HOME="/home/hm-user/.local/state"
-  '';
-
-  expected = pkgs.writeText "expected" (if isDarwin then darwinExpected else linuxExpected);
-
-in
 {
   # Keep this test to plain session variables. On Darwin the terminfo module
   # would otherwise add its TERMINFO_DIRS merge and TERM re-export here; both
@@ -66,8 +22,8 @@ in
 
         WARNING, defined in `${toString ./session-variables.nix}'
 
-      Home Manager applies the session variables file once per session
-      today. Applying it again in a new shell could change these values.
+      Home Manager applies the session variables file in each new shell,
+      so these values can change repeatedly.
 
       For search paths, use home.sessionPath,
       home.sessionSearchVariables, or home.sessionSearchVariablesAppend.
@@ -80,9 +36,94 @@ in
     ''
   ];
 
+  # Keep the alias and heredoc top-level and verbatim. Wrapping delays alias
+  # expansion, while indenting moves the heredoc terminator.
+  home.sessionVariablesExtra = ''
+    shopt -s expand_aliases 2>/dev/null || true
+    alias hm_extra_alias='EXTRA_ALIAS_OK=1'
+    hm_extra_alias
+    export EXTRA_ALIAS_OK
+    EXTRA_RUNS=$((''${EXTRA_RUNS:-0} + 1))
+    export EXTRA_RUNS
+    HEREDOC_OK=$(cat <<'EOT'
+    verbatim
+    EOT
+    )
+    export HEREDOC_OK
+  '';
+
   nmt.script = ''
-    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
-    assertFileContent home-path/etc/profile.d/hm-session-vars.sh \
-      ${expected}
+    hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
+    assertFileExists $hmSessVars
+
+    for shellBin in \
+      "$BASH" \
+      ${realPkgs.dash}/bin/dash \
+      "${realPkgs.zsh}/bin/zsh -f"; do
+
+      env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+        WARNING=base \
+        $shellBin -uc '
+          unset V1 V2 IS_EMPTY IS_NULL IS_TRUE IS_FALSE EXTRA_RUNS
+          . "$1"
+
+          [ "$V1" = v1 ] || { echo "V1: $V1"; exit 1; }
+          [ "$V2" = v2-v1 ] || { echo "V2: $V2"; exit 1; }
+          [ "$IS_EMPTY" = "" ] || { echo "IS_EMPTY: $IS_EMPTY"; exit 1; }
+          [ "$IS_TRUE" = true ] || { echo "IS_TRUE: $IS_TRUE"; exit 1; }
+          [ "$IS_FALSE" = false ] || { echo "IS_FALSE: $IS_FALSE"; exit 1; }
+          [ "$WARNING" = base/suffix ] \
+            || { echo "WARNING: $WARNING"; exit 1; }
+
+          # A null value is skipped entirely rather than exported empty.
+          [ -z "''${IS_NULL+set}" ] || { echo "IS_NULL was exported"; exit 1; }
+
+          [ "$EXTRA_RUNS" = 1 ] || { echo "EXTRA_RUNS: $EXTRA_RUNS"; exit 1; }
+          [ "$HEREDOC_OK" = verbatim ] \
+            || { echo "HEREDOC_OK: <$HEREDOC_OK>"; exit 1; }
+          [ "$EXTRA_ALIAS_OK" = 1 ] \
+            || { echo "EXTRA_ALIAS_OK: <$EXTRA_ALIAS_OK>"; exit 1; }
+          exit 0
+        ' shell "$TESTED/$hmSessVars" \
+        || fail "$shellBin: first source did not apply session variables"
+
+      # The headline behaviour: a stale inherited value is replaced, while the
+      # extra section stays once per session.
+      env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+        V1=stale V2=stale WARNING=base \
+        $shellBin -uc '
+          . "$1"
+          [ "$V1" = v1 ] || { echo "stale V1 survived: $V1"; exit 1; }
+          [ "$V2" = v2-v1 ] || { echo "stale V2 survived: $V2"; exit 1; }
+
+          . "$1"
+          [ "$V1" = v1 ] || { echo "V1 after re-source: $V1"; exit 1; }
+          [ "$WARNING" = base/suffix/suffix ] \
+            || { echo "WARNING after re-source: $WARNING"; exit 1; }
+          [ "$EXTRA_RUNS" = 1 ] \
+            || { echo "extra section ran again: $EXTRA_RUNS"; exit 1; }
+          exit 0
+        ' shell "$TESTED/$hmSessVars" \
+        || fail "$shellBin: re-sourcing did not refresh session variables"
+
+      # A child that inherits the sourced marker still refreshes plain values,
+      # because only the extra section is guarded.
+      env -u __HM_SESS_VARS_MERGED \
+        __HM_SESS_VARS_SOURCED=1 V1=stale WARNING=base EXTRA_RUNS=1 \
+        $shellBin -uc '
+          . "$1"
+          [ "$V1" = v1 ] || { echo "child kept stale V1: $V1"; exit 1; }
+          [ "$WARNING" = base/suffix ] \
+            || { echo "child WARNING: $WARNING"; exit 1; }
+          [ "$EXTRA_RUNS" = 1 ] \
+            || { echo "child re-ran the extra section: $EXTRA_RUNS"; exit 1; }
+          exit 0
+        ' shell "$TESTED/$hmSessVars" \
+        || fail "$shellBin: inherited session did not refresh"
+    done
+
+    # Syntax check under a strict POSIX shell.
+    ${realPkgs.dash}/bin/dash -n "$TESTED/$hmSessVars" \
+      || fail "generated file is not valid POSIX sh"
   '';
 }

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -16,6 +16,13 @@
   };
 
   nmt.script = ''
+    sessionVars=home-path/etc/profile.d/hm-session-vars.sh
+    env -u __HM_SESS_VARS_SOURCED "$BASH" --noprofile --norc -uc '
+      . "$1"
+      [ "$__HM_SESS_VARS_SOURCED" = 1 ]
+    ' shell "$TESTED/$sessionVars" \
+      || fail "an empty extra section did not set the sourced marker"
+
     assertFileExists home-files/.profile
     assertFileContent \
       "$(normalizeStorePaths home-files/.profile)" \

--- a/tests/modules/programs/fish/session-variables.nix
+++ b/tests/modules/programs/fish/session-variables.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, realPkgs, ... }:
 
 {
   config = {
@@ -7,14 +7,41 @@
       V2 = "v2-${config.home.sessionVariables.V1}";
     };
 
+    # Arithmetic expansion does not survive babelfish, which the extra section
+    # still goes through, so count with string append instead.
+    home.sessionVariablesExtra = ''
+      EXTRA_RUNS="''${EXTRA_RUNS-}x"
+      export EXTRA_RUNS
+    '';
+
     programs.fish.enable = true;
 
     nmt.script = ''
-      assertFileExists home-path/etc/profile.d/hm-session-vars.fish
-      assertFileRegex home-path/etc/profile.d/hm-session-vars.fish \
-        "set -gx V1 'v1'"
-      assertFileRegex home-path/etc/profile.d/hm-session-vars.fish \
-        "set -gx V1 'v1'"
+      sessionVars=home-path/etc/profile.d/hm-session-vars.fish
+      assertFileExists $sessionVars
+
+      # Fish is the shell most likely to diverge, because it gets a separate
+      # generator rather than a translation of the POSIX file. Assert the same
+      # behaviour that file is checked for, rather than pinning its text.
+      env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+        ${realPkgs.fish}/bin/fish --no-config -c '
+          set -gx V1 stale
+          set -gx V2 stale
+
+          source $argv[1]
+          test "$V1" = v1; or begin; echo "V1: $V1"; exit 1; end
+          test "$V2" = v2-v1; or begin; echo "V2: $V2"; exit 1; end
+          test "$EXTRA_RUNS" = x
+          or begin; echo "EXTRA_RUNS: $EXTRA_RUNS"; exit 1; end
+
+          # Applying it again converges and does not re-run the extra section.
+          source $argv[1]
+          test "$V1" = v1; or begin; echo "V1 after re-source: $V1"; exit 1; end
+          test "$EXTRA_RUNS" = x
+          or begin; echo "extra ran again: $EXTRA_RUNS"; exit 1; end
+          exit 0
+        ' "$TESTED/$sessionVars" \
+        || fail "fish did not refresh session variables"
     '';
   };
 }

--- a/tests/modules/programs/zsh/session-variables.nix
+++ b/tests/modules/programs/zsh/session-variables.nix
@@ -1,6 +1,8 @@
-{ config, ... }:
+{ config, realPkgs, ... }:
 
 {
+  home.sessionVariables.COLLIDE = "generic";
+
   programs.zsh = {
     enable = true;
 
@@ -8,6 +10,7 @@
       ALT_CONSTANT = "\${ALT_CONSTANT:+fixed}";
       ALT_IDENTITY = "\${ALT_IDENTITY:+$ALT_IDENTITY}";
       BRACED = "\${BRACED}";
+      COLLIDE = "zsh";
       DEFAULT = "\${DEFAULT:-fallback}";
       DIRECT = "$DIRECT";
       ESCAPED = "\\$ESCAPED";
@@ -28,8 +31,8 @@
         ESCAPED, defined in `${toString ./session-variables.nix}'
         PATH, defined in `${toString ./session-variables.nix}'
 
-      Home Manager applies these values once per session today.
-      Applying them in each new Zsh process could change them again.
+      Home Manager reapplies these values after the generated session
+      variables change, so self-referential values can change again.
 
       For search paths, use home.sessionPath,
       home.sessionSearchVariables, or home.sessionSearchVariablesAppend.
@@ -47,5 +50,32 @@
     assertFileContent $(normalizeStorePaths home-files/.zshenv) ${./session-variables.zshenv}
     assertFileExists home-files/.zprofile
     assertFileContent $(normalizeStorePaths home-files/.zprofile) ${./session-variables.zprofile}
+
+    env -u __HM_SESS_VARS_SOURCED -u __HM_ZSH_SESS_VARS_SOURCED \
+      PATH=/base HOME=/home/hm-user \
+      ${realPkgs.zsh}/bin/zsh -f -c '
+        export __HM_ZSH_SESS_VARS_SOURCED=1
+        . "$1"
+
+        [ "$V1" = v1 ] || { echo "legacy marker kept V1: $V1"; exit 1; }
+        [ "$COLLIDE" = zsh ] \
+          || { echo "first COLLIDE: $COLLIDE"; exit 1; }
+        [ "$PATH" = /home/hm-user/bin:/base ] \
+          || { echo "first PATH: $PATH"; exit 1; }
+        [ "$__HM_ZSH_SESS_VARS_SOURCED" != 1 ] \
+          || { echo "legacy marker survived"; exit 1; }
+
+        firstMarker=$__HM_ZSH_SESS_VARS_SOURCED
+        ${realPkgs.zsh}/bin/zsh -f -c "
+          . \"\$1\"
+          [ \"\$PATH\" = \"\$2\" ] \
+            || { echo \"nested PATH: \$PATH\"; exit 1; }
+          [ \"\$COLLIDE\" = zsh ] \
+            || { echo \"nested COLLIDE: \$COLLIDE\"; exit 1; }
+          [ \"\$__HM_ZSH_SESS_VARS_SOURCED\" = \"\$3\" ] \
+            || { echo \"nested marker changed\"; exit 1; }
+        " child "$1" "$PATH" "$firstMarker"
+      ' shell "$TESTED/home-files/.zshenv" \
+      || fail "Zsh session variables did not follow the generation token"
   '';
 }

--- a/tests/modules/programs/zsh/session-variables.zprofile
+++ b/tests/modules/programs/zsh/session-variables.zprofile
@@ -1,12 +1,12 @@
-# Environment variables
-. "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
-
-# Only source this once
-if [[ -z "${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
-  export __HM_ZSH_SESS_VARS_SOURCED=1
+# Apply one generated version per process tree. The token changes when
+# either the generic or Zsh-specific variables change.
+if [[ "${__HM_ZSH_SESS_VARS_SOURCED-}" != "/nix/store/00000000000000000000000000000000-hm-session-vars.sh:2aa49d79310bce950e24944ffad9ea8f9a09cabb4231227a7ea196f33298224c" ]]; then
+  export __HM_ZSH_SESS_VARS_SOURCED="/nix/store/00000000000000000000000000000000-hm-session-vars.sh:2aa49d79310bce950e24944ffad9ea8f9a09cabb4231227a7ea196f33298224c"
+  . "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
   export ALT_CONSTANT="${ALT_CONSTANT:+fixed}"
   export ALT_IDENTITY="${ALT_IDENTITY:+$ALT_IDENTITY}"
   export BRACED="${BRACED}"
+  export COLLIDE="zsh"
   export DEFAULT="${DEFAULT:-fallback}"
   export DIRECT="$DIRECT"
   export ESCAPED="\\$ESCAPED"

--- a/tests/modules/programs/zsh/session-variables.zshenv
+++ b/tests/modules/programs/zsh/session-variables.zshenv
@@ -1,13 +1,13 @@
 if [[ ! -o login ]]; then
-  # Environment variables
-  . "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
-
-  # Only source this once
-  if [[ -z "${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
-    export __HM_ZSH_SESS_VARS_SOURCED=1
+  # Apply one generated version per process tree. The token changes when
+  # either the generic or Zsh-specific variables change.
+  if [[ "${__HM_ZSH_SESS_VARS_SOURCED-}" != "/nix/store/00000000000000000000000000000000-hm-session-vars.sh:2aa49d79310bce950e24944ffad9ea8f9a09cabb4231227a7ea196f33298224c" ]]; then
+    export __HM_ZSH_SESS_VARS_SOURCED="/nix/store/00000000000000000000000000000000-hm-session-vars.sh:2aa49d79310bce950e24944ffad9ea8f9a09cabb4231227a7ea196f33298224c"
+    . "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
     export ALT_CONSTANT="${ALT_CONSTANT:+fixed}"
     export ALT_IDENTITY="${ALT_IDENTITY:+$ALT_IDENTITY}"
     export BRACED="${BRACED}"
+    export COLLIDE="zsh"
     export DEFAULT="${DEFAULT:-fallback}"
     export DIRECT="$DIRECT"
     export ESCAPED="\\$ESCAPED"


### PR DESCRIPTION
### Description

Refreshes plain and search variables when `hm-session-vars.sh` is applied,
instead of returning at the start of the file. Zsh, Fish, and
`targets.genericLinux.enable` startup paths therefore pick up values from the
current Home Manager generation without requiring a logout.

`home.sessionVariablesExtra` remains once per session. Its guard is placed
immediately before the unmodified extra body so aliases, heredocs, and other
parser-sensitive shell code retain top-level behavior. The legacy
`__HM_SESS_VARS_SOURCED` marker remains exported even when the extra section is
empty.

Zsh uses an exported token derived from the generic session-variable package
and rendered `programs.zsh.sessionVariables`. A legacy Boolean marker or a
changed generated value reapplies both generic and Zsh-specific values.
Unchanged nested shells skip both layers, which preserves Zsh precedence and
avoids repeating self-referential values.

Plain values are re-evaluated whenever the file is applied. Command
substitutions run again, and some self-references can change repeatedly.
Search-variable merges add only missing entries. Removing a variable still
requires a new session because Home Manager does not record prior exports.

`targets.genericLinux.enable` starts refreshing here because its Bash startup
already sources `hm-session-vars.sh`; the old whole-file guard made that a
no-op.

Closes #3999
Closes #4559

Part of splitting #9735 into independently reviewable changes; the stack as a
whole supersedes that PR.

### Checklist

- [ ] Change is backwards compatible. (Repeated evaluation is intentional and
  documented in the news and 26.11 release notes.)
- [x] Code formatted with `nix fmt`.
- [x] Code tested through `nix build .#test-all`.
- [x] Test cases updated/added.
- [x] Commit messages follow the `{component}: {description}` format.
