### PR TITLE
gromit-mpx: expose freeform INI settings

### DIFF
--- a/modules/misc/news/2026/09/2026-09-11_00-00-00-gromit-mpx-settings.nix
+++ b/modules/misc/news/2026/09/2026-09-11_00-00-00-gromit-mpx-settings.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+
+{
+  time = "2026-09-11T00:00:00+00:00";
+  condition = config.services.gromit-mpx.enable;
+  message = ''
+    Gromit-MPX now exposes its INI configuration through
+    `services.gromit-mpx.iniSettings`. The deprecated
+    `services.gromit-mpx.opacity` option remains available as an alias for
+    `services.gromit-mpx.iniSettings.Drawing.Opacity`.
+  '';
+}

--- a/modules/services/gromit-mpx.nix
+++ b/modules/services/gromit-mpx.nix
@@ -33,15 +33,6 @@ let
     undokey
   ];
 
-  # Gromit reads and writes from this file to store it's run time
-  # state.  That will break our config so we set it manually which,
-  # thanks to the read-only Nix store, prevents Gromit from writing to
-  # it.
-  keyFile = lib.generators.toINI { } {
-    General.ShowIntroOnStartup = false;
-    Drawing.Opacity = cfg.opacity;
-  };
-
   # Allowed modifiers:
   modsAndButtons = [
     "1"
@@ -134,6 +125,22 @@ let
 
 in
 {
+  imports =
+    lib.hm.deprecations.mkSettingsRenamedOptionModules
+      [ "services" "gromit-mpx" ]
+      [ "services" "gromit-mpx" ]
+      { }
+      [
+        {
+          old = "opacity";
+          new = [
+            "iniSettings"
+            "Drawing"
+            "Opacity"
+          ];
+        }
+      ];
+
   meta.maintainers = [ lib.maintainers.pjones ];
 
   options.services.gromit-mpx = {
@@ -164,13 +171,27 @@ in
       '';
     };
 
-    opacity = mkOption {
-      type = types.addCheck types.float (f: f >= 0.0 && f <= 1.0) // {
-        description = "float between 0.0 and 1.0 (inclusive)";
+    iniSettings = mkOption {
+      type = types.submodule {
+        freeformType = (pkgs.formats.ini { }).type;
+        config = {
+          General.ShowIntroOnStartup = lib.mkOptionDefault false;
+          Drawing.Opacity = lib.mkOptionDefault 0.75;
+        };
       };
-      default = 0.75;
-      example = 1.0;
-      description = "Opacity of the drawing overlay.";
+      default = { };
+      example = {
+        General.ShowIntroOnStartup = false;
+        Drawing.Opacity = 0.75;
+      };
+      description = ''
+        Settings written to {file}`$XDG_CONFIG_HOME/gromit-mpx.ini`.
+        The defaults are `General.ShowIntroOnStartup = false` and
+        `Drawing.Opacity = 0.75`. The file is read-only, so changes made
+        through Gromit-MPX are not saved. Drawing tools belong in
+        {option}`services.gromit-mpx.tools` or
+        {option}`services.gromit-mpx.extraConfig`.
+      '';
     };
 
     extraConfig = mkOption {
@@ -235,13 +256,15 @@ in
       (lib.hm.assertions.assertPlatform "services.gromit-mpx" pkgs lib.platforms.linux)
     ];
 
-    xdg.configFile."gromit-mpx.ini".text = keyFile;
-    xdg.configFile."gromit-mpx.cfg".text = lib.concatStringsSep "\n" (
-      lib.filter (settings: settings != "") [
-        (lib.concatStringsSep "\n" (lib.imap1 toolToCfg cfg.tools))
-        cfg.extraConfig
-      ]
-    );
+    xdg.configFile = {
+      "gromit-mpx.ini".text = lib.generators.toINI { } cfg.iniSettings;
+      "gromit-mpx.cfg".text = lib.concatStringsSep "\n" (
+        lib.filter (settings: settings != "") [
+          (lib.concatStringsSep "\n" (lib.imap1 toolToCfg cfg.tools))
+          cfg.extraConfig
+        ]
+      );
+    };
 
     home.packages = [ cfg.package ];
 

--- a/tests/modules/services/gromit-mpx/basic-configuration.nix
+++ b/tests/modules/services/gromit-mpx/basic-configuration.nix
@@ -1,9 +1,13 @@
-{ config, ... }:
+{ lib, ... }:
 
 {
   services.gromit-mpx = {
     enable = true;
-    package = config.lib.test.mkStubPackage { };
+    iniSettings = lib.mkDefault {
+      Drawing.Opacity = 0.5;
+      General.ShowIntroOnStartup = true;
+      Custom.Enabled = true;
+    };
     tools = [
       {
         device = "default";
@@ -19,5 +23,16 @@
     ];
   };
 
-  nmt.script = import ./nmt-script.nix ./basic-configuration.cfg;
+  nmt.script = (import ./nmt-script.nix ./basic-configuration.cfg) + ''
+    assertFileContent home-files/.config/gromit-mpx.ini ${builtins.toFile "expected.ini" ''
+      [Custom]
+      Enabled=true
+
+      [Drawing]
+      Opacity=0.500000
+
+      [General]
+      ShowIntroOnStartup=true
+    ''}
+  '';
 }

--- a/tests/modules/services/gromit-mpx/default-configuration.nix
+++ b/tests/modules/services/gromit-mpx/default-configuration.nix
@@ -1,12 +1,15 @@
-{ config, ... }:
-
 {
   services.gromit-mpx = {
     enable = true;
-    package = config.lib.test.mkStubPackage { };
   };
 
   nmt.script = (import ./nmt-script.nix ./default-configuration.cfg) + ''
-    assertFileRegex home-files/.config/gromit-mpx.ini 'ShowIntroOnStartup=false'
+    assertFileContent home-files/.config/gromit-mpx.ini ${builtins.toFile "expected.ini" ''
+      [Drawing]
+      Opacity=0.750000
+
+      [General]
+      ShowIntroOnStartup=false
+    ''}
   '';
 }

--- a/tests/modules/services/gromit-mpx/default.nix
+++ b/tests/modules/services/gromit-mpx/default.nix
@@ -5,4 +5,5 @@ lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   gromit-mpx-basic-configuration = ./basic-configuration.nix;
   gromit-mpx-extra-config = ./extra-config.nix;
   gromit-mpx-disabled = ./disabled.nix;
+  gromit-mpx-whole-tree-force = ./whole-tree-force.nix;
 }

--- a/tests/modules/services/gromit-mpx/disabled.nix
+++ b/tests/modules/services/gromit-mpx/disabled.nix
@@ -2,6 +2,7 @@
   services.gromit-mpx = {
     enable = false;
     extraConfig = throw "disabled Gromit-MPX extra configuration was evaluated";
+    iniSettings = throw "disabled Gromit-MPX INI settings were evaluated";
   };
 
   nmt.script = ''

--- a/tests/modules/services/gromit-mpx/extra-config.nix
+++ b/tests/modules/services/gromit-mpx/extra-config.nix
@@ -1,4 +1,9 @@
-{ lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 
 {
   imports = [
@@ -16,6 +21,7 @@
 
   services.gromit-mpx = {
     enable = true;
+    opacity = lib.mkDefault 0.25;
     tools = [
       {
         device = "generated";
@@ -28,7 +34,25 @@
     '';
   };
 
+  assertions = [
+    {
+      assertion = config.services.gromit-mpx.opacity == 0.25;
+      message = "Legacy opacity must read back the canonical value.";
+    }
+  ];
+
+  test.asserts.warnings.expected = [
+    "The option `services.gromit-mpx.opacity' defined in ${lib.showFiles options.services.gromit-mpx.opacity.files} has been renamed to `services.gromit-mpx.iniSettings.Drawing.Opacity'."
+  ];
+
   nmt.script = ''
+    assertFileContent home-files/.config/gromit-mpx.ini ${builtins.toFile "expected.ini" ''
+      [Drawing]
+      Opacity=0.250000
+
+      [General]
+      ShowIntroOnStartup=false
+    ''}
     assertFileContent home-files/.config/gromit-mpx.cfg ${builtins.toFile "gromit-mpx.cfg" ''
       "tool-1" = PEN (size=5 color="green");
       "generated" = "tool-1";

--- a/tests/modules/services/gromit-mpx/nmt-script.nix
+++ b/tests/modules/services/gromit-mpx/nmt-script.nix
@@ -6,7 +6,7 @@ golden_file:
   assertFileExists $serviceFile
   assertFileRegex $serviceFile 'X-Restart-Triggers=.*gromitmpx\.cfg'
   assertFileRegex $serviceFile 'X-Restart-Triggers=.*gromitmpx\.ini'
-  assertFileRegex $serviceFile 'ExecStart=.*/bin/gromit-mpx'
+  assertFileRegex $serviceFile 'ExecStart=.*/bin/gromit-mpx --key F9 --undo-key F10$'
 
   assertFileExists home-files/.config/gromit-mpx.ini
   assertFileExists home-files/.config/gromit-mpx.cfg

--- a/tests/modules/services/gromit-mpx/whole-tree-force.nix
+++ b/tests/modules/services/gromit-mpx/whole-tree-force.nix
@@ -1,0 +1,42 @@
+{
+  config,
+  lib,
+  options,
+  ...
+}:
+
+{
+  services.gromit-mpx = {
+    enable = true;
+    opacity = 0.25;
+    iniSettings = lib.mkForce {
+      Drawing.Opacity = 0.5;
+      General.ShowIntroOnStartup = true;
+    };
+    hotKey = 42;
+    undoKey = null;
+  };
+
+  assertions = [
+    {
+      assertion = config.services.gromit-mpx.opacity == 0.5;
+      message = "Legacy opacity must read back the forced canonical value.";
+    }
+  ];
+
+  test.asserts.warnings.expected = [
+    "The option `services.gromit-mpx.opacity' defined in ${lib.showFiles options.services.gromit-mpx.opacity.files} has been renamed to `services.gromit-mpx.iniSettings.Drawing.Opacity'."
+  ];
+
+  nmt.script = ''
+    assertFileContent home-files/.config/gromit-mpx.ini ${builtins.toFile "expected.ini" ''
+      [Drawing]
+      Opacity=0.500000
+
+      [General]
+      ShowIntroOnStartup=true
+    ''}
+    assertFileContent home-files/.config/gromit-mpx.cfg ${./default-configuration.cfg}
+    assertFileRegex home-files/.config/systemd/user/gromit-mpx.service 'ExecStart=.*/bin/gromit-mpx --keycode 42 --undo-key none$'
+  '';
+}


### PR DESCRIPTION
### Description

Expose the complete Gromit-MPX INI configuration through `services.gromit-mpx.iniSettings`. Keep `opacity` as a compatibility alias with the existing INI defaults. Drawing tools, ordered CFG extra configuration, hotkeys, and service integration stay unchanged.

Part of #9801.

Validated five targeted NMT tests, `nix fmt`, HTML/manpage builds, and GLib parsing of generated INI files.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
