### PR TITLE
direnv: git.ignores drop `.envrc`

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -79,8 +79,7 @@ in
 
     enableGitIntegration = mkEnableOption "Git integration" // {
       description = ''
-        Whether to configure Git to globally ignore {file}`.envrc`
-        and {file}`.direnv/`.
+        Whether to configure Git to globally ignore {file}`.direnv/`.
       '';
     };
 
@@ -129,7 +128,6 @@ in
         };
 
         git.ignores = mkIf cfg.enableGitIntegration [
-          ".envrc"
           ".direnv/"
         ];
 

--- a/tests/modules/programs/direnv/git-integration.nix
+++ b/tests/modules/programs/direnv/git-integration.nix
@@ -17,7 +17,6 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/git/ignore
-    assertFileContains home-files/.config/git/ignore ".envrc"
     assertFileContains home-files/.config/git/ignore ".direnv/"
   '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Drop `.envrc` from `programs.direnv.enableGitIntegration`, leaving only `.direnv/` to be ignored.

`.envrc` is frequently tracked and committed intentionally in repositories (e.g. in projects using `cachix/devenv` or `use flake` conditionals), whereas `.direnv/` is strictly a cache and artifact directory that should never be tracked.

Following up on #9923 and https://github.com/nix-community/home-manager/pull/9923#discussion_r3991125892.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
