### PR TITLE
xdg-mime-apps: add glob support

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -227,6 +227,12 @@
     github = "glmlm";
     githubId = 91877885;
   };
+  hectorgray = {
+    name = "Hector Gray";
+    email = "nix.giant993@passmail.net";
+    github = "hectorgray";
+    githubId = 194114763;
+  };
   henrisota = {
     email = "henrisota@users.noreply.github.com";
     github = "henrisota";

--- a/modules/misc/news/2026/08/2026-08-31_12-44-25.nix
+++ b/modules/misc/news/2026/08/2026-08-31_12-44-25.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+{
+  time = "2026-08-31T00:44:25+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    The `xdg.mimeApps` options `defaultApplications`, `associations.added`, and
+    `associations.removed` now support glob keys.
+
+    A key ending in `*` expands against all MIME types known to
+    shared-mime-info, and exact keys take precedence over glob matches, e.g.:
+
+    ```nix
+    xdg.mimeApps.defaultApplications = {
+      "text/*" = "editor.desktop";
+      "text/html" = "browser.desktop";
+    };
+    ```
+  '';
+}

--- a/modules/misc/news/2026/08/2026-08-31_12-44-25.nix
+++ b/modules/misc/news/2026/08/2026-08-31_12-44-25.nix
@@ -6,8 +6,9 @@
     The `xdg.mimeApps` options `defaultApplications`, `associations.added`, and
     `associations.removed` now support glob keys.
 
-    A key ending in `*` expands against all MIME types known to
-    shared-mime-info, and exact keys take precedence over glob matches, e.g.:
+    Keys ending in `*` are treated as prefix globs. They are expanded against
+    all MIME types known to the shared-mime-info database before being written
+    to `mimeapps.list`. Exact keys take precedence over glob matches, e.g.:
 
     ```nix
     xdg.mimeApps.defaultApplications = {

--- a/modules/misc/xdg/mime-apps.nix
+++ b/modules/misc/xdg/mime-apps.nix
@@ -47,10 +47,10 @@ in
         mimetypes, as if the .desktop file was listing this mimetype
         in the first place.
 
-        Keys ending in `*` are treated as prefix globs, expanding
-        against all MIME types known to the shared-mime-info database.
-        Exact keys take precedence over glob matches, e.g.,
-        `"text/html"` overrides `"text/*"`.
+        Keys ending in `*` are treated as prefix globs. They are expanded
+        against all MIME types known to the shared-mime-info database before
+        being written to `mimeapps.list`. Exact keys take precedence over glob
+        matches, e.g., `"text/html"` overrides `"text/*"`.
       '';
     };
 
@@ -66,8 +66,9 @@ in
         .desktop file was *not* listing this
         mimetype in the first place.
 
-        Keys ending in `*` are treated as prefix globs, expanding
-        against all MIME types known to the shared-mime-info database.
+        Keys ending in `*` are treated as prefix globs. They are expanded
+        against all MIME types known to the shared-mime-info database before
+        being written to `mimeapps.list`.
       '';
     };
 
@@ -89,10 +90,11 @@ in
         application is no longer installed, the next application in
         the list is attempted, and so on.
 
-        Keys ending in `*` are treated as prefix globs, expanding
-        against all MIME types known to the shared-mime-info database.
-        Exact keys take precedence over glob matches, e.g.,
-        `"text/html"` overrides `"text/*"`.
+        Keys ending in `*` are treated as prefix globs. They are
+        expanded against all MIME types known to the shared-mime-info
+        database before being written to `mimeapps.list`. Exact keys
+        take precedence over glob matches, e.g., `"text/html"`
+        overrides `"text/*"`.
       '';
     };
 

--- a/modules/misc/xdg/mime-apps.nix
+++ b/modules/misc/xdg/mime-apps.nix
@@ -40,11 +40,17 @@ in
           "foo3.desktop"
         ];
         "mimetype2" = "foo4.desktop";
+        "image/*" = "foo5.desktop";
       };
       description = ''
         Defines additional associations of applications with
         mimetypes, as if the .desktop file was listing this mimetype
         in the first place.
+
+        Keys ending in `*` are treated as prefix globs, expanding
+        against all MIME types known to the shared-mime-info database.
+        Exact keys take precedence over glob matches, e.g.,
+        `"text/html"` overrides `"text/*"`.
       '';
     };
 
@@ -53,11 +59,15 @@ in
       default = { };
       example = {
         "mimetype1" = "foo5.desktop";
+        "text/*" = "foo6.desktop";
       };
       description = ''
         Removes associations of applications with mimetypes, as if the
         .desktop file was *not* listing this
         mimetype in the first place.
+
+        Keys ending in `*` are treated as prefix globs, expanding
+        against all MIME types known to the shared-mime-info database.
       '';
     };
 
@@ -69,6 +79,8 @@ in
           "default1.desktop"
           "default2.desktop"
         ];
+        "text/*" = "default3.desktop";
+        "text/html" = "default4.desktop";
       };
       description = ''
         The default application to be used for a given mimetype. This
@@ -76,6 +88,11 @@ in
         double-clicking on a file in a file manager. If the
         application is no longer installed, the next application in
         the list is attempted, and so on.
+
+        Keys ending in `*` are treated as prefix globs, expanding
+        against all MIME types known to the shared-mime-info database.
+        Exact keys take precedence over glob matches, e.g.,
+        `"text/html"` overrides `"text/*"`.
       '';
     };
 
@@ -154,10 +171,35 @@ in
         let
           joinValues = lib.mapAttrs (_n: lib.concatStringsSep ";");
 
+          allTypes = lib.pipe "${pkgs.shared-mime-info}/share/mime/types" [
+            builtins.readFile
+            (lib.splitString "\n")
+            (builtins.filter (s: s != ""))
+          ]; # -> [ "text/html" "text/plain" "video/mp4" ... ]
+
+          expandGlob =
+            glob: app: # "text/*" -> "foo.desktop"
+            lib.pipe allTypes [
+              (builtins.filter (lib.hasPrefix (lib.removeSuffix "*" glob)))
+              (lib.flip lib.genAttrs (_: app))
+            ]; # -> { "text/html" = "foo.desktop"; "text/plain" = "foo.desktop"; ... }
+
+          expand =
+            attrs: # { "text/*" = "foo.desktop"; "text/html" = "bar.desktop" }
+            let
+              globAttrs = lib.filterAttrs (k: _v: lib.hasSuffix "*" k) attrs;
+              exactAttrs = lib.filterAttrs (k: _v: !(lib.hasSuffix "*" k)) attrs;
+            in
+            lib.pipe globAttrs [
+              (lib.mapAttrsToList expandGlob)
+              lib.mergeAttrsList
+              (acc: acc // exactAttrs) # rhs wins on conflicts
+            ]; # -> { "text/plain" = "foo.desktop"; ...; "text/html" = "bar.desktop" }
+
           baseFile = (pkgs.formats.ini { }).generate "mimeapps.list" {
-            "Added Associations" = joinValues cfg.associations.added;
-            "Removed Associations" = joinValues cfg.associations.removed;
-            "Default Applications" = joinValues cfg.defaultApplications;
+            "Added Associations" = joinValues (expand cfg.associations.added);
+            "Removed Associations" = joinValues (expand cfg.associations.removed);
+            "Default Applications" = joinValues (expand cfg.defaultApplications);
           };
 
           # With default application packages merged into the generated base file.

--- a/tests/modules/misc/xdg/linux.nix
+++ b/tests/modules/misc/xdg/linux.nix
@@ -1,5 +1,6 @@
 {
   xdg-mime-apps-basics = ./mime-apps-basics.nix;
+  xdg-mime-apps-globs = ./mime-apps-globs.nix;
   xdg-system-dirs = ./system-dirs.nix;
   xdg-desktop-entries = ./desktop-entries.nix;
   xdg-portal = ./portal.nix;

--- a/tests/modules/misc/xdg/mime-apps-globs.nix
+++ b/tests/modules/misc/xdg/mime-apps-globs.nix
@@ -1,0 +1,17 @@
+_:
+
+{
+  xdg.mimeApps = {
+    enable = true;
+    defaultApplications = {
+      "text/*" = "editor.desktop";
+      "text/html" = "browser.desktop";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/mimeapps.list
+    assertFileRegex home-files/.config/mimeapps.list '^text/plain=editor\.desktop$'
+    assertFileRegex home-files/.config/mimeapps.list '^text/html=browser\.desktop$'
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

MIME type keys ending in `*` in `xdg.mimeApps.defaultApplications`, `xdg.mimeApps.associations.added`, and `xdg.mimeApps.associations.removed` are now expanded against the shared-mime-info database, with exact keys taking precedence over glob matches (so `"text/html"` beats `"text/*"`).

Closes #8752

Following the discussion, this implementation adapts [my own](https://github.com/hectorgray/nix-sugar/blob/main/homeModules/mimeGlobs.nix) with `lib.pipe` and extends the native options rather than creating a new namespace. Please let me know if I've missed any Home Manager conventions!

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [X] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
