### PR TITLE
module/impala: TUI for managing wifi on Linux

### DIFF
--- a/modules/misc/news/2026/08/2026-08-29_13-41-49.nix
+++ b/modules/misc/news/2026/08/2026-08-29_13-41-49.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+{
+  time = "2026-08-29T08:11:49+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'programs.impala'
+
+    TUI for managing wifi on Linux, with iwd as the wifi backend.
+    See <https://github.com/pythops/impala> for more.
+  '';
+}

--- a/modules/programs/impala.nix
+++ b/modules/programs/impala.nix
@@ -1,0 +1,82 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.impala;
+  tomlFormat = pkgs.formats.toml { };
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    mkIf
+    ;
+in
+{
+  meta.maintainers = [ lib.maintainers.rachitvrma ];
+
+  options.programs.impala = {
+    enable = mkEnableOption "impala, a TUI for iwd network";
+    package = mkPackageOption pkgs "impala" { nullable = true; };
+    settings = mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = {
+        access_point = {
+          start = "n";
+          stop = "x";
+        };
+        ascii = false;
+        device = {
+          infos = "i";
+          toggle_power = "o";
+        };
+        esc_quit = false;
+        mode = "station";
+        station = {
+          known_network = {
+            remove = "d";
+            share = "p";
+            show_all = "a";
+            toggle_autoconnect = "t";
+          };
+          new_network = {
+            connect_hidden = "";
+            show_all = "a";
+          };
+          toggle_scanning = "s";
+        };
+        switch = "r";
+        theme = {
+          background = "dark gray";
+          border = "green";
+          error_color = "red";
+          hidden_color = "dark gray";
+          info_color = "green";
+          text_color = "white";
+          warning_color = "yellow";
+        };
+      };
+      description = ''
+        Settings writteng to {file}`XDG_CONFIG_HOME/impala/config.toml`.
+
+        See <https://github.com/pythops/impala#%EF%B8%8Fcustom-keybindings-and-themes>
+        for more configuration options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.impala" pkgs lib.platforms.linux)
+    ];
+
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."impala/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "hm_impala-config.toml" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/impala/default.nix
+++ b/tests/modules/programs/impala/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  impala-empty-config = ./empty-config.nix;
+  impala-example-config = ./example-config.nix;
+}

--- a/tests/modules/programs/impala/empty-config.nix
+++ b/tests/modules/programs/impala/empty-config.nix
@@ -1,0 +1,7 @@
+{
+  programs.impala.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/impala"
+  '';
+}

--- a/tests/modules/programs/impala/example-config.nix
+++ b/tests/modules/programs/impala/example-config.nix
@@ -1,0 +1,45 @@
+{
+  programs.impala = {
+    enable = true;
+    settings = {
+      access_point = {
+        start = "n";
+        stop = "x";
+      };
+      ascii = false;
+      device = {
+        infos = "i";
+        toggle_power = "o";
+      };
+      esc_quit = false;
+      mode = "station";
+      station = {
+        known_network = {
+          remove = "d";
+          share = "p";
+          show_all = "a";
+          toggle_autoconnect = "t";
+        };
+        new_network = {
+          connect_hidden = "";
+          show_all = "a";
+        };
+        toggle_scanning = "s";
+      };
+      switch = "r";
+      theme = {
+        background = "dark gray";
+        border = "green";
+        error_color = "red";
+        hidden_color = "dark gray";
+        info_color = "green";
+        text_color = "white";
+        warning_color = "yellow";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent "home-files/.config/impala/config.toml" ${./expected-config.toml}
+  '';
+}

--- a/tests/modules/programs/impala/expected-config.toml
+++ b/tests/modules/programs/impala/expected-config.toml
@@ -1,0 +1,34 @@
+ascii = false
+esc_quit = false
+mode = "station"
+switch = "r"
+
+[access_point]
+start = "n"
+stop = "x"
+
+[device]
+infos = "i"
+toggle_power = "o"
+
+[station]
+toggle_scanning = "s"
+
+[station.known_network]
+remove = "d"
+share = "p"
+show_all = "a"
+toggle_autoconnect = "t"
+
+[station.new_network]
+connect_hidden = ""
+show_all = "a"
+
+[theme]
+background = "dark gray"
+border = "green"
+error_color = "red"
+hidden_color = "dark gray"
+info_color = "green"
+text_color = "white"
+warning_color = "yellow"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
impala v0.9.0 introduces a configuration file to configure impala.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
