### PR TITLE
targets/generic-linux: restore the Nix environment in child shells

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -768,6 +768,9 @@ in
         mkSections [
           (config.lib.shell.exportAll cfg.sessionVariables)
           searchSection
+          (lib.optionalString config.targets.genericLinux.enable ''
+            . "${config.targets.genericLinux.nixEnvironmentPackage}/etc/profile.d/hm-nix-env.sh"
+          '')
           # Keep arbitrary extra code at top level. A compound wrapper would
           # change when aliases and parser options take effect.
           ''

--- a/modules/lib/fish-session-variables.nix
+++ b/modules/lib/fish-session-variables.nix
@@ -76,6 +76,9 @@ pkgs.runCommandLocal "hm-session-vars.fish" { } ''
     }
     ${pkgs.buildPackages.babelfish}/bin/babelfish < ${prelude}
     ${lib.optionalString hasMerges "${pkgs.buildPackages.babelfish}/bin/babelfish < ${mergeScript}"}
+    ${lib.optionalString config.targets.genericLinux.enable ''
+      echo "  source ${config.targets.genericLinux.nixEnvironmentPackage}/etc/profile.d/hm-nix-env.fish"
+    ''}
     ${pkgs.buildPackages.babelfish}/bin/babelfish < ${extra}
     echo "end"
 

--- a/modules/misc/news/2026/09/2026-09-10_12-00-00.nix
+++ b/modules/misc/news/2026/09/2026-09-10_12-00-00.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+{
+  time = "2026-09-10T12:00:00+00:00";
+  condition = config.targets.genericLinux.enable;
+  message = ''
+    Generic Linux shell startup now restores the standard Nix profile
+    environment when a parent login environment removes it. The refresh keeps
+    existing search-path positions, explicit scalar values, and empty scalar
+    overrides. It covers the standard Nix profile script variables; additional
+    side effects from custom `nix.package` profile scripts are not reproduced.
+  '';
+}

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -431,13 +431,60 @@ in
       envVarsStr = config.lib.zsh.exportAll cfg.sessionVariables { indent = "  "; };
       sessionVarsToken = "${config.home.sessionVariablesPackage}:${builtins.hashString "sha256" envVarsStr}";
       localVarsStr = config.lib.zsh.defineAll cfg.localVariables;
+      nixEnvironmentRefresh = lib.optionalString config.targets.genericLinux.enable ''
+        . "${config.targets.genericLinux.nixEnvironmentPackage}/etc/profile.d/hm-nix-env.sh"
+      '';
+      nixScalarFallbacks =
+        let
+          configuredDeclaration =
+            name:
+            let
+              zshValue = cfg.sessionVariables.${name} or null;
+              homeValue = config.home.sessionVariables.${name} or null;
+            in
+            if zshValue != null then
+              {
+                exporter = config.lib.zsh.export;
+                value = zshValue;
+              }
+            else if homeValue != null then
+              {
+                exporter = config.lib.shell.export;
+                value = homeValue;
+              }
+            else
+              null;
+          mkFallback =
+            name:
+            let
+              declaration = configuredDeclaration name;
+            in
+            lib.optionalString (declaration != null) ''
+              if (( ! ''${+${name}} )); then
+                ${declaration.exporter name declaration.value}
+              fi
+            '';
+        in
+        lib.concatMapStrings mkFallback [
+          "NIX_PROFILES"
+          "NIX_SSL_CERT_FILE"
+        ];
       sessionVarsStr = lib.removeSuffix "\n" ''
         # Apply one generated version per process tree. The token changes when
         # either the generic or Zsh-specific variables change.
         if [[ "''${__HM_ZSH_SESS_VARS_SOURCED-}" != "${sessionVarsToken}" ]]; then
           export __HM_ZSH_SESS_VARS_SOURCED="${sessionVarsToken}"
           . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
-          ${envVarsStr}
+          ${envVarsStr}${
+            lib.optionalString config.targets.genericLinux.enable (
+              "\n"
+              + ''
+                else
+                  ${nixScalarFallbacks}
+                  ${nixEnvironmentRefresh}
+              ''
+            )
+          }
         fi
       '';
       indentNonEmptyLines =

--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -6,12 +6,220 @@
 }:
 
 let
-
   cfg = config.targets.genericLinux;
 
   inherit (config.home) profileDirectory;
 
   nixPkg = if config.nix.package == null then pkgs.nix else config.nix.package;
