### PR TITLE
hyprland: use `isPathLike`

### DIFF
--- a/modules/services/window-managers/hyprland/lib.nix
+++ b/modules/services/window-managers/hyprland/lib.nix
@@ -51,8 +51,6 @@ let
   luaLocalName = name: value: value.name or name;
 
   hasNonStringValue = values: lib.any (value: !isString value) values;
-
-  isPathLike = value: lib.isPath value || lib.isStorePath value;
 in
 {
   inherit
@@ -250,7 +248,10 @@ in
   extraLuaFiles = lib.mapAttrs' (
     name: file:
     lib.nameValuePair "hypr/${luaFileName name}" (
-      if isPathLike file.content then { source = file.content; } else { text = file.content; }
+      if lib.hm.strings.isPathLike file.content then
+        { source = file.content; }
+      else
+        { text = file.content; }
     )
   ) config.extraLuaFiles;
 }

--- a/tests/modules/services/hyprland/lua-files-config.lua
+++ b/tests/modules/services/hyprland/lua-files-config.lua
@@ -5,5 +5,6 @@
 local hm_xdg_config_home = os.getenv("XDG_CONFIG_HOME") or "/home/hm-user/.config"
 package.path = hm_xdg_config_home .. "/hypr/?.lua;" .. hm_xdg_config_home .. "/hypr/?/init.lua;" .. package.path
 require("00-vars")
+require("from-nested-store-path")
 require("from-path")
 require("ui.bindings")

--- a/tests/modules/services/hyprland/lua-files-config.nix
+++ b/tests/modules/services/hyprland/lua-files-config.nix
@@ -1,4 +1,10 @@
-_:
+{ pkgs, ... }:
+let
+  nestedStorePath = pkgs.runCommandLocal "nested-store-path" { } ''
+    mkdir -p "$out"
+    ln -s ${./lua-file-from-path.lua} "$out/lua-file-in-store.lua"
+  '';
+in
 
 {
   wayland.windowManager.hyprland = {
@@ -33,6 +39,7 @@ _:
       };
 
       "from-path.lua" = ./lua-file-from-path.lua;
+      "from-nested-store-path.lua" = "${nestedStorePath}/lua-file-in-store.lua";
     };
   };
 
@@ -54,6 +61,8 @@ _:
       ${./lua-files-helpers.lua}
 
     assertFileContent home-files/.config/hypr/from-path.lua \
+      ${./lua-file-from-path.lua}
+    assertFileContent home-files/.config/hypr/from-nested-store-path.lua \
       ${./lua-file-from-path.lua}
   '';
 }


### PR DESCRIPTION
### Description

the previous implementation using `isStorePath` was bugged as that only accepts root paths in the store, not files under those paths. home-manager already has a function that handles this logic, we can just use that instead.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```