### PR TITLE
mpv: rename config to settings

### DIFF
--- a/modules/misc/news/2026/08/2026-08-13_00-00-00-mpv-settings.nix
+++ b/modules/misc/news/2026/08/2026-08-13_00-00-00-mpv-settings.nix
@@ -1,0 +1,9 @@
+{ config, ... }:
+{
+  time = "2026-08-13T00:00:00+00:00";
+  condition = config.programs.mpv.enable;
+  message = ''
+    `programs.mpv.config` is now `programs.mpv.settings`. The old option remains
+    available as a deprecated alias.
+  '';
+}

--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -17,6 +17,24 @@ let
 
   cfg = config.programs.mpv;
 
+  hasLineBreak = value: lib.isString value && (lib.hasInfix "\n" value || lib.hasInfix "\r" value);
+
+  namesHaveLineBreak =
+    value:
+    lib.isAttrs value
+    && (
+      lib.any hasLineBreak (lib.attrNames value) || lib.any namesHaveLineBreak (lib.attrValues value)
+    );
+
+  rawValuesHaveLineBreak =
+    value:
+    if lib.isList value then
+      lib.any rawValuesHaveLineBreak value
+    else if lib.isAttrs value then
+      lib.any rawValuesHaveLineBreak (lib.attrValues value)
+    else
+      hasLineBreak value;
+
   mpvOption = with types; either str (either int (either bool float));
   mpvOptionDup = with types; either mpvOption (listOf mpvOption);
   mpvOptions = with types; attrsOf mpvOptionDup;
@@ -79,6 +97,10 @@ in
     chuangzhu
   ];
 
+  imports = [
+    (lib.mkRenamedOptionModule [ "programs" "mpv" "config" ] [ "programs" "mpv" "settings" ])
+  ];
+
   options = {
     programs.mpv = {
       enable = lib.mkEnableOption "mpv";
@@ -139,7 +161,7 @@ in
         };
       };
 
-      config = mkOption {
+      settings = mkOption {
         description = ''
           Configuration written to
           {file}`$XDG_CONFIG_HOME/mpv/mpv.conf`. See
@@ -152,7 +174,7 @@ in
           profile = "gpu-hq";
           force-window = true;
           ytdl-format = "bestvideo+bestaudio";
-          cache-default = 4000000;
+          cache-secs = 4000000;
         };
       };
 
@@ -175,7 +197,7 @@ in
         description = ''
           Sub-configuration options for specific profiles written to
           {file}`$XDG_CONFIG_HOME/mpv/mpv.conf`. See
-          {option}`programs.mpv.config` for more information.
+          {option}`programs.mpv.settings` for more information.
         '';
         type = mpvProfiles;
         default = { };
@@ -195,7 +217,7 @@ in
       defaultProfiles = mkOption {
         description = ''
           Profiles to be applied by default. Options set by them are overridden
-          by options set in [](#opt-programs.mpv.config).
+          by options set in [](#opt-programs.mpv.settings).
         '';
         type = mpvDefaultProfiles;
         default = [ ];
@@ -242,6 +264,25 @@ in
             assertion = wrapperRequiresOverride -> (cfg.package == options.programs.mpv.package.default);
             message = ''The programs.mpv "package" option is mutually exclusive with "scripts", "extraMakeWrapperArgs" options.'';
           }
+          {
+            assertion =
+              !namesHaveLineBreak {
+                inherit (cfg)
+                  bindings
+                  profiles
+                  scriptOpts
+                  settings
+                  ;
+              };
+            message = "The programs.mpv configuration names must not contain literal line breaks.";
+          }
+          {
+            assertion =
+              !rawValuesHaveLineBreak {
+                inherit (cfg) bindings includes scriptOpts;
+              };
+            message = "The programs.mpv raw-line configuration values must not contain literal line breaks.";
+          }
         ];
       }
       {
@@ -255,10 +296,10 @@ in
         };
       })
 
