### PR TITLE
gtk: fix gtk-interface-color-scheme

### DIFF
--- a/modules/misc/gtk/lib.nix
+++ b/modules/misc/gtk/lib.nix
@@ -76,8 +76,9 @@ in
       "gtk-cursor-theme-size" = cursorTheme.size;
     }
     // optionalAttrs (colorScheme == "dark") { "gtk-application-prefer-dark-theme" = true; }
-    // optionalAttrs (gtkVersion == 4 && colorScheme == "dark") { "gtk-interface-color-scheme" = 2; }
-    // optionalAttrs (gtkVersion == 4 && colorScheme == "light") { "gtk-interface-color-scheme" = 3; };
+    // optionalAttrs (gtkVersion == 4 && colorScheme != null) {
+      "gtk-interface-color-scheme" = colorScheme;
+    };
 
   # Package collection helper for all GTK versions
   collectGtkPackages =

--- a/tests/modules/misc/gtk/gtk-colorscheme.nix
+++ b/tests/modules/misc/gtk/gtk-colorscheme.nix
@@ -22,7 +22,7 @@
     assertFileContains home-files/.config/gtk-4.0/settings.ini \
       'gtk-application-prefer-dark-theme=true'
     assertFileContains home-files/.config/gtk-4.0/settings.ini \
-      'gtk-interface-color-scheme=2'
+      'gtk-interface-color-scheme=dark'
 
     echo "ColorScheme test completed successfully"
   '';

--- a/tests/modules/misc/gtk/gtk-global-inheritance-gtk4-expected.ini
+++ b/tests/modules/misc/gtk/gtk-global-inheritance-gtk4-expected.ini
@@ -4,4 +4,4 @@ gtk-cursor-theme-name=Adwaita
 gtk-cursor-theme-size=24
 gtk-font-name=Ubuntu 12
 gtk-icon-theme-name=Adwaita
-gtk-interface-color-scheme=2
+gtk-interface-color-scheme=dark


### PR DESCRIPTION
### Description

Fixes an issue introduced in #7763 where gtk4 apps would print the
following warning:

```
Error setting gtk-interface-color-scheme in /home/mithic/.config/gtk-4.0/settings.ini: Key file contains key “gtk-interface-color-scheme” which has a value that cannot be interpreted.
```

The value should be set to the nickname (`light` or `dark` in this
case), rather than the actual numerical value of the enum.  This lookup
happens at [`gtksettings.c:1863`](https://gitlab.gnome.org/GNOME/gtk/-/blob/4.22.4/gtk/gtksettings.c#L1863).

These nicknames appear to be undocumented and automatically generated at
compile time, but in general they appear to follow the pattern where an
enum value `FOO_BAR_BAZ_QUUX` of the enum `FOO_BAR` has nickname `baz-quux`.
Regardless, they can be looked up in the generated file
`gtktypebuiltins.c` (it unfortunately appears that nix only keeps
`gtktypebuiltins.h`, which does not contain the nicknames).



<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
