### PR TITLE
yopass: add module

### DIFF
--- a/modules/misc/news/2026/08/2026-08-29_08-55-25.nix
+++ b/modules/misc/news/2026/08/2026-08-29_08-55-25.nix
@@ -1,0 +1,9 @@
+{
+  time = "2026-08-29T06:55:25+00:00";
+  message = ''
+    A new module is available: 'programs.yopass'.
+
+    Yopass is a tool for sharing secrets and files securely. The module
+    manages the yopass command line client's configuration file.
+  '';
+}

--- a/modules/programs/yopass.nix
+++ b/modules/programs/yopass.nix
@@ -1,0 +1,52 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.yopass;
+in
+{
+  meta.maintainers = [ lib.maintainers.fraggerfox ];
+
+  options.programs.yopass = {
+    enable = lib.mkEnableOption "Yopass, a tool for sharing secrets and files securely";
+
+    package = lib.mkPackageOption pkgs "yopass" { nullable = true; };
+
+    settings = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.oneOf [
+          lib.types.bool
+          lib.types.int
+          lib.types.str
+        ]
+      );
+      default = { };
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/yopass/defaults.yml`.
+
+        See the [CLI documentation](https://yopass.se/docs/cli) for the
+        full list of available settings (`api`, `api-token`, `url`,
+        `one-time`, `expiration`).
+      '';
+      example = {
+        api = "https://api.example.com";
+        url = "https://example.com";
+        "one-time" = false;
+        expiration = "1d";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."yopass/defaults.yml" = lib.mkIf (cfg.settings != { }) {
+      text = lib.generators.toYAML { } cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/yopass/default.nix
+++ b/tests/modules/programs/yopass/default.nix
@@ -1,0 +1,3 @@
+{
+  yopass-settings = ./settings.nix;
+}

--- a/tests/modules/programs/yopass/settings.nix
+++ b/tests/modules/programs/yopass/settings.nix
@@ -1,0 +1,19 @@
+{
+  programs.yopass = {
+    enable = true;
+    settings = {
+      api = "https://api.example.com";
+      url = "https://example.com";
+      "one-time" = false;
+      expiration = "1d";
+    };
+  };
+
+  test.stubs.yopass = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/yopass/defaults.yml
+    assertFileContent home-files/.config/yopass/defaults.yml \
+      ${./settings.yml}
+  '';
+}

--- a/tests/modules/programs/yopass/settings.yml
+++ b/tests/modules/programs/yopass/settings.yml
@@ -1,0 +1,1 @@
+{"api":"https://api.example.com","expiration":"1d","one-time":false,"url":"https://example.com"}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add a module for the [Yopass](https://yopass.se/) command line client,   a tool for sharing secrets and files securely.

The module manages the client's configuration file   (`$XDG_CONFIG_HOME/yopass/defaults.yml`) through an RFC 42-style  `settings` option, so defaults like the API endpoint, secret URL,   one-time visibility and expiration don't have to be passed as flags on every invocation.

Upstream: https://github.com/jhaals/yopass
CLI docs: https://yopass.se/docs/cli

The server side counterpart (`services.yopass`) was recently raised as PR to nixpkgs in NixOS/nixpkgs#557242.

> Disclosure: this pull request summary was drafted with assistance from Claude Code (Claude Fable 5). All changes were reviewed and tested by me, and the commit carries an Assisted-by: trailer.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
