### PR TITLE
omniwm: add module

### DIFF
--- a/modules/misc/news/2026/09/2026-09-04_09-48-53.nix
+++ b/modules/misc/news/2026/09/2026-09-04_09-48-53.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+{
+  time = "2026-09-04T09:48:53+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin;
+  message = ''
+    A new module is available `programs.omniwm`.
+
+    OmniWM is a macOS tiling window manager inspired by Niri and
+    Hyprland. The module manages its launchd agent and writes its
+    `settings.toml` configuration.
+  '';
+}

--- a/modules/programs/omniwm.nix
+++ b/modules/programs/omniwm.nix
@@ -1,0 +1,96 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.omniwm;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.maintainers; [ davsanchez ];
+
+  options.programs.omniwm = {
+    enable = lib.mkEnableOption "OmniWM window manager";
+
+    package = lib.mkPackageOption pkgs "omniwm" { };
+
+    launchd = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether to manage OmniWM with a launchd agent.";
+      };
+
+      keepAlive = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether the launchd agent should be kept alive.";
+      };
+    };
+
+    settings = lib.mkOption {
+      type = with lib.types; either path tomlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        # Attrset (serialized to TOML)
+        {
+          general = {
+            updateChecksEnabled = false;
+          };
+        }
+
+        # Or a path to an existing TOML file
+        ./omniwm-settings.toml
+      '';
+      description = ''
+        OmniWM settings written to
+        {file}`$XDG_CONFIG_HOME/omniwm/settings.toml`.
+
+        Either a path to a TOML file or an attrset that will be
+        serialized to TOML. The path form is useful when the file is
+        managed as a template (e.g. in a dotfiles repository), since
+        OmniWM rewrites this file from its GUI and replaces symlinks
+        with regular files.
+
+        See <https://github.com/BarutSRB/OmniWM> for configuration
+        details.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.omniwm" pkgs lib.platforms.darwin)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    launchd.agents.omniwm = {
+      inherit (cfg.launchd) enable;
+      config = {
+        Program = "${cfg.package}/Applications/OmniWM.app/Contents/MacOS/OmniWM";
+        KeepAlive = cfg.launchd.keepAlive;
+        RunAtLoad = true;
+        StandardOutPath = "/tmp/omniwm.log";
+        StandardErrorPath = "/tmp/omniwm.err.log";
+      };
+    };
+
+    # OmniWM rewrites `settings.toml` from the GUI, replacing this
+    # symlink with a regular file. `force = true` makes the next switch
+    # re-link the declarative template (from the Nix store) over that
+    # file instead of failing with a clobber error. The template is the
+    # source of truth: any GUI change you want to keep must be mirrored
+    # into it.
+    xdg.configFile."omniwm/settings.toml" = lib.mkIf (cfg.settings != { }) {
+      source =
+        if lib.hm.strings.isPathLike cfg.settings then
+          cfg.settings
+        else
+          tomlFormat.generate "omniwm-settings.toml" cfg.settings;
+      force = true;
+    };
+  };
+}

--- a/tests/modules/programs/omniwm/default.nix
+++ b/tests/modules/programs/omniwm/default.nix
@@ -1,0 +1,6 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+  omniwm = ./omniwm.nix;
+  omniwm-settings = ./omniwm-settings.nix;
+}

--- a/tests/modules/programs/omniwm/omniwm-service-expected.plist
+++ b/tests/modules/programs/omniwm/omniwm-service-expected.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Label</key>
+	<string>org.nix-community.home.omniwm</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sh</string>
+		<string>-c</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec /nix/store/00000000000000000000000000000000-omniwm/Applications/OmniWM.app/Contents/MacOS/OmniWM</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/tmp/omniwm.err.log</string>
+	<key>StandardOutPath</key>
+	<string>/tmp/omniwm.log</string>
+</dict>
+</plist>

--- a/tests/modules/programs/omniwm/omniwm-settings-expected.toml
+++ b/tests/modules/programs/omniwm/omniwm-settings-expected.toml
@@ -1,0 +1,29 @@
+[[appRules]]
+bundleId = "com.apple.Safari"
+id = "81426D13-C1A5-475E-AFBC-00BBA05042D0"
+minHeight = 220.0
+minWidth = 574.0
+
+[appearance]
+mode = "dark"
+
+[borders]
+enabled = true
+width = 2.0
+
+[borders.color]
+alpha = 1.0
+blue = 0.69
+green = 0.7
+red = 0.7
+
+[gaps]
+size = 8.0
+
+[general]
+defaultLayoutType = "niri"
+updateChecksEnabled = false
+
+[[hotkeys]]
+binding = "Control+1"
+id = "switchWorkspace.0"

