### PR TITLE
gromit-mpx: add extraConfig

### DIFF
--- a/modules/misc/news/2026/09/2026-09-01_00-00-00-gromit-mpx.nix
+++ b/modules/misc/news/2026/09/2026-09-01_00-00-00-gromit-mpx.nix
@@ -1,0 +1,11 @@
+{ config, ... }:
+
+{
+  time = "2026-09-01T00:00:00+00:00";
+  condition = config.services.gromit-mpx.enable;
+  message = ''
+    The `services.gromit-mpx.extraConfig` option appends ordered CFG
+    declarations after the generated tool declarations. They are written to
+    the Nix store and must not contain secrets.
+  '';
+}

--- a/modules/services/gromit-mpx.nix
+++ b/modules/services/gromit-mpx.nix
@@ -173,6 +173,19 @@ in
       description = "Opacity of the drawing overlay.";
     };
 
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra configuration lines appended to
+        {file}`$XDG_CONFIG_HOME/gromit-mpx.cfg` after the declarations
+        generated from {option}`services.gromit-mpx.tools`. Definition order
+        is preserved. `HOTKEY` and `UNDOKEY` declarations here are overridden
+        by the `hotKey` and `undoKey` command-line arguments. The file is
+        written to the Nix store and must not contain secrets.
+      '';
+    };
+
     tools = mkOption {
       type = types.listOf (types.submodule toolOptions);
       default = [
@@ -223,7 +236,12 @@ in
     ];
 
     xdg.configFile."gromit-mpx.ini".text = keyFile;
-    xdg.configFile."gromit-mpx.cfg".text = lib.concatStringsSep "\n" (lib.imap1 toolToCfg cfg.tools);
+    xdg.configFile."gromit-mpx.cfg".text = lib.concatStringsSep "\n" (
+      lib.filter (settings: settings != "") [
+        (lib.concatStringsSep "\n" (lib.imap1 toolToCfg cfg.tools))
+        cfg.extraConfig
+      ]
+    );
 
     home.packages = [ cfg.package ];
 

--- a/tests/modules/services/gromit-mpx/default-configuration.nix
+++ b/tests/modules/services/gromit-mpx/default-configuration.nix
@@ -6,5 +6,7 @@
     package = config.lib.test.mkStubPackage { };
   };
 
-  nmt.script = import ./nmt-script.nix ./default-configuration.cfg;
+  nmt.script = (import ./nmt-script.nix ./default-configuration.cfg) + ''
+    assertFileRegex home-files/.config/gromit-mpx.ini 'ShowIntroOnStartup=false'
+  '';
 }

--- a/tests/modules/services/gromit-mpx/default.nix
+++ b/tests/modules/services/gromit-mpx/default.nix
@@ -3,4 +3,6 @@
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   gromit-mpx-default-configuration = ./default-configuration.nix;
   gromit-mpx-basic-configuration = ./basic-configuration.nix;
+  gromit-mpx-extra-config = ./extra-config.nix;
+  gromit-mpx-disabled = ./disabled.nix;
 }

--- a/tests/modules/services/gromit-mpx/disabled.nix
+++ b/tests/modules/services/gromit-mpx/disabled.nix
@@ -1,0 +1,12 @@
+{
+  services.gromit-mpx = {
+    enable = false;
+    extraConfig = throw "disabled Gromit-MPX extra configuration was evaluated";
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/gromit-mpx.ini
+    assertPathNotExists home-files/.config/gromit-mpx.cfg
+    assertPathNotExists home-files/.config/systemd/user/gromit-mpx.service
+  '';
+}

--- a/tests/modules/services/gromit-mpx/extra-config.nix
+++ b/tests/modules/services/gromit-mpx/extra-config.nix
@@ -1,0 +1,44 @@
+{ lib, ... }:
+
+{
+  imports = [
+    {
+      services.gromit-mpx.extraConfig = lib.mkBefore ''
+        "native Line" = LINE (color = "green");
+      '';
+    }
+    {
+      services.gromit-mpx.extraConfig = lib.mkAfter ''
+        "default" = "inherited Line";
+      '';
+    }
+  ];
+
+  services.gromit-mpx = {
+    enable = true;
+    tools = [
+      {
+        device = "generated";
+        color = "green";
+      }
+    ];
+    extraConfig = ''
+      "inherited Line" = "native Line";
+      "generated Child" = "tool-1";
+    '';
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/gromit-mpx.cfg ${builtins.toFile "gromit-mpx.cfg" ''
+      "tool-1" = PEN (size=5 color="green");
+      "generated" = "tool-1";
+
+      "native Line" = LINE (color = "green");
+
+      "inherited Line" = "native Line";
+      "generated Child" = "tool-1";
+
+      "default" = "inherited Line";
+    ''}
+  '';
+}


### PR DESCRIPTION
### Description

Add `services.gromit-mpx.extraConfig` for native CFG declarations appended
after the generated `tools` entries. This supports tool types, properties,
and aliases that the structured options cannot express, without replacing
the generated configuration.

Declarations retain their order so tools can reference earlier definitions.
Generated output for existing configurations is unchanged. INI preferences,
including `opacity` and the disabled startup introduction, are unchanged.

Related to #9801. This adds the ordered CFG escape hatch; the freeform INI
settings boundary tracked there remains separate.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)



