### PR TITLE
keepassxc: add native messaging host for LibreWolf

### DIFF
--- a/modules/programs/keepassxc.nix
+++ b/modules/programs/keepassxc.nix
@@ -120,6 +120,7 @@ in
         programs.chromium.nativeMessagingHosts = [ cfg.package ];
         programs.firefox.nativeMessagingHosts = [ cfg.package ];
         programs.floorp.nativeMessagingHosts = [ cfg.package ];
+        programs.librewolf.nativeMessagingHosts = [ cfg.package ];
         programs.vivaldi.nativeMessagingHosts = [ cfg.package ];
       })
 


### PR DESCRIPTION
### Description

Minor addition: the KeePassXC package is now also automatically added to LibreWolf's native messaging hosts.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```
