### PR TITLE
worktrunk: add shell and Claude Code integrations

### DIFF
--- a/modules/misc/news/2026/09/2026-09-12_22-59-50.nix
+++ b/modules/misc/news/2026/09/2026-09-12_22-59-50.nix
@@ -1,0 +1,10 @@
+{ config, ... }:
+{
+  time = "2026-09-13T03:59:50+00:00";
+  condition = config.programs.worktrunk.enable;
+  message = ''
+    Worktrunk now supports Bash, Zsh, Fish, and Nushell integrations.
+    Enable Claude Code integration with
+    'programs.worktrunk.claudeCodeIntegration.enable = true'.
+  '';
+}

--- a/modules/programs/worktrunk.nix
+++ b/modules/programs/worktrunk.nix
@@ -7,6 +7,23 @@
 let
   cfg = config.programs.worktrunk;
   tomlFormat = pkgs.formats.toml { };
+  wt = lib.getExe cfg.package;
+  jq = lib.getExe pkgs.jq;
+
+  mkClaudeCodeIntegrationEnableOption =
+    msg:
+    lib.mkEnableOption msg
+    // {
+      default = cfg.claudeCodeIntegration.enable;
+      defaultText = lib.literalExpression "config.programs.worktrunk.claudeCodeIntegration.enable";
+    };
+
+  # Best-effort `wt config state marker` hook entry. `|| true` ensures a failure
+  # (e.g. running outside a git worktree) never blocks Claude Code.
+  mkMarkerHook = op: {
+    type = "command";
+    command = "${wt} config state marker ${op} || true";
+  };
 in
 {
   meta.maintainers = [ lib.maintainers.eveeifyeve ];
@@ -29,6 +46,46 @@ in
         Configuration written to `$XDG_CONFIG_HOME/worktrunk/config.toml`.
       '';
     };