--- a/tests/modules/programs/omniwm/omniwm-settings.nix
+++ b/tests/modules/programs/omniwm/omniwm-settings.nix
@@ -1,0 +1,67 @@
+{ config, pkgs, ... }:
+let
+  hmPkgs = pkgs.extend (
+    _self: _super: {
+      omniwm = config.lib.test.mkStubPackage {
+        name = "omniwm";
+        buildScript = ''
+          mkdir -p $out/Applications/OmniWM.app/Contents/MacOS
+          touch $out/Applications/OmniWM.app/Contents/MacOS/OmniWM
+          chmod 755 $out/Applications/OmniWM.app/Contents/MacOS/OmniWM
+        '';
+      };
+    }
+  );
+in
+{
+  xdg.enable = true;
+
+  programs.omniwm = {
+    enable = true;
+    package = hmPkgs.omniwm;
+
+    launchd.enable = true;
+
+    settings = {
+      appearance.mode = "dark";
+      general = {
+        defaultLayoutType = "niri";
+        updateChecksEnabled = false;
+      };
+      gaps.size = 8.0;
+      borders = {
+        enabled = true;
+        width = 2.0;
+        color = {
+          alpha = 1.0;
+          blue = 0.69;
+          green = 0.7;
+          red = 0.7;
+        };
+      };
+      hotkeys = [
+        {
+          binding = "Control+1";
+          id = "switchWorkspace.0";
+        }
+      ];
+      appRules = [
+        {
+          bundleId = "com.apple.Safari";
+          id = "81426D13-C1A5-475E-AFBC-00BBA05042D0";
+          minHeight = 220.0;
+          minWidth = 574.0;
+        }
+      ];
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/.config/omniwm/settings.toml"
+    assertFileContent "home-files/.config/omniwm/settings.toml" ${./omniwm-settings-expected.toml}
+
+    serviceFile=$(normalizeStorePaths LaunchAgents/org.nix-community.home.omniwm.plist)
+    assertFileExists $serviceFile
+    assertFileContent "$serviceFile" ${./omniwm-service-expected.plist}
+  '';
+}

--- a/tests/modules/programs/omniwm/omniwm.nix
+++ b/tests/modules/programs/omniwm/omniwm.nix
@@ -1,0 +1,29 @@
+{ config, pkgs, ... }:
+let
+  hmPkgs = pkgs.extend (
+    _self: _super: {
+      omniwm = config.lib.test.mkStubPackage {
+        name = "omniwm";
+        buildScript = ''
+          mkdir -p $out/Applications/OmniWM.app/Contents/MacOS
+          touch $out/Applications/OmniWM.app/Contents/MacOS/OmniWM
+          chmod 755 $out/Applications/OmniWM.app/Contents/MacOS/OmniWM
+        '';
+      };
+    }
+  );
+in
+{
+  programs.omniwm = {
+    enable = true;
+    package = hmPkgs.omniwm;
+  };
+
+  nmt.script = ''
+    assertPathNotExists "home-files/.config/omniwm/settings.toml"
+
+    serviceFile=$(normalizeStorePaths LaunchAgents/org.nix-community.home.omniwm.plist)
+    assertFileExists $serviceFile
+    assertFileContent "$serviceFile" ${./omniwm-service-expected.plist}
+  '';
+}


### PR DESCRIPTION
## Description

Adds a `programs.omniwm` Home Manager module for [OmniWM](https://omniwm.app), a macOS tiling window manager inspired by Niri and Hyprland.

The module:
- installs the `omniwm` package
- manages an optional launchd agent (`programs.omniwm.launchd`)
- writes `settings.toml` to `$XDG_CONFIG_HOME/omniwm/settings.toml`, either from an attrset (serialized to TOML) or from an existing TOML file (`programs.omniwm.settings`)

It is modeled closely on the existing `programs.aerospace` module (darwin-only, launchd agent, TOML settings). I have been using the module on my local configs [here](https://github.com/DavSanchez/nix-dotfiles/blob/6bd8a3bf79e3e619e4db05360c807adb3a17dd26/modules/home/omniwm.nix).

## Notes for reviewers

- **`settings` type** is `either path tomlFormat.type`. The path form is intentional: OmniWM rewrites this file from its GUI and replaces the symlink with a regular file, so pointing at a managed template (e.g. in a dotfiles repo) is a supported use case. Happy to drop it if you'd prefer a pure structured `settings`.
- **`launchd.enable` defaults to `true`** (unlike aerospace's `false`) since OmniWM is a window manager that needs to run; open to changing the default.
- **`force = true`** on the config file re-links the declarative template over the file OmniWM rewrites on next switch (documented in the module).
- Depends on `pkgs.omniwm`, which recently landed in nixpkgs (currently 0.6.3).

## Tests

Darwin-gated golden tests under `tests/modules/programs/omniwm` cover both the minimal config and the settings-serialization + launchd plist paths. Verified locally with `nix build .#legacyPackages.aarch64-darwin.test-omniwm` and `...#legacyPackages.aarch64-darwin.test-omniwm-settings`.

- [x] Formatting (`nix fmt`)
- [x] Maintainer set (`meta.maintainers = [ davsanchez ]`)
- [x] News entry added