### PR TITLE
qcal: add freeform settings

### DIFF
--- a/modules/misc/news/2026/09/2026-09-01_00-00-00-qcal-settings.nix
+++ b/modules/misc/news/2026/09/2026-09-01_00-00-00-qcal-settings.nix
@@ -1,0 +1,14 @@
+{ config, ... }:
+{
+  time = "2026-09-01T00:00:00+00:00";
+  condition = config.programs.qcal.enable;
+  message = ''
+    The qcal module now exposes its JSON configuration through
+    `programs.qcal.settings` and per-calendar entries through
+    `accounts.calendar.accounts.<name>.qcal.settings`.
+
+    `programs.qcal.timezone` and `programs.qcal.defaultNumDays` are
+    deprecated aliases of `programs.qcal.settings.Timezone` and
+    `programs.qcal.settings.DefaultNumDays`.
+  '';
+}

--- a/modules/programs/qcal.nix
+++ b/modules/programs/qcal.nix
@@ -6,31 +6,35 @@
 }:
 
 let
-
   cfg = config.programs.qcal;
 
-  qcalAccounts = lib.attrValues (
-    lib.filterAttrs (_: a: a.qcal.enable) config.accounts.calendar.accounts
-  );
+  jsonFormat = pkgs.formats.json { };
 
-  filteredAccounts =
-    let
-      mkAccount =
-        account:
-        lib.filterAttrs (_: v: v != null) (
-          with account.remote;
-          {
-            Url = url;
-            Username = if userName == null then null else userName;
-            PasswordCmd = if passwordCommand == null then null else toString passwordCommand;
-          }
-        );
-    in
-    map mkAccount qcalAccounts;
-
+  qcalAccounts = lib.filterAttrs (_: account: account.qcal.enable) config.accounts.calendar.accounts;
 in
 {
   meta.maintainers = with lib.maintainers; [ antonmosich ];
+
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "programs" "qcal" "timezone" ]
+      [
+        "programs"
+        "qcal"
+        "settings"
+        "Timezone"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "programs" "qcal" "defaultNumDays" ]
+      [
+        "programs"
+        "qcal"
+        "settings"
+        "DefaultNumDays"
+      ]
+    )
+  ];
 
   options = {
     programs.qcal = {
@@ -38,40 +42,81 @@ in
 
       package = lib.mkPackageOption pkgs "qcal" { nullable = true; };
 
-      timezone = lib.mkOption {
-        type = lib.types.singleLineStr;
-        default = "Local";
-        example = "Europe/Vienna";
-        description = "Timezone to display calendar entries in";
-      };
+      settings = lib.mkOption {
+        inherit (jsonFormat) type;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            Timezone = "Europe/Vienna";
+            DefaultNumDays = 7;
+          }
+        '';
+        description = ''
+          Configuration written to {file}`$XDG_CONFIG_HOME/qcal/config.json`.
+          See <https://git.sr.ht/~psic4t/qcal> for supported keys.
 
-      defaultNumDays = lib.mkOption {
-        type = lib.types.ints.positive;
-        default = 30;
-        description = "Default number of days to show calendar entries for";
+          `Calendars` defaults to the enabled
+          {option}`accounts.calendar.accounts.<name>.qcal` accounts. Setting
+          it here replaces that list.
+
+          Values are written to the Nix store. Use `PasswordCmd` instead of
+          `Password` for calendar credentials.
+        '';
       };
     };
 
     accounts.calendar.accounts = lib.mkOption {
       type =
         with lib.types;
-        attrsOf (submodule {
-          options.qcal.enable = lib.mkEnableOption "qcal access";
-        });
+        attrsOf (
+          submodule (
+            { config, ... }:
+            {
+              options.qcal = {
+                enable = lib.mkEnableOption "qcal access";
+
+                settings = lib.mkOption {
+                  inherit (jsonFormat) type;
+                  default = { };
+                  example = lib.literalExpression ''
+                    {
+                      Url = "https://cal.example.com/work";
+                      PasswordCmd = "pass show calendar/work";
+                    }
+                  '';
+                  description = ''
+                    Calendar entry written to `Calendars` in
+                    {file}`$XDG_CONFIG_HOME/qcal/config.json`. `Url`, `Username`,
+                    and `PasswordCmd` default to the account's `remote` options.
+
+                    Values are written to the Nix store. Use `PasswordCmd` or
+                    `remote.passwordCommand` instead of `Password`.
+                  '';
+                };
+              };
+
+              config.qcal.settings = lib.mkIf (config.remote != null) {
+                Url = lib.mkIf (config.remote.url != null) (lib.mkDefault config.remote.url);
+                Username = lib.mkIf (config.remote.userName != null) (lib.mkDefault config.remote.userName);
+                PasswordCmd = lib.mkIf (config.remote.passwordCommand != null) (
+                  lib.mkDefault (toString config.remote.passwordCommand)
+                );
+              };
+            }
+          )
+        );
     };
   };
 
   config = lib.mkIf cfg.enable {
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-    xdg.configFile."qcal/config.json".source =
-      let
-        jsonFormat = pkgs.formats.json { };
-      in
-      jsonFormat.generate "qcal.json" {
-        DefaultNumDays = cfg.defaultNumDays;
-        Timezone = cfg.timezone;
-        Calendars = filteredAccounts;
-      };
+    programs.qcal.settings = {
+      Timezone = lib.mkDefault "Local";
+      DefaultNumDays = lib.mkDefault 30;
+      Calendars = lib.mkDefault (map (account: account.qcal.settings) (lib.attrValues qcalAccounts));
+    };
+
+    xdg.configFile."qcal/config.json".source = jsonFormat.generate "qcal.json" cfg.settings;
   };
 }