+
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
+    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
+
+    # Claude Code integration.
+    claudeCodeIntegration = {
+      enable = lib.mkEnableOption "Integrate worktrunk with Claude Code's statusLine, worktree isolation, and skills";
+
+      # Route Claude Code worktree isolation (`isolation: "worktree"`) through `wt`
+      # instead of `git worktree add`, so agent-created worktrees get worktrunk's
+      # naming, hooks, and lifecycle. https://worktrunk.dev/claude-code/#worktree-isolation
+      worktreeHooks = mkClaudeCodeIntegrationEnableOption "Claude Code WorktreeCreate/WorktreeRemove hooks";
+
+      # Activity tracking: mirror upstream's state-marker hooks so `wt list` (and
+      # the statusline) show 🤖 (working) / 💬 (waiting) per branch, cleared on
+      # session end. https://worktrunk.dev/claude-code/#activity-tracking
+      activityTrackingHooks = mkClaudeCodeIntegrationEnableOption "Claude Code activity-tracking state markers (🤖/💬 in wt list)";
+
+      # Install the `/worktrunk` configuration skill (loads when editing worktrunk's
+      # config/hooks). Off by default: `settings` already manages
+      # `~/.config/worktrunk/config.toml`, and this skill would have the agent edit
+      # it directly, which is unsafe and may fail due to insufficient permissions.
+      configurationSkill = lib.mkEnableOption ''
+        Worktrunk's /worktrunk configuration skill.
+
+        Warning: this should not be enabled together with `settings`, as the skill
+        may attempt to modify the Home Manager-managed Worktrunk configuration file.
+        Such edits will fail due to insufficient permissions and may cause the agent
+        to attempt unsafe workarounds such as using elevated privileges
+      '';
+
+      # Install the `/wt-switch-create` skill — a slash command that creates a new
+      # worktree and switches the session into it.
+      switchCreateSkill = mkClaudeCodeIntegrationEnableOption "worktrunk's /wt-switch-create skill";
+
+      # Opt-in to use `wt` for Claude Code's statusLine, which shows the current worktree and branch.
+      statusLine = mkClaudeCodeIntegrationEnableOption "Claude Code statusLine powered by worktrunk";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -36,6 +93,127 @@ in
 
     xdg.configFile."worktrunk/config.toml" = lib.mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "config.toml" cfg.settings;
+    };
+
+    # The shell integrations and the Claude Code integration below need the `wt`
+    # binary, so they are inert when `package` is set to null.
+    programs.bash.initExtra = lib.mkIf (cfg.enableBashIntegration && cfg.package != null) ''
+      eval "$(${wt} config shell init bash)"
+    '';
+
+    programs.zsh.initContent = lib.mkIf (cfg.enableZshIntegration && cfg.package != null) ''
+      eval "$(${wt} config shell init zsh)"
+    '';
+
+    programs.fish.interactiveShellInit = lib.mkIf (cfg.enableFishIntegration && cfg.package != null) ''
+      ${wt} config shell init fish | source
+    '';
+
+    programs.nushell = lib.mkIf (cfg.enableNushellIntegration && cfg.package != null) {
+      extraConfig = ''
+        source ${
+          pkgs.runCommand "worktrunk-nushell-config.nu" { } ''
+            ${wt} config shell init nu > $out
+          ''
+        }
+      '';
+    };
+
+    # Claude Code integration: https://worktrunk.dev/claude-code/
+    programs.claude-code = lib.mkIf (cfg.package != null && cfg.claudeCodeIntegration.enable) {
+      settings = {
+        hooks = lib.mkMerge [
+          # Route Claude Code worktree create/remove through `wt` (worktree isolation).
+          # Mirrors the upstream plugin's hooks, calling `wt`/`jq` by absolute nix path
+          # so nothing depends on $PATH or the plugin being installed.
+          (lib.mkIf cfg.claudeCodeIntegration.worktreeHooks {
+            # stdin: {"name": "<branch>"} → creates a sibling worktree, prints its path.
+            WorktreeCreate = [
+              {
+                hooks = [
+                  {
+                    type = "command";
+                    command = "bash -c 'set -o pipefail; name=$(${jq} -er .name) || exit 1; cd \"\${CLAUDE_PROJECT_DIR:-.}\" || exit 1; ${wt} switch --create \"$name\" --no-cd --format=json | ${jq} -er .path'";
+                  }
+                ];
+              }
+            ];
+            # stdin: {"worktree_path": "<path>"} → removes the worktree.
+            WorktreeRemove = [
+              {
+                hooks = [
+                  {
+                    type = "command";
+                    command = "bash -c 'p=$(${jq} -er .worktree_path) || exit 1; [ -e \"$p/.git\" ] || exit 0; ${wt} -C \"$p\" remove --foreground \"$p\"'";
+                  }
+                ];
+              }
+            ];
+          })
+
+          # Activity tracking — mirrors the upstream plugin's marker hooks
+          # (https://github.com/max-sixty/worktrunk/blob/main/plugins/worktrunk/hooks/hooks.json),
+          # calling `wt` by absolute nix path. The hook-list type merges with
+          # claude-code.nix's own hooks (e.g. the GUI Notification) by concatenation.
+          (lib.mkIf cfg.claudeCodeIntegration.activityTrackingHooks {
+            # 🤖 the user submitted a prompt → the agent is working.
+            UserPromptSubmit = [
+              {
+                hooks = [ (mkMarkerHook "set 🤖") ];
+              }
+            ];
+            # 💬 the agent paused and is waiting for the user.
+            Notification = [
+              {
+                matcher = "";
+                hooks = [ (mkMarkerHook "set 💬") ];
+              }
+            ];
+            PreToolUse = [
+              {
+                matcher = "AskUserQuestion";
+                hooks = [ (mkMarkerHook "set 💬") ];
+              }
+            ];
+            PermissionRequest = [
+              {
+                matcher = "";
+                hooks = [ (mkMarkerHook "set 💬") ];
+              }
+            ];
+            Stop = [
+              {
+                hooks = [ (mkMarkerHook "set 💬") ];
+              }
+            ];
+            # Clear the marker when the session ends.
+            SessionEnd = [
+              {
+                matcher = "";
+                hooks = [ (mkMarkerHook "clear") ];
+              }
+            ];
+          })
+        ];
+
+        statusLine = lib.mkIf cfg.claudeCodeIntegration.statusLine {
+          type = "command";
+          command = "${wt} list statusline --format=claude-code";
+        };
+      };
+
+      # Install worktrunk's skills directly into Claude Code (no plugin marketplace).
+      # The skill markdown ships inside the nixpkgs `worktrunk` package,
+      # version-aligned with the `wt` binary. Each skill has its own enable flag.
+      skills = lib.mkMerge [
+        (lib.mkIf cfg.claudeCodeIntegration.configurationSkill {
+          worktrunk = "${cfg.package}/skills/worktrunk";
+        })
+
+        (lib.mkIf cfg.claudeCodeIntegration.switchCreateSkill {
+          wt-switch-create = "${cfg.package}/skills/wt-switch-create";
+        })
+      ];
     };
   };
 }

