### PR TITLE
module/emacs: allow passing flags to the EDITOR/VISUAL in emacs module

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -84,6 +84,19 @@ in
           Command-line arguments to pass to {command}`emacsclient`.
         '';
       };
+      editorArguments = mkOption {
+        type = with types; listOf str;
+        default = [ "--create-frame" ];
+        example = [
+          "--create-frame"
+          "--no-wait"
+        ];
+        description = ''
+          Command-line arguments to pass to {command}`emacsclient` when it is
+          used as {env}`EDITOR`/{env}`VISUAL` and invoked with no arguments
+          of its own.
+        '';
+      };
     };
 
     # Attrset for forward-compatibility; there may be a need to customize the
@@ -123,7 +136,13 @@ in
     home.sessionVariables =
       let
         editorBin = lib.getBin (
-          pkgs.writeShellScript "editor" ''exec ${lib.getBin cfg.package}/bin/emacsclient "''${@:---create-frame}"''
+          pkgs.writeShellScript "editor" ''
+            if [ "$#" -eq 0 ]; then
+              exec emacsclient ${lib.escapeShellArgs cfg.client.editorArguments}
+            else
+              exec emacsclient "$@"
+            fi
+          ''
         );
       in
       mkIf cfg.defaultEditor {
@@ -131,9 +150,12 @@ in
         VISUAL = editorBin;
       };
 
-    home.packages = optional (cfg.client.enable && pkgs.stdenv.hostPlatform.isLinux) (
-      lib.hiPrio clientDesktopItem
-    );
+    home.packages =
+      optional (cfg.client.enable && pkgs.stdenv.hostPlatform.isLinux) (lib.hiPrio clientDesktopItem)
+      # emacsclient is invoked via $PATH lookup (not cfg.package directly) so
+      # EDITOR/VISUAL survive switch+GC; make sure it's actually on PATH here
+      # when programs.emacs isn't already installing it.
+      ++ optional (cfg.defaultEditor && !emacsCfg.enable) cfg.package;
 
     systemd.user.services.emacs = {
       Unit = {

--- a/tests/modules/services/emacs/linux/emacs-default-editor.sh
+++ b/tests/modules/services/emacs/linux/emacs-default-editor.sh
@@ -1,5 +1,6 @@
 set +u
 source $TESTED/home-path/etc/profile.d/hm-session-vars.sh
+export PATH="$TESTED/home-path/bin:$PATH"
 set -u
 
 check_arguments () {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

By default, `$EDITOR` and `$VISUAL` are not able to accept custom flags. This PR offers an idea to be able to pass more flags to `$EDITOR`/`$VISUAL` variables

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
