### PR TITLE
ci: compare reviewer logins case-insensitively

### DIFF
--- a/lib/python/manage-reviewers.py
+++ b/lib/python/manage-reviewers.py
@@ -125,11 +125,11 @@ def get_manual_reviewer_actions(
             if not node or not node.get("requestedReviewer") or not node.get("actor"):
                 continue
 
-            reviewer_login = node["requestedReviewer"]["login"]
+            reviewer_login = node["requestedReviewer"]["login"].casefold()
             actor_login = node["actor"].get("login")
 
             # Skip bot actions
-            if actor_login == bot_user_name:
+            if actor_login and actor_login.casefold() == bot_user_name.casefold():
                 continue
 
             # Check node type to determine if it's a request or removal
@@ -148,7 +148,11 @@ def get_users_from_gh(args: list[str], error_message: str) -> set[str]:
     """A generic helper to get a set of users from a 'gh' command."""
     try:
         result = run_gh_command(args)
-        return {user.strip() for user in result.stdout.split("\n") if user.strip()}
+        return {
+            user.strip().casefold()
+            for user in result.stdout.split("\n")
+            if user.strip()
+        }
     except GHError as e:
         logging.error("%s: %s", error_message, e)
         return set()
@@ -286,7 +290,7 @@ def main() -> None:
     no_changed_files = not args.changed_files.strip()
 
     # --- 1. Fetch current state from GitHub ---
-    maintainers: set[str] = set(args.current_maintainers.split())
+    maintainers = {user.casefold() for user in args.current_maintainers.split()}
     pending_reviewers = get_pending_reviewers(args.pr_number)
     past_reviewers = get_past_reviewers(args.owner, args.repo, args.pr_number)
     manually_requested, manually_removed = get_manual_reviewer_actions(
@@ -335,7 +339,10 @@ def main() -> None:
             )
         else:
             users_to_exclude = (
-                {args.pr_author} | past_reviewers | pending_reviewers | manually_removed
+                {args.pr_author.casefold()}
+                | past_reviewers
+                | pending_reviewers
+                | manually_removed
             )
             potential_reviewers = maintainers - users_to_exclude
 


### PR DESCRIPTION
### Description

Compare GitHub usernames case-insensitively when managing review requests. In #9907, maintainer metadata used `johnrtitor` while GitHub returned `JohnRTitor`, so each workflow run removed and re-requested the same reviewer.

Normalize maintainers, pending and past reviewers, manual actions, and author/bot comparisons before matching. Existing reviewer exclusions and limits are unchanged.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [ ] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`. Not applicable; verified locally with mocked GitHub inputs.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
