### PR TITLE
fontconfig: force-overwrite generated conf.d entries

### DIFF
--- a/modules/misc/fontconfig.nix
+++ b/modules/misc/fontconfig.nix
@@ -436,6 +436,14 @@ in
       _name: config:
       lib.nameValuePair "fontconfig/conf.d/${config.target}" {
         inherit (config) enable source;
+        # This path is exclusively home-manager's own namespace (the
+        # `target` default embeds "-hm-" in the filename), so anything
+        # found occupying it is provably stale or foreign and safe to
+        # unconditionally overwrite. This also fixes the case where an
+        # external tool (e.g. KDE's fontinst) replaces the managed symlink
+        # with a plain-file copy of its target, which would otherwise make
+        # Home Manager's own collision check fail activation.
+        force = true;
       }
     ) cfg.configFile;
   };

--- a/tests/modules/misc/fontconfig/default.nix
+++ b/tests/modules/misc/fontconfig/default.nix
@@ -8,6 +8,7 @@
   fontconfig-custom-rendering = ./custom-rendering.nix;
   fontconfig-extra-config-files = ./extra-config-files.nix;
   fontconfig-fonts = ./fonts.nix;
+  fontconfig-force-overwrite = ./force-overwrite.nix;
 
   fontconfig-legacy-default-configFile-toggle = ./legacy-default-configFile-toggle.nix;
 }

--- a/tests/modules/misc/fontconfig/force-overwrite.nix
+++ b/tests/modules/misc/fontconfig/force-overwrite.nix
@@ -1,0 +1,30 @@
+{ config, ... }:
+
+{
+  fonts.fontconfig.enable = true;
+
+  fonts.fontconfig.configFile.tamzen-disable-antialiasing = {
+    enable = true;
+    text = ''
+      <?xml version="1.0"?>
+      <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+      <fontconfig></fontconfig>
+    '';
+  };
+
+  assertions = [
+    {
+      assertion = config.xdg.configFile."fontconfig/conf.d/10-hm-fonts.conf".force;
+      message = ''
+        Expected the generated fontconfig conf.d entries to be forcibly
+        overwritten, since an external tool (e.g. KDE's fontinst) replacing
+        the managed symlink with a plain-file copy would otherwise make
+        activation fail on the next rebuild.
+      '';
+    }
+    {
+      assertion = config.xdg.configFile."fontconfig/conf.d/90-hm-tamzen-disable-antialiasing.conf".force;
+      message = "Expected user-defined fontconfig.configFile entries to be forced too, since they live in the same home-manager-owned path.";
+    }
+  ];
+}


### PR DESCRIPTION
## Summary

`fonts.fontconfig`'s generated `xdg.configFile` entries under
`~/.config/fontconfig/conf.d/` didn't set `force = true`, so Home
Manager's `checkLinkTargets` activation step hard-fails if anything
other than a symlink into a `*-home-manager-files` store path occupies
one of those paths.

On KDE this happens routinely: opening System Settings -> Appearance &
Style -> Fonts D-Bus-activates `org.kde.fontinst`, which replaces every
symlink under that directory with a plain-file copy of its target on
every single start. The next rebuild's freshly generated file always
differs byte-for-byte from that stale copy (embeds a new
`home-manager-path` store hash), so activation then fails with
`Existing file ... would be clobbered` until the file is removed by
hand.

Every target path this module writes to already embeds `-hm-` in the
filename by default (`target = "${priority}-hm-${label}.conf"`), i.e.
the path is exclusively Home Manager's own namespace, so anything found
occupying it is provably stale or foreign and safe to unconditionally
overwrite -- same reasoning already applied to
`programs.libreoffice`'s registrymodifications.xcu. This lets Home
Manager fix the collision itself instead of requiring manual
intervention, regardless of what clobbers the symlink (KDE's fontinst
here, but anything else capable of the same would trigger it too).

Fixes #6221.

## Test plan

- [x] Added `tests/modules/misc/fontconfig/force-overwrite.nix`,
      asserting `force` on both a built-in (`fonts`) and a user-defined
      `fonts.fontconfig.configFile` entry.
- [x] All existing `fontconfig-*` nmt tests still pass
      (`nix build .#legacyPackages.x86_64-linux.test-fontconfig-<name>`).
- [x] `nix fmt` reports no changes needed.