### PR TITLE
ripasso: add module

### DIFF
--- a/modules/misc/news/2026/09/2026-09-03_18-17-49.nix
+++ b/modules/misc/news/2026/09/2026-09-03_18-17-49.nix
@@ -1,0 +1,10 @@
+{
+  time = "2026-09-03T12:47:49+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.ripasso`
+
+    Ripasso is a TUI for pass-cli built in Rust.
+    See <https://github.com/cortex/ripasso/> for more details.
+  '';
+}

--- a/modules/programs/ripasso.nix
+++ b/modules/programs/ripasso.nix
@@ -1,0 +1,43 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.ripasso;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = [ lib.maintainers.rachitvrma ];
+
+  options.programs.ripasso = {
+    enable = lib.mkEnableOption "ripasso, a TUI for pass, built on Rust";
+
+    package = lib.mkPackageOption pkgs "ripasso-cursive" { nullable = true; };
+
+    settings = lib.mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = {
+        stores.default = {
+          path = "/home/user/.password";
+          pgp_implementation = "gpg";
+        };
+      };
+      description = ''
+        Settings to write to {file}`XDG_CONFIG_HOME/ripasso/settings.toml`.
+
+        See <https://github.com/cortex/ripasso> for more details.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."ripasso/settings.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "hm_ripasso.toml" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/ripasso/default.nix
+++ b/tests/modules/programs/ripasso/default.nix
@@ -1,0 +1,4 @@
+{
+  ripasso-empty-config = ./empty-config.nix;
+  ripasso-example-config = ./example-config.nix;
+}

--- a/tests/modules/programs/ripasso/empty-config.nix
+++ b/tests/modules/programs/ripasso/empty-config.nix
@@ -1,0 +1,7 @@
+{
+  programs.ripasso.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/ripasso"
+  '';
+}

--- a/tests/modules/programs/ripasso/example-config.nix
+++ b/tests/modules/programs/ripasso/example-config.nix
@@ -1,0 +1,15 @@
+{
+  programs.ripasso = {
+    enable = true;
+    settings = {
+      stores.default = {
+        path = "/home/user/.password-store";
+        pgp_implementation = "gpg";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent "home-files/.config/ripasso/settings.toml" ${./expected-config.toml}
+  '';
+}

--- a/tests/modules/programs/ripasso/expected-config.toml
+++ b/tests/modules/programs/ripasso/expected-config.toml
@@ -1,0 +1,3 @@
+[stores.default]
+path = "/home/user/.password-store"
+pgp_implementation = "gpg"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Ripasso-cursive is a TUI for pass-cli, built on Rust, with a ncurses interface.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
