### PR TITLE
docs: map Nixpkgs `lib` declarations to `<nixpkgs/...>`

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -69,6 +69,12 @@ let
 
   hmPath = toString ./..;
 
+  # The Nixpkgs source tree, used to rewrite declaration sites that come from
+  # Nixpkgs' own `lib` rather than from Home Manager. Currently that is the
+  # generic `meta.maintainers` / `meta.teams` module, which
+  # `modules/services-modular` pulls in via `lib/services`.
+  nixpkgsPath = toString pkgs.path;
+
   # Keep submodule option docs visible when wrapped in `either` (and therefore
   # in `nullOr (either ...)`), which upstream currently omits.
   docsLib = lib.extend (
@@ -182,6 +188,10 @@ let
                 # TODO: handle this in a better way (may require upstream
                 # changes to nixpkgs)
                 gitHubDeclaration "NixOS" "nixpkgs" decl
+              else if lib.hasPrefix nixpkgsPath (toString decl) then
+                gitHubDeclaration "NixOS" "nixpkgs" (
+                  lib.removePrefix "/" (lib.removePrefix nixpkgsPath (toString decl))
+                )
               else
                 decl
             ) opt.declarations;


### PR DESCRIPTION
### Description

`docs/default.nix`'s `transformOptions` rewrites two kinds of declaration site
and lets everything else through unchanged:

```nix
if lib.hasPrefix hmPath (toString decl) then ...      # Home Manager's own tree
else if decl == "lib/modules.nix" then ...            # Nixpkgs' internal module
else decl
```

Declarations that come from Nixpkgs' `lib` as real paths fall into that last
branch. Today there is exactly one: `lib/modules/generic/meta-maintainers.nix`,
which `modules/services-modular` pulls in through `lib/services`. It declares
`meta.maintainers` and `meta.teams`, which land on 11 options (including
submodules such as `programs.firefox.profiles.<name>.bookmarks`).

So `options.json` ships entries like:

```json
"meta.maintainers": {
  "declarations": ["/nix/store/<hash>-source/lib/modules/generic/meta-maintainers.nix"]
}
```

That is unhelpful in the rendered manual, and because the path is `toString`ed
its string context is dropped, so Nix warns on every evaluation that
instantiates the manual. `manual.manpages.enable` defaults to `true` and the
manpage is built from `hmOptionsDocs.optionsJSON`, so in practice this is every
Home Manager build:

```
warning: Using 'builtins.derivation' to create a derivation named 'options.json'
that references the store path '/nix/store/<hash>-source' without a proper
context. The resulting derivation will not have a correct store reference, so
this is unreliable and may stop working in the future.
```

This adds a third branch that maps those declarations to `<nixpkgs/...>`, the
same shape already used for `lib/modules.nix`.

After the change the same option renders as:

```json
"declarations": [{
  "name": "<nixpkgs/lib/modules/generic/meta-maintainers.nix>",
  "url": "https://github.com/NixOS/nixpkgs/blob/master/lib/modules/generic/meta-maintainers.nix"
}]
```

### Verification

Evaluated a real `nix-darwin` + Home Manager system, same revision on both
sides, only this patch differing:

| | `options.json` warning |
|---|---|
| unpatched | present |
| patched | gone |

Then built the affected derivations and inspected the output:

- `options.json` builds; 5591 options before and after; raw `/nix/store/...`
  declarations go from 1 distinct path (22 occurrences) to 0.
- `home-configuration-reference-manpage` builds, and renders
  `<nixpkgs/lib/modules/generic/meta-maintainers.nix>`. Note this derivation
  sets `allowedReferences = [ "out" ]`, so it also confirms nothing new leaked
  into the closure.
- The generated URL returns HTTP 200.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted. `nixfmt --check docs/default.nix` is clean.
- [ ] `nix build .#test-all` not run. This is a docs-only change with no module
      surface, and I verified the two derivations it actually affects directly,
      as above. Happy to run the full suite if you'd like it before merge.
- [ ] Test cases not added. There is no existing harness asserting on generated
      declaration sites; let me know if you'd like one and where it should live.
- [x] Commit message formatted as `{component}: {description}`.

### Note on scope

A narrower alternative would be fixing this in Nixpkgs instead, by giving
`lib/modules/generic/*.nix` an explicit relative `_file` the way
`lib/modules.nix` already does. That would fix it for every downstream
documentation builder at once rather than just Home Manager. I went with the
Home Manager side because it is self-contained and unblocks the warning now,
but I am happy to take it upstream instead if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
