### PR TITLE
nh: split clean.extraArgs into separate launchd arguments

### DIFF
--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -157,7 +157,7 @@ in
           "clean"
           "user"
         ]
-        ++ lib.optional (cfg.clean.extraArgs != "") cfg.clean.extraArgs;
+        ++ lib.filter (arg: arg != "") (lib.splitString " " cfg.clean.extraArgs);
         StartCalendarInterval = lib.hm.darwin.mkCalendarInterval cfg.clean.dates;
       };
     };

--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -83,11 +83,22 @@ in
       };
 
       extraArgs = lib.mkOption {
-        type = lib.types.singleLineStr;
+        type = with lib.types; either singleLineStr (listOf str);
         default = "";
-        example = "--keep 5 --keep-since 3d";
+        example = [
+          "--keep"
+          "5"
+          "--keep-since"
+          "3d"
+        ];
         description = ''
           Options given to nh clean when the service is run automatically.
+
+          A list is preferred, each element being one argument.
+
+          A string keeps its platform-specific meaning: on Linux it is command
+          line text that systemd splits into arguments, on Darwin it is passed
+          to nh as a single argument.
 
           See `nh clean all --help` for more information.
         '';
@@ -136,7 +147,15 @@ in
         Unit.Description = "Nh clean (user)";
         Service = {
           Type = "oneshot";
-          ExecStart = "${lib.getExe cfg.package} clean user ${cfg.clean.extraArgs}";
+          ExecStart =
+            let
+              extraArgs =
+                if builtins.isList cfg.clean.extraArgs then
+                  lib.escapeShellArgs cfg.clean.extraArgs
+                else
+                  cfg.clean.extraArgs;
+            in
+            "${lib.getExe cfg.package} clean user" + lib.optionalString (extraArgs != "") " ${extraArgs}";
         };
       };
       timers.nh-clean = {
@@ -157,7 +176,12 @@ in
           "clean"
           "user"
         ]
-        ++ lib.filter (arg: arg != "") (lib.splitString " " cfg.clean.extraArgs);
+        ++ (
+          if builtins.isList cfg.clean.extraArgs then
+            cfg.clean.extraArgs
+          else
+            lib.optional (cfg.clean.extraArgs != "") cfg.clean.extraArgs
+        );
         StartCalendarInterval = lib.hm.darwin.mkCalendarInterval cfg.clean.dates;
       };
     };

--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -151,7 +151,7 @@ in
             let
               extraArgs =
                 if builtins.isList cfg.clean.extraArgs then
-                  lib.escapeShellArgs cfg.clean.extraArgs
+                  lib.hm.strings.escapeSystemdExecArgs cfg.clean.extraArgs
                 else
                   cfg.clean.extraArgs;
             in

--- a/tests/modules/programs/nh/darwin/clean-extra-args-empty.nix
+++ b/tests/modules/programs/nh/darwin/clean-extra-args-empty.nix
@@ -5,12 +5,7 @@
     clean = {
       enable = true;
       dates = "weekly";
-      extraArgs = [
-        "--keep"
-        "5"
-        "--keep-since"
-        "3d"
-      ];
+      extraArgs = [ ];
     };
   };
 
@@ -19,6 +14,6 @@
     serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
 
     assertFileExists $serviceFile
-    assertFileContent $serviceFileNormalized ${./clean-extra-args.plist}
+    assertFileContent $serviceFileNormalized ${./launchd.plist}
   '';
 }

--- a/tests/modules/programs/nh/darwin/clean-extra-args-spaces.nix
+++ b/tests/modules/programs/nh/darwin/clean-extra-args-spaces.nix
@@ -6,10 +6,8 @@
       enable = true;
       dates = "weekly";
       extraArgs = [
-        "--keep"
-        "5"
         "--keep-since"
-        "3d"
+        "1 day"
       ];
     };
   };
@@ -19,6 +17,6 @@
     serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
 
     assertFileExists $serviceFile
-    assertFileContent $serviceFileNormalized ${./clean-extra-args.plist}
+    assertFileContent $serviceFileNormalized ${./clean-extra-args-spaces.plist}
   '';
 }

--- a/tests/modules/programs/nh/darwin/clean-extra-args-spaces.plist
+++ b/tests/modules/programs/nh/darwin/clean-extra-args-spaces.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>org.nix-community.home.nh-clean</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sh</string>
+		<string>-c</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec @nh@/bin/nh clean user --keep-since &apos;1 day&apos;</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<array>
+		<dict>
+			<key>Hour</key>
+			<integer>0</integer>
+			<key>Minute</key>
+			<integer>0</integer>
+			<key>Weekday</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/tests/modules/programs/nh/darwin/clean-extra-args-string.nix
+++ b/tests/modules/programs/nh/darwin/clean-extra-args-string.nix
@@ -5,12 +5,7 @@
     clean = {
       enable = true;
       dates = "weekly";
-      extraArgs = [
-        "--keep"
-        "5"
-        "--keep-since"
-        "3d"
-      ];
+      extraArgs = "--keep-since=1 day";
     };
   };
 
