### PR TITLE
Use addCheck in fish module

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -271,10 +271,9 @@ let
                   (listOf str)
                 ]);
             in
-            origin
+            types.addCheck origin (x: if !config.erase && isNull x then false else origin.check x)
             // {
               description = "string or list of string (optional when erase is set to true)";
-              check = x: if !config.erase && isNull x then false else origin.check x;
             };
           default = null;
         };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Fixes error 

```
      Please use `lib.types.addCheck` instead of `type // { check }' to add
       custom validation. For example
```

in fish module

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
