### PR TITLE
starship: precompute fish init script

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -117,94 +117,105 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    home = {
-      packages =
-        if cfg.extraPackages != [ ] then
-          [
-            (pkgs.symlinkJoin {
-              name = "${lib.getName cfg.package}-wrapped-${lib.getVersion cfg.package}";
-              paths = [ cfg.package ];
-              preferLocalBuild = true;
-              nativeBuildInputs = [ pkgs.makeWrapper ];
-              postBuild = ''
-                wrapProgram $out/bin/starship \
-                  --suffix PATH : ${lib.makeBinPath cfg.extraPackages}
-              '';
-            })
-          ]
-        else
-          [ cfg.package ];
-
-      sessionVariables.STARSHIP_CONFIG = cfg.configPath;
-
-      file.${cfg.configPath} = mkIf hasGeneratedConfig (
-        let
-          settingsFile = tomlFormat.generate "starship-config" cfg.settings;
-        in
-        if cfg.presets == [ ] then
-          { source = settingsFile; }
-        else
+  config =
+    let
+      starshipFishConfig =
+        pkgs.runCommand "starship-fish-config.fish"
           {
-            source =
-              pkgs.runCommand "starship.toml"
-                {
-                  nativeBuildInputs = [ pkgs.yq ];
-                }
-                ''
-                  tomlq -s -t 'reduce .[] as $item ({}; . * $item)' \
-                    ${
-                      lib.concatStringsSep " " (map (f: "${cfg.package}/share/starship/presets/${f}.toml") cfg.presets)
-                    } \
-                    ${settingsFile} \
-                    > $out
+            nativeBuildInputs = [ pkgs.writableTmpDirAsHomeHook ];
+          }
+          ''
+            ${lib.getExe cfg.package} init fish --print-full-init > "$out"
+          '';
+    in
+    mkIf cfg.enable {
+      home = {
+        packages =
+          if cfg.extraPackages != [ ] then
+            [
+              (pkgs.symlinkJoin {
+                name = "${lib.getName cfg.package}-wrapped-${lib.getVersion cfg.package}";
+                paths = [ cfg.package ];
+                preferLocalBuild = true;
+                nativeBuildInputs = [ pkgs.makeWrapper ];
+                postBuild = ''
+                  wrapProgram $out/bin/starship \
+                    --suffix PATH : ${lib.makeBinPath cfg.extraPackages}
                 '';
-          }
-      );
+              })
+            ]
+          else
+            [ cfg.package ];
 
-    };
+        sessionVariables.STARSHIP_CONFIG = cfg.configPath;
 
-    programs = {
-      bash.initExtra = mkIf cfg.enableBashIntegration (
-        lib.mkOrder 1900 ''
+        file.${cfg.configPath} = mkIf hasGeneratedConfig (
+          let
+            settingsFile = tomlFormat.generate "starship-config" cfg.settings;
+          in
+          if cfg.presets == [ ] then
+            { source = settingsFile; }
+          else
+            {
+              source =
+                pkgs.runCommand "starship.toml"
+                  {
+                    nativeBuildInputs = [ pkgs.yq ];
+                  }
+                  ''
+                    tomlq -s -t 'reduce .[] as $item ({}; . * $item)' \
+                      ${
+                        lib.concatStringsSep " " (map (f: "${cfg.package}/share/starship/presets/${f}.toml") cfg.presets)
+                      } \
+                      ${settingsFile} \
+                      > $out
+                  '';
+            }
+        );
+
+      };
+
+      programs = {
+        bash.initExtra = mkIf cfg.enableBashIntegration (
+          lib.mkOrder 1900 ''
+            if [[ $TERM != "dumb" ]]; then
+              eval "$(${lib.getExe cfg.package} init bash --print-full-init)"
+            fi
+          ''
+        );
+
+        zsh.initContent = mkIf cfg.enableZshIntegration ''
           if [[ $TERM != "dumb" ]]; then
-            eval "$(${lib.getExe cfg.package} init bash --print-full-init)"
+            eval "$(${lib.getExe cfg.package} init zsh)"
           fi
-        ''
-      );
-
-      zsh.initContent = mkIf cfg.enableZshIntegration ''
-        if [[ $TERM != "dumb" ]]; then
-          eval "$(${lib.getExe cfg.package} init zsh)"
-        fi
-      '';
-
-      fish.${initFish} = mkIf cfg.enableFishIntegration ''
-        if test "$TERM" != "dumb"
-          ${lib.getExe cfg.package} init fish | source
-          ${lib.optionalString cfg.enableTransience "enable_transience"}
-        end
-      '';
-
-      ion.initExtra = mkIf cfg.enableIonIntegration ''
-        if test $TERM != "dumb"
-          eval $(${lib.getExe cfg.package} init ion)
-        end
-      '';
-
-      nushell = mkIf cfg.enableNushellIntegration {
-        # Unfortunately nushell doesn't allow conditionally sourcing nor
-        # conditionally setting (global) environment variables, which is why the
-        # check for terminal compatibility (as seen above for the other shells) is
-        # not done here.
-        extraConfig = ''
-          use ${
-            pkgs.runCommand "starship-nushell-config.nu" { } ''
-              ${lib.getExe cfg.package} init nu >> "$out"
-            ''
-          }
         '';
+
+        fish.${initFish} = mkIf cfg.enableFishIntegration ''
+          if test "$TERM" != "dumb"
+            source ${starshipFishConfig}
+            ${lib.optionalString cfg.enableTransience "enable_transience"}
+          end
+        '';
+
+        ion.initExtra = mkIf cfg.enableIonIntegration ''
+          if test $TERM != "dumb"
+            eval $(${lib.getExe cfg.package} init ion)
+          end
+        '';
+
+        nushell = mkIf cfg.enableNushellIntegration {
+          # Unfortunately nushell doesn't allow conditionally sourcing nor
+          # conditionally setting (global) environment variables, which is why the
+          # check for terminal compatibility (as seen above for the other shells) is
+          # not done here.
+          extraConfig = ''
+            use ${
+              pkgs.runCommand "starship-nushell-config.nu" { } ''
+                ${lib.getExe cfg.package} init nu >> "$out"
+              ''
+            }
+          '';
+        };
       };
     };
-  };
 }