--- a/tests/modules/programs/qcal/default.nix
+++ b/tests/modules/programs/qcal/default.nix
@@ -2,4 +2,6 @@
   qcal-http = ./http-calendar.nix;
   qcal-webdav = ./webdav-calendar.nix;
   qcal-mixed = ./mixed.nix;
+  qcal-settings = ./settings.nix;
+  qcal-legacy-options = ./legacy-options.nix;
 }

--- a/tests/modules/programs/qcal/legacy-options.json-expected
+++ b/tests/modules/programs/qcal/legacy-options.json-expected
@@ -1,0 +1,9 @@
+{
+  "Calendars": [
+    {
+      "Url": "https://example.com/events.ical"
+    }
+  ],
+  "DefaultNumDays": 23,
+  "Timezone": "Europe/Berlin"
+}

--- a/tests/modules/programs/qcal/legacy-options.nix
+++ b/tests/modules/programs/qcal/legacy-options.nix
@@ -1,0 +1,25 @@
+{ lib, options, ... }:
+{
+  programs.qcal = {
+    enable = true;
+    defaultNumDays = 23;
+    timezone = "Europe/Berlin";
+    settings.Calendars = [
+      { Url = "https://example.com/events.ical"; }
+    ];
+  };
+
+  accounts.calendar.accounts.ignored = {
+    qcal.enable = true;
+    remote.url = "https://ignored.example.com/events.ical";
+  };
+
+  test.asserts.warnings.expected = [
+    "The option `programs.qcal.defaultNumDays' defined in ${lib.showFiles options.programs.qcal.defaultNumDays.files} has been renamed to `programs.qcal.settings.DefaultNumDays'."
+    "The option `programs.qcal.timezone' defined in ${lib.showFiles options.programs.qcal.timezone.files} has been renamed to `programs.qcal.settings.Timezone'."
+  ];
+
+  nmt.script = ''
+    assertFileContent home-files/.config/qcal/config.json ${./legacy-options.json-expected}
+  '';
+}

--- a/tests/modules/programs/qcal/settings.json-expected
+++ b/tests/modules/programs/qcal/settings.json-expected
@@ -1,0 +1,17 @@
+{
+  "Calendars": [
+    {
+      "Name": "Local",
+      "Url": "https://local.example.com/events.ical"
+    },
+    {
+      "Name": "Work",
+      "PasswordCmd": "pass show work",
+      "Url": "https://cal.example.com/work",
+      "Username": "override"
+    }
+  ],
+  "Custom": true,
+  "DefaultNumDays": 7,
+  "Timezone": "Europe/Paris"
+}

--- a/tests/modules/programs/qcal/settings.nix
+++ b/tests/modules/programs/qcal/settings.nix
@@ -1,0 +1,46 @@
+{
+  programs.qcal = {
+    enable = true;
+    settings = {
+      DefaultNumDays = 7;
+      Timezone = "Europe/Paris";
+      Custom = true;
+    };
+  };
+
+  accounts.calendar.accounts = {
+    work = {
+      qcal = {
+        enable = true;
+        settings = {
+          Name = "Work";
+          Username = "override";
+        };
+      };
+      remote = {
+        url = "https://cal.example.com/work";
+        userName = "anton";
+        passwordCommand = [
+          "pass"
+          "show"
+          "work"
+        ];
+      };
+    };
+    disabled = {
+      qcal.settings.Name = "Disabled";
+      remote.url = "https://disabled.example.com/events.ical";
+    };
+    local.qcal = {
+      enable = true;
+      settings = {
+        Name = "Local";
+        Url = "https://local.example.com/events.ical";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/qcal/config.json ${./settings.json-expected}
+  '';
+}

--- a/tests/modules/programs/qcal/webdav-calendar.nix
+++ b/tests/modules/programs/qcal/webdav-calendar.nix
@@ -1,8 +1,10 @@
 {
   programs.qcal = {
     enable = true;
-    defaultNumDays = 23;
-    timezone = "Europe/Berlin";
+    settings = {
+      DefaultNumDays = 23;
+      Timezone = "Europe/Berlin";
+    };
   };
   accounts.calendar.accounts.test = {
     qcal.enable = true;


### PR DESCRIPTION
### Description

Add `programs.qcal.settings` and
`accounts.calendar.accounts.<name>.qcal.settings` as freeform JSON options.
Generated `Calendars` entries and the account `remote` projections use
`mkDefault`, so they can be overridden or replaced. `timezone` and
`defaultNumDays` become renamed aliases of `settings.Timezone` and
`settings.DefaultNumDays`. Accounts without a `remote` no longer fail
evaluation.

Part of #9801

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

