### PR TITLE
autorandr: document hotplug triggers

### DIFF
--- a/modules/services/autorandr.nix
+++ b/modules/services/autorandr.nix
@@ -20,6 +20,18 @@ in
           Whether to enable the Autorandr systemd service.
           This module is complementary to {option}`programs.autorandr`
           which handles the configuration (profiles).
+
+          This user service will only trigger during `graphical-session.target`
+          (i.e. when the user logs into the graphical session). It won't
+          trigger when you plug or unplug monitors. If you want the user
+          service to trigger on plug events, add this udev rule to your system
+          configuration:
+          ```nix
+          services.udev.extraRules = '''
+            ACTION=="change", SUBSYSTEM=="drm", ENV{HOTPLUG}=="1", \
+              TAG+="systemd", ENV{SYSTEMD_USER_WANTS}+="autorandr.service"
+          ''';
+          ```
         '';
       };
 


### PR DESCRIPTION
### Description

The current autorandr user service only triggers during `graphical-session.target`. This means it'll only trigger once, during user login to a graphical session.

You can use a udev rule that triggers the user service when you plug/unplug monitors, but that requires system configuration. This commit documents that approach.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
