### PR TITLE
firefox: adjust relnote and news for macOS 27

### DIFF
--- a/docs/release-notes/rl-2611.md
+++ b/docs/release-notes/rl-2611.md
@@ -55,8 +55,10 @@ changes are only active if the `home.stateVersion` option is set to
   `Library/Application Support/Firefox` to
   `Library/Application Support/org.nixos.firefox` when
   `programs.firefox.package` is not `null`. Explicit `configPath` values remain
-  unchanged. Before updating `home.stateVersion`, quit Firefox and move your
-  Firefox data from `~/Library/Application Support/Firefox` to
+  unchanged. Users with a `home.stateVersion` earlier than `"26.11"` should set
+  `programs.firefox.configPath = "Library/Application Support/org.nixos.firefox";`
+  explicitly. Before changing `configPath`, quit Firefox and move your data from
+  `~/Library/Application Support/Firefox` to
   `~/Library/Application Support/org.nixos.firefox`.
 
 - The KDL options under `programs.zellij` will now correctly escape backslashes

--- a/modules/misc/news/2026/08/2026-08-27_23-50-03.nix
+++ b/modules/misc/news/2026/08/2026-08-27_23-50-03.nix
@@ -12,8 +12,10 @@
     `Library/Application Support/org.nixos.firefox`.
 
     This is needed on macOS 27 and later, where Firefox builds not signed by
-    Mozilla cannot access the traditional data directory. Before updating
-    `home.stateVersion`, quit Firefox and migrate your Firefox data from
+    Mozilla cannot access the traditional data directory. Users with a
+    `home.stateVersion` earlier than `"26.11"` should set
+    `programs.firefox.configPath = "Library/Application Support/org.nixos.firefox";`
+    explicitly. Before changing `configPath`, quit Firefox and migrate your data from
     `~/Library/Application Support/Firefox` to
     `~/Library/Application Support/org.nixos.firefox`.
   '';


### PR DESCRIPTION
### Description

Don't nudge users to change their version. Instead, ask to set
configPath explicitly.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