+
+  nixPackagePname = nixPkg.pname or (lib.getName nixPkg);
+  nixPackageVersion = nixPkg.version or null;
+  supportsNixStateHome =
+    nixPackagePname == "nix"
+    && nixPackageVersion != null
+    && lib.versionAtLeast nixPackageVersion "2.25";
+
+  nixEnvironmentPackage =
+    let
+      posixScript = pkgs.writeText "hm-nix-environment.sh" ''
+        # shellcheck shell=sh
+        # Keep this resolver in sync with the standard Nix profile script.
+        if [ -n "''${HOME-}" ]; then
+          __hm_nix_prepend() {
+            __hm_nix_name=$1
+            __hm_nix_entry=$2
+            eval "__hm_nix_value=\''${$__hm_nix_name-}"
+            case ":$__hm_nix_value:" in
+              *":$__hm_nix_entry:"*) return ;;
+            esac
+            __hm_nix_value="$__hm_nix_entry''${__hm_nix_value:+:}$__hm_nix_value"
+            eval "$__hm_nix_name=\$__hm_nix_value"
+            export "$__hm_nix_name"
+          }
+
+          __hm_nix_append() {
+            __hm_nix_name=$1
+            __hm_nix_entry=$2
+            eval "__hm_nix_value=\''${$__hm_nix_name-}"
+            case ":$__hm_nix_value:" in
+              *":$__hm_nix_entry:"*) return ;;
+            esac
+            __hm_nix_value="$__hm_nix_value''${__hm_nix_value:+:}$__hm_nix_entry"
+            eval "$__hm_nix_name=\$__hm_nix_value"
+            export "$__hm_nix_name"
+          }
+
+          __hm_nix_hm_profile=${lib.escapeShellArg (toString profileDirectory)}
+          ${
+            if supportsNixStateHome then
+              ''
+                if [ -n "''${NIX_STATE_HOME-}" ]; then
+                  __hm_nix_profile="$NIX_STATE_HOME/profile"
+                else
+                  __hm_nix_profile="$HOME/.nix-profile"
+                  if [ -n "''${XDG_STATE_HOME-}" ]; then
+                    __hm_nix_xdg_profile="$XDG_STATE_HOME/nix/profile"
+                  else
+                    __hm_nix_xdg_profile="$HOME/.local/state/nix/profile"
+                  fi
+                  if [ -e "$__hm_nix_xdg_profile" ]; then
+                    __hm_nix_profile="$__hm_nix_xdg_profile"
+                  fi
+                fi
+              ''
+            else
+              ''
+                __hm_nix_profile="$HOME/.nix-profile"
+                if [ -n "''${XDG_STATE_HOME-}" ]; then
+                  __hm_nix_xdg_profile="$XDG_STATE_HOME/nix/profile"
+                else
+                  __hm_nix_xdg_profile="$HOME/.local/state/nix/profile"
+                fi
+                if [ -e "$__hm_nix_xdg_profile" ]; then
+                  __hm_nix_profile="$__hm_nix_xdg_profile"
+                fi
+              ''
+          }
+
+          # Match the existing Generic Linux command precedence on a cold start:
+          # Nix adds its active profile, then Home Manager adds its own profile.
+          __hm_nix_prepend PATH "$__hm_nix_profile/bin"
+          __hm_nix_prepend PATH "$__hm_nix_hm_profile/bin"
+
+          if [ -z "''${XDG_DATA_DIRS-}" ]; then
+            XDG_DATA_DIRS=/usr/local/share:/usr/share
+            export XDG_DATA_DIRS
+          fi
+          __hm_nix_prepend XDG_DATA_DIRS "$__hm_nix_hm_profile/share"
+          __hm_nix_prepend XDG_DATA_DIRS "''${NIX_STATE_DIR:-/nix/var/nix}/profiles/default/share"
+          __hm_nix_append XDG_DATA_DIRS "$__hm_nix_profile/share"
+
+          if [ -n "''${MANPATH-}" ]; then
+            __hm_nix_prepend MANPATH "$__hm_nix_profile/share/man"
+          fi
+
+          if [ -z "''${NIX_PROFILES+x}" ]; then
+            NIX_PROFILES="/nix/var/nix/profiles/default $__hm_nix_profile"
+            export NIX_PROFILES
+          fi
+
+          if [ -z "''${NIX_SSL_CERT_FILE+x}" ]; then
+            for __hm_nix_cert in \
+              /etc/ssl/certs/ca-certificates.crt \
+              /etc/ssl/ca-bundle.pem \
+              /etc/ssl/certs/ca-bundle.crt \
+              /etc/pki/tls/certs/ca-bundle.crt \
+              "$__hm_nix_profile/etc/ssl/certs/ca-bundle.crt" \
+              "$__hm_nix_profile/etc/ca-bundle.crt"
+            do
+              if [ -e "$__hm_nix_cert" ]; then
+                NIX_SSL_CERT_FILE=$__hm_nix_cert
+                export NIX_SSL_CERT_FILE
+                break
+              fi
+            done
+          fi
+
+          unset -f __hm_nix_prepend __hm_nix_append
+          unset __hm_nix_name __hm_nix_entry __hm_nix_value
+          unset __hm_nix_hm_profile __hm_nix_profile __hm_nix_xdg_profile __hm_nix_cert
+        fi
+      '';
+
+      fishScript = pkgs.writeText "hm-nix-environment.fish" ''
+        function __hm_nix_prepend_path --argument-names name entry
+            contains -- $entry $$name; and return
+            set -gx $name $entry $$name
+        end
+
+        function __hm_nix_prepend_xdg --argument-names entry
+            contains -- $entry (string split : -- "$XDG_DATA_DIRS"); and return
+            set -gx XDG_DATA_DIRS "$entry"(test -n "$XDG_DATA_DIRS"; and printf :%s "$XDG_DATA_DIRS")
+        end
+
+        function __hm_nix_append_xdg --argument-names entry
+            contains -- $entry (string split : -- "$XDG_DATA_DIRS"); and return
+            set -gx XDG_DATA_DIRS "$XDG_DATA_DIRS"(test -n "$XDG_DATA_DIRS"; and printf :)"$entry"
+        end
+
+        if test -n "$HOME"
+            set -l __hm_nix_hm_profile ${lib.escapeShellArg (toString profileDirectory)}
+            set -l __hm_nix_profile "$HOME/.nix-profile"
+            set -l __hm_nix_xdg_profile
+            set -l __hm_nix_state_dir /nix/var/nix
+            ${
+              if supportsNixStateHome then
+                ''
+                  if test -n "$NIX_STATE_HOME"
+                      set __hm_nix_profile "$NIX_STATE_HOME/profile"
+                  else
+                      if test -n "$XDG_STATE_HOME"
+                          set __hm_nix_xdg_profile "$XDG_STATE_HOME/nix/profile"
+                      else
+                          set __hm_nix_xdg_profile "$HOME/.local/state/nix/profile"
+                      end
+                      if test -e "$__hm_nix_xdg_profile"
+                          set __hm_nix_profile "$__hm_nix_xdg_profile"
+                      end
+                  end
+                ''
+              else
+                ''
+                  if test -n "$XDG_STATE_HOME"
+                      set __hm_nix_xdg_profile "$XDG_STATE_HOME/nix/profile"
+                  else
+                      set __hm_nix_xdg_profile "$HOME/.local/state/nix/profile"
+                  end
+                  if test -e "$__hm_nix_xdg_profile"
+                      set __hm_nix_profile "$__hm_nix_xdg_profile"
+                  end
+                ''
+            }
+
+            __hm_nix_prepend_path PATH "$__hm_nix_profile/bin"
+            __hm_nix_prepend_path PATH "$__hm_nix_hm_profile/bin"
+
+            if test -z "$XDG_DATA_DIRS"
+                set -gx XDG_DATA_DIRS /usr/local/share:/usr/share
+            end
+            if test -n "$NIX_STATE_DIR"
+                set __hm_nix_state_dir "$NIX_STATE_DIR"
+            end
+            __hm_nix_prepend_xdg "$__hm_nix_hm_profile/share"
+            __hm_nix_prepend_xdg "$__hm_nix_state_dir/profiles/default/share"
+            __hm_nix_append_xdg "$__hm_nix_profile/share"
+
+            if test -n "$MANPATH"
+                __hm_nix_prepend_path MANPATH "$__hm_nix_profile/share/man"
+            end
+
+            if not set -q NIX_PROFILES
+                set -gx NIX_PROFILES "/nix/var/nix/profiles/default $__hm_nix_profile"
+            end
+
+            if not set -q NIX_SSL_CERT_FILE
+                for __hm_nix_cert in \
+                    /etc/ssl/certs/ca-certificates.crt \
+                    /etc/ssl/ca-bundle.pem \
+                    /etc/ssl/certs/ca-bundle.crt \
+                    /etc/pki/tls/certs/ca-bundle.crt \
+                    "$__hm_nix_profile/etc/ssl/certs/ca-bundle.crt" \
+                    "$__hm_nix_profile/etc/ca-bundle.crt"
+                    if test -e "$__hm_nix_cert"
+                        set -gx NIX_SSL_CERT_FILE "$__hm_nix_cert"
+                        break
+                    end
+                end
+            end
+        end
+
+        functions -e __hm_nix_prepend_path __hm_nix_prepend_xdg __hm_nix_append_xdg
+      '';
+    in
+    pkgs.runCommandLocal "hm-generic-linux-nix-environment" { } ''
+      install -Dm644 ${posixScript} $out/etc/profile.d/hm-nix-env.sh
+      install -Dm644 ${fishScript} $out/etc/profile.d/hm-nix-env.fish
+    '';
 
 in
 {
@@ -35,6 +243,12 @@ in
         Whether to enable settings that make Home Manager work better on
         GNU/Linux distributions other than NixOS.
       '';
+    };
+
+    nixEnvironmentPackage = lib.mkOption {
+      type = lib.types.package;
+      internal = true;
+      readOnly = true;
     };
   };
 
