### PR TITLE
[Backport release-26.05] firefox: apply configPath to package wrapper; {firefox,thunderbird}: add booxter as maintainer

### DIFF
--- a/modules/misc/news/2026/09/2026-09-12_16-24-06.nix
+++ b/modules/misc/news/2026/09/2026-09-12_16-24-06.nix
@@ -1,0 +1,16 @@
+{ config, pkgs, ... }:
+{
+  time = "2026-09-12T16:24:06+00:00";
+  condition =
+    pkgs.stdenv.hostPlatform.isDarwin
+    && config.programs.firefox.enable
+    && config.programs.firefox.package != null;
+  message = ''
+    On macOS 27 and later, Firefox builds not signed by Mozilla cannot access
+    the traditional data directory. Set
+    `programs.firefox.configPath = "Library/Application Support/org.nixos.firefox";`
+    explicitly. Before changing `configPath`, quit Firefox and migrate your data from
+    `~/Library/Application Support/Firefox` to
+    `~/Library/Application Support/org.nixos.firefox`.
+  '';
+}

--- a/modules/programs/firefox/default.nix
+++ b/modules/programs/firefox/default.nix
@@ -50,6 +50,7 @@ let
 in
 {
   meta.maintainers = with lib.maintainers; [
+    booxter
     bricked
     rycee
     lib.hm.maintainers.HPsaucii

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -31,6 +31,8 @@ let
     ;
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
+  defaultConfigPath = with platforms; if isDarwin then darwin.configPath else linux.configPath;
+
   appName = name;
 
   moduleName = concatStringsSep "." modulePath;
@@ -191,17 +193,46 @@ let
 
       # The configuration expected by the Firefox wrapper builder.
       bcfg = setAttrByPath [ browserName ] fcfg;
+
+      configureAppDataDir = cfg.configPath != defaultConfigPath;
+
+      absoluteConfigPath =
+        if lib.hasPrefix "/" cfg.configPath then
+          cfg.configPath
+        else
+          "${config.home.homeDirectory}/${cfg.configPath}";
+
+      callWithAppDataDir =
+        wrapper: args:
+        let
+          wrapperArgs = lib.functionArgs wrapper;
+          supportsAppDataDir = wrapperArgs ? appDataDir;
+          # Gracefully handle wrappers that don't, yet, support appDataDir.
+          appDataDirArgs = lib.optionalAttrs (configureAppDataDir && supportsAppDataDir) {
+            appDataDir = absoluteConfigPath;
+          };
+          argsWithAppDataDir =
+            if lib.isFunction args then
+              # Modern wrapped packages pass an override function.
+              old: args old // appDataDirArgs
+            else
+              # Legacy wrapFirefox passes an attribute set.
+              args // appDataDirArgs;
+        in
+        lib.warnIf (configureAppDataDir && !supportsAppDataDir)
+          "${moduleName}: '${browserName}' does not support the 'appDataDir' wrapper argument; 'configPath' will not be applied to the package wrapper."
+          (wrapper argsWithAppDataDir);
     in
     if package == null then
       null
     else if isWrapped then
-      package.override (old: {
+      callWithAppDataDir package.override (old: {
         cfg = old.cfg or { } // fcfg;
         extraPolicies = (old.extraPolicies or { }) // cfg.policies;
         pkcs11Modules = (old.pkcs11Modules or [ ]) ++ cfg.pkcs11Modules;
       })
     else
-      (pkgs.wrapFirefox.override { config = bcfg; }) package { };
+      callWithAppDataDir ((pkgs.wrapFirefox.override { config = bcfg; }) package) { };
 
   bookmarkTypes = import ./profiles/bookmark-types.nix { inherit lib; };
 in
@@ -314,11 +345,19 @@ in
     };
 
     configPath = mkOption {
-      internal = true;
       type = types.str;
-      default = with platforms; if isDarwin then darwin.configPath else linux.configPath;
+      default = defaultConfigPath;
+      defaultText = literalExpression "platform specific default config path";
       example = ".mozilla/firefox";
-      description = "Directory containing the ${appName} configuration files.";
+      description = ''
+        Directory containing the ${appName} configuration files. A relative
+        path is interpreted relative to the user's home directory.
+
+        Setting this to a non-default path also configures the package wrapper
+        to use it as the application data directory. This can be useful on
+        macOS 27 and later, where wrapped applications may be denied access to
+        the traditional application data directory.
+      '';
     };
 
     nativeMessagingHosts = mkOption {

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -390,9 +390,10 @@ let
 
 in
 {
-  meta.maintainers = [
+  meta.maintainers = with lib.maintainers; [
+    booxter
     lib.hm.maintainers.d-dervishi
-    lib.maintainers.jkarlson
+    jkarlson
   ];
 
   options = {

--- a/tests/modules/programs/firefox/config-path-wrapper.nix
+++ b/tests/modules/programs/firefox/config-path-wrapper.nix
@@ -1,0 +1,90 @@
+{
+  absolute ? false,
+  configPath,
+  supportsAppDataDir ? true,
+}:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.firefox;
+
+  effectiveConfigPath = if absolute then "${config.home.homeDirectory}/${configPath}" else configPath;
+
+  expectedAppDataDir = "${config.home.homeDirectory}/${configPath}";
+
+  mkPackage =
+    appDataDir:
+    config.lib.test.mkStubPackage {
+      name = "firefox-config-path-test-stub";
+      buildScript = ''
+        mkdir -p "$out/lib/mozilla/native-messaging-hosts"
+      '';
+      extraAttrs = {
+        browserName = "firefox";
+        inherit appDataDir;
+        meta.mainProgram = "firefox";
+      };
+    };
+
+  packageWithAppDataDir = lib.makeOverridable (
+    {
+      cfg ? { },
+      extraPolicies ? { },
+      pkcs11Modules ? [ ],
+      appDataDir ? null,
+    }:
+    builtins.deepSeq [
+      cfg
+      extraPolicies
+      pkcs11Modules
+    ] (mkPackage appDataDir)
+  ) { };
+
+  packageWithoutAppDataDir = lib.makeOverridable (
+    {
+      cfg ? { },
+      extraPolicies ? { },
+      pkcs11Modules ? [ ],
+    }:
+    builtins.deepSeq [
+      cfg
+      extraPolicies
+      pkcs11Modules
+    ] (mkPackage null)
+  ) { };
+in
+{
+  config = lib.mkIf config.test.enableBig {
+    home = {
+      homeDirectory = lib.mkForce (
+        if pkgs.stdenv.hostPlatform.isDarwin then "/Users/hm-user" else "/home/hm-user"
+      );
+      stateVersion = "26.05";
+    };
+
+    programs.firefox = {
+      enable = true;
+      configPath = effectiveConfigPath;
+      package = if supportsAppDataDir then packageWithAppDataDir else packageWithoutAppDataDir;
+      profiles.test.settings."general.smoothScroll" = false;
+    };
+
+    assertions = [
+      {
+        assertion =
+          cfg.finalPackage.appDataDir == (if supportsAppDataDir then expectedAppDataDir else null);
+        message = "Firefox wrapper received an unexpected appDataDir";
+      }
+    ];
+
+    mozilla.firefoxNativeMessagingHosts = lib.mkForce [ ];
+
+    nmt.script = ''
+      assertFileExists "home-files/${configPath}/profiles.ini"
+    '';
+  };
+}

--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -2,6 +2,17 @@
 {
   "firefox-config-path-explicit-legacy" = ./config-path-explicit-legacy.nix;
   "firefox-config-path-explicit-xdg" = ./config-path-explicit-xdg.nix;
+  "firefox-config-path-wrapper-absolute" = import ./config-path-wrapper.nix {
+    absolute = true;
+    configPath = "Library/Application Support/org.nixos.firefox";
+  };
+  "firefox-config-path-wrapper-relative" = import ./config-path-wrapper.nix {
+    configPath = "Library/Application Support/org.nixos.firefox";
+  };
+  "firefox-config-path-wrapper-unsupported" = import ./config-path-wrapper.nix {
+    configPath = "Library/Application Support/org.nixos.firefox";
+    supportsAppDataDir = false;
+  };
   "firefox-config-path-xdg-default" = ./config-path-xdg-default.nix;
   "firefox-config-path-warning" = ./config-path-warning.nix;
   "firefox-multiple-derivatives" = ./multiple-derivatives.nix;

--- a/tests/modules/programs/firefox/final-package.nix
+++ b/tests/modules/programs/firefox/final-package.nix
@@ -2,7 +2,6 @@ modulePath:
 {
   config,
   lib,
-  pkgs,
   realPkgs,
   ...
 }:
@@ -13,14 +12,9 @@ let
 
 in
 lib.mkIf config.test.enableBig (
-  lib.setAttrByPath modulePath (
-    {
-      enable = true;
-    }
-    // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
-      configPath = ".mozilla/firefox";
-    }
-  )
+  lib.setAttrByPath modulePath {
+    enable = true;
+  }
   // {
     _module.args.pkgs = lib.mkForce realPkgs;
 


### PR DESCRIPTION
### Description

This is a manual backport of the two patches from the series that are fitting
for release-26.05. Because we don't have stateVersion == 26.11 on this branch,
we can't automatically enable the new configPath for users, and they will have
to set configPath manually to point outside of the default datadir once they
move to macOS 27+.

~~We may want to backport the news entry from the master PR (but not release
notes piece), to give a heads-up to users. But it would probably need significant
rewording since it refers to non-existing stateVersion. Plus there's a pending
[suggestion](https://github.com/nix-community/home-manager/pull/9852#discussion_r3990905480) to change the wording in the original news entry that we should
resolve before backport.~~

I added a 26.05 only version of the news entry.

Note: since macOS 27 ships on Monday, I'd prefer this to get merged before
then.

Commits:
- **firefox: apply configPath to package wrapper**
- **{firefox,thunderbird}: add booxter as maintainer**

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
