### PR TITLE
fish: add conf.d support

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -427,6 +427,31 @@ let
     in
     builtins.concatStringsSep "\n" (lib.mapAttrsToList sourceFunction handlerFunctions);
 
+  confDFile = types.submodule (
+    { config, name, ... }:
+    {
+      options = {
+        text = mkOption {
+          type = types.nullOr types.lines;
+          default = null;
+          description = ''
+            Text of the fish file.
+            If this is null, {option}`source` must be set.
+          '';
+        };
+
+        source = mkOption {
+          type = types.path;
+          description = ''
+            Path of the fish file to use. If {option}`text` is set,
+            this defaults to a generated file containing that text.
+          '';
+        };
+      };
+
+      config.source = mkIf (config.text != null) (lib.mkDefault (fishIndent "${name}.fish" config.text));
+    }
+  );
 in
 {
   meta.maintainers = [ lib.maintainers.SunOfLife1 ];
@@ -544,6 +569,15 @@ in
         description = ''
           Shell script code called during interactive fish shell
           initialisation, this will be the last thing executed in fish startup.
+        '';
+      };
+
+      confD = mkOption {
+        type = types.attrsOf confDFile;
+        default = { };
+        description = ''
+          Fish files to be put in
+          {file}`$XDG_CONFIG_HOME/fish/conf.d/`.
         '';
       };
     };
@@ -871,6 +905,15 @@ in
             '';
           }) cfg.plugins
         );
+      })
+
+      (lib.mkIf (cfg.confD != { }) {
+        xdg.configFile = lib.mapAttrs' (
+          name: file:
+          lib.nameValuePair "fish/conf.d/${name}.fish" {
+            inherit (file) source;
+          }
+        ) cfg.confD;
       })
     ]
   );

--- a/tests/modules/programs/fish/confd.nix
+++ b/tests/modules/programs/fish/confd.nix
@@ -1,0 +1,14 @@
+{
+  programs.fish = {
+    enable = true;
+
+    confD."foo".text = ''
+      # foo fish file
+    '';
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/fish/conf.d/foo.fish
+    assertFileRegex home-files/.config/fish/conf.d/foo.fish '# foo fish file'
+  '';
+}

--- a/tests/modules/programs/fish/default.nix
+++ b/tests/modules/programs/fish/default.nix
@@ -9,4 +9,5 @@
   fish-manpage = ./manpage.nix;
   fish-binds = ./binds.nix;
   fish-session-variables = ./session-variables.nix;
+  fish-confd = ./confd.nix;
 }


### PR DESCRIPTION
### Description

Add option in `fish` module to add files to `fish/conf.d/` directory.

Refer: https://fishshell.com/docs/current/#configuration
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