@@ -19,6 +14,6 @@
     serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
 
     assertFileExists $serviceFile
-    assertFileContent $serviceFileNormalized ${./clean-extra-args.plist}
+    assertFileContent $serviceFileNormalized ${./clean-extra-args-string.plist}
   '';
 }

--- a/tests/modules/programs/nh/darwin/clean-extra-args-string.plist
+++ b/tests/modules/programs/nh/darwin/clean-extra-args-string.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>org.nix-community.home.nh-clean</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sh</string>
+		<string>-c</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec @nh@/bin/nh clean user &apos;--keep-since=1 day&apos;</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<array>
+		<dict>
+			<key>Hour</key>
+			<integer>0</integer>
+			<key>Minute</key>
+			<integer>0</integer>
+			<key>Weekday</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/tests/modules/programs/nh/darwin/clean-extra-args.nix
+++ b/tests/modules/programs/nh/darwin/clean-extra-args.nix
@@ -1,0 +1,19 @@
+{
+  programs.nh = {
+    enable = true;
+
+    clean = {
+      enable = true;
+      dates = "weekly";
+      extraArgs = "--keep 5 --keep-since 3d";
+    };
+  };
+
+  nmt.script = ''
+    serviceFile="LaunchAgents/org.nix-community.home.nh-clean.plist"
+    serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+
+    assertFileExists $serviceFile
+    assertFileContent $serviceFileNormalized ${./clean-extra-args.plist}
+  '';
+}

--- a/tests/modules/programs/nh/darwin/clean-extra-args.plist
+++ b/tests/modules/programs/nh/darwin/clean-extra-args.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>org.nix-community.home.nh-clean</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sh</string>
+		<string>-c</string>
+		<string>/bin/wait4path /nix/store &amp;&amp; exec @nh@/bin/nh clean user --keep 5 --keep-since 3d</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<array>
+		<dict>
+			<key>Hour</key>
+			<integer>0</integer>
+			<key>Minute</key>
+			<integer>0</integer>
+			<key>Weekday</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/tests/modules/programs/nh/default.nix
+++ b/tests/modules/programs/nh/default.nix
@@ -2,7 +2,14 @@
 (lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
   nh = ./darwin/config.nix;
   nh-clean-extra-args = ./darwin/clean-extra-args.nix;
+  nh-clean-extra-args-spaces = ./darwin/clean-extra-args-spaces.nix;
+  nh-clean-extra-args-string = ./darwin/clean-extra-args-string.nix;
+  nh-clean-extra-args-empty = ./darwin/clean-extra-args-empty.nix;
 })
 // (lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   nh = ./linux/config.nix;
+  nh-clean-extra-args = ./linux/clean-extra-args.nix;
+  nh-clean-extra-args-spaces = ./linux/clean-extra-args-spaces.nix;
+  nh-clean-extra-args-string = ./linux/clean-extra-args-string.nix;
+  nh-clean-extra-args-empty = ./linux/clean-extra-args-empty.nix;
 })

--- a/tests/modules/programs/nh/default.nix
+++ b/tests/modules/programs/nh/default.nix
@@ -1,6 +1,7 @@
 { lib, pkgs, ... }:
 (lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
   nh = ./darwin/config.nix;
+  nh-clean-extra-args = ./darwin/clean-extra-args.nix;
 })
 // (lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   nh = ./linux/config.nix;

--- a/tests/modules/programs/nh/default.nix
+++ b/tests/modules/programs/nh/default.nix
@@ -10,6 +10,7 @@
   nh = ./linux/config.nix;
   nh-clean-extra-args = ./linux/clean-extra-args.nix;
   nh-clean-extra-args-spaces = ./linux/clean-extra-args-spaces.nix;
+  nh-clean-extra-args-newline = ./linux/clean-extra-args-newline.nix;
   nh-clean-extra-args-string = ./linux/clean-extra-args-string.nix;
   nh-clean-extra-args-empty = ./linux/clean-extra-args-empty.nix;
 })

