### PR TITLE
worktrunk: fix skills path after installAgentSkills migration

### DIFF
--- a/modules/programs/worktrunk.nix
+++ b/modules/programs/worktrunk.nix
@@ -206,15 +206,15 @@ in
       };
 
       # Install worktrunk's skills directly into Claude Code (no plugin marketplace).
-      # The skill markdown ships inside the nixpkgs `worktrunk` package,
-      # version-aligned with the `wt` binary. Each skill has its own enable flag.
+      # The skills ship inside the nixpkgs `worktrunk` package, version-aligned with
+      # the `wt` binary. Each skill has its own enable flag.
       skills = lib.mkMerge [
         (lib.mkIf cfg.claudeCodeIntegration.configurationSkill {
-          worktrunk = "${cfg.package}/skills/worktrunk";
+          worktrunk = "${cfg.package}/share/skills/worktrunk/worktrunk";
         })
 
         (lib.mkIf cfg.claudeCodeIntegration.switchCreateSkill {
-          wt-switch-create = "${cfg.package}/skills/wt-switch-create";
+          wt-switch-create = "${cfg.package}/share/skills/worktrunk/wt-switch-create";
         })
       ];
     };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

NixOS/nixpkgs#558216 switched the worktrunk package to the `installAgentSkills` hook, moving the bundled skills from `$out/skills/` to `$out/share/skills/worktrunk/`.

~~Requires a nixpkgs bump containing the migration (NixOS/nixpkgs#c127c4cb4dccbd135ead65b8f07b9de65854aab2).~~

**NOTE:** I'm not quite sure about here is how we're supposed to maintain backward compatibility. The migration is already in `unstable` and was backported to the `release-26.05`, and there wasn't a version bump when the change was made. So I'm not sure there's a reliable way for us to tell whether we should use the old or the new location.

Assisted-by: Claude-Code:GLM-5.3

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -A dev --run treefmt`.

- [x] Code tested through `nix build .#test-all`
      or a targeted `nix run .#tests -- <pattern>`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