--- a/tests/modules/programs/starship/fish-package.nix
+++ b/tests/modules/programs/starship/fish-package.nix
@@ -1,0 +1,23 @@
+{ lib, pkgs, ... }:
+
+let
+  starshipPackage = pkgs.writeShellScriptBin "starship" ''
+    if [ "$1" = init ] && [ "$2" = fish ]; then
+      printf 'starship fish init args:'
+      printf ' %s' "$@"
+      printf '\n'
+    else
+      echo "unexpected starship invocation: $*" >&2
+      exit 1
+    fi
+  '';
+in
+
+{
+  programs.starship.package = starshipPackage;
+
+  # Needed to avoid error with dummy starship package.
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
+    builtins.toFile "empty" ""
+  );
+}

--- a/tests/modules/programs/starship/fish_with_interactive.nix
+++ b/tests/modules/programs/starship/fish_with_interactive.nix
@@ -1,4 +1,6 @@
 {
+  imports = [ ./fish-package.nix ];
+
   programs = {
     fish.enable = true;
     starship.enable = true;
@@ -6,11 +8,23 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/fish/config.fish
+    assertFileRegex \
+      home-files/.config/fish/config.fish \
+      'source /nix/store/[^/]*-starship-fish-config\.fish'
+    assertFileNotRegex home-files/.config/fish/config.fish 'starship init fish'
+
+    starshipFishConfig=$(
+      sed -n 's|^[[:space:]]*source \(/nix/store/[^ ]*-starship-fish-config\.fish\).*|\1|p' \
+        "$TESTED/home-files/.config/fish/config.fish" | head -n1
+    )
+    assertFileExists "$starshipFishConfig"
+    assertFileContains "$starshipFishConfig" \
+      'starship fish init args: init fish --print-full-init'
 
     export GOT="$(tail -n 5 `_abs home-files/.config/fish/config.fish`)"
     export NOT_EXPECTED="
     if test \"\$TERM\" != dumb
-        @starship@/bin/starship init fish | source
+        source $starshipFishConfig
 
     end"
 

--- a/tests/modules/programs/starship/fish_with_transience.nix
+++ b/tests/modules/programs/starship/fish_with_transience.nix
@@ -1,4 +1,6 @@
 {
+  imports = [ ./fish-package.nix ];
+
   programs = {
     fish.enable = true;
 

--- a/tests/modules/programs/starship/fish_without_interactive.nix
+++ b/tests/modules/programs/starship/fish_without_interactive.nix
@@ -1,4 +1,6 @@
 {
+  imports = [ ./fish-package.nix ];
+
   programs = {
     fish.enable = true;
 
@@ -10,11 +12,23 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/fish/config.fish
+    assertFileRegex \
+      home-files/.config/fish/config.fish \
+      'source /nix/store/[^/]*-starship-fish-config\.fish'
+    assertFileNotRegex home-files/.config/fish/config.fish 'starship init fish'
+
+    starshipFishConfig=$(
+      sed -n 's|^[[:space:]]*source \(/nix/store/[^ ]*-starship-fish-config\.fish\).*|\1|p' \
+        "$TESTED/home-files/.config/fish/config.fish" | head -n1
+    )
+    assertFileExists "$starshipFishConfig"
+    assertFileContains "$starshipFishConfig" \
+      'starship fish init args: init fish --print-full-init'
 
     export GOT="$(tail -n 5 `_abs home-files/.config/fish/config.fish`)"
     export EXPECTED="
     if test \"\$TERM\" != dumb
-        @starship@/bin/starship init fish | source
+        source $starshipFishConfig
 
     end"
 

--- a/tests/modules/programs/starship/fish_without_transience.nix
+++ b/tests/modules/programs/starship/fish_without_transience.nix
@@ -1,4 +1,6 @@
 {
+  imports = [ ./fish-package.nix ];
+
   programs = {
     fish.enable = true;
     starship.enable = true;


### PR DESCRIPTION
### Description

Precompute the starship fish init script at build time and have fish source the generated store path instead of running starship init fish on every interactive shell startup, which in turn calls starship init fish --print-full-init.

Similar to #9259.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