--- a/modules/programs/worktrunk.nix
+++ b/modules/programs/worktrunk.nix
@@ -26,7 +26,10 @@ let
   };
 in
 {
-  meta.maintainers = [ lib.maintainers.eveeifyeve ];
+  meta.maintainers = with lib.maintainers; [
+    eveeifyeve
+    yzx9
+  ];
 
   options.programs.worktrunk = {
     enable = lib.mkEnableOption "worktrunk";

--- a/tests/modules/programs/worktrunk/claude-code.nix
+++ b/tests/modules/programs/worktrunk/claude-code.nix
@@ -1,0 +1,40 @@
+{ config, ... }:
+{
+  programs.claude-code = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "claude-code";
+      version = "2.1.157";
+      buildScript = ''
+        mkdir -p $out/bin
+        touch $out/bin/claude
+        chmod 755 $out/bin/claude
+      '';
+    };
+  };
+
+  # The integration is opt-in: enabling programs.worktrunk alone must not
+  # touch programs.claude-code. configurationSkill stays at its default (off),
+  # so only /wt-switch-create should be installed — not the /worktrunk config
+  # skill.
+  programs.worktrunk = {
+    enable = true;
+    claudeCodeIntegration.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.claude/settings.json
+    # The integration wires statusLine, the activity state-marker hook, and the
+    # worktree-isolation hook through `wt` (scrubbed to @worktrunk@ in tests).
+    # We match stable substrings because WorktreeCreate/Remove also embed the jq
+    # store path, which the test harness does not scrub.
+    assertFileRegex home-files/.claude/settings.json '@worktrunk@/bin/wt list statusline --format=claude-code'
+    assertFileRegex home-files/.claude/settings.json '@worktrunk@/bin/wt config state marker set 🤖'
+    assertFileRegex home-files/.claude/settings.json '@worktrunk@/bin/wt switch --create'
+    # Skills install as directories under .claude/skills — not as a bogus key in
+    # settings.json.
+    assertFileExists home-files/.claude/skills/wt-switch-create/SKILL.md
+    # configurationSkill is off by default, so /worktrunk is not installed.
+    assertPathNotExists home-files/.claude/skills/worktrunk
+  '';
+}

--- a/tests/modules/programs/worktrunk/default.nix
+++ b/tests/modules/programs/worktrunk/default.nix
@@ -1,4 +1,5 @@
 {
   worktrunk-example-settings = ./example-settings.nix;
   worktrunk-empty-settings = ./empty-settings.nix;
+  worktrunk-claude-code = ./claude-code.nix;
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Build on the existing `programs.worktrunk` module:

- add bash/zsh/fish/nushell shell integrations, enabled by default via the corresponding `home.shell.enable<SHELL>Integration` options,
- add `programs.worktrunk.claudeCodeIntegration`, which wires worktrunk into `programs.claude-code` (enabled by default whenever `programs.claude-code` is enabled): a [statusLine](https://worktrunk.dev/claude-code/#statusline-claude-code-only), [WorktreeCreate/ WorktreeRemove hooks](https://worktrunk.dev/claude-code/#worktree-isolation-claude-code-only) (so agent isolation routes through wt), [activity tracking hooks](https://worktrunk.dev/claude-code/#activity-tracking), and [skills](https://worktrunk.dev/claude-code/#wt-switch-create-command-claude-code-only).

Follow-up to #9226, recreating the integration part of #9788.

Assisted-by: Claude-Code:GLM-5.3

CC @yajo @khaneliman


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
