### PR TITLE
module/stylua: drop the stylua wrapper package

### DIFF
--- a/modules/programs/stylua.nix
+++ b/modules/programs/stylua.nix
@@ -11,22 +11,8 @@ let
     mkEnableOption
     mkPackageOption
     mkIf
-    types
     ;
   tomlFormat = pkgs.formats.toml { };
-
-  styluaPackage =
-    if cfg.settings != { } then
-      pkgs.symlinkJoin {
-        name = "stylua-wrapped";
-        paths = [ cfg.package ];
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-        postBuild = ''
-          wrapProgram $out/bin/stylua --add-flags '--search-parent-directories'
-        '';
-      }
-    else
-      cfg.package;
 in
 {
   meta.maintainers = [ lib.maintainers.rachitvrma ];
@@ -34,12 +20,6 @@ in
   options.programs.stylua = {
     enable = mkEnableOption "stylua, a formatter for lua";
     package = mkPackageOption pkgs "stylua" { };
-    finalPackage = mkOption {
-      readOnly = true;
-      visible = false;
-      type = types.package;
-      description = "Resulting stylua package";
-    };
     settings = mkOption {
       inherit (tomlFormat) type;
       default = { };
@@ -53,7 +33,10 @@ in
         quote_style = "AutoPreferSingle";
       };
       description = ''
-        Configuration options that are written to {file}`XDG_CONFIG_HOME/stylua/stylua.toml`
+        Configuration options that are written to {file}`XDG_CONFIG_HOME/stylua/stylua.toml`.
+        To use this configuration file pass the `--search-parent-directories` flag to `stylua`.
+        Many formatters use this flag by default (for example `conform.nvim` passes this flag to stylua
+        by default).
 
         See <https://github.com/JohnnyMorganz/StyLua#options> for more options.
       '';
@@ -61,9 +44,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.finalPackage ];
-
-    programs.stylua.finalPackage = styluaPackage;
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."stylua/stylua.toml" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "hm_stylua.toml" cfg.settings;

--- a/tests/modules/programs/stylua/example-config.nix
+++ b/tests/modules/programs/stylua/example-config.nix
@@ -1,4 +1,4 @@
-{ realPkgs, ... }: {
+{
   programs.stylua = {
     enable = true;
     settings = {
@@ -11,10 +11,8 @@
       quote_style = "AutoPreferSingle";
     };
   };
-  test.unstubs = [ (_self: _super: { inherit (realPkgs) stylua; }) ];
 
   nmt.script = ''
     assertFileContent "home-files/.config/stylua/stylua.toml" ${./expected-config.toml}
-    assertFileRegex "home-path/bin/stylua" "search-parent-directories"
   '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Many formatters use default flags (for example `conform.nvim` uses the `--search-parent-directories` by default. Using the wrapper package, breaks it, since the flag is being passed twice). Instead of passing the flag in a wrapper, we provide the information on how to use it in the description.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