@@ -66,18 +280,11 @@ in
       ];
     };
 
-    home.sessionVariablesExtra = ''
-      . "${nixPkg}/etc/profile.d/nix.sh"
+    targets.genericLinux.nixEnvironmentPackage = nixEnvironmentPackage;
 
+    home.sessionVariablesExtra = ''
       # reset TERM with new TERMINFO available (if any)
       export TERM="$TERM"
-    '';
-
-    # Interactive Bash refreshes the session variables file itself; nix.sh
-    # is still needed here as noted in
-    # https://github.com/nix-community/home-manager/pull/797#issuecomment-544783247
-    programs.bash.initExtra = ''
-      . "${nixPkg}/etc/profile.d/nix.sh"
     '';
 
     programs.zsh.envExtra = ''

--- a/tests/modules/targets-linux/default.nix
+++ b/tests/modules/targets-linux/default.nix
@@ -1,5 +1,18 @@
 {
   targets-generic-linux = ./generic-linux.nix;
+  targets-generic-linux-lix-profile = ./generic-linux-lix-profile.nix;
+  targets-generic-linux-recovery = {
+    imports = [ ./generic-linux-recovery.nix ];
+    _module.args.genericLinuxRecoveryScalarMode = "discovered";
+  };
+  targets-generic-linux-recovery-home-scalars = {
+    imports = [ ./generic-linux-recovery.nix ];
+    _module.args.genericLinuxRecoveryScalarMode = "home";
+  };
+  targets-generic-linux-recovery-zsh-scalars = {
+    imports = [ ./generic-linux-recovery.nix ];
+    _module.args.genericLinuxRecoveryScalarMode = "zsh";
+  };
   targets-generic-linux-gpu-basic = ./generic-linux-gpu/basic-enable.nix;
   targets-generic-linux-gpu-setup-contents = ./generic-linux-gpu/setup-package-contents.nix;
   targets-generic-linux-gpu-nvidia = ./generic-linux-gpu/nvidia-enabled.nix;

--- a/tests/modules/targets-linux/generic-linux-lix-profile.nix
+++ b/tests/modules/targets-linux/generic-linux-lix-profile.nix
@@ -1,0 +1,57 @@
+{ config, realPkgs, ... }:
+{
+  targets.genericLinux.enable = true;
+  nix.package = realPkgs.lixPackageSets.latest.lix;
+
+  nmt.script = ''
+    runtimeHome="$TMPDIR/lix-profile"
+    mkdir -p "$runtimeHome/.nix-profile" "$runtimeHome/state/profile"
+    refresh=${config.targets.genericLinux.nixEnvironmentPackage}/etc/profile.d
+
+    for layout in legacy xdg; do
+      expected="$runtimeHome/.nix-profile"
+      if [ "$layout" = xdg ]; then
+        expected="$runtimeHome/xdg/nix/profile"
+        mkdir -p "$expected"
+      fi
+
+      # Lix uses the existing XDG profile or the legacy profile, even when
+      # NIX_STATE_HOME points to another profile.
+      ${realPkgs.coreutils}/bin/env -i \
+        HOME="$runtimeHome" USER=hm-user \
+        PATH=/usr/bin:/bin MANPATH=/usr/share/man: \
+        XDG_STATE_HOME="$runtimeHome/xdg" NIX_STATE_HOME="$runtimeHome/state" \
+        EXPECTED_PROFILE="$expected" \
+        ${realPkgs.bash}/bin/bash --noprofile --norc -c '
+          set -eu
+          . "$1"
+          . "$1"
+          [ "$NIX_PROFILES" = "/nix/var/nix/profiles/default $EXPECTED_PROFILE" ]
+          [ "$MANPATH" = "$EXPECTED_PROFILE/share/man:/usr/share/man:" ]
+          case ":$PATH:" in
+            *":$NIX_STATE_HOME/profile/bin:"*) exit 1 ;;
+          esac
+          case ":$PATH:" in
+            *":$EXPECTED_PROFILE/bin:"*) ;;
+            *) exit 1 ;;
+          esac
+        ' shell "$refresh/hm-nix-env.sh" \
+        || fail "Lix POSIX profile selection failed for $layout"
+
+      ${realPkgs.coreutils}/bin/env -i \
+        HOME="$runtimeHome" USER=hm-user \
+        PATH=/usr/bin:/bin MANPATH=/usr/share/man: \
+        XDG_STATE_HOME="$runtimeHome/xdg" NIX_STATE_HOME="$runtimeHome/state" \
+        EXPECTED_PROFILE="$expected" \
+        ${realPkgs.fish}/bin/fish --no-config -c '
+          source $argv[1]
+          source $argv[1]
+          test "$NIX_PROFILES" = "/nix/var/nix/profiles/default $EXPECTED_PROFILE"; or exit 1
+          test "$MANPATH" = "$EXPECTED_PROFILE/share/man:/usr/share/man:"; or exit 1
+          contains -- "$EXPECTED_PROFILE/bin" $PATH; or exit 1
+          not contains -- "$NIX_STATE_HOME/profile/bin" $PATH
+        ' "$refresh/hm-nix-env.fish" \
+        || fail "Lix Fish profile selection failed for $layout"
+    done
+  '';
+}

