### PR TITLE
generic-linux-gpu: elevate `non-nixos-gpu-setup` if not root

### DIFF
--- a/modules/targets/generic-linux/gpu/setup/non-nixos-gpu-setup
+++ b/modules/targets/generic-linux/gpu/setup/non-nixos-gpu-setup
@@ -2,6 +2,10 @@
 
 set -e
 
+if [ "$EUID" -ne 0 ]; then
+  exec sudo "$0" "$@"
+fi
+
 # Migrate from old systemd service setup
 old_unit=/etc/systemd/system/non-nixos-gpu.service
 if [[ -L "$old_unit" || -f "$old_unit" ]]; then

--- a/modules/targets/generic-linux/gpu/setup/non-nixos-gpu-setup
+++ b/modules/targets/generic-linux/gpu/setup/non-nixos-gpu-setup
@@ -3,6 +3,7 @@
 set -e
 
 if [ "$EUID" -ne 0 ]; then
+  echo "This script requires root privileges to modify /etc and manage systemd configurations. Elevating via sudo..."
   exec sudo "$0" "$@"
 fi
 


### PR DESCRIPTION
### Description

Closes #9867 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
