### PR TITLE
wayland.windowManager.dwl: add module

### DIFF
--- a/modules/services/window-managers/default.nix
+++ b/modules/services/window-managers/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./awesome.nix
     ./bspwm
+    ./dwl.nix
     ./exwm.nix
     ./fluxbox.nix
     ./herbstluftwm.nix

--- a/modules/services/window-managers/dwl.nix
+++ b/modules/services/window-managers/dwl.nix
@@ -1,0 +1,90 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    concatStringsSep
+    hm
+    maintainers
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    platforms
+    types
+    ;
+
+  cfg = config.wayland.windowManager.dwl;
+in
+{
+  meta.maintainers = with maintainers; [
+    glmlm
+  ];
+
+  options.wayland.windowManager.dwl = {
+    enable = mkEnableOption "dwl, a compact, hackable wayland compositor based on wlroots";
+
+    package = mkPackageOption pkgs "dwl" {
+      nullable = true;
+      extraDescription = "Set to `null` to not add any dwl package to your path.";
+    };
+
+    systemd = {
+      enable = mkEnableOption "systemd" // {
+        default = true;
+        description = ''
+          Whether to enable {file}`dwl-session.target` on dwl startup.
+          This links to {file}`graphical-session.target`.
+        '';
+      };
+
+      variables = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Environment variables imported into the systemd and D-Bus user environment.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "wayland.windowManager.dwl" pkgs platforms.linux)
+      {
+        assertion = cfg.systemd.enable -> cfg.package != null;
+        message = "wayland.windowManager.dwl.systemd.enable requires a non-null package";
+      }
+    ];
+
+    home.packages =
+      let
+        systemdVariables = concatStringsSep " " cfg.systemd.variables;
+
+        systemdActivation = pkgs.writeShellScript "dwl-startup" ''
+          ${pkgs.dbus}/bin/dbus-update-activation-environment --systemd ${systemdVariables}
+          ${pkgs.systemd}/bin/systemctl --user import-environment ${systemdVariables}
+          ${pkgs.systemd}/bin/systemctl --user reset-failed
+          ${pkgs.systemd}/bin/systemctl --user start dwl-session.target
+        '';
+
+        dwlWrapped = pkgs.writeShellScriptBin "dwl" ''
+          trap "${pkgs.systemd}/bin/systemctl --user stop dwl-session.target" EXIT
+          ${cfg.package}/bin/dwl -s ${systemdActivation} "$@"
+        '';
+      in
+      mkIf (cfg.package != null) (if cfg.systemd.enable then [ dwlWrapped ] else [ cfg.package ]);
+
+    systemd.user.targets = mkIf cfg.systemd.enable {
+      dwl-session.Unit = {
+        Description = "dwl compositor session";
+        Documentation = [ "man:systemd.special(7)" ];
+        BindsTo = [ "graphical-session.target" ];
+        Wants = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session-pre.target" ];
+      };
+    };
+  };
+}

--- a/tests/modules/services/dwl/default.nix
+++ b/tests/modules/services/dwl/default.nix
@@ -1,0 +1,6 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  dwl-systemd-enable = ./dwl-systemd-enable.nix;
+  dwl-systemd-disable = ./dwl-systemd-disable.nix;
+}

--- a/tests/modules/services/dwl/dwl-expected.sh
+++ b/tests/modules/services/dwl/dwl-expected.sh
@@ -1,0 +1,4 @@
+#!/nix/store/00000000000000000000000000000000-bash/bin/bash
+trap "@systemd@/bin/systemctl --user stop dwl-session.target" EXIT
+/nix/store/00000000000000000000000000000000-dummy/bin/dwl -s /nix/store/00000000000000000000000000000000-dwl-startup "$@"
+

--- a/tests/modules/services/dwl/dwl-systemd-disable.nix
+++ b/tests/modules/services/dwl/dwl-systemd-disable.nix
@@ -1,0 +1,22 @@
+{
+  wayland.windowManager.dwl = {
+    enable = true;
+    systemd.enable = false;
+  };
+
+  test.stubs.dwl = {
+    outPath = null;
+    buildScript = ''
+      mkdir -p $out/bin
+      touch $out/bin/dwl
+    '';
+  };
+
+  nmt.script = ''
+    touch emptyFile
+
+    assertFileExists home-path/bin/dwl
+    assertFileContent home-path/bin/dwl emptyFile
+    assertPathNotExists home-files/.config/systemd/user/dwl-session.target
+  '';
+}

--- a/tests/modules/services/dwl/dwl-systemd-enable.nix
+++ b/tests/modules/services/dwl/dwl-systemd-enable.nix
@@ -1,0 +1,20 @@
+{
+  wayland.windowManager.dwl = {
+    enable = true;
+    systemd.enable = true;
+  };
+
+  test.stubs.dwl = {
+    outPath = null;
+    buildScript = ''
+      mkdir -p $out/bin
+      touch $out/bin/dwl
+    '';
+  };
+
+  nmt.script = ''
+    assertFileExists home-path/bin/dwl
+    assertFileContent "$(normalizeStorePaths home-path/bin/dwl)" ${./dwl-expected.sh}
+    assertFileExists home-files/.config/systemd/user/dwl-session.target
+  '';
+}


### PR DESCRIPTION
### Description

Closes #9878

As a first step, this PR focuses on the systemd setup for startup.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