-      (mkIf (cfg.config != { } || cfg.profiles != { }) {
+      (mkIf (cfg.settings != { } || cfg.profiles != { }) {
         xdg.configFile."mpv/mpv.conf".text = ''
           ${lib.optionalString (cfg.defaultProfiles != [ ]) (renderDefaultProfiles cfg.defaultProfiles)}
-          ${lib.optionalString (cfg.config != { }) (renderOptions cfg.config)}
+          ${lib.optionalString (cfg.settings != { }) (renderOptions cfg.settings)}
           ${lib.optionalString (cfg.profiles != { }) (renderProfiles cfg.profiles)}
         '';
       })

--- a/tests/modules/programs/mpv/default.nix
+++ b/tests/modules/programs/mpv/default.nix
@@ -1,7 +1,8 @@
 {
-  # Temporarily commented until fixed for recent changes in Nixpkgs.
   mpv-example-settings = ./mpv-example-settings.nix;
   mpv-invalid-settings = ./mpv-invalid-settings.nix;
   mpv-scripts = ./mpv-scripts.nix;
   mpv-extra-wrapper-args = ./mpv-extra-wrapper-args.nix;
+  mpv-legacy-config = ./legacy-config.nix;
+  mpv-newline-values = ./newline-values.nix;
 }

--- a/tests/modules/programs/mpv/legacy-config.nix
+++ b/tests/modules/programs/mpv/legacy-config.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  options,
+  ...
+}:
+{
+  programs.mpv = {
+    enable = true;
+    config = {
+      force-window = true;
+      ytdl-format = "bestvideo+bestaudio";
+      cache-secs = 4000000;
+    };
+  };
+
+  test.asserts.warnings.expected = [
+    "The option `programs.mpv.config' defined in ${lib.showFiles options.programs.mpv.config.files} has been renamed to `programs.mpv.settings'."
+  ];
+
+  nmt.script = ''
+    assertFileContent home-files/.config/mpv/mpv.conf ${
+      builtins.toFile "legacy-config.expected" (
+        lib.concatStringsSep "\n" [
+          ""
+          "cache-secs=%7%4000000"
+          "force-window=%3%yes"
+          "ytdl-format=%19%bestvideo+bestaudio"
+          ""
+          ""
+          ""
+        ]
+      )
+    }
+  '';
+}

--- a/tests/modules/programs/mpv/mpv-example-settings-expected-config
+++ b/tests/modules/programs/mpv/mpv-example-settings-expected-config
@@ -1,6 +1,6 @@
 profile=%6%gpu-hq
 
-cache-default=%7%4000000
+cache-secs=%7%4000000
 force-window=%3%yes
 ytdl-format=%19%bestvideo+bestaudio
 

--- a/tests/modules/programs/mpv/mpv-example-settings.nix
+++ b/tests/modules/programs/mpv/mpv-example-settings.nix
@@ -16,10 +16,10 @@
 
     includes = [ "manual.conf" ];
 
-    config = {
+    settings = {
       force-window = true;
       ytdl-format = "bestvideo+bestaudio";
-      cache-default = 4000000;
+      cache-secs = 4000000;
     };
 
     scriptOpts = {

--- a/tests/modules/programs/mpv/mpv-invalid-settings.nix
+++ b/tests/modules/programs/mpv/mpv-invalid-settings.nix
@@ -10,9 +10,13 @@
     enable = true;
     package = pkgs.emptyDirectory;
     scripts = [ pkgs.mpvScript ];
+    includes = [ "safe\ninjected.conf" ];
+    settings."safe\ninjected" = true;
   };
 
   test.asserts.assertions.expected = [
     ''The programs.mpv "package" option is mutually exclusive with "scripts", "extraMakeWrapperArgs" options.''
+    "The programs.mpv configuration names must not contain literal line breaks."
+    "The programs.mpv raw-line configuration values must not contain literal line breaks."
   ];
 }

--- a/tests/modules/programs/mpv/newline-values.nix
+++ b/tests/modules/programs/mpv/newline-values.nix
@@ -1,0 +1,13 @@
+{
+  programs.mpv = {
+    enable = true;
+    settings.title = "line\nvalue";
+    profiles.multiline.profile-desc = "profile\nvalue";
+  };
+
+  nmt.script = ''
+    assertFileContains home-files/.config/mpv/mpv.conf 'title=%10%line'
+    assertFileContains home-files/.config/mpv/mpv.conf 'profile-desc=%13%profile'
+    assertFileContains home-files/.config/mpv/mpv.conf 'value'
+  '';
+}


### PR DESCRIPTION
### Description

Rename `programs.mpv.config` to `programs.mpv.settings`. The old option remains
available as a deprecated alias. Line breaks that could add unintended
configuration entries are rejected.

Part of #9801

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