--- a/tests/modules/programs/nh/linux/clean-extra-args-empty.nix
+++ b/tests/modules/programs/nh/linux/clean-extra-args-empty.nix
@@ -1,0 +1,17 @@
+{
+  programs.nh = {
+    enable = true;
+
+    clean = {
+      enable = true;
+      dates = "weekly";
+      extraArgs = [ ];
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/nh-clean.service)
+
+    assertFileContent "$serviceFile" ${./clean-extra-args-empty.service}
+  '';
+}

--- a/tests/modules/programs/nh/linux/clean-extra-args-empty.service
+++ b/tests/modules/programs/nh/linux/clean-extra-args-empty.service
@@ -1,0 +1,6 @@
+[Service]
+ExecStart=@nh@/bin/nh clean user
+Type=oneshot
+
+[Unit]
+Description=Nh clean (user)

--- a/tests/modules/programs/nh/linux/clean-extra-args-newline.nix
+++ b/tests/modules/programs/nh/linux/clean-extra-args-newline.nix
@@ -1,0 +1,20 @@
+{
+  programs.nh = {
+    enable = true;
+
+    clean = {
+      enable = true;
+      dates = "weekly";
+      extraArgs = [
+        "--keep-since"
+        "1\nday"
+      ];
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/nh-clean.service)
+
+    assertFileContent "$serviceFile" ${./clean-extra-args-newline.service}
+  '';
+}

--- a/tests/modules/programs/nh/linux/clean-extra-args-newline.service
+++ b/tests/modules/programs/nh/linux/clean-extra-args-newline.service
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=@nh@/bin/nh clean user "--keep-since" "1 day"
+ExecStart=@nh@/bin/nh clean user "--keep-since" "1\nday"
 Type=oneshot
 
 [Unit]

--- a/tests/modules/programs/nh/linux/clean-extra-args-spaces.nix
+++ b/tests/modules/programs/nh/linux/clean-extra-args-spaces.nix
@@ -1,0 +1,20 @@
+{
+  programs.nh = {
+    enable = true;
+
+    clean = {
+      enable = true;
+      dates = "weekly";
+      extraArgs = [
+        "--keep-since"
+        "1 day"
+      ];
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/nh-clean.service)
+
+    assertFileContent "$serviceFile" ${./clean-extra-args-spaces.service}
+  '';
+}

--- a/tests/modules/programs/nh/linux/clean-extra-args-spaces.service
+++ b/tests/modules/programs/nh/linux/clean-extra-args-spaces.service
@@ -1,0 +1,6 @@
+[Service]
+ExecStart=@nh@/bin/nh clean user --keep-since '1 day'
+Type=oneshot
+
+[Unit]
+Description=Nh clean (user)

--- a/tests/modules/programs/nh/linux/clean-extra-args-string.nix
+++ b/tests/modules/programs/nh/linux/clean-extra-args-string.nix
@@ -1,0 +1,17 @@
+{
+  programs.nh = {
+    enable = true;
+
+    clean = {
+      enable = true;
+      dates = "weekly";
+      extraArgs = "--keep-since=1 day";
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/nh-clean.service)
+
+    assertFileContent "$serviceFile" ${./clean-extra-args-string.service}
+  '';
+}

--- a/tests/modules/programs/nh/linux/clean-extra-args-string.service
+++ b/tests/modules/programs/nh/linux/clean-extra-args-string.service
@@ -1,0 +1,6 @@
+[Service]
+ExecStart=@nh@/bin/nh clean user --keep-since=1 day
+Type=oneshot
+
+[Unit]
+Description=Nh clean (user)

--- a/tests/modules/programs/nh/linux/clean-extra-args.nix
+++ b/tests/modules/programs/nh/linux/clean-extra-args.nix
@@ -1,0 +1,22 @@
+{
+  programs.nh = {
+    enable = true;
+
+    clean = {
+      enable = true;
+      dates = "weekly";
+      extraArgs = [
+        "--keep"
+        "5"
+        "--keep-since"
+        "3d"
+      ];
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/nh-clean.service)
+
+    assertFileContent "$serviceFile" ${./clean-extra-args.service}
+  '';
+}

--- a/tests/modules/programs/nh/linux/clean-extra-args.service
+++ b/tests/modules/programs/nh/linux/clean-extra-args.service
@@ -1,0 +1,6 @@
+[Service]
+ExecStart=@nh@/bin/nh clean user --keep 5 --keep-since 3d
+Type=oneshot
+
+[Unit]
+Description=Nh clean (user)

--- a/tests/modules/programs/nh/linux/clean-extra-args.service
+++ b/tests/modules/programs/nh/linux/clean-extra-args.service
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=@nh@/bin/nh clean user --keep 5 --keep-since 3d
+ExecStart=@nh@/bin/nh clean user "--keep" "5" "--keep-since" "3d"
 Type=oneshot
 
 [Unit]


### PR DESCRIPTION
### Description

On darwin, `programs.nh.clean.extraArgs` is appended to `ProgramArguments` as a single list element:
`++ lib.optional (cfg.clean.extraArgs != "") cfg.clean.extraArgs;`

The launchd module shell-quotes each element, so every flag arrives as one argument and the agent fails on each run:
```
 nh clean user '--keep 5 --keep-since 3d'
 error: unexpected argument '--keep 5 --keep-since 3d' found
   tip: a similar argument exists: '--keep-since'
```

This affects the option's own documented example, `"--keep 5 --keep-since 3d"` - only a single valueless flag such as `--keep-one` happens to work. The failure is invisible because the generated agent sets no `StandardErrorPath`.

Linux is unaffected: there `extraArgs` is interpolated into `ExecStart` as text, and systemd splits that into arguments itself. This PR makes darwin behave the same way.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
