### PR TITLE
home-environment: honor fish.preferAbbrs for shell aliases

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -636,7 +636,10 @@ in
 
     programs.bash.shellAliases = cfg.shellAliases;
     programs.zsh.shellAliases = cfg.shellAliases;
-    programs.fish.shellAliases = cfg.shellAliases;
+    programs.fish = {
+      shellAliases = lib.mkIf (!config.programs.fish.preferAbbrs) cfg.shellAliases;
+      shellAbbrs = lib.mkIf config.programs.fish.preferAbbrs cfg.shellAliases;
+    };
     programs.nushell.shellAliases = cfg.shellAliases;
 
     home.sessionVariables =

--- a/tests/modules/programs/fish/default.nix
+++ b/tests/modules/programs/fish/default.nix
@@ -1,5 +1,6 @@
 {
   fish-abbrs = ./abbrs.nix;
+  fish-home-shell-aliases-prefer-abbrs = ./home-shell-aliases-prefer-abbrs.nix;
   fish-format-scripts = ./format-scripts.nix;
   fish-functions = ./functions.nix;
   fish-completions = ./completions.nix;

--- a/tests/modules/programs/fish/home-shell-aliases-prefer-abbrs.nix
+++ b/tests/modules/programs/fish/home-shell-aliases-prefer-abbrs.nix
@@ -1,0 +1,24 @@
+{
+  config = {
+    home.shellAliases = {
+      g = "git";
+      ll = "ls -l";
+    };
+
+    programs.fish = {
+      enable = true;
+      preferAbbrs = true;
+    };
+
+    nmt = {
+      description = "if fish.preferAbbrs is enabled, home.shellAliases become abbreviations";
+      script = ''
+        assertFileContains home-files/.config/fish/config.fish \
+          "abbr --add -- g git"
+        assertFileContains home-files/.config/fish/config.fish \
+          "abbr --add -- ll 'ls -l'"
+        assertFileNotRegex home-files/.config/fish/config.fish '^alias (g|ll) '
+      '';
+    };
+  };
+}


### PR DESCRIPTION
## Description

When home.shellAliases is used with programs.fish.preferAbbrs = true, Home Manager currently writes the shared aliases as fish alias commands. That bypasses the explicit user preference for abbreviations.

Route the shared aliases to programs.fish.shellAbbrs when preferAbbrs is enabled, while retaining the existing shellAliases behavior by default. Add an NMT regression test that checks the generated abbreviations and verifies that the corresponding alias lines are absent.

Fixes #9784

## Verification

- nix fmt -- --fail-on-change
- test-fish-home-shell-aliases-prefer-abbrs
- test-fish-abbrs
- test-fish-session-variables

The issue discussion explicitly requested this behavior and the module maintainer confirmed that a PR is welcome.

OpenAI Codex assisted with implementation and verification.