### PR TITLE
direnv: add enableGitIntegration option

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -77,6 +77,13 @@ in
 
     enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
+    enableGitIntegration = mkEnableOption "Git integration" // {
+      description = ''
+        Whether to configure Git to globally ignore {file}`.envrc`
+        and {file}`.direnv/`.
+      '';
+    };
+
     enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
@@ -120,6 +127,11 @@ in
             log_filter = "^$";
           };
         };
+
+        git.ignores = mkIf cfg.enableGitIntegration [
+          ".envrc"
+          ".direnv/"
+        ];
 
         bash.initExtra = mkIf cfg.enableBashIntegration (
           # Using `mkAfter` to make it more likely to appear after other

--- a/tests/modules/programs/direnv/default.nix
+++ b/tests/modules/programs/direnv/default.nix
@@ -1,3 +1,4 @@
 {
   direnv = ./basic-config.nix;
+  direnv-git-integration = ./git-integration.nix;
 }

--- a/tests/modules/programs/direnv/git-integration.nix
+++ b/tests/modules/programs/direnv/git-integration.nix
@@ -1,0 +1,23 @@
+{ config, ... }:
+{
+  programs = {
+    direnv = {
+      enable = true;
+      enableGitIntegration = true;
+      nix-direnv.package = config.lib.test.mkStubPackage {
+        buildScript = ''
+          mkdir -p $out/share/nix-direnv/
+          touch $out/share/nix-direnv/direnvrc
+        '';
+      };
+    };
+
+    git.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/ignore
+    assertFileContains home-files/.config/git/ignore ".envrc"
+    assertFileContains home-files/.config/git/ignore ".direnv/"
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adds the `programs.direnv.enableGitIntegration` option. When enabled, it automatically adds `.envrc` and `.direnv/` to `programs.git.ignores`, globally ignoring direnv environment files and nix-direnv cache directories.

This is disabled by default to preserve backwards compatibility for users who intentionally commit `.envrc` files.

RELATED: nix-community/nix-direnv#789

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