--- a/tests/modules/targets-linux/generic-linux-recovery.nix
+++ b/tests/modules/targets-linux/generic-linux-recovery.nix
@@ -1,0 +1,377 @@
+{
+  config,
+  genericLinuxRecoveryScalarMode,
+  lib,
+  realPkgs,
+  ...
+}:
+
+let
+  hasConfiguredScalars = genericLinuxRecoveryScalarMode != "discovered";
+  hasZshScalarOverrides = genericLinuxRecoveryScalarMode == "zsh";
+
+  runtimeCertificate = realPkgs.runCommand "hm-recovery-runtime-certificate" { } ''
+    mkdir -p $out/etc/ssl/certs
+    touch $out/etc/ssl/certs/ca-bundle.crt
+  '';
+
+  expectedGenericProfiles =
+    {
+      home = "configured-profiles";
+      zsh = "home-profiles";
+    }
+    .${genericLinuxRecoveryScalarMode} or null;
+  expectedGenericCertificate =
+    {
+      home = "/configured/ca.pem";
+      zsh = "/home/ca.pem";
+    }
+    .${genericLinuxRecoveryScalarMode} or null;
+  expectedZshProfiles =
+    if hasZshScalarOverrides then "`printf zsh-profiles`" else expectedGenericProfiles;
+  expectedZshCertificate = if hasZshScalarOverrides then "" else expectedGenericCertificate;
+in
+{
+  config = {
+    targets.genericLinux.enable = true;
+
+    # Use real package metadata to select the same profile policy as Nix.
+    # The default NMT package scrubber replaces pkgs.nix with a marker.
+    test.unstubs = [ (_self: _super: { inherit (realPkgs) nix; }) ];
+
+    programs = {
+      bash = {
+        enable = true;
+        enableCompletion = false;
+      };
+      fish = {
+        enable = true;
+        generateCompletions = false;
+        package = realPkgs.fish;
+      };
+      zsh = {
+        enable = true;
+        sessionVariables = {
+          SELF_REFERENTIAL = "$SELF_REFERENTIAL/suffix";
+        }
+        // lib.optionalAttrs (genericLinuxRecoveryScalarMode == "home") {
+          NIX_PROFILES = null;
+          NIX_SSL_CERT_FILE = null;
+        }
+        // lib.optionalAttrs hasZshScalarOverrides {
+          NIX_PROFILES = "`printf zsh-profiles`";
+          NIX_SSL_CERT_FILE = "";
+        };
+      };
+    };
+
+    home.sessionVariables =
+      lib.optionalAttrs (genericLinuxRecoveryScalarMode == "home") {
+        NIX_PROFILES = "`printf configured-profiles`";
+        NIX_SSL_CERT_FILE = "\${NIX_SSL_CERT_FILE:-\"/configured/ca.pem\"}";
+      }
+      // lib.optionalAttrs hasZshScalarOverrides {
+        NIX_PROFILES = "home-profiles";
+        NIX_SSL_CERT_FILE = "/home/ca.pem";
+      };
+
+    home.sessionVariablesExtra = ''
+      EXTRA_RUNS="''${EXTRA_RUNS-}x"
+      export EXTRA_RUNS
+    '';
+
+    home.packages = [
+      (realPkgs.writeShellScriptBin "hm-recovery-command" "exit 0")
+      runtimeCertificate
+    ];
+
+    test.asserts.warnings.expected = [
+      ''
+        The following programs.zsh.sessionVariables may change when applied again:
+
+          SELF_REFERENTIAL, defined in `${toString ./generic-linux-recovery.nix}'
+
+        Home Manager reapplies these values after the generated session
+        variables change, so self-referential values can change again.
+
+        For search paths, use home.sessionPath,
+        home.sessionSearchVariables, or home.sessionSearchVariablesAppend.
+        Those options add only the entries that are missing. For other
+        variables, assign a complete value without referring to its previous
+        contents.
+
+        This check is best-effort and detects only direct parameter references
+        such as $NAME, ''${NAME...}, and ''${#NAME}.
+      ''
+    ];
+
+    nmt.script = ''
+      set -eu
+      failures=0
+
+      runtimeHome="$TMPDIR/generic-linux-recovery-home"
+      ${realPkgs.coreutils}/bin/rm -rf "$runtimeHome"
+      ${realPkgs.coreutils}/bin/mkdir -p "$runtimeHome"
+      ${realPkgs.coreutils}/bin/cp "$TESTED/home-files/.bash_profile" "$runtimeHome/.bash_profile"
+      ${realPkgs.coreutils}/bin/cp "$TESTED/home-files/.bashrc" "$runtimeHome/.bashrc"
+      ${realPkgs.coreutils}/bin/cp "$TESTED/home-files/.profile" "$runtimeHome/.profile"
+      ${realPkgs.coreutils}/bin/cp "$TESTED/home-files/.zshenv" "$runtimeHome/.zshenv"
+      ${realPkgs.coreutils}/bin/cp -R "$TESTED/home-files/.config" "$runtimeHome/.config"
+      ${realPkgs.coreutils}/bin/ln -s "$TESTED/home-path" "$runtimeHome/.nix-profile"
+
+      nixEnvironment=${config.targets.genericLinux.nixEnvironmentPackage}/etc/profile.d/hm-nix-env.sh
+      assertFileContains "$nixEnvironment" 'NIX_STATE_HOME'
+      assertFileContains \
+        ${config.targets.genericLinux.nixEnvironmentPackage}/etc/profile.d/hm-nix-env.fish \
+        'NIX_STATE_HOME'
+
+      # Standard Nix 2.25 and newer selects NIX_STATE_HOME before the legacy
+      # and XDG profile locations. The resolver also preserves explicitly set
+      # empty scalar values on later refreshes.
+      ${realPkgs.coreutils}/bin/mkdir -p "$runtimeHome/nix-state"
+      ${realPkgs.coreutils}/bin/ln -s "$TESTED/home-path" "$runtimeHome/nix-state/profile"
+      ${realPkgs.coreutils}/bin/env -i \
+        HOME="$runtimeHome" NIX_STATE_HOME="$runtimeHome/nix-state" \
+        PATH=/usr/bin:/bin XDG_DATA_DIRS=/fixture MANPATH=/usr/share/man: \
+        ${realPkgs.bash}/bin/bash --noprofile --norc -c '
+          . "$1"
+          [ "$NIX_PROFILES" = "/nix/var/nix/profiles/default $NIX_STATE_HOME/profile" ] || exit 1
+          [ -n "$NIX_SSL_CERT_FILE" ] || exit 1
+          [ "$MANPATH" = "$NIX_STATE_HOME/profile/share/man:/usr/share/man:" ] || exit 1
+          case ":$PATH:" in
+            *":/home/hm-user/.nix-profile/bin:"*) ;;
+            *) exit 1 ;;
+          esac
+          case ":$PATH:" in
+            *":$NIX_STATE_HOME/profile/bin:"*) ;;
+            *) exit 1 ;;
+          esac
+          NIX_PROFILES=
+          NIX_SSL_CERT_FILE=
+          export NIX_PROFILES NIX_SSL_CERT_FILE
+          . "$1"
+          [ "''${NIX_PROFILES+x}:$NIX_PROFILES" = x: ] || exit 1
+          [ "''${NIX_SSL_CERT_FILE+x}:$NIX_SSL_CERT_FILE" = x: ] || exit 1
+        ' shell "$nixEnvironment" \
+        || fail "Nix 2.25 profile selection or scalar preservation failed"
+
+      # Cold startup establishes the runtime profile using a HOME that differs
+      # from HM's configured home. Configured scalar values take precedence
+      # over values that the Nix profile script would discover.
+      ${realPkgs.coreutils}/bin/env -i \
+        HOME="$runtimeHome" USER=hm-user TMPDIR="$TMPDIR" \
+        PATH=/usr/bin:/bin MANPATH=/usr/share/man: \
+        ${realPkgs.bash}/bin/bash --noprofile --norc -c '
+          printf "%s\n" BASH_COLD_START
+          . "$HOME/.bash_profile"
+          ${
+            if hasConfiguredScalars then
+              ''
+                [ "$NIX_PROFILES" = ${lib.escapeShellArg expectedGenericProfiles} ] || exit 1
+                [ "$NIX_SSL_CERT_FILE" = ${lib.escapeShellArg expectedGenericCertificate} ] || exit 1
+              ''
+            else
+              ''
+                [ "$NIX_PROFILES" = "/nix/var/nix/profiles/default $HOME/.nix-profile" ] || exit 1
+                [ -n "$NIX_SSL_CERT_FILE" ] || exit 1
+              ''
+          }
+          [ "$MANPATH" = "$HOME/.nix-profile/share/man:/usr/share/man:" ] || exit 1
+          [ "$(command -v hm-recovery-command)" = "$HOME/.nix-profile/bin/hm-recovery-command" ] || exit 1
+          [ "$EXTRA_RUNS" = x ] || exit 1
+
+          # Retain the exported markers while simulating a login environment
+          # that lost the values established by nix.sh.
+          unset NIX_PROFILES NIX_SSL_CERT_FILE
+          PATH=/usr/bin:/bin
+          unset XDG_DATA_DIRS
+          MANPATH=/usr/share/man:
+          printf "%s\n" BASH_RECOVERY_START
+          . "$HOME/.bash_profile"
+          ${
+            if hasConfiguredScalars then
+              ''
+                [ "$NIX_PROFILES" = ${lib.escapeShellArg expectedGenericProfiles} ] || exit 1
+                [ "$NIX_SSL_CERT_FILE" = ${lib.escapeShellArg expectedGenericCertificate} ] || exit 1
+              ''
+            else
+              ''
+                [ "$NIX_PROFILES" = "/nix/var/nix/profiles/default $HOME/.nix-profile" ] || exit 1
+                [ -n "$NIX_SSL_CERT_FILE" ] || exit 1
+              ''
+          }
+          [ "$MANPATH" = "$HOME/.nix-profile/share/man:/usr/share/man:" ] || exit 1
+          [ "$(command -v hm-recovery-command)" = "$HOME/.nix-profile/bin/hm-recovery-command" ] || exit 1
+          [ "$EXTRA_RUNS" = x ] || exit 1
+          for entry in \
+            /nix/var/nix/profiles/default/share \
+            /home/hm-user/.nix-profile/share \
+            "$HOME/.nix-profile/share"
+          do
+            count=$(printf "%s" "$XDG_DATA_DIRS" | ${realPkgs.coreutils}/bin/tr : "\n" | ${realPkgs.gnugrep}/bin/grep -cFx "$entry")
+            [ "$count" = 1 ] || exit 1
+          done
+        ' \
+        || {
+          echo "BASH_RECOVERY_FAILED"
+          failures=1
+        }
+
+      # Recovery must preserve the position of an existing profile entry.
+      ${realPkgs.coreutils}/bin/mkdir -p "$runtimeHome/precedence"
+      ${realPkgs.coreutils}/bin/ln -s "$runtimeHome/.nix-profile/bin/hm-recovery-command" \
+        "$runtimeHome/precedence/hm-recovery-command"
+      ${realPkgs.coreutils}/bin/env -i \
+        HOME="$runtimeHome" USER=hm-user TMPDIR="$TMPDIR" \
+        PATH="$runtimeHome/precedence:$runtimeHome/.nix-profile/bin:/usr/bin:/bin" MANPATH=/usr/share/man: \
+        __HM_SESS_VARS_SOURCED=1 __HM_SESS_VARS_MERGED=1 \
+        ${realPkgs.bash}/bin/bash --noprofile --norc -c '
+          . "$HOME/.bash_profile"
+          [ "$(command -v hm-recovery-command)" = "$HOME/precedence/hm-recovery-command" ] || exit 1
+        ' \
+        || {
+          echo "BASH_PRECEDENCE_FAILED"
+          failures=1
+        }
+
+      # Zsh does not run .zshenv when invoked with -f, so source the generated
+      # startup explicitly in both shells. The unchanged token permits generic
+      # recovery but must not evaluate the self-reference twice.
+      ${realPkgs.coreutils}/bin/env -i \
+        HOME="$runtimeHome" USER=hm-user TMPDIR="$TMPDIR" \
+        PATH=/usr/bin:/bin MANPATH=/usr/share/man: SELF_REFERENTIAL=base \
+        EXPECTED_ZSH_PROFILES=${
+          lib.escapeShellArg (if hasConfiguredScalars then expectedZshProfiles else "")
+        } \
+        EXPECTED_ZSH_CERTIFICATE=${
+          lib.escapeShellArg (if hasConfiguredScalars then expectedZshCertificate else "")
+        } \
+        ${realPkgs.zsh}/bin/zsh -f -c '
+          print ZSH_COLD_START
+          source "$HOME/.zshenv"
+          ${
+            if hasConfiguredScalars then
+              ''
+                [ "$NIX_PROFILES" = "$EXPECTED_ZSH_PROFILES" ] || exit 1
+                [ "$NIX_SSL_CERT_FILE" = "$EXPECTED_ZSH_CERTIFICATE" ] || exit 1
+              ''
+            else
+              ''
+                [ "$NIX_PROFILES" = "/nix/var/nix/profiles/default $HOME/.nix-profile" ] || exit 1
+                [ -n "$NIX_SSL_CERT_FILE" ] || exit 1
+              ''
+          }
+          [ "$SELF_REFERENTIAL" = base/suffix ] || exit 1
+          unset NIX_PROFILES NIX_SSL_CERT_FILE
+          PATH=/usr/bin:/bin
+          unset XDG_DATA_DIRS
+          MANPATH=/usr/share/man:
+          print ZSH_RECOVERY_START
+          ${realPkgs.coreutils}/bin/env \
+            -u NIX_PROFILES -u NIX_SSL_CERT_FILE -u XDG_DATA_DIRS \
+            HOME="$HOME" USER=hm-user TMPDIR="$TMPDIR" \
+            PATH="$PATH" MANPATH="$MANPATH" \
+            SELF_REFERENTIAL="$SELF_REFERENTIAL" \
+            EXPECTED_ZSH_PROFILES="$EXPECTED_ZSH_PROFILES" \
+            EXPECTED_ZSH_CERTIFICATE="$EXPECTED_ZSH_CERTIFICATE" \
+            __HM_ZSH_SESS_VARS_SOURCED="$__HM_ZSH_SESS_VARS_SOURCED" \
+            ${realPkgs.zsh}/bin/zsh -f -c "
+              source \"\$HOME/.zshenv\"
+              ${
+                if hasConfiguredScalars then
+                  ''
+                    [ \"\$NIX_PROFILES\" = \"\$EXPECTED_ZSH_PROFILES\" ] || exit 1
+                    [ \"\$NIX_SSL_CERT_FILE\" = \"\$EXPECTED_ZSH_CERTIFICATE\" ] || exit 1
+                  ''
+                else
+                  ''
+                    [ \"\$NIX_PROFILES\" = \"/nix/var/nix/profiles/default \$HOME/.nix-profile\" ] || exit 1
+                    [ -n \"\$NIX_SSL_CERT_FILE\" ] || exit 1
+                  ''
+              }
+              [ \"\$MANPATH\" = \"\$HOME/.nix-profile/share/man:/usr/share/man:\" ] || exit 1
+              [ \"\$SELF_REFERENTIAL\" = base/suffix ] || exit 1
+              [ \"\$(command -v hm-recovery-command)\" = \"\$HOME/.nix-profile/bin/hm-recovery-command\" ] || exit 1
+              for entry in \
+                /nix/var/nix/profiles/default/share \
+                /home/hm-user/.nix-profile/share \
+                \"\$HOME/.nix-profile/share\"
+              do
+                count=\$(printf \"%s\" \"\$XDG_DATA_DIRS\" | ${realPkgs.coreutils}/bin/tr : \"\\n\" | ${realPkgs.gnugrep}/bin/grep -cFx \"\$entry\")
+                [ \"\$count\" = 1 ] || exit 1
+              done
+            "
+        ' \
+        || {
+          echo "ZSH_RECOVERY_FAILED"
+          failures=1
+        }
+
+      fishConfig="$runtimeHome/.config/fish/config.fish"
+      assertFileExists "$fishConfig"
+
+      # Seed Fish's native startup, then launch a child with the exported
+      # Home Manager session guards intact and runtime values removed.
+      ${realPkgs.coreutils}/bin/env -i \
+        HOME="$runtimeHome" USER=hm-user TMPDIR="$TMPDIR" \
+        PATH=/usr/bin:/bin MANPATH=/usr/share/man: \
+        ${realPkgs.fish}/bin/fish --no-config -c '
+          echo FISH_COLD_START
+          source $argv[1]
+          ${
+            if hasConfiguredScalars then
+              ''
+                test "$NIX_PROFILES" = ${lib.escapeShellArg expectedGenericProfiles}; or exit 1
+                test "$NIX_SSL_CERT_FILE" = ${lib.escapeShellArg expectedGenericCertificate}; or exit 1
+              ''
+            else
+              ''
+                test "$NIX_PROFILES" = "/nix/var/nix/profiles/default $HOME/.nix-profile"; or exit 1
+                test -n "$NIX_SSL_CERT_FILE"; or exit 1
+              ''
+          }
+          test "$MANPATH" = "$HOME/.nix-profile/share/man:/usr/share/man:"; or exit 1
+          type -q hm-recovery-command; or exit 1
+          test "$EXTRA_RUNS" = x; or exit 1
+          set -gx __HM_SESS_VARS_SOURCED "$__HM_SESS_VARS_SOURCED"
+          set -e NIX_PROFILES
+          set -e NIX_SSL_CERT_FILE
+          set -gx PATH /usr/bin /bin
+          set -e XDG_DATA_DIRS
+          set -gx MANPATH /usr/share/man ""
+          echo FISH_RECOVERY_START
+          ${realPkgs.fish}/bin/fish --no-config -c "
+            source \"\$argv[1]\"
+            ${
+              if hasConfiguredScalars then
+                ''
+                  test \"\$NIX_PROFILES\" = ${lib.escapeShellArg expectedGenericProfiles}; or exit 1
+                  test \"\$NIX_SSL_CERT_FILE\" = ${lib.escapeShellArg expectedGenericCertificate}; or exit 1
+                ''
+              else
+                ''
+                  test \"\$NIX_PROFILES\" = \"/nix/var/nix/profiles/default \$HOME/.nix-profile\"; or exit 1
+                  test -n \"\$NIX_SSL_CERT_FILE\"; or exit 1
+                ''
+            }
+            test \"\$MANPATH\" = \"\$HOME/.nix-profile/share/man:/usr/share/man:\"; or exit 1
+            type -q hm-recovery-command; or exit 1
+            test \"\$EXTRA_RUNS\" = x; or exit 1
+            for entry in \
+              /nix/var/nix/profiles/default/share \
+              /home/hm-user/.nix-profile/share \
+              \"\$HOME/.nix-profile/share\"
+              set count (string split : -- \"\$XDG_DATA_DIRS\" | string match -e -- \"\$entry\" | count)
+              test \"\$count\" = 1; or exit 1
+            end
+          " "$argv[1]"
+        ' "$fishConfig" \
+        || {
+          echo "FISH_RECOVERY_FAILED"
+          failures=1
+        }
+
+      [ "$failures" -eq 0 ] || fail "Generic Linux recovery shell checks failed"
+    '';
+  };
+}

--- a/tests/modules/targets-linux/generic-linux-runtime.nix
+++ b/tests/modules/targets-linux/generic-linux-runtime.nix
@@ -1,0 +1,64 @@
+{
+  pkgs,
+  expectedXdgDataDirs,
+}:
+
+''
+  set -eu
+
+  testHome="$TMPDIR/generic-linux-bash-home"
+  ${pkgs.coreutils}/bin/rm -rf "$testHome"
+  ${pkgs.coreutils}/bin/mkdir -p "$testHome"
+  ${pkgs.coreutils}/bin/cp "$TESTED/home-files/.bash_profile" "$testHome/.bash_profile"
+  ${pkgs.coreutils}/bin/cp "$TESTED/home-files/.bashrc" "$testHome/.bashrc"
+  ${pkgs.coreutils}/bin/cp "$TESTED/home-files/.profile" "$testHome/.profile"
+  ${pkgs.coreutils}/bin/ln -s "$TESTED/home-path" "$testHome/.nix-profile"
+
+  initialPath="/usr/bin:/bin"
+  initialXdgDataDirs="/fixture/xdg-data"
+  bashPath="$BASH"
+  ${pkgs.coreutils}/bin/env -i \
+    HOME="$testHome" \
+    PATH="$initialPath" \
+    TMPDIR="$TMPDIR" \
+    XDG_DATA_DIRS="$initialXdgDataDirs" \
+    EXPECTED_XDG_DATA_DIRS="${expectedXdgDataDirs}:$initialXdgDataDirs:$testHome/.nix-profile/share" \
+    __HM_SESS_VARS_SOURCED=1 \
+    "$bashPath" --noprofile --norc -i -c '
+        . "$HOME/.bash_profile" || exit 1
+        firstPath="$PATH"
+        firstXdgDataDirs="$XDG_DATA_DIRS"
+        [ "$XDG_DATA_DIRS" = "$EXPECTED_XDG_DATA_DIRS" ] \
+          || { echo "XDG_DATA_DIRS did not refresh on startup"; exit 1; }
+        . "$HOME/.bash_profile" || exit 1
+        [ "$(command -v hm-profile-command)" = "$HOME/.nix-profile/bin/hm-profile-command" ] \
+          || { echo "profile command was not found through PATH"; exit 1; }
+        [ "$PATH" = "$firstPath" ] \
+          || { echo "PATH changed on repeated startup"; exit 1; }
+        [ "$XDG_DATA_DIRS" = "$firstXdgDataDirs" ] \
+          || { echo "XDG_DATA_DIRS changed on repeated startup"; exit 1; }
+        profileBinCount=$(
+          printf "%s" ":$PATH:" | ${pkgs.coreutils}/bin/tr : "\n" |
+            ${pkgs.gnugrep}/bin/grep -cFx "$HOME/.nix-profile/bin"
+        )
+        [ "$profileBinCount" = 1 ] \
+          || { echo "profile bin appeared $profileBinCount times"; exit 1; }
+      ' \
+    || fail "Bash startup did not preserve profile command lookup or session variables"
+
+  ${pkgs.coreutils}/bin/mkdir -p "$testHome/precedence"
+  ${pkgs.coreutils}/bin/ln -s "$testHome/.nix-profile/bin/hm-profile-command" \
+    "$testHome/precedence/hm-profile-command"
+  ${pkgs.coreutils}/bin/env -i \
+    HOME="$testHome" \
+    PATH="$testHome/precedence:$testHome/.nix-profile/bin:$initialPath" \
+    TMPDIR="$TMPDIR" \
+    XDG_DATA_DIRS="$initialXdgDataDirs" \
+    __HM_SESS_VARS_SOURCED=1 \
+    "$bashPath" --noprofile --norc -i -c '
+        . "$HOME/.bash_profile" || exit 1
+        [ "$(command -v hm-profile-command)" = "$HOME/precedence/hm-profile-command" ] \
+          || { echo "existing profile command lost precedence"; exit 1; }
+      ' \
+    || fail "Bash startup changed precedence of an existing profile command"
+''

--- a/tests/modules/targets-linux/generic-linux-xdg.nix
+++ b/tests/modules/targets-linux/generic-linux-xdg.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   expectedXdgDataDirs = lib.concatStringsSep ":" [
     "\${NIX_STATE_DIR:-/nix/var/nix}/profiles/default/share"
@@ -13,6 +18,18 @@ in
 {
   config = {
     targets.genericLinux.enable = true;
+
+    nix.package = pkgs.runCommand "lix-99.0" {
+      pname = "lix";
+      version = "99.0";
+    } "mkdir -p $out";
+
+    programs.bash = {
+      enable = true;
+      enableCompletion = false;
+    };
+
+    home.packages = [ (pkgs.writeShellScriptBin "hm-profile-command" "exit 0") ];
 
     xdg.systemDirs.data = [ "/foo" ];
 
@@ -29,11 +46,19 @@ in
       sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
       assertFileExists $sessionVarsFile
       assertFileContains $sessionVarsFile \
-        '. "${pkgs.nix}/etc/profile.d/nix.sh"'
+        '. "${config.targets.genericLinux.nixEnvironmentPackage}/etc/profile.d/hm-nix-env.sh"'
+      assertFileNotRegex $sessionVarsFile 'profile\.d/nix\.sh'
+      assertFileNotRegex \
+        ${config.targets.genericLinux.nixEnvironmentPackage}/etc/profile.d/hm-nix-env.sh \
+        'NIX_STATE_HOME'
 
       assertFileContains \
         home-path/etc/profile.d/hm-session-vars.sh \
         'export TERM="$TERM"'
+
+      ${(import ./generic-linux-runtime.nix) {
+        inherit pkgs expectedXdgDataDirs;
+      }}
     '';
   };
 }

--- a/tests/modules/targets-linux/generic-linux.nix
+++ b/tests/modules/targets-linux/generic-linux.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   expectedXdgDataDirs = lib.concatStringsSep ":" [
     "\${NIX_STATE_DIR:-/nix/var/nix}/profiles/default/share"
@@ -14,6 +19,23 @@ in
   config = {
     targets.genericLinux.enable = true;
 
+    nix.package = pkgs.runCommand "nix-2.24.0" {
+      pname = "nix";
+      version = "2.24.0";
+    } "mkdir -p $out";
+
+    programs.bash = {
+      enable = true;
+      enableCompletion = false;
+    };
+
+    home.packages = [ (pkgs.writeShellScriptBin "hm-profile-command" "exit 0") ];
+
+    home.sessionVariablesExtra = ''
+      EXTRA_RUNS="''${EXTRA_RUNS-}x"
+      export EXTRA_RUNS
+    '';
+
     xdg.systemDirs.data = [ "/foo" ];
 
     nmt.script = ''
@@ -27,11 +49,51 @@ in
       sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
       assertFileExists $sessionVarsFile
       assertFileContains $sessionVarsFile \
-        '. "${pkgs.nix}/etc/profile.d/nix.sh"'
+        '. "${config.targets.genericLinux.nixEnvironmentPackage}/etc/profile.d/hm-nix-env.sh"'
+      assertFileNotRegex $sessionVarsFile 'profile\.d/nix\.sh'
+      assertFileNotRegex \
+        ${config.targets.genericLinux.nixEnvironmentPackage}/etc/profile.d/hm-nix-env.sh \
+        'NIX_STATE_HOME'
 
       assertFileContains \
         home-path/etc/profile.d/hm-session-vars.sh \
         'export TERM="$TERM"'
+
+      # The refresh is repeatable and lives before the arbitrary-extra guard.
+      # Bash must not carry a second repair path.
+      assertFileExists home-files/.bashrc
+      assertFileNotRegex home-files/.bashrc 'hm-nix-env\.sh'
+      nixEnvCount=$(grep -c 'profile\.d/hm-nix-env\.sh' \
+        "$TESTED/home-path/etc/profile.d/hm-session-vars.sh")
+      [ "$nixEnvCount" = 1 ] \
+        || fail "Nix refresh referenced $nixEnvCount times in hm-session-vars.sh"
+
+      # Applying the file twice refreshes twice while arbitrary extra code runs
+      # only once.
+      printf '%s\n' \
+        'NIX_ENV_RUNS=$(( ''${NIX_ENV_RUNS:-0} + 1 ))' \
+        'export NIX_ENV_RUNS' \
+        > "$TMPDIR/fake-nix-env.sh"
+      sed "s|\. \"${config.targets.genericLinux.nixEnvironmentPackage}/etc/profile.d/hm-nix-env.sh\"|. \"$TMPDIR/fake-nix-env.sh\"|" \
+        "$TESTED/home-path/etc/profile.d/hm-session-vars.sh" > "$TMPDIR/sessvars.sh"
+      grep -q 'fake-nix-env.sh' "$TMPDIR/sessvars.sh" \
+        || fail "could not substitute the Nix refresh stand-in"
+
+      env -u __HM_SESS_VARS_SOURCED -u NIX_ENV_RUNS -u EXTRA_RUNS \
+        TERM=dumb "$BASH" --noprofile --norc -c '
+          . "$1"
+          . "$1"
+          [ "$NIX_ENV_RUNS" = 2 ] \
+            || { echo "Nix refresh ran $NIX_ENV_RUNS times"; exit 1; }
+          [ "$EXTRA_RUNS" = x ] \
+            || { echo "sessionVariablesExtra ran more than once"; exit 1; }
+          exit 0
+        ' shell "$TMPDIR/sessvars.sh" \
+        || fail "Nix refresh and guarded extra code did not repeat correctly"
+
+      ${(import ./generic-linux-runtime.nix) {
+        inherit pkgs expectedXdgDataDirs;
+      }}
     '';
   };
 }


### PR DESCRIPTION
### Description

On generic Linux, Home Manager sources `nix.sh` through the guarded session variables file and again from Bash `initExtra`. `nix.sh` is not idempotent, so every interactive Bash startup adds duplicate `PATH` and `XDG_DATA_DIRS` entries. Removing the direct call alone is not enough: a login environment can strip the values `nix.sh` set while keeping the exported session guard, and child shells then start without the Nix profile on `PATH`, without `NIX_PROFILES`, and without a certificate file.

Generic Linux now owns a repeatable initializer for the standard Nix environment, in POSIX and native Fish, and sources it instead of `nix.sh`. It fills `PATH`, `XDG_DATA_DIRS`, a nonempty `MANPATH`, and a missing `NIX_PROFILES` or `NIX_SSL_CERT_FILE`. Entries already present keep their positions. Explicit scalar values, including empty strings, are kept. Zsh applies the same initializer in its unchanged-token branch, with scalar fallbacks that preserve the precedence of `home.sessionVariables` and `programs.zsh.sessionVariables` declarations.

Profile selection follows the package: Nix 2.25 and later honor `NIX_STATE_HOME`; older Nix and Lix keep legacy or existing XDG selection.

**Stated compatibility change**: custom profile scripts shipped in a `nix.package` are no longer executed, so their additional side effects are not reproduced. The news entry says so.

Tests run the generated Bash, Zsh, and Fish startup files with an inherited guard and stripped values. They cover repeated application, explicit empty and custom scalars, existing `PATH` precedence, home and Zsh scalar declarations, and profile selection against real Lix package metadata. Startup was also checked against Debian's real login files as an unprivileged user in a container, and against actual Nix 2.34.8 and Lix 2.95.2 packages across legacy, XDG, and `NIX_STATE_HOME` layouts.

Top of the session-variable stack. Part of splitting #9735 into independently reviewable changes; the stack as a whole supersedes that PR.

### Checklist

- [ ] Change is backwards compatible. (Stated change for custom `nix.package` profile scripts; news entry included.)
- [x] Code formatted with `nix fmt`.
- [x] Code tested through `nix build .#test-all`.
- [x] Test cases updated/added.
- [x] Commit messages follow the `{component}: {description}` format.
