### PR TITLE
programs/bash: refresh session variables in interactive shells

### DIFF
--- a/docs/release-notes/rl-2611.md
+++ b/docs/release-notes/rl-2611.md
@@ -62,6 +62,25 @@ This release has the following notable changes:
   Removing a variable still requires a new session because Home Manager does
   not record what a previous generation exported.
 
+- Interactive non-login Bash shells now apply the session variables file, so
+  they pick up changes from `home-manager switch` like Zsh and Fish already do.
+
+  This is a compatibility break worth stating plainly. Previously a value that
+  {option}`programs.bash.profileExtra` exported at login reached those shells
+  by ordinary environment inheritance, and nothing re-asserted Home Manager's
+  value afterwards. Now Home Manager's value is applied again in each
+  interactive non-login shell, so a `profileExtra` assignment to a name that
+  Home Manager also manages is overwritten there.
+
+  Move such an override to {option}`programs.bash.initExtra`, which runs after
+  the refresh and only for interactive shells. {option}`programs.bash.bashrcExtra`
+  also runs after the refresh, but it additionally runs for `bash -c` under
+  `SSH_SOURCE_BASHRC`, so prefer `initExtra` unless you need that.
+
+  Shell expansions in {option}`programs.bash.sessionVariables` now run when
+  each interactive non-login shell starts. Self-referential values can change
+  repeatedly; Home Manager warns about direct references it can detect.
+
 ## State Version Changes {#sec-release-26.11-state-version-changes}
 
 The state version in this release includes the changes below. These

--- a/modules/misc/news/2026/08/2026-08-27_14-30-00.nix
+++ b/modules/misc/news/2026/08/2026-08-27_14-30-00.nix
@@ -1,0 +1,22 @@
+{ config, ... }:
+{
+  time = "2026-08-27T14:30:00+00:00";
+  condition = config.programs.bash.enable;
+  message = ''
+    Interactive non-login Bash shells now apply the session variables file, so
+    a new terminal picks up values changed by `home-manager switch` instead of
+    keeping whatever the session it started from had.
+
+    If {option}`programs.bash.profileExtra` sets a variable that Home Manager
+    also manages, that assignment no longer survives into those shells: Home
+    Manager's value is applied again after login. Move the override to
+    {option}`programs.bash.initExtra`, which runs after the refresh and only
+    for interactive shells.
+
+    Shell expansions in {option}`programs.bash.sessionVariables` now run when
+    each interactive non-login shell starts. Self-referential values can change
+    repeatedly; Home Manager warns about direct references it can detect.
+
+    Login shells and non-interactive shells are unaffected.
+  '';
+}

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -150,6 +151,10 @@ in
         description = ''
           Environment variables that will be set for the Bash session.
 
+          These values are applied again when each interactive non-login shell
+          starts. Shell expansions run each time, so self-referential values
+          can change repeatedly.
+
           Setting a value to `null` will skip setting the variable at all, which
           may be useful when overriding.
         '';
@@ -246,6 +251,15 @@ in
     mkIf cfg.enable {
       home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
+      warnings = config.lib.shell.selfReferenceWarnings {
+        option = options.programs.bash.sessionVariables;
+        optionPath = "programs.bash.sessionVariables";
+        rationale = ''
+          Home Manager applies these values in each interactive non-login Bash
+          shell, so self-referential values can change repeatedly.
+        '';
+      };
+
       home.file.".bash_profile".source = writeBashScript "bash_profile" ''
         # include .profile if it exists
         [[ -f ~/.profile ]] && . ~/.profile
@@ -274,6 +288,19 @@ in
       '';
 
       home.file.".bashrc".source = writeBashScript "bashrc" ''
+        # .profile handles login shells. Skip non-interactive shells because
+        # sshd can read .bashrc for remote commands, where startup output can
+        # corrupt protocols such as scp and rsync.
+        ${lib.concatStringsSep "\n" (
+          [
+            "if [[ $- == *i* ]] && ! shopt -q login_shell; then"
+            "  . \"${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh\""
+          ]
+          # Keep generated exports unindented because continuation lines are data.
+          ++ lib.optional (sessionVarsStr != "") sessionVarsStr
+          ++ [ "fi" ]
+        )}
+
         ${cfg.bashrcExtra}
 
         # Commands that should be applied only for interactive shells.

--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -73,11 +73,11 @@ in
       export TERM="$TERM"
     '';
 
-    # We need to source both nix.sh and hm-session-vars.sh as noted in
+    # Interactive Bash refreshes the session variables file itself; nix.sh
+    # is still needed here as noted in
     # https://github.com/nix-community/home-manager/pull/797#issuecomment-544783247
     programs.bash.initExtra = ''
       . "${nixPkg}/etc/profile.d/nix.sh"
-      . "${profileDirectory}/etc/profile.d/hm-session-vars.sh"
     '';
 
     programs.zsh.envExtra = ''

--- a/tests/modules/programs/bash/default.nix
+++ b/tests/modules/programs/bash/default.nix
@@ -1,4 +1,5 @@
 {
+  bash-session-variables-refresh = ./session-variables-refresh.nix;
   bash-completion = ./completion.nix;
   bash-logout = ./logout.nix;
   bash-session-variables = ./session-variables.nix;

--- a/tests/modules/programs/bash/session-variables-refresh.nix
+++ b/tests/modules/programs/bash/session-variables-refresh.nix
@@ -1,0 +1,179 @@
+_:
+
+{
+  programs.bash.enable = true;
+
+  home.sessionVariables.GENERIC = "current";
+  programs.bash.sessionVariables = {
+    BASH_OWNED = "from-bash";
+    # A value spanning lines is emitted verbatim inside double quotes, so
+    # anything that reformats the export statement changes the value.
+    BASH_MULTILINE = "first\nsecond";
+    REPEATED = "$REPEATED:again";
+  };
+  home.sessionPath = [
+    "/hm/bin"
+    "/hm/extra"
+  ];
+
+  programs.bash.profileExtra = ''
+    export FROM_PROFILE_EXTRA=login-only
+    export BASH_OWNED=login-override
+  '';
+  programs.bash.bashrcExtra = ''
+    export FROM_BASHRC_EXTRA=every-shell
+  '';
+  programs.bash.initExtra = ''
+    export GENERIC=overridden-by-initExtra
+  '';
+
+  test.asserts.warnings.expected = [
+    ''
+      The following programs.bash.sessionVariables may change when applied again:
+
+        REPEATED, defined in `${toString ./session-variables-refresh.nix}'
+
+      Home Manager applies these values in each interactive non-login Bash
+      shell, so self-referential values can change repeatedly.
+
+      For search paths, use home.sessionPath,
+      home.sessionSearchVariables, or home.sessionSearchVariablesAppend.
+      Those options add only the entries that are missing. For other
+      variables, assign a complete value without referring to its previous
+      contents.
+
+      This check is best-effort and detects only direct parameter references
+      such as $NAME, ''${NAME...}, and ''${#NAME}.
+    ''
+  ];
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileExists home-files/.profile
+
+    testHome=$TMPDIR/home
+    mkdir -p "$testHome"
+    cp "$TESTED/home-files/.bashrc" "$testHome/.bashrc"
+    cp "$TESTED/home-files/.profile" "$testHome/.profile"
+
+    # An interactive non-login shell refreshes generic and Bash-owned values,
+    # and initExtra still wins because it runs after the refresh.
+    env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+      HOME="$testHome" TERM=dumb PATH=/usr/bin \
+      GENERIC=stale BASH_OWNED=stale \
+      "$BASH" --noprofile --norc -ic '
+        . "$HOME/.bashrc"
+        [ "$GENERIC" = overridden-by-initExtra ] \
+          || { echo "GENERIC: $GENERIC"; exit 1; }
+        [ "$BASH_OWNED" = from-bash ] \
+          || { echo "BASH_OWNED: $BASH_OWNED"; exit 1; }
+        [ "$FROM_BASHRC_EXTRA" = every-shell ] \
+          || { echo "bashrcExtra did not run"; exit 1; }
+        case ":$PATH:" in *:/hm/bin:*) ;; *) echo "sessionPath missing: $PATH"; exit 1 ;; esac
+        exit 0
+      ' \
+      || fail "interactive non-login shell did not refresh"
+
+    # Search paths stay stable, while plain Bash values are re-evaluated.
+    env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+      HOME="$testHome" TERM=dumb PATH=/usr/bin REPEATED=base \
+      "$BASH" --noprofile --norc -ic '
+        . "$HOME/.bashrc"
+        first="$PATH"
+        [ "$REPEATED" = base:again ] \
+          || { echo "first REPEATED: $REPEATED"; exit 1; }
+        . "$HOME/.bashrc"
+        [ "$PATH" = "$first" ] || { echo "PATH grew: $PATH"; exit 1; }
+        [ "$REPEATED" = base:again:again ] \
+          || { echo "second REPEATED: $REPEATED"; exit 1; }
+        exit 0
+      ' \
+      || fail "repeated .bashrc sourcing was not idempotent"
+
+    # The headline case: a terminal spawned from a session that already
+    # sourced an older generation. Both guards are inherited, a managed value
+    # is stale, and PATH lost one configured entry while keeping the other in
+    # a position something else chose.
+    env __HM_SESS_VARS_SOURCED=1 __HM_SESS_VARS_MERGED=1 \
+      HOME="$testHome" TERM=dumb PATH=/usr/bin:/hm/extra:/bin \
+      BASH_OWNED=stale \
+      "$BASH" --noprofile --norc -ic '
+        . "$HOME/.bashrc"
+        [ "$BASH_OWNED" = from-bash ] \
+          || { echo "stale value survived: $BASH_OWNED"; exit 1; }
+        case ":$PATH:" in
+          *:/hm/bin:*) ;;
+          *) echo "missing entry not added: $PATH"; exit 1 ;;
+        esac
+        # /hm/extra was already present, so a later merge must leave it where
+        # it was instead of pulling it back to the configured position.
+        [ "$PATH" = /hm/bin:/usr/bin:/hm/extra:/bin ] \
+          || { echo "PATH repositioned: $PATH"; exit 1; }
+        exit 0
+      ' \
+      || fail "stale session was not refreshed"
+
+    # A multi-line value must survive the refresh unchanged: an interactive
+    # non-login shell has to see exactly what a login shell sees.
+    expected=$(printf 'first\nsecond')
+
+    nonLogin=$(env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+      HOME="$testHome" TERM=dumb PATH=/usr/bin \
+      "$BASH" --noprofile --norc -ic '
+        . "$HOME/.bashrc"
+        printf "%s" "$BASH_MULTILINE"
+      ') || fail "multi-line refresh shell failed"
+
+    login=$(env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+      HOME="$testHome" TERM=dumb PATH=/usr/bin \
+      "$BASH" --noprofile --norc -lic '
+        . "$HOME/.profile"
+        printf "%s" "$BASH_MULTILINE"
+      ') || fail "multi-line login shell failed"
+
+    [ "$login" = "$expected" ] \
+      || fail "login shell multi-line value: <$login>"
+    [ "$nonLogin" = "$login" ] \
+      || fail "refresh changed a multi-line value: <$nonLogin>"
+
+    # A login shell must not run the refresh: .profile already did it, and
+    # profileExtra runs after it there.
+    env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+      HOME="$testHome" TERM=dumb PATH=/usr/bin \
+      "$BASH" --noprofile --norc -lic '
+        . "$HOME/.profile"
+        [ "$FROM_PROFILE_EXTRA" = login-only ] \
+          || { echo "profileExtra did not run at login"; exit 1; }
+        [ "$GENERIC" = current ] || { echo "GENERIC: $GENERIC"; exit 1; }
+        exit 0
+      ' \
+      || fail "login shell path broken"
+
+    # The distro layout: a .bash_profile that chains .bashrc. .bashrc runs in
+    # a login shell there, so the refresh must stay out of the way and let
+    # profileExtra keep the last word over a name Home Manager also manages.
+    env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+      HOME="$testHome" TERM=dumb PATH=/usr/bin \
+      "$BASH" --noprofile --norc -lic '
+        . "$HOME/.profile"
+        . "$HOME/.bashrc"
+        [ "$BASH_OWNED" = login-override ] \
+          || { echo "refresh ran in a login shell: $BASH_OWNED"; exit 1; }
+        [ "$FROM_BASHRC_EXTRA" = every-shell ] \
+          || { echo "bashrcExtra did not run at login"; exit 1; }
+        exit 0
+      ' \
+      || fail "login shell chaining .bashrc lost profileExtra"
+
+    # Non-interactive shells must stay silent and untouched. bash reads
+    # .bashrc for `ssh host cmd`, where any output breaks scp and rsync.
+    out=$(env -u __HM_SESS_VARS_SOURCED -u __HM_SESS_VARS_MERGED \
+      HOME="$testHome" TERM=dumb PATH=/usr/bin GENERIC=stale \
+      "$BASH" --noprofile --norc -c '
+        . "$HOME/.bashrc"
+        printf "%s" "$GENERIC"
+      ')
+    [ "$out" = stale ] \
+      || fail "non-interactive shell was modified or noisy: <$out>"
+  '';
+}

--- a/tests/modules/programs/fabric-ai/bashrc
+++ b/tests/modules/programs/fabric-ai/bashrc
@@ -1,3 +1,10 @@
+# .profile handles login shells. Skip non-interactive shells because
+# sshd can read .bashrc for remote commands, where startup output can
+# corrupt protocols such as scp and rsync.
+if [[ $- == *i* ]] && ! shopt -q login_shell; then
+  . "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
+fi
+
 
 
 # Commands that should be applied only for interactive shells.

--- a/tests/modules/programs/fabric-ai/example-config.nix
+++ b/tests/modules/programs/fabric-ai/example-config.nix
@@ -10,7 +10,7 @@
     assertFileExists home-files/.bashrc
     assertFileExists home-files/.zshrc
 
-    assertFileContent home-files/.bashrc ${./bashrc}
+    assertFileContent $(normalizeStorePaths home-files/.bashrc) ${./bashrc}
     assertFileContent home-files/.zshrc ${./zshrc}
   '';
 }


### PR DESCRIPTION
### Description

Interactive non-login Bash shells now apply the session variables file, so a new terminal picks up values changed by `home-manager switch`. Zsh and Fish got this earlier in the stack; Bash needs its own gate: `[[ $- == *i* ]] && ! shopt -q login_shell`. Login shells are skipped because `.profile` already applied the file. Non-interactive shells are skipped because Bash can read `.bashrc` for remote commands, where startup output can corrupt protocols such as scp and rsync.

The generic Linux hook no longer sources the session variables file separately; it keeps its existing `nix.sh` call, which #9925 above replaces.

There is no ownership manifest; ordering does its job. The refresh runs first, then `bashrcExtra`, then `initExtra`, so anything that must survive is declared in a place that runs after it.

`programs.bash.sessionVariables` is reapplied after the generic values to preserve its precedence. Its expansions run whenever an interactive non-login shell starts. Direct self-references can therefore change repeatedly; Home Manager warns about the forms it can detect. Declarative search variables remain idempotent.

**Stated compatibility break**: a `profileExtra` assignment to a name Home Manager also manages previously reached these shells by inheritance and is now overwritten. The release note and news entry say so and point at `initExtra` as the migration target.

Part of splitting #9735 into independently reviewable changes; the stack as a whole supersedes that PR.

### Checklist

- [ ] Change is backwards compatible. (Stated break for `profileExtra` collisions; release note and news entry included.)
- [x] Code formatted with `nix fmt`.
- [x] Code tested through `nix build .#test-all`.
- [x] Test cases updated/added.
- [x] Commit messages follow the `{component}: {description}` format.



